### PR TITLE
[C++] Remove forbidden instances of typename keyword.

### DIFF
--- a/src/multibody/joint/joint-prismatic.hpp
+++ b/src/multibody/joint/joint-prismatic.hpp
@@ -240,13 +240,13 @@ namespace se3
   {
     // TODO: I am not able to write the next three lines as a template. Why?
     template<>
-    struct ActionReturn<typename JointPrismatic<0>::ConstraintPrismatic >  
+    struct ActionReturn<JointPrismatic<0>::ConstraintPrismatic >
     { typedef Eigen::Matrix<double,6,1> Type; };
     template<>
-    struct ActionReturn<typename JointPrismatic<1>::ConstraintPrismatic >  
+    struct ActionReturn<JointPrismatic<1>::ConstraintPrismatic >
     { typedef Eigen::Matrix<double,6,1> Type; };
     template<>
-    struct ActionReturn<typename JointPrismatic<2>::ConstraintPrismatic >  
+    struct ActionReturn<JointPrismatic<2>::ConstraintPrismatic >
     { typedef Eigen::Matrix<double,6,1> Type; };
   }
 

--- a/src/multibody/joint/joint-revolute-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unaligned.hpp
@@ -165,10 +165,10 @@ namespace se3
   {
     typedef JointDataRevoluteUnaligned JointData;
     typedef JointModelRevoluteUnaligned JointModel;
-    typedef typename JointRevoluteUnaligned::ConstraintRevoluteUnaligned Constraint_t;
+    typedef JointRevoluteUnaligned::ConstraintRevoluteUnaligned Constraint_t;
     typedef SE3 Transformation_t;
-    typedef typename JointRevoluteUnaligned::MotionRevoluteUnaligned Motion_t;
-    typedef typename JointRevoluteUnaligned::BiasZero Bias_t;
+    typedef JointRevoluteUnaligned::MotionRevoluteUnaligned Motion_t;
+    typedef JointRevoluteUnaligned::BiasZero Bias_t;
     typedef Eigen::Matrix<double,6,1> F_t;
     enum {
       NQ = 1,

--- a/src/multibody/joint/joint-revolute.hpp
+++ b/src/multibody/joint/joint-revolute.hpp
@@ -264,13 +264,13 @@ namespace se3
   {
     // TODO: I am not able to write the next three lines as a template. Why?
     template<>
-    struct ActionReturn<typename JointRevolute<0>::ConstraintRevolute >  
+    struct ActionReturn<JointRevolute<0>::ConstraintRevolute >
     { typedef Eigen::Matrix<double,6,1> Type; };
     template<>
-    struct ActionReturn<typename JointRevolute<1>::ConstraintRevolute >  
+    struct ActionReturn<JointRevolute<1>::ConstraintRevolute >
     { typedef Eigen::Matrix<double,6,1> Type; };
     template<>
-    struct ActionReturn<typename JointRevolute<2>::ConstraintRevolute >  
+    struct ActionReturn<JointRevolute<2>::ConstraintRevolute >
     { typedef Eigen::Matrix<double,6,1> Type; };
   }
 


### PR DESCRIPTION
  - This is necessary to build with older compiler versions.
  - The keyword typename must only be used in template declarations
    and definitions and only in contexts in which dependent names can
    be used. This excludes explicit specialization declarations and
    explicit instantiation declarations (until C++11).