### PR TITLE
Topic/joint dense

### DIFF
--- a/src/multibody/joint/joint-base.hpp
+++ b/src/multibody/joint/joint-base.hpp
@@ -18,8 +18,8 @@
 #ifndef __se3_joint_base_hpp__
 #define __se3_joint_base_hpp__
 
-#include "pinocchio/spatial/fwd.hpp"
-#include "pinocchio/spatial/motion.hpp"
+#include "pinocchio/spatial/se3.hpp"
+#include "pinocchio/spatial/inertia.hpp"
 #include "pinocchio/multibody/constraint.hpp"
 #include <Eigen/Geometry>
 #include <Eigen/StdVector>
@@ -65,18 +65,18 @@ namespace se3
    */
 #ifdef __clang__
 
-#define SE3_JOINT_TYPEDEF_ARG(prefix)					     \
-  typedef int Index;						     \
-  typedef prefix traits<Joint>::JointData JointData;		     \
-  typedef prefix traits<Joint>::JointModel JointModel;	     \
-  typedef prefix traits<Joint>::Constraint_t Constraint_t;	     \
-  typedef prefix traits<Joint>::Transformation_t Transformation_t; \
-  typedef prefix traits<Joint>::Motion_t Motion_t;		     \
-  typedef prefix traits<Joint>::Bias_t Bias_t;		     \
-  typedef prefix traits<Joint>::F_t F_t;			     \
-  enum {							     \
-    NQ = traits<Joint>::NQ,					     \
-    NV = traits<Joint>::NV					     \
+#define SE3_JOINT_TYPEDEF_ARG(prefix)              \
+   typedef int Index;                \
+   typedef prefix traits<Joint>::JointData JointData;        \
+   typedef prefix traits<Joint>::JointModel JointModel;      \
+   typedef prefix traits<Joint>::Constraint_t Constraint_t;      \
+   typedef prefix traits<Joint>::Transformation_t Transformation_t; \
+   typedef prefix traits<Joint>::Motion_t Motion_t;        \
+   typedef prefix traits<Joint>::Bias_t Bias_t;        \
+   typedef prefix traits<Joint>::F_t F_t;          \
+   enum {                  \
+    NQ = traits<Joint>::NQ,              \
+    NV = traits<Joint>::NV               \
   }
 
 #define SE3_JOINT_TYPEDEF SE3_JOINT_TYPEDEF_ARG()
@@ -84,32 +84,32 @@ namespace se3
 
 #elif (__GNUC__ == 4) && (__GNUC_MINOR__ == 4) && (__GNUC_PATCHLEVEL__ == 2)
 
-#define SE3_JOINT_TYPEDEF_NOARG()				\
-  typedef int Index;						\
-  typedef traits<Joint>::JointData JointData;			\
-  typedef traits<Joint>::JointModel JointModel;			\
-  typedef traits<Joint>::Constraint_t Constraint_t;		\
-  typedef traits<Joint>::Transformation_t Transformation_t;	\
-  typedef traits<Joint>::Motion_t Motion_t;			\
-  typedef traits<Joint>::Bias_t Bias_t;				\
-  typedef traits<Joint>::F_t F_t;				\
-  enum {							\
-    NQ = traits<Joint>::NQ,					\
-    NV = traits<Joint>::NV					\
+#define SE3_JOINT_TYPEDEF_NOARG()       \
+  typedef int Index;            \
+  typedef traits<Joint>::JointData JointData;     \
+  typedef traits<Joint>::JointModel JointModel;     \
+  typedef traits<Joint>::Constraint_t Constraint_t;   \
+  typedef traits<Joint>::Transformation_t Transformation_t; \
+  typedef traits<Joint>::Motion_t Motion_t;     \
+  typedef traits<Joint>::Bias_t Bias_t;       \
+  typedef traits<Joint>::F_t F_t;       \
+  enum {              \
+    NQ = traits<Joint>::NQ,         \
+    NV = traits<Joint>::NV          \
   }
 
-#define SE3_JOINT_TYPEDEF_ARG(prefix)					\
-  typedef int Index;							\
-  typedef prefix traits<Joint>::JointData JointData;			\
-  typedef prefix traits<Joint>::JointModel JointModel;			\
-  typedef prefix traits<Joint>::Constraint_t Constraint_t;		\
-  typedef prefix traits<Joint>::Transformation_t Transformation_t;	\
-  typedef prefix traits<Joint>::Motion_t Motion_t;			\
-  typedef prefix traits<Joint>::Bias_t Bias_t;				\
-  typedef prefix traits<Joint>::F_t F_t;				\
-  enum {								\
-    NQ = traits<Joint>::NQ,						\
-    NV = traits<Joint>::NV						\
+#define SE3_JOINT_TYPEDEF_ARG(prefix)         \
+  typedef int Index;              \
+  typedef prefix traits<Joint>::JointData JointData;      \
+  typedef prefix traits<Joint>::JointModel JointModel;      \
+  typedef prefix traits<Joint>::Constraint_t Constraint_t;    \
+  typedef prefix traits<Joint>::Transformation_t Transformation_t;  \
+  typedef prefix traits<Joint>::Motion_t Motion_t;      \
+  typedef prefix traits<Joint>::Bias_t Bias_t;        \
+  typedef prefix traits<Joint>::F_t F_t;        \
+  enum {                \
+    NQ = traits<Joint>::NQ,           \
+    NV = traits<Joint>::NV            \
   }
 
 #define SE3_JOINT_TYPEDEF SE3_JOINT_TYPEDEF_NOARG()
@@ -137,16 +137,21 @@ namespace se3
 #endif
 
 #define SE3_JOINT_USE_INDEXES \
-    typedef JointModelBase<JointModel> Base; \
-    using Base::idx_q; \
-    using Base::idx_v
+  typedef JointModelBase<JointModel> Base; \
+  using Base::idx_q; \
+  using Base::idx_v
+
+
+  template <int _NQ, int _NV> struct JointDataDense;
+  template <int _NQ, int _NV> struct JointModelDense;
+  template <int _NQ, int _NV> struct JointDense;
 
   template<typename _JointData>
   struct JointDataBase
   {
     typedef typename traits<_JointData>::Joint Joint;
     SE3_JOINT_TYPEDEF_TEMPLATE;
-
+public:
     JointData& derived() { return *static_cast<JointData*>(this); }
     const JointData& derived() const { return *static_cast<const JointData*>(this); }
 
@@ -155,6 +160,9 @@ namespace se3
     const Motion_t         & v() const  { return static_cast<const JointData*>(this)->v;   }
     const Bias_t           & c() const  { return static_cast<const JointData*>(this)->c;   }
     F_t& F()        { return static_cast<      JointData*>(this)->F; }
+
+    JointDataDense<NQ, NV> toDense() const  { return static_cast<const JointData*>(this)->toDense_impl();   }
+
   };
 
   template<typename _JointModel>
@@ -168,14 +176,14 @@ namespace se3
 
     JointData createData() const { return static_cast<const JointModel*>(this)->createData(); }
     void calc( JointData& data, 
-	       const Eigen::VectorXd & qs ) const
+      const Eigen::VectorXd & qs ) const
     { return static_cast<const JointModel*>(this)->calc(data,qs); }
     void calc( JointData& data, 
-	       const Eigen::VectorXd & qs, 
-	       const Eigen::VectorXd & vs ) const
+      const Eigen::VectorXd & qs, 
+      const Eigen::VectorXd & vs ) const
     { return static_cast<const JointModel*>(this)->calc(data,qs,vs); }
 
-  private:
+  public:
     Index i_id; // ID of the joint in the multibody list.
     int i_q;    // Index of the joint configuration in the joint configuration vector.
     int i_v;    // Index of the joint velocity in the joint velocity vector.
@@ -187,8 +195,9 @@ namespace se3
     Eigen::Matrix<double,NV,1> velocityMax;
 
   public:
-          int     nv()    const { return NV; }
-          int     nq()    const { return NQ; }
+    
+    int     nv()    const { return NV; }
+    int     nq()    const { return NQ; }
     const int &   idx_q() const { return i_q; }
     const int &   idx_v() const { return i_v; }
     const Index & id()    const { return i_id; }
@@ -220,7 +229,7 @@ namespace se3
 
     void setMaxEffortLimit(const Eigen::VectorXd & effort)
     {
-      if (effort.rows() == NQ)
+      if (effort.rows() == NV)
         effortMax = effort;
       else
         effortMax.fill(std::numeric_limits<double>::infinity());
@@ -261,7 +270,136 @@ namespace se3
     typename D::template FixedSegmentReturnType<NV>::Type jointTangentLimit(Eigen::MatrixBase<D>& limit) const 
     { return limit.template segment<NV>(i_v); }
 
+
+    JointModelDense<NQ, NV> toDense() const  { return static_cast<const JointModel*>(this)->toDense_impl();   }
   };
+
+  
+
+  template<int _NQ, int _NV>
+  struct traits< JointDense<_NQ, _NV > >
+  {
+    typedef JointDataDense<_NQ, _NV> JointData;
+    typedef JointModelDense<_NQ, _NV> JointModel;
+    typedef ConstraintXd Constraint_t;
+    typedef SE3 Transformation_t;
+    typedef Motion Motion_t;
+    typedef BiasZero Bias_t;
+    typedef Eigen::Matrix<double,6,Eigen::Dynamic> F_t;
+    enum {
+      NQ = _NQ, // pb 
+      NV = _NV
+    };
+  };
+
+  template<int _NQ, int _NV> struct traits< JointDataDense<_NQ, _NV > > { typedef JointDense<_NQ,_NV > Joint; };
+  template<int _NQ, int _NV> struct traits< JointModelDense<_NQ, _NV > > { typedef JointDense<_NQ,_NV > Joint; };
+
+  template <int _NQ, int _NV>
+  struct JointDataDense : public JointDataBase< JointDataDense<_NQ, _NV > >
+  {
+    typedef JointDense<_NQ, _NV > Joint;
+    SE3_JOINT_TYPEDEF_TEMPLATE;
+public:
+    Constraint_t S;
+    Transformation_t M;
+    Motion_t v;
+    Bias_t c;
+
+    F_t F;
+
+    /// Removed Default constructor of JointDataDense because it was calling default constructor of
+    /// ConstraintXd -> eigen_static_assert
+    /// JointDataDense should always be instanciated from a JointDataXX.toDense()
+    // JointDataDense() : M(1)
+    // {
+    //   M.translation(SE3::Vector3::Zero());
+    // }
+
+    JointDataDense( Constraint_t S,
+                    Transformation_t M,
+                    Motion_t v,
+                    Bias_t c,
+                    F_t F
+                    )
+    : S(S)
+    , M(M)
+    , v(v)
+    , c(c)
+    , F(F)
+    {}
+
+    JointDataDense<_NQ, _NV> toDense_impl() const
+    {
+      assert(false && "Trying to convert a jointDataDense to JointDataDense : useless"); // disapear with release optimizations
+      return *this;
+    }
+
+  }; // struct JointDataDense
+
+  template <int _NQ, int _NV>
+  struct JointModelDense : public JointModelBase< JointModelDense<_NQ, _NV > >
+  {
+    typedef JointDense<_NQ, _NV > Joint;
+    SE3_JOINT_TYPEDEF_TEMPLATE;
+
+    using JointModelBase<JointModelDense<_NQ, _NV > >::idx_q;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::idx_v;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::setLowerPositionLimit;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::setUpperPositionLimit;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::setMaxEffortLimit;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::setMaxVelocityLimit;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::setIndexes;
+    
+    JointData createData() const
+    {
+      assert(false && "JointModelDense is read-only, should not createData");
+      return JointData();
+    }
+    void calc( JointData& , 
+     const Eigen::VectorXd &  ) const
+    {
+      assert(false && "JointModelDense is read-only, should not perform any calc");
+    }
+
+    void calc( JointData&  ,
+     const Eigen::VectorXd & , 
+     const Eigen::VectorXd &  ) const
+    {
+      assert(false && "JointModelDense is read-only, should not perform any calc");
+    }
+
+    JointModelDense()
+    {
+      setIndexes(1, 1, 1);
+      setLowerPositionLimit(Eigen::Matrix<double,NQ,1>(1));
+      setUpperPositionLimit(Eigen::Matrix<double,NQ,1>(1));
+      setMaxEffortLimit(Eigen::Matrix<double,NQ,1>(1));
+      setMaxVelocityLimit(Eigen::Matrix<double,NV,1>(1));
+    }
+    JointModelDense(  Index idx,
+                      int idx_q,
+                      int idx_v,
+                      Eigen::Matrix<double,NQ,1> lowPos,
+                      Eigen::Matrix<double,NQ,1> upPos,
+                      Eigen::Matrix<double,NQ,1> maxEff,
+                      Eigen::Matrix<double,NV,1> maxVel
+                    )
+    {
+      setIndexes(idx, idx_q, idx_v);
+      setLowerPositionLimit(lowPos);
+      setUpperPositionLimit(upPos);
+      setMaxEffortLimit(maxEff);
+      setMaxVelocityLimit(maxVel);
+    }
+
+    JointModelDense<_NQ, _NV> toDense_impl() const
+    {
+      assert(false && "Trying to convert a jointModelDense to JointModelDense : useless"); // disapear with release optimizations
+      return *this;
+    }
+
+  }; // struct JointModelDense
 
 } // namespace se3
 

--- a/src/multibody/joint/joint-planar.hpp
+++ b/src/multibody/joint/joint-planar.hpp
@@ -121,6 +121,7 @@ namespace se3
   {
 
     SPATIAL_TYPEDEF_NO_TEMPLATE(ConstraintPlanar);
+    enum { NV = 3, Options = 0 }; // to check
     typedef traits<ConstraintPlanar>::JointMotion JointMotion;
     typedef traits<ConstraintPlanar>::JointForce JointForce;
     typedef traits<ConstraintPlanar>::DenseBase DenseBase;
@@ -128,6 +129,8 @@ namespace se3
 
     Motion operator* (const MotionPlanar & vj) const
     { return vj; }
+
+    int nv_impl() const { return NV; }
 
 
     struct ConstraintTranspose
@@ -264,13 +267,29 @@ namespace se3
     Motion_t v;
     Bias_t c;
 
+    F_t F; // TODO if not used anymore, clean F_t
+
     JointDataPlanar () : M(1) {}
+
+    JointDataDense<NQ, NV> toDense_impl() const
+    {
+      return JointDataDense<NQ, NV>(S, M, v, c, F);
+    }
   }; // struct JointDataPlanar
 
   struct JointModelPlanar : public JointModelBase<JointModelPlanar>
   {
     typedef JointPlanar Joint;
     SE3_JOINT_TYPEDEF;
+
+    using JointModelBase<JointModelPlanar>::id;
+    using JointModelBase<JointModelPlanar>::idx_q;
+    using JointModelBase<JointModelPlanar>::idx_v;
+    using JointModelBase<JointModelPlanar>::lowerPosLimit;
+    using JointModelBase<JointModelPlanar>::upperPosLimit;
+    using JointModelBase<JointModelPlanar>::maxEffortLimit;
+    using JointModelBase<JointModelPlanar>::maxVelocityLimit;
+    using JointModelBase<JointModelPlanar>::setIndexes;
 
     JointData createData() const { return JointData(); }
 
@@ -301,6 +320,23 @@ namespace se3
       data.v.x_dot_ = q_dot(0);
       data.v.y_dot_ = q_dot(1);
       data.v.theta_dot_ = q_dot(2);
+    }
+
+    JointModelDense<NQ, NV> toDense_impl() const
+    {
+      return JointModelDense<NQ, NV>( id(),
+                                      idx_q(),
+                                      idx_v(),
+                                      lowerPosLimit(),
+                                      upperPosLimit(),
+                                      maxEffortLimit(),
+                                      maxVelocityLimit()
+                                    );
+    }
+
+    bool operator == (const JointModelPlanar& /*Ohter*/) const
+    {
+      return true; // TODO ?? used to bind variant in python
     }
   }; // struct JointModelPlanar
 

--- a/src/multibody/joint/joint-prismatic.hpp
+++ b/src/multibody/joint/joint-prismatic.hpp
@@ -154,6 +154,8 @@ namespace se3
      return res;
     }
 
+    int nv_impl() const { return NV; }
+
     struct TransposeConst
     {
       const ConstraintPrismatic & ref; 
@@ -346,6 +348,12 @@ namespace se3
     {
       M.rotation(SE3::Matrix3::Identity());
     }
+
+    JointDataDense<NQ, NV> toDense_impl() const
+    {
+      return JointDataDense<NQ, NV>(S, M, v, c, F);
+    }
+
   }; // struct JointDataPrismatic
 
   template<int axis>
@@ -354,8 +362,13 @@ namespace se3
     typedef JointPrismatic<axis> Joint;
     SE3_JOINT_TYPEDEF_TEMPLATE;
 
+    using JointModelBase<JointModelPrismatic>::id;
     using JointModelBase<JointModelPrismatic>::idx_q;
     using JointModelBase<JointModelPrismatic>::idx_v;
+    using JointModelBase<JointModelPrismatic>::lowerPosLimit;
+    using JointModelBase<JointModelPrismatic>::upperPosLimit;
+    using JointModelBase<JointModelPrismatic>::maxEffortLimit;
+    using JointModelBase<JointModelPrismatic>::maxVelocityLimit;
     using JointModelBase<JointModelPrismatic>::setIndexes;
     
     JointData createData() const { return JointData(); }
@@ -375,6 +388,23 @@ namespace se3
 
       data.M.translation(JointPrismatic<axis>::cartesianTranslation(q));
       data.v.v = v;
+    }
+
+    JointModelDense<NQ, NV> toDense_impl() const
+    {
+      return JointModelDense<NQ, NV>( id(),
+                                      idx_q(),
+                                      idx_v(),
+                                      lowerPosLimit(),
+                                      upperPosLimit(),
+                                      maxEffortLimit(),
+                                      maxVelocityLimit()
+                                    );
+    }
+
+    bool operator == (const JointModelPrismatic& /*Ohter*/) const
+    {
+      return true; // TODO ?? used to bind variant in python
     }
   }; // struct JointModelPrismatic
 

--- a/src/multibody/joint/joint-revolute-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unaligned.hpp
@@ -113,6 +113,10 @@ namespace se3
     struct ConstraintRevoluteUnaligned : ConstraintBase < ConstraintRevoluteUnaligned >
     {
       SPATIAL_TYPEDEF_NO_TEMPLATE(ConstraintRevoluteUnaligned);
+      enum { NV = 1, Options = 0 };
+      typedef traits<ConstraintRevoluteUnaligned>::JointMotion JointMotion;
+      typedef traits<ConstraintRevoluteUnaligned>::JointForce JointForce;
+      typedef traits<ConstraintRevoluteUnaligned>::DenseBase DenseBase;
 
       ConstraintRevoluteUnaligned() : axis(Eigen::Vector3d::Constant(NAN)) {}
       ConstraintRevoluteUnaligned(const Motion::Vector3 & _axis) : axis(_axis) {}
@@ -133,6 +137,8 @@ namespace se3
         res.head<3>() = m.translation().cross(res.tail<3>());
         return res;
       }
+
+      int nv_impl() const { return NV; }
 
       struct TransposeConst
       {
@@ -250,6 +256,11 @@ namespace se3
       : M(1),S(axis),v(axis,NAN)
       ,angleaxis(NAN,axis)
     {}
+
+    JointDataDense<NQ, NV> toDense_impl() const
+    {
+      return JointDataDense<NQ, NV>(S, M, v, c, F);
+    }
   };
 
   struct JointModelRevoluteUnaligned : public JointModelBase< JointModelRevoluteUnaligned >
@@ -257,8 +268,13 @@ namespace se3
     typedef JointRevoluteUnaligned Joint;
     SE3_JOINT_TYPEDEF;
 
+    using JointModelBase<JointModelRevoluteUnaligned>::id;
     using JointModelBase<JointModelRevoluteUnaligned>::idx_q;
     using JointModelBase<JointModelRevoluteUnaligned>::idx_v;
+    using JointModelBase<JointModelRevoluteUnaligned>::lowerPosLimit;
+    using JointModelBase<JointModelRevoluteUnaligned>::upperPosLimit;
+    using JointModelBase<JointModelRevoluteUnaligned>::maxEffortLimit;
+    using JointModelBase<JointModelRevoluteUnaligned>::maxVelocityLimit;
     using JointModelBase<JointModelRevoluteUnaligned>::setIndexes;
     
     JointModelRevoluteUnaligned() : axis(Eigen::Vector3d::Constant(NAN))   {}
@@ -296,6 +312,23 @@ namespace se3
     }
 
     Eigen::Vector3d axis;
+
+    JointModelDense<NQ, NV> toDense_impl() const
+    {
+      return JointModelDense<NQ, NV>( id(),
+                                      idx_q(),
+                                      idx_v(),
+                                      lowerPosLimit(),
+                                      upperPosLimit(),
+                                      maxEffortLimit(),
+                                      maxVelocityLimit()
+                                    );
+    }
+
+    bool operator == (const JointModelRevoluteUnaligned& /*Ohter*/) const
+    {
+      return true; // TODO ?? used to bind variant in python
+    }
   };
 
 } //namespace se3

--- a/src/multibody/joint/joint-revolute.hpp
+++ b/src/multibody/joint/joint-revolute.hpp
@@ -18,10 +18,10 @@
 #ifndef __se3_joint_revolute_hpp__
 #define __se3_joint_revolute_hpp__
 
-#include "pinocchio/multibody/joint/joint-base.hpp"
-#include "pinocchio/multibody/constraint.hpp"
-#include "pinocchio/spatial/inertia.hpp"
+// #include "pinocchio/multibody/constraint.hpp"
 #include "pinocchio/math/sincos.hpp"
+#include "pinocchio/spatial/inertia.hpp"
+#include "pinocchio/multibody/joint/joint-base.hpp"
 
 namespace se3
 {
@@ -37,12 +37,11 @@ namespace se3
       double w; 
       CartesianVector3(const double & w) : w(w) {}
       CartesianVector3() : w(1) {}
-      operator Eigen::Vector3d ();
-    }; // struct CartesianVector3
+      operator Eigen::Vector3d (); // { return Eigen::Vector3d(w,0,0); }
+    };
     template<>CartesianVector3<0>::operator Eigen::Vector3d () { return Eigen::Vector3d(w,0,0); }
     template<>CartesianVector3<1>::operator Eigen::Vector3d () { return Eigen::Vector3d(0,w,0); }
     template<>CartesianVector3<2>::operator Eigen::Vector3d () { return Eigen::Vector3d(0,0,w); }
-
     Eigen::Vector3d operator+ (const Eigen::Vector3d & w1,const CartesianVector3<0> & wx)
     { return Eigen::Vector3d(w1[0]+wx.w,w1[1],w1[2]); }
     Eigen::Vector3d operator+ (const Eigen::Vector3d & w1,const CartesianVector3<1> & wy)
@@ -52,6 +51,7 @@ namespace se3
   } // namespace revolute
 
   template<int axis> struct MotionRevolute;
+
   template<int axis>
   struct traits< MotionRevolute < axis > >
   {
@@ -106,6 +106,7 @@ namespace se3
   }
 
   template<int axis> struct ConstraintRevolute;
+
   template<int axis>
   struct traits< ConstraintRevolute<axis> >
   {
@@ -154,6 +155,8 @@ namespace se3
       return res;
     }
 
+    int nv_impl() const { return NV; }
+    
     struct TransposeConst
     {
       const ConstraintRevolute<axis> & ref; 
@@ -182,8 +185,8 @@ namespace se3
      *   - MatrixBase operator* (Constraint::Transpose S, ForceSet::Block)
      *   - SE3::act(ForceSet::Block)
      */
-    operator ConstraintXd () const
-    {
+     operator ConstraintXd () const
+     {
       Eigen::Matrix<double,6,1> S;
       S << Eigen::Vector3d::Zero(), (Eigen::Vector3d)revolute::CartesianVector3<axis>();
       return ConstraintXd(S);
@@ -373,6 +376,11 @@ namespace se3
     {
       M.translation(SE3::Vector3::Zero());
     }
+
+    JointDataDense<NQ, NV> toDense_impl() const
+    {
+      return JointDataDense<NQ, NV>(S, M, v, c, F);
+    }
   }; // struct JointDataRevolute
 
   template<int axis>
@@ -381,8 +389,13 @@ namespace se3
     typedef JointRevolute<axis> Joint;
     SE3_JOINT_TYPEDEF_TEMPLATE;
 
+    using JointModelBase<JointModelRevolute>::id;
     using JointModelBase<JointModelRevolute>::idx_q;
     using JointModelBase<JointModelRevolute>::idx_v;
+    using JointModelBase<JointModelRevolute>::lowerPosLimit;
+    using JointModelBase<JointModelRevolute>::upperPosLimit;
+    using JointModelBase<JointModelRevolute>::maxEffortLimit;
+    using JointModelBase<JointModelRevolute>::maxVelocityLimit;
     using JointModelBase<JointModelRevolute>::setIndexes;
     
     JointData createData() const { return JointData(); }
@@ -404,6 +417,22 @@ namespace se3
       data.v.w = v;
     }
 
+    JointModelDense<NQ, NV> toDense_impl() const
+    {
+      return JointModelDense<NQ, NV>( id(),
+                                      idx_q(),
+                                      idx_v(),
+                                      lowerPosLimit(),
+                                      upperPosLimit(),
+                                      maxEffortLimit(),
+                                      maxVelocityLimit()
+                                    );
+    }
+
+    bool operator == (const JointModelRevolute<axis>& /*Other*/) const
+    {
+      return true; // TODO ??
+    }
 
   }; // struct JointModelRevolute
 

--- a/src/multibody/joint/joint-translation.hpp
+++ b/src/multibody/joint/joint-translation.hpp
@@ -117,6 +117,7 @@ namespace se3
   struct ConstraintTranslationSubspace : ConstraintBase < ConstraintTranslationSubspace >
   {
     SPATIAL_TYPEDEF_NO_TEMPLATE(ConstraintTranslationSubspace);
+    enum { NV = 3, Options = 0 };
     typedef traits<ConstraintTranslationSubspace>::JointMotion JointMotion;
     typedef traits<ConstraintTranslationSubspace>::JointForce JointForce;
     typedef traits<ConstraintTranslationSubspace>::DenseBase DenseBase;
@@ -125,6 +126,7 @@ namespace se3
     Motion operator* (const MotionTranslation & vj) const
     { return Motion (vj (), Motion::Vector3::Zero ()); }
 
+    int nv_impl() const { return NV; }
 
     struct ConstraintTranspose
     {
@@ -235,13 +237,29 @@ namespace se3
     Motion_t v;
     Bias_t c;
 
+    F_t F; // TODO if not used anymore, clean F_t
+
     JointDataTranslation () : M(1) {}
+
+    JointDataDense<NQ, NV> toDense_impl() const
+    {
+      return JointDataDense<NQ, NV>(S, M, v, c, F);
+    }
   }; // struct JointDataTranslation
 
   struct JointModelTranslation : public JointModelBase<JointModelTranslation>
   {
     typedef JointTranslation Joint;
     SE3_JOINT_TYPEDEF;
+
+    using JointModelBase<JointModelTranslation>::id;
+    using JointModelBase<JointModelTranslation>::idx_q;
+    using JointModelBase<JointModelTranslation>::idx_v;
+    using JointModelBase<JointModelTranslation>::lowerPosLimit;
+    using JointModelBase<JointModelTranslation>::upperPosLimit;
+    using JointModelBase<JointModelTranslation>::maxEffortLimit;
+    using JointModelBase<JointModelTranslation>::maxVelocityLimit;
+    using JointModelBase<JointModelTranslation>::setIndexes;
 
     JointData createData() const { return JointData(); }
 
@@ -256,6 +274,23 @@ namespace se3
     {
       data.M.translation (qs.segment<NQ> (idx_q ()));
       data.v () = vs.segment<NQ> (idx_v ());
+    }
+
+    JointModelDense<NQ, NV> toDense_impl() const
+    {
+      return JointModelDense<NQ, NV>( id(),
+                                      idx_q(),
+                                      idx_v(),
+                                      lowerPosLimit(),
+                                      upperPosLimit(),
+                                      maxEffortLimit(),
+                                      maxVelocityLimit()
+                                    );
+    }
+
+    bool operator == (const JointModelTranslation& /*Ohter*/) const
+    {
+      return true; // TODO ?? used to bind variant in python
     }
   }; // struct JointModelTranslation
   

--- a/unittest/joints.cpp
+++ b/unittest/joints.cpp
@@ -1016,3 +1016,55 @@ BOOST_AUTO_TEST_CASE ( test_merge_body )
 }
 
 BOOST_AUTO_TEST_SUITE_END ()
+
+BOOST_AUTO_TEST_SUITE ( JointDense )
+
+BOOST_AUTO_TEST_CASE ( toJointModelDense )
+{
+  using namespace se3;
+
+
+  JointModelRX jmodel;
+  jmodel.setIndexes (2, 0, 0);
+
+  JointModelDense<JointModelBase<JointModelRX>::NQ, JointModelBase<JointModelRX>::NV> jmd(jmodel.id(), jmodel.idx_q(), jmodel.idx_v(), jmodel.lowerPosLimit(),
+                          jmodel.upperPosLimit(), jmodel.maxEffortLimit(), jmodel.maxVelocityLimit());
+  JointModelDense<JointModelBase<JointModelRX>::NQ, JointModelBase<JointModelRX>::NV> jmd2 = jmodel.toDense();
+  (void)jmd; (void)jmd2;
+
+  assert(jmd.idx_q() == jmodel.idx_q() && "The comparison of the joint index in configuration space failed");
+  assert(jmd.idx_q() == jmd2.idx_q() && "The comparison of the joint index in  configuration space failed");
+
+  assert(jmd.idx_v() == jmodel.idx_v() && "The comparison of the joint index in velocity space failed");
+  assert(jmd.idx_v() == jmd2.idx_v() && "The comparison of the joint index in  velocity space failed");
+
+  assert(jmd.id() == jmodel.id() && "The comparison of the joint index in model's kinematic tree failed");
+  assert(jmd.id() == jmd2.id() && "The comparison of the joint index in model's kinematic tree failed");
+
+}
+
+BOOST_AUTO_TEST_CASE ( toJointDataDense )
+{
+  // using namespace se3;
+
+  // JointModelRX jmodel;
+  // jmodel.setIndexes (2, 0, 0);
+
+  // JointDataRX jdata;
+
+  // JointDataDense< JointDataBase<JointModelRX::JointData>::NQ,
+  //                 JointDataBase<JointModelRX::JointData>::NV
+  //                                                                     > jdd = jdata.toDense(); (void) jdd;
+
+  // asert(jdata.S().nv() == jdd.S().nv() && "");
+
+  
+      // JointDataBase<JointDataDense> & jddb = jdd;
+
+      // std::cout << "S nv: \t" ;
+      // std::cout << jdata.S().nv() << std::endl;
+      // JointDataDense::Transformation_t mm = jdd.M1();
+      // std::cout //<< "M\t" << mm << std::endl;
+                // << jdd.S << std::endl;
+}
+BOOST_AUTO_TEST_SUITE_END ()


### PR DESCRIPTION
Added two classes JointModelDense and JointDataDense.
Their aim is to be as generic as possible and to possibly allow conversion to these types for any joints thanks to the methods toDense(). Cf in tests.
They are given as it with a possible use in C++. Unfortunately, the initial goal that was to bind this joint in python as a read-only joint is difficult. Instead, the binding of each joints can be done automatically and will allow the instantiation of such joints. Coming in a future pull request.