### PR TITLE
[C++][Debug] Fixed operator * : Y*S in joint revolute unaligned

### DIFF
--- a/src/multibody/joint/joint-revolute-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unaligned.hpp
@@ -141,14 +141,14 @@ namespace se3
   Eigen::Matrix<double,6,1>
   operator*( const Inertia& Y,const JointRevoluteUnaligned::ConstraintRevoluteUnaligned & cru)
   { 
-    /* YS = [ m mcx ; -mcx I-mcxcx ] [ 0 ; w ] = [ mcxw ; Iw -mcxcxw ] */
+    /* YS = [ m -mcx ; mcx I-mcxcx ] [ 0 ; w ] = [ mcxw ; Iw -mcxcxw ] */
     const double &m                 = Y.mass();
     const Inertia::Vector3 & c      = Y.lever();
     const Inertia::Symmetric3 & I   = Y.inertia();
 
     const Motion::Vector3 mcxw = m*c.cross(cru.axis);
     Eigen::Matrix<double,6,1> res;
-    res.head<3>() = mcxw;
+    res.head<3>() = -mcxw;
     res.tail<3>() = I*cru.axis - c.cross(mcxw);
     return res;
   }


### PR DESCRIPTION
The error in Joint Revolute Unaligned was the operator implying a spatial inertia and the ConstraintRevoluteUnaligned, needed by CRBA.
Using the script sent by antonio, now inertia_matrix_rnea and inertia_matrix_crba are equal ( some value to xx e-15 though)