### PR TITLE
Topic/joint dense

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,7 @@ SET(${PROJECT_NAME}_SPATIAL_HEADERS
 
 SET(${PROJECT_NAME}_MULTIBODY_JOINT_HEADERS
   multibody/joint/joint-base.hpp
+  multibody/joint/joint-dense.hpp
   multibody/joint/joint-revolute.hpp
   multibody/joint/joint-revolute-unaligned.hpp
   multibody/joint/joint-spherical.hpp

--- a/src/algorithm/center-of-mass.hpp
+++ b/src/algorithm/center-of-mass.hpp
@@ -263,7 +263,8 @@ namespace se3
       	  = data.mass[i]*oSk.template topLeftCorner<3,1>() 
       	  - data.com[i].cross(oSk.template bottomLeftCorner<3,1>()) ;
       else
-      	data.Jcom.template block<3,JointModel::NV>(0,jmodel.idx_v())
+      	jmodel.jointCols(data.Jcom)
+          //data.Jcom.template block<3,JointModel::NV>(0,jmodel.idx_v())
       	  = data.mass[i]*oSk.template topRows<3>() 
       	  - skew(data.com[i]) * oSk.template bottomRows<3>() ;
 

--- a/src/algorithm/crba.hpp
+++ b/src/algorithm/crba.hpp
@@ -86,7 +86,8 @@ namespace se3
       const Model::Index & i = (Model::Index) jmodel.id();
 
       /* F[1:6,i] = Y*S */
-      data.Fcrb[i].block<6,JointModel::NV>(0,jmodel.idx_v()) = data.Ycrb[i] * jdata.S();
+      //data.Fcrb[i].block<6,JointModel::NV>(0,jmodel.idx_v()) = data.Ycrb[i] * jdata.S();
+      jmodel.jointCols(data.Fcrb[i]) = data.Ycrb[i] * jdata.S();
 
       /* M[i,SUBTREE] = S'*F[1:6,SUBTREE] */
       data.M.block(jmodel.idx_v(),jmodel.idx_v(),jmodel.nv(),data.nvSubtree[i]) 

--- a/src/algorithm/jacobian.hpp
+++ b/src/algorithm/jacobian.hpp
@@ -62,7 +62,7 @@ namespace se3
       if(parent>0) data.oMi[i] = data.oMi[parent]*data.liMi[i];
       else         data.oMi[i] = data.liMi[i];
 
-      data.J.block(0,jmodel.idx_v(),6,jmodel.nv()) = data.oMi[i].act(jdata.S());
+      jmodel.jointCols(data.J) = data.oMi[i].act(jdata.S());
     }
 
   };
@@ -128,7 +128,7 @@ namespace se3
       data.liMi[i] = model.jointPlacements[i]*jdata.M();
       data.iMf[parent] = data.liMi[i]*data.iMf[i];
 
-      data.J.block(0,jmodel.idx_v(),6,jmodel.nv()) = data.iMf[i].inverse().act(jdata.S());
+      jmodel.jointCols(data.J) = data.iMf[i].inverse().act(jdata.S());
     }
 
   };

--- a/src/algorithm/joint-limits.hpp
+++ b/src/algorithm/joint-limits.hpp
@@ -52,11 +52,11 @@ namespace se3
       using namespace se3;
       
       // TODO: as limits are static, no need of q, nor computations
-      jmodel.jointVelocitySpace(data.effortLimit) = jmodel.maxEffortLimit();
-      jmodel.jointVelocitySpace(data.velocityLimit) = jmodel.maxVelocityLimit();
+      jmodel.jointVelocitySelector(data.effortLimit) = jmodel.maxEffortLimit();
+      jmodel.jointVelocitySelector(data.velocityLimit) = jmodel.maxVelocityLimit();
 
-      jmodel.jointConfigSpace(data.lowerPositionLimit) = jmodel.lowerPosLimit(); // if computation needed, do it here, or may be in lowerPosLimit
-      jmodel.jointConfigSpace(data.upperPositionLimit) = jmodel.upperPosLimit();
+      jmodel.jointConfigSelector(data.lowerPositionLimit) = jmodel.lowerPosLimit(); // if computation needed, do it here, or may be in lowerPosLimit
+      jmodel.jointConfigSelector(data.upperPositionLimit) = jmodel.upperPosLimit();
     }
 
   };

--- a/src/algorithm/joint-limits.hpp
+++ b/src/algorithm/joint-limits.hpp
@@ -52,11 +52,11 @@ namespace se3
       using namespace se3;
       
       // TODO: as limits are static, no need of q, nor computations
-      jmodel.jointLimit(data.effortLimit) = jmodel.maxEffortLimit();
-      jmodel.jointTangentLimit(data.velocityLimit) = jmodel.maxVelocityLimit();
+      jmodel.jointVelocitySpace(data.effortLimit) = jmodel.maxEffortLimit();
+      jmodel.jointVelocitySpace(data.velocityLimit) = jmodel.maxVelocityLimit();
 
-      jmodel.jointLimit(data.lowerPositionLimit) = jmodel.lowerPosLimit(); // if computation needed, do it here, or may be in lowerPosLimit
-      jmodel.jointLimit(data.upperPositionLimit) = jmodel.upperPosLimit();
+      jmodel.jointConfigSpace(data.lowerPositionLimit) = jmodel.lowerPosLimit(); // if computation needed, do it here, or may be in lowerPosLimit
+      jmodel.jointConfigSpace(data.upperPositionLimit) = jmodel.upperPosLimit();
     }
 
   };

--- a/src/algorithm/kinematics.hpp
+++ b/src/algorithm/kinematics.hpp
@@ -180,7 +180,7 @@ namespace se3
       else
         data.oMi[i] = data.liMi[i];
       
-      data.a[i]  = jdata.S() * jmodel.jointVelocitySpace(a) + jdata.c() + (data.v[i] ^ jdata.v()) ;
+      data.a[i]  = jdata.S() * jmodel.jointVelocitySelector(a) + jdata.c() + (data.v[i] ^ jdata.v()) ;
       data.a[i] += data.liMi[i].actInv(data.a[parent]);
     }
   };

--- a/src/algorithm/kinematics.hpp
+++ b/src/algorithm/kinematics.hpp
@@ -180,7 +180,7 @@ namespace se3
       else
         data.oMi[i] = data.liMi[i];
       
-      data.a[i]  = jdata.S() * jmodel.jointMotion(a) + jdata.c() + (data.v[i] ^ jdata.v()) ;
+      data.a[i]  = jdata.S() * jmodel.jointVelocitySpace(a) + jdata.c() + (data.v[i] ^ jdata.v()) ;
       data.a[i] += data.liMi[i].actInv(data.a[parent]);
     }
   };

--- a/src/algorithm/non-linear-effects.hpp
+++ b/src/algorithm/non-linear-effects.hpp
@@ -88,7 +88,7 @@ namespace se3
 		     const size_t i)
     {
       const Model::Index & parent  = model.parents[i];      
-      jmodel.jointForce(data.nle)  = jdata.S().transpose()*data.f[i];
+      jmodel.jointVelocitySpace(data.nle)  = jdata.S().transpose()*data.f[i];
       if(parent>0) data.f[(size_t) parent] += data.liMi[i].act(data.f[i]);
     }
   };

--- a/src/algorithm/non-linear-effects.hpp
+++ b/src/algorithm/non-linear-effects.hpp
@@ -88,7 +88,7 @@ namespace se3
 		     const size_t i)
     {
       const Model::Index & parent  = model.parents[i];      
-      jmodel.jointVelocitySpace(data.nle)  = jdata.S().transpose()*data.f[i];
+      jmodel.jointVelocitySelector(data.nle)  = jdata.S().transpose()*data.f[i];
       if(parent>0) data.f[(size_t) parent] += data.liMi[i].act(data.f[i]);
     }
   };

--- a/src/algorithm/rnea.hpp
+++ b/src/algorithm/rnea.hpp
@@ -67,7 +67,7 @@ namespace se3
       data.v[(Model::Index)i] = jdata.v();
       if(parent>0) data.v[(Model::Index)i] += data.liMi[(Model::Index)i].actInv(data.v[parent]);
       
-      data.a[(Model::Index)i]  = jdata.S()*jmodel.jointVelocitySpace(a) + jdata.c() + (data.v[(Model::Index)i] ^ jdata.v()) ; 
+      data.a[(Model::Index)i]  = jdata.S()*jmodel.jointVelocitySelector(a) + jdata.c() + (data.v[(Model::Index)i] ^ jdata.v()) ; 
       data.a[(Model::Index)i] += data.liMi[(Model::Index)i].actInv(data.a[parent]);
       
       data.f[(Model::Index)i] = model.inertias[(Model::Index)i]*data.a[(Model::Index)i] + model.inertias[(Model::Index)i].vxiv(data.v[(Model::Index)i]); // -f_ext
@@ -92,7 +92,7 @@ namespace se3
 		     int i)
     {
       const Model::Index & parent  = model.parents[(Model::Index)i];      
-      jmodel.jointVelocitySpace(data.tau)  = jdata.S().transpose()*data.f[(Model::Index)i];
+      jmodel.jointVelocitySelector(data.tau)  = jdata.S().transpose()*data.f[(Model::Index)i];
       if(parent>0) data.f[(Model::Index)parent] += data.liMi[(Model::Index)i].act(data.f[(Model::Index)i]);
     }
   };

--- a/src/algorithm/rnea.hpp
+++ b/src/algorithm/rnea.hpp
@@ -67,7 +67,7 @@ namespace se3
       data.v[(Model::Index)i] = jdata.v();
       if(parent>0) data.v[(Model::Index)i] += data.liMi[(Model::Index)i].actInv(data.v[parent]);
       
-      data.a[(Model::Index)i]  = jdata.S()*jmodel.jointMotion(a) + jdata.c() + (data.v[(Model::Index)i] ^ jdata.v()) ; 
+      data.a[(Model::Index)i]  = jdata.S()*jmodel.jointVelocitySpace(a) + jdata.c() + (data.v[(Model::Index)i] ^ jdata.v()) ; 
       data.a[(Model::Index)i] += data.liMi[(Model::Index)i].actInv(data.a[parent]);
       
       data.f[(Model::Index)i] = model.inertias[(Model::Index)i]*data.a[(Model::Index)i] + model.inertias[(Model::Index)i].vxiv(data.v[(Model::Index)i]); // -f_ext
@@ -92,7 +92,7 @@ namespace se3
 		     int i)
     {
       const Model::Index & parent  = model.parents[(Model::Index)i];      
-      jmodel.jointForce(data.tau)  = jdata.S().transpose()*data.f[(Model::Index)i];
+      jmodel.jointVelocitySpace(data.tau)  = jdata.S().transpose()*data.f[(Model::Index)i];
       if(parent>0) data.f[(Model::Index)parent] += data.liMi[(Model::Index)i].act(data.f[(Model::Index)i]);
     }
   };

--- a/src/multibody/joint.hpp
+++ b/src/multibody/joint.hpp
@@ -19,6 +19,7 @@
 #define __se3_joint_hpp__
 
 #include "pinocchio/multibody/joint/joint-base.hpp"
+#include "pinocchio/multibody/joint/joint-dense.hpp"
 #include "pinocchio/multibody/joint/joint-revolute.hpp"
 #include "pinocchio/multibody/joint/joint-revolute-unaligned.hpp"
 #include "pinocchio/multibody/joint/joint-spherical.hpp"

--- a/src/multibody/joint/joint-base.hpp
+++ b/src/multibody/joint/joint-base.hpp
@@ -18,8 +18,8 @@
 #ifndef __se3_joint_base_hpp__
 #define __se3_joint_base_hpp__
 
-#include "pinocchio/spatial/fwd.hpp"
-#include "pinocchio/spatial/motion.hpp"
+#include "pinocchio/spatial/se3.hpp"
+#include "pinocchio/spatial/inertia.hpp"
 #include "pinocchio/multibody/constraint.hpp"
 #include <Eigen/Geometry>
 #include <Eigen/StdVector>
@@ -65,18 +65,18 @@ namespace se3
    */
 #ifdef __clang__
 
-#define SE3_JOINT_TYPEDEF_ARG(prefix)					     \
-  typedef int Index;						     \
-  typedef prefix traits<Joint>::JointData JointData;		     \
-  typedef prefix traits<Joint>::JointModel JointModel;	     \
-  typedef prefix traits<Joint>::Constraint_t Constraint_t;	     \
-  typedef prefix traits<Joint>::Transformation_t Transformation_t; \
-  typedef prefix traits<Joint>::Motion_t Motion_t;		     \
-  typedef prefix traits<Joint>::Bias_t Bias_t;		     \
-  typedef prefix traits<Joint>::F_t F_t;			     \
-  enum {							     \
-    NQ = traits<Joint>::NQ,					     \
-    NV = traits<Joint>::NV					     \
+#define SE3_JOINT_TYPEDEF_ARG(prefix)              \
+   typedef int Index;                \
+   typedef prefix traits<Joint>::JointData JointData;        \
+   typedef prefix traits<Joint>::JointModel JointModel;      \
+   typedef prefix traits<Joint>::Constraint_t Constraint_t;      \
+   typedef prefix traits<Joint>::Transformation_t Transformation_t; \
+   typedef prefix traits<Joint>::Motion_t Motion_t;        \
+   typedef prefix traits<Joint>::Bias_t Bias_t;        \
+   typedef prefix traits<Joint>::F_t F_t;          \
+   enum {                  \
+    NQ = traits<Joint>::NQ,              \
+    NV = traits<Joint>::NV               \
   }
 
 #define SE3_JOINT_TYPEDEF SE3_JOINT_TYPEDEF_ARG()
@@ -84,32 +84,32 @@ namespace se3
 
 #elif (__GNUC__ == 4) && (__GNUC_MINOR__ == 4) && (__GNUC_PATCHLEVEL__ == 2)
 
-#define SE3_JOINT_TYPEDEF_NOARG()				\
-  typedef int Index;						\
-  typedef traits<Joint>::JointData JointData;			\
-  typedef traits<Joint>::JointModel JointModel;			\
-  typedef traits<Joint>::Constraint_t Constraint_t;		\
-  typedef traits<Joint>::Transformation_t Transformation_t;	\
-  typedef traits<Joint>::Motion_t Motion_t;			\
-  typedef traits<Joint>::Bias_t Bias_t;				\
-  typedef traits<Joint>::F_t F_t;				\
-  enum {							\
-    NQ = traits<Joint>::NQ,					\
-    NV = traits<Joint>::NV					\
+#define SE3_JOINT_TYPEDEF_NOARG()       \
+  typedef int Index;            \
+  typedef traits<Joint>::JointData JointData;     \
+  typedef traits<Joint>::JointModel JointModel;     \
+  typedef traits<Joint>::Constraint_t Constraint_t;   \
+  typedef traits<Joint>::Transformation_t Transformation_t; \
+  typedef traits<Joint>::Motion_t Motion_t;     \
+  typedef traits<Joint>::Bias_t Bias_t;       \
+  typedef traits<Joint>::F_t F_t;       \
+  enum {              \
+    NQ = traits<Joint>::NQ,         \
+    NV = traits<Joint>::NV          \
   }
 
-#define SE3_JOINT_TYPEDEF_ARG(prefix)					\
-  typedef int Index;							\
-  typedef prefix traits<Joint>::JointData JointData;			\
-  typedef prefix traits<Joint>::JointModel JointModel;			\
-  typedef prefix traits<Joint>::Constraint_t Constraint_t;		\
-  typedef prefix traits<Joint>::Transformation_t Transformation_t;	\
-  typedef prefix traits<Joint>::Motion_t Motion_t;			\
-  typedef prefix traits<Joint>::Bias_t Bias_t;				\
-  typedef prefix traits<Joint>::F_t F_t;				\
-  enum {								\
-    NQ = traits<Joint>::NQ,						\
-    NV = traits<Joint>::NV						\
+#define SE3_JOINT_TYPEDEF_ARG(prefix)         \
+  typedef int Index;              \
+  typedef prefix traits<Joint>::JointData JointData;      \
+  typedef prefix traits<Joint>::JointModel JointModel;      \
+  typedef prefix traits<Joint>::Constraint_t Constraint_t;    \
+  typedef prefix traits<Joint>::Transformation_t Transformation_t;  \
+  typedef prefix traits<Joint>::Motion_t Motion_t;      \
+  typedef prefix traits<Joint>::Bias_t Bias_t;        \
+  typedef prefix traits<Joint>::F_t F_t;        \
+  enum {                \
+    NQ = traits<Joint>::NQ,           \
+    NV = traits<Joint>::NV            \
   }
 
 #define SE3_JOINT_TYPEDEF SE3_JOINT_TYPEDEF_NOARG()
@@ -137,16 +137,21 @@ namespace se3
 #endif
 
 #define SE3_JOINT_USE_INDEXES \
-    typedef JointModelBase<JointModel> Base; \
-    using Base::idx_q; \
-    using Base::idx_v
+  typedef JointModelBase<JointModel> Base; \
+  using Base::idx_q; \
+  using Base::idx_v
+
+
+  template <int _NQ, int _NV> struct JointDataDense;
+  template <int _NQ, int _NV> struct JointModelDense;
+  template <int _NQ, int _NV> struct JointDense;
 
   template<typename _JointData>
   struct JointDataBase
   {
     typedef typename traits<_JointData>::Joint Joint;
     SE3_JOINT_TYPEDEF_TEMPLATE;
-
+public:
     JointData& derived() { return *static_cast<JointData*>(this); }
     const JointData& derived() const { return *static_cast<const JointData*>(this); }
 
@@ -155,6 +160,9 @@ namespace se3
     const Motion_t         & v() const  { return static_cast<const JointData*>(this)->v;   }
     const Bias_t           & c() const  { return static_cast<const JointData*>(this)->c;   }
     F_t& F()        { return static_cast<      JointData*>(this)->F; }
+
+    JointDataDense<NQ, NV> toDense() const  { return static_cast<const JointData*>(this)->toDense_impl();   }
+
   };
 
   template<typename _JointModel>
@@ -168,14 +176,14 @@ namespace se3
 
     JointData createData() const { return static_cast<const JointModel*>(this)->createData(); }
     void calc( JointData& data, 
-	       const Eigen::VectorXd & qs ) const
+      const Eigen::VectorXd & qs ) const
     { return static_cast<const JointModel*>(this)->calc(data,qs); }
     void calc( JointData& data, 
-	       const Eigen::VectorXd & qs, 
-	       const Eigen::VectorXd & vs ) const
+      const Eigen::VectorXd & qs, 
+      const Eigen::VectorXd & vs ) const
     { return static_cast<const JointModel*>(this)->calc(data,qs,vs); }
 
-  private:
+  public:
     Index i_id; // ID of the joint in the multibody list.
     int i_q;    // Index of the joint configuration in the joint configuration vector.
     int i_v;    // Index of the joint velocity in the joint velocity vector.
@@ -187,8 +195,9 @@ namespace se3
     Eigen::Matrix<double,NV,1> velocityMax;
 
   public:
-          int     nv()    const { return NV; }
-          int     nq()    const { return NQ; }
+    
+    int     nv()    const { return NV; }
+    int     nq()    const { return NQ; }
     const int &   idx_q() const { return i_q; }
     const int &   idx_v() const { return i_v; }
     const Index & id()    const { return i_id; }
@@ -220,7 +229,7 @@ namespace se3
 
     void setMaxEffortLimit(const Eigen::VectorXd & effort)
     {
-      if (effort.rows() == NQ)
+      if (effort.rows() == NV)
         effortMax = effort;
       else
         effortMax.fill(std::numeric_limits<double>::infinity());
@@ -261,7 +270,136 @@ namespace se3
     typename D::template FixedSegmentReturnType<NV>::Type jointTangentLimit(Eigen::MatrixBase<D>& limit) const 
     { return limit.template segment<NV>(i_v); }
 
+
+    JointModelDense<NQ, NV> toDense() const  { return static_cast<const JointModel*>(this)->toDense_impl();   }
   };
+
+  
+
+  template<int _NQ, int _NV>
+  struct traits< JointDense<_NQ, _NV > >
+  {
+    typedef JointDataDense<_NQ, _NV> JointData;
+    typedef JointModelDense<_NQ, _NV> JointModel;
+    typedef ConstraintXd Constraint_t;
+    typedef SE3 Transformation_t;
+    typedef Motion Motion_t;
+    typedef BiasZero Bias_t;
+    typedef Eigen::Matrix<double,6,Eigen::Dynamic> F_t;
+    enum {
+      NQ = _NQ, // pb 
+      NV = _NV
+    };
+  };
+
+  template<int _NQ, int _NV> struct traits< JointDataDense<_NQ, _NV > > { typedef JointDense<_NQ,_NV > Joint; };
+  template<int _NQ, int _NV> struct traits< JointModelDense<_NQ, _NV > > { typedef JointDense<_NQ,_NV > Joint; };
+
+  template <int _NQ, int _NV>
+  struct JointDataDense : public JointDataBase< JointDataDense<_NQ, _NV > >
+  {
+    typedef JointDense<_NQ, _NV > Joint;
+    SE3_JOINT_TYPEDEF_TEMPLATE;
+public:
+    Constraint_t S;
+    Transformation_t M;
+    Motion_t v;
+    Bias_t c;
+
+    F_t F;
+
+    /// Removed Default constructor of JointDataDense because it was calling default constructor of
+    /// ConstraintXd -> eigen_static_assert
+    /// JointDataDense should always be instanciated from a JointDataXX.toDense()
+    // JointDataDense() : M(1)
+    // {
+    //   M.translation(SE3::Vector3::Zero());
+    // }
+
+    JointDataDense( Constraint_t S,
+                    Transformation_t M,
+                    Motion_t v,
+                    Bias_t c,
+                    F_t F
+                    )
+    : S(S)
+    , M(M)
+    , v(v)
+    , c(c)
+    , F(F)
+    {}
+
+    JointDataDense<_NQ, _NV> toDense_impl() const
+    {
+      assert(false && "Trying to convert a jointDataDense to JointDataDense : useless"); // disapear with release optimizations
+      return *this;
+    }
+
+  }; // struct JointDataDense
+
+  template <int _NQ, int _NV>
+  struct JointModelDense : public JointModelBase< JointModelDense<_NQ, _NV > >
+  {
+    typedef JointDense<_NQ, _NV > Joint;
+    SE3_JOINT_TYPEDEF_TEMPLATE;
+
+    using JointModelBase<JointModelDense<_NQ, _NV > >::idx_q;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::idx_v;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::setLowerPositionLimit;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::setUpperPositionLimit;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::setMaxEffortLimit;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::setMaxVelocityLimit;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::setIndexes;
+    
+    JointData createData() const
+    {
+      assert(false && "JointModelDense is read-only, should not createData");
+      return JointData();
+    }
+    void calc( JointData& , 
+     const Eigen::VectorXd &  ) const
+    {
+      assert(false && "JointModelDense is read-only, should not perform any calc");
+    }
+
+    void calc( JointData&  ,
+     const Eigen::VectorXd & , 
+     const Eigen::VectorXd &  ) const
+    {
+      assert(false && "JointModelDense is read-only, should not perform any calc");
+    }
+
+    JointModelDense()
+    {
+      setIndexes(1, 1, 1);
+      setLowerPositionLimit(Eigen::Matrix<double,NQ,1>(1));
+      setUpperPositionLimit(Eigen::Matrix<double,NQ,1>(1));
+      setMaxEffortLimit(Eigen::Matrix<double,NQ,1>(1));
+      setMaxVelocityLimit(Eigen::Matrix<double,NV,1>(1));
+    }
+    JointModelDense(  Index idx,
+                      int idx_q,
+                      int idx_v,
+                      Eigen::Matrix<double,NQ,1> lowPos,
+                      Eigen::Matrix<double,NQ,1> upPos,
+                      Eigen::Matrix<double,NQ,1> maxEff,
+                      Eigen::Matrix<double,NV,1> maxVel
+                    )
+    {
+      setIndexes(idx, idx_q, idx_v);
+      setLowerPositionLimit(lowPos);
+      setUpperPositionLimit(upPos);
+      setMaxEffortLimit(maxEff);
+      setMaxVelocityLimit(maxVel);
+    }
+
+    JointModelDense<_NQ, _NV> toDense_impl() const
+    {
+      assert(false && "Trying to convert a jointModelDense to JointModelDense : useless"); // disapear with release optimizations
+      return *this;
+    }
+
+  }; // struct JointModelDense
 
 } // namespace se3
 

--- a/src/multibody/joint/joint-base.hpp
+++ b/src/multibody/joint/joint-base.hpp
@@ -269,33 +269,33 @@ namespace se3
     // Const access
     template<typename D>
     typename SizeDepType<NQ>::template SegmentReturn<D>::ConstType 
-    jointConfigSpace(const Eigen::MatrixBase<D>& a) const       { return derived().jointConfigSpace_impl(a); }
+    jointConfigSelector(const Eigen::MatrixBase<D>& a) const       { return derived().jointConfigSelector_impl(a); }
     template<typename D>
     typename SizeDepType<NQ>::template SegmentReturn<D>::ConstType 
-    jointConfigSpace_impl(const Eigen::MatrixBase<D>& a) const   { return a.template segment<NQ>(i_q); }
+    jointConfigSelector_impl(const Eigen::MatrixBase<D>& a) const   { return a.template segment<NQ>(i_q); }
     // Non-const access
     template<typename D>
     typename SizeDepType<NQ>::template SegmentReturn<D>::Type 
-    jointConfigSpace( Eigen::MatrixBase<D>& a) const { return derived().jointConfigSpace_impl(a); }
+    jointConfigSelector( Eigen::MatrixBase<D>& a) const { return derived().jointConfigSelector_impl(a); }
     template<typename D>
     typename SizeDepType<NQ>::template SegmentReturn<D>::Type 
-    jointConfigSpace_impl( Eigen::MatrixBase<D>& a) const { return a.template segment<NQ>(i_q); }
+    jointConfigSelector_impl( Eigen::MatrixBase<D>& a) const { return a.template segment<NQ>(i_q); }
 
     /* Acces to dedicated segment in robot config velocity space.  */
     // Const access
     template<typename D>
     typename SizeDepType<NV>::template SegmentReturn<D>::ConstType 
-    jointVelocitySpace(const Eigen::MatrixBase<D>& a) const       { return derived().jointVelocitySpace_impl(a); }
+    jointVelocitySelector(const Eigen::MatrixBase<D>& a) const       { return derived().jointVelocitySelector_impl(a); }
     template<typename D>
     typename SizeDepType<NV>::template SegmentReturn<D>::ConstType 
-    jointVelocitySpace_impl(const Eigen::MatrixBase<D>& a) const   { return a.template segment<NV>(i_v); }
+    jointVelocitySelector_impl(const Eigen::MatrixBase<D>& a) const   { return a.template segment<NV>(i_v); }
     // Non-const access
     template<typename D>
     typename SizeDepType<NV>::template SegmentReturn<D>::Type 
-    jointVelocitySpace( Eigen::MatrixBase<D>& a) const { return derived().jointVelocitySpace_impl(a); }
+    jointVelocitySelector( Eigen::MatrixBase<D>& a) const { return derived().jointVelocitySelector_impl(a); }
     template<typename D>
     typename SizeDepType<NV>::template SegmentReturn<D>::Type 
-    jointVelocitySpace_impl( Eigen::MatrixBase<D>& a) const { return a.template segment<NV>(i_v); }
+    jointVelocitySelector_impl( Eigen::MatrixBase<D>& a) const { return a.template segment<NV>(i_v); }
 
 
     template<typename D>

--- a/src/multibody/joint/joint-base.hpp
+++ b/src/multibody/joint/joint-base.hpp
@@ -163,7 +163,7 @@ namespace se3
 
     JointDataDense<NQ, NV> toDense() const  { return static_cast<const JointData*>(this)->toDense_impl();   }
 
-  };
+  }; // struct JointDataBase
 
   template<int NV>
   struct SizeDepType
@@ -312,7 +312,7 @@ namespace se3
     jointCols_impl(Eigen::MatrixBase<D>& A) const       { return A.template middleCols<NV>(i_v); }
 
     JointModelDense<NQ, NV> toDense() const  { return static_cast<const JointModel*>(this)->toDense_impl();   }
-  };
+  }; // struct JointModelBase
 
 } // namespace se3
 

--- a/src/multibody/joint/joint-base.hpp
+++ b/src/multibody/joint/joint-base.hpp
@@ -151,7 +151,7 @@ namespace se3
   {
     typedef typename traits<_JointData>::Joint Joint;
     SE3_JOINT_TYPEDEF_TEMPLATE;
-public:
+
     JointData& derived() { return *static_cast<JointData*>(this); }
     const JointData& derived() const { return *static_cast<const JointData*>(this); }
 
@@ -216,7 +216,6 @@ public:
       const Eigen::VectorXd & vs ) const
     { return static_cast<const JointModel*>(this)->calc(data,qs,vs); }
 
-  public:
     Index i_id; // ID of the joint in the multibody list.
     int i_q;    // Index of the joint configuration in the joint configuration vector.
     int i_v;    // Index of the joint velocity in the joint velocity vector.
@@ -227,7 +226,6 @@ public:
     Eigen::Matrix<double,NV,1> effortMax;
     Eigen::Matrix<double,NV,1> velocityMax;
 
-  public:
     
     int     nv()    const { return derived().nv_impl(); }
     int     nq()    const { return derived().nq_impl(); }
@@ -315,195 +313,6 @@ public:
 
     JointModelDense<NQ, NV> toDense() const  { return static_cast<const JointModel*>(this)->toDense_impl();   }
   };
-
-  
-
-  template<int _NQ, int _NV>
-  struct traits< JointDense<_NQ, _NV > >
-  {
-    typedef JointDataDense<_NQ, _NV> JointData;
-    typedef JointModelDense<_NQ, _NV> JointModel;
-    typedef ConstraintXd Constraint_t;
-    typedef SE3 Transformation_t;
-    typedef Motion Motion_t;
-    typedef BiasZero Bias_t;
-    typedef Eigen::Matrix<double,6,Eigen::Dynamic> F_t;
-    enum {
-      NQ = _NQ, // pb 
-      NV = _NV
-    };
-  };
-
-  template<int _NQ, int _NV> struct traits< JointDataDense<_NQ, _NV > > { typedef JointDense<_NQ,_NV > Joint; };
-  template<int _NQ, int _NV> struct traits< JointModelDense<_NQ, _NV > > { typedef JointDense<_NQ,_NV > Joint; };
-
-  template <int _NQ, int _NV>
-  struct JointDataDense : public JointDataBase< JointDataDense<_NQ, _NV > >
-  {
-    typedef JointDense<_NQ, _NV > Joint;
-    SE3_JOINT_TYPEDEF_TEMPLATE;
-public:
-    Constraint_t S;
-    Transformation_t M;
-    Motion_t v;
-    Bias_t c;
-
-    F_t F;
-
-    /// Removed Default constructor of JointDataDense because it was calling default constructor of
-    /// ConstraintXd -> eigen_static_assert
-    /// JointDataDense should always be instanciated from a JointDataXX.toDense()
-    // JointDataDense() : M(1)
-    // {
-    //   M.translation(SE3::Vector3::Zero());
-    // }
-
-    JointDataDense() {};
-
-    JointDataDense( Constraint_t S,
-                    Transformation_t M,
-                    Motion_t v,
-                    Bias_t c,
-                    F_t F
-                    )
-    : S(S)
-    , M(M)
-    , v(v)
-    , c(c)
-    , F(F)
-    {}
-
-    JointDataDense<_NQ, _NV> toDense_impl() const
-    {
-      assert(false && "Trying to convert a jointDataDense to JointDataDense : useless"); // disapear with release optimizations
-      return *this;
-    }
-
-  }; // struct JointDataDense
-
-  template <int _NQ, int _NV>
-  struct JointModelDense : public JointModelBase< JointModelDense<_NQ, _NV > >
-  {
-    typedef JointDense<_NQ, _NV > Joint;
-    SE3_JOINT_TYPEDEF_TEMPLATE;
-
-    using JointModelBase<JointModelDense<_NQ, _NV > >::idx_q;
-    using JointModelBase<JointModelDense<_NQ, _NV > >::idx_v;
-    using JointModelBase<JointModelDense<_NQ, _NV > >::setLowerPositionLimit;
-    using JointModelBase<JointModelDense<_NQ, _NV > >::setUpperPositionLimit;
-    using JointModelBase<JointModelDense<_NQ, _NV > >::setMaxEffortLimit;
-    using JointModelBase<JointModelDense<_NQ, _NV > >::setMaxVelocityLimit;
-    using JointModelBase<JointModelDense<_NQ, _NV > >::setIndexes;
-    using JointModelBase<JointModelDense<_NQ, _NV > >::i_v;
-    using JointModelBase<JointModelDense<_NQ, _NV > >::i_q;
-
-    int nv_dyn,nq_dyn;
-    
-    JointData createData() const
-    {
-      //assert(false && "JointModelDense is read-only, should not createData");
-      return JointData();
-    }
-    void calc( JointData& , 
-     const Eigen::VectorXd &  ) const
-    {
-      assert(false && "JointModelDense is read-only, should not perform any calc");
-    }
-
-    void calc( JointData&  ,
-     const Eigen::VectorXd & , 
-     const Eigen::VectorXd &  ) const
-    {
-      assert(false && "JointModelDense is read-only, should not perform any calc");
-    }
-
-    JointModelDense()
-    {
-      setIndexes(1, 1, 1);
-      setLowerPositionLimit(Eigen::Matrix<double,NQ,1>(1));
-      setUpperPositionLimit(Eigen::Matrix<double,NQ,1>(1));
-      setMaxEffortLimit(Eigen::Matrix<double,NV,1>(1));
-      setMaxVelocityLimit(Eigen::Matrix<double,NV,1>(1));
-    }
-    JointModelDense(  Index idx,
-                      int idx_q,
-                      int idx_v,
-                      Eigen::Matrix<double,NQ,1> lowPos,
-                      Eigen::Matrix<double,NQ,1> upPos,
-                      Eigen::Matrix<double,NV,1> maxEff,
-                      Eigen::Matrix<double,NV,1> maxVel
-                    )
-    {
-      setIndexes(idx, idx_q, idx_v);
-      setLowerPositionLimit(lowPos);
-      setUpperPositionLimit(upPos);
-      setMaxEffortLimit(maxEff);
-      setMaxVelocityLimit(maxVel);
-    }
-
-    int     nv_impl() const { return nv_dyn; }
-    int     nq_impl() const { return nq_dyn; }
-
-    template<typename D>
-    typename SizeDepType<NQ>::template SegmentReturn<D>::ConstType
-    jointConfigSpace_impl(const Eigen::MatrixBase<D>& a) const { return a.template segment(i_q,nq_dyn); }
-    template<typename D>
-    typename SizeDepType<NQ>::template SegmentReturn<D>::Type
-    jointConfigSpace_impl( Eigen::MatrixBase<D>& a) const { return a.template segment(i_q,nq_dyn); }
-
-    template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::ConstType
-    jointVelocitySpace_impl(const Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
-    template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::Type
-    jointVelocitySpace_impl( Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
-
-    template<typename D>
-    typename SizeDepType<NV>::template ColsReturn<D>::ConstType 
-    jointCols_impl(const Eigen::MatrixBase<D>& A) const { return A.template middleCols<NV>(i_v); }
-    template<typename D>
-    typename SizeDepType<NV>::template ColsReturn<D>::Type 
-    jointCols_impl(Eigen::MatrixBase<D>& A) const { return A.template middleCols<NV>(i_v); }
-
-    JointModelDense<_NQ, _NV> toDense_impl() const
-    {
-      assert(false && "Trying to convert a jointModelDense to JointModelDense : useless"); // disapear with release optimizations
-      return *this;
-    }
-
-  }; // struct JointModelDense
-
-  template<>
-  template<typename D>
-  typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::ConstType
-  JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointConfigSpace_impl(const Eigen::MatrixBase<D>& a) const { return a.segment(i_q,nq_dyn); }
-  template<>
-  template<typename D>
-  typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::Type
-  JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointConfigSpace_impl(Eigen::MatrixBase<D>& a) const { return a.segment(i_q,nq_dyn); }
-  template<>
-  template<typename D>
-  typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::ConstType
-  JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointVelocitySpace_impl(const Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
-  template<>
-  template<typename D>
-  typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::Type
-  JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointVelocitySpace_impl(Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
-
-  template<>
-  template<typename D>
-  typename SizeDepType<Eigen::Dynamic>::template ColsReturn<D>::ConstType 
-  JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointCols_impl(const Eigen::MatrixBase<D>& A) const { return A.middleCols(i_v,nv_dyn); }
-  template<>
-  template<typename D>
-  typename SizeDepType<Eigen::Dynamic>::template ColsReturn<D>::Type 
-  JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointCols_impl(Eigen::MatrixBase<D>& A) const { return A.middleCols(i_v,nv_dyn); }
 
 } // namespace se3
 

--- a/src/multibody/joint/joint-base.hpp
+++ b/src/multibody/joint/joint-base.hpp
@@ -224,7 +224,7 @@ public:
     Eigen::Matrix<double,NQ,1> position_lower;
     Eigen::Matrix<double,NQ,1> position_upper;
 
-    Eigen::Matrix<double,NQ,1> effortMax;
+    Eigen::Matrix<double,NV,1> effortMax;
     Eigen::Matrix<double,NV,1> velocityMax;
 
   public:
@@ -242,7 +242,7 @@ public:
     const Eigen::Matrix<double,NQ,1> & lowerPosLimit() const { return position_lower;}
     const Eigen::Matrix<double,NQ,1> & upperPosLimit() const { return position_upper;}
 
-    const Eigen::Matrix<double,NQ,1> & maxEffortLimit() const { return effortMax;}
+    const Eigen::Matrix<double,NV,1> & maxEffortLimit() const { return effortMax;}
     const Eigen::Matrix<double,NV,1> & maxVelocityLimit() const { return velocityMax;}
 
     void setIndexes(Index id,int q,int v) { i_id = id, i_q = q; i_v = v; }
@@ -267,69 +267,38 @@ public:
       velocityMax = v;
     }
 
-    /* Acces to dedicated segment in robot config velocity.  */
+    /* Acces to dedicated segment in robot config space.  */
     // Const access
     template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::ConstType 
-    jointMotion(const Eigen::MatrixBase<D>& a) const       { return derived().jointMotion_impl(a); }
+    typename SizeDepType<NQ>::template SegmentReturn<D>::ConstType 
+    jointConfigSpace(const Eigen::MatrixBase<D>& a) const       { return derived().jointConfigSpace_impl(a); }
     template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::ConstType 
-    jointMotion_impl(const Eigen::MatrixBase<D>& a) const   { return a.template segment<NV>(i_v); }
+    typename SizeDepType<NQ>::template SegmentReturn<D>::ConstType 
+    jointConfigSpace_impl(const Eigen::MatrixBase<D>& a) const   { return a.template segment<NQ>(i_q); }
     // Non-const access
     template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::Type 
-    jointMotion( Eigen::MatrixBase<D>& a) const { return derived().jointMotion_impl(a); }
+    typename SizeDepType<NQ>::template SegmentReturn<D>::Type 
+    jointConfigSpace( Eigen::MatrixBase<D>& a) const { return derived().jointConfigSpace_impl(a); }
     template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::Type 
-    jointMotion_impl( Eigen::MatrixBase<D>& a) const { return a.template segment<NV>(i_v); }
+    typename SizeDepType<NQ>::template SegmentReturn<D>::Type 
+    jointConfigSpace_impl( Eigen::MatrixBase<D>& a) const { return a.template segment<NQ>(i_q); }
 
-    /* Acces to dedicated segment in robot joint torques.  */
+    /* Acces to dedicated segment in robot config velocity space.  */
     // Const access
     template<typename D>
     typename SizeDepType<NV>::template SegmentReturn<D>::ConstType 
-    jointForce(const Eigen::MatrixBase<D>& a) const { return derived().jointForce_impl(a); }
+    jointVelocitySpace(const Eigen::MatrixBase<D>& a) const       { return derived().jointVelocitySpace_impl(a); }
     template<typename D>
     typename SizeDepType<NV>::template SegmentReturn<D>::ConstType 
-    jointForce_impl(const Eigen::MatrixBase<D>& a) const { return a.template segment<NV>(i_v); }
+    jointVelocitySpace_impl(const Eigen::MatrixBase<D>& a) const   { return a.template segment<NV>(i_v); }
     // Non-const access
     template<typename D>
     typename SizeDepType<NV>::template SegmentReturn<D>::Type 
-    jointForce( Eigen::MatrixBase<D>& a) const { return derived().jointForce_impl(a); }
+    jointVelocitySpace( Eigen::MatrixBase<D>& a) const { return derived().jointVelocitySpace_impl(a); }
     template<typename D>
     typename SizeDepType<NV>::template SegmentReturn<D>::Type 
-    jointForce_impl( Eigen::MatrixBase<D>& a) const { return a.template segment<NV>(i_v); }
+    jointVelocitySpace_impl( Eigen::MatrixBase<D>& a) const { return a.template segment<NV>(i_v); }
 
-    /* Acces to dedicated segment in robot config limit. */
-    // Const access
-    template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::ConstType 
-    jointLimit (const Eigen::MatrixBase<D>& a) const { return derived().jointLimit_impl(a); }
-    template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::ConstType 
-    jointLimit_impl(const Eigen::MatrixBase<D>& a) const { return a.template segment<NV>(i_v); }
-    // Non-const access
-    template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::Type 
-    jointLimit( Eigen::MatrixBase<D>& a) const { return derived().jointLimit_impl(a); }
-    template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::Type 
-    jointLimit_impl( Eigen::MatrixBase<D>& a) const { return a.template segment<NV>(i_v); }
-
-    /* Acces to dedicated segment in robot config velocityLimit. */
-    // Const access
-    template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::ConstType 
-    jointVelocityLimit (const Eigen::MatrixBase<D>& a) const { return derived().jointVelocityLimit_impl(a); }
-    template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::ConstType 
-    jointVelocityLimit_impl(const Eigen::MatrixBase<D>& a) const   { return a.template segment<NV>(i_v); }
-    // Non-const access
-    template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::Type 
-    jointVelocityLimit( Eigen::MatrixBase<D>& a) const { return derived().jointVelocityLimit_impl(a); }
-    template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::Type 
-    jointVelocityLimit_impl( Eigen::MatrixBase<D>& a) const { return a.template segment<NV>(i_v); }
 
     template<typename D>
     typename SizeDepType<NV>::template ColsReturn<D>::ConstType 
@@ -453,7 +422,7 @@ public:
       setIndexes(1, 1, 1);
       setLowerPositionLimit(Eigen::Matrix<double,NQ,1>(1));
       setUpperPositionLimit(Eigen::Matrix<double,NQ,1>(1));
-      setMaxEffortLimit(Eigen::Matrix<double,NQ,1>(1));
+      setMaxEffortLimit(Eigen::Matrix<double,NV,1>(1));
       setMaxVelocityLimit(Eigen::Matrix<double,NV,1>(1));
     }
     JointModelDense(  Index idx,
@@ -461,7 +430,7 @@ public:
                       int idx_v,
                       Eigen::Matrix<double,NQ,1> lowPos,
                       Eigen::Matrix<double,NQ,1> upPos,
-                      Eigen::Matrix<double,NQ,1> maxEff,
+                      Eigen::Matrix<double,NV,1> maxEff,
                       Eigen::Matrix<double,NV,1> maxVel
                     )
     {
@@ -476,29 +445,18 @@ public:
     int     nq_impl() const { return nq_dyn; }
 
     template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::ConstType
-    jointMotion_impl(const Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
+    typename SizeDepType<NQ>::template SegmentReturn<D>::ConstType
+    jointConfigSpace_impl(const Eigen::MatrixBase<D>& a) const { return a.template segment(i_q,nq_dyn); }
     template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::Type
-    jointMotion_impl( Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
-    template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::ConstType
-    jointForce_impl(const Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
-    template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::Type
-    jointForce_impl( Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
+    typename SizeDepType<NQ>::template SegmentReturn<D>::Type
+    jointConfigSpace_impl( Eigen::MatrixBase<D>& a) const { return a.template segment(i_q,nq_dyn); }
+
     template<typename D>
     typename SizeDepType<NV>::template SegmentReturn<D>::ConstType
-    jointLimit_impl(const Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
+    jointVelocitySpace_impl(const Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
     template<typename D>
     typename SizeDepType<NV>::template SegmentReturn<D>::Type
-    jointLimit_impl( Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
-    template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::ConstType
-    jointVelocityLimit_impl(const Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
-    template<typename D>
-    typename SizeDepType<NV>::template SegmentReturn<D>::Type
-    jointVelocityLimit_impl( Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
+    jointVelocitySpace_impl( Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
 
     template<typename D>
     typename SizeDepType<NV>::template ColsReturn<D>::ConstType 
@@ -519,42 +477,22 @@ public:
   template<typename D>
   typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::ConstType
   JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointMotion_impl(const Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
+  jointConfigSpace_impl(const Eigen::MatrixBase<D>& a) const { return a.segment(i_q,nq_dyn); }
   template<>
   template<typename D>
   typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::Type
   JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointMotion_impl(Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
+  jointConfigSpace_impl(Eigen::MatrixBase<D>& a) const { return a.segment(i_q,nq_dyn); }
   template<>
   template<typename D>
   typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::ConstType
   JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointForce_impl(const Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
+  jointVelocitySpace_impl(const Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
   template<>
   template<typename D>
   typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::Type
   JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointForce_impl(Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
-  template<>
-  template<typename D>
-  typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::ConstType
-  JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointLimit_impl(const Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
-  template<>
-  template<typename D>
-  typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::Type
-  JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointLimit_impl(Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
-  template<>
-  template<typename D>
-  typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::ConstType
-  JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointVelocityLimit_impl(const Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
-  template<>
-  template<typename D>
-  typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::Type
-  JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointVelocityLimit_impl(Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
+  jointVelocitySpace_impl(Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
 
   template<>
   template<typename D>

--- a/src/multibody/joint/joint-dense.hpp
+++ b/src/multibody/joint/joint-dense.hpp
@@ -1,0 +1,214 @@
+//
+// Copyright (c) 2015 CNRS
+//
+// This file is part of Pinocchio
+// Pinocchio is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// Pinocchio is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// Pinocchio If not, see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef __se3_joint_dense_hpp__
+#define __se3_joint_dense_hpp__
+
+#include "pinocchio/multibody/joint/joint-base.hpp"
+
+namespace se3
+{
+
+  template<int _NQ, int _NV>
+  struct traits< JointDense<_NQ, _NV > >
+  {
+    typedef JointDataDense<_NQ, _NV> JointData;
+    typedef JointModelDense<_NQ, _NV> JointModel;
+    typedef ConstraintXd Constraint_t;
+    typedef SE3 Transformation_t;
+    typedef Motion Motion_t;
+    typedef BiasZero Bias_t;
+    typedef Eigen::Matrix<double,6,Eigen::Dynamic> F_t;
+    enum {
+      NQ = _NQ, // pb 
+      NV = _NV
+    };
+  };
+
+  template<int _NQ, int _NV> struct traits< JointDataDense<_NQ, _NV > > { typedef JointDense<_NQ,_NV > Joint; };
+  template<int _NQ, int _NV> struct traits< JointModelDense<_NQ, _NV > > { typedef JointDense<_NQ,_NV > Joint; };
+
+  template <int _NQ, int _NV>
+  struct JointDataDense : public JointDataBase< JointDataDense<_NQ, _NV > >
+  {
+    typedef JointDense<_NQ, _NV > Joint;
+    SE3_JOINT_TYPEDEF_TEMPLATE;
+
+    Constraint_t S;
+    Transformation_t M;
+    Motion_t v;
+    Bias_t c;
+
+    F_t F;
+
+    /// Removed Default constructor of JointDataDense because it was calling default constructor of
+    /// ConstraintXd -> eigen_static_assert
+    /// JointDataDense should always be instanciated from a JointDataXX.toDense()
+    // JointDataDense() : M(1)
+    // {
+    //   M.translation(SE3::Vector3::Zero());
+    // }
+
+    JointDataDense() {};
+
+    JointDataDense( Constraint_t S,
+                    Transformation_t M,
+                    Motion_t v,
+                    Bias_t c,
+                    F_t F
+                    )
+    : S(S)
+    , M(M)
+    , v(v)
+    , c(c)
+    , F(F)
+    {}
+
+    JointDataDense<_NQ, _NV> toDense_impl() const
+    {
+      assert(false && "Trying to convert a jointDataDense to JointDataDense : useless"); // disapear with release optimizations
+      return *this;
+    }
+
+  }; // struct JointDataDense
+
+  template <int _NQ, int _NV>
+  struct JointModelDense : public JointModelBase< JointModelDense<_NQ, _NV > >
+  {
+    typedef JointDense<_NQ, _NV > Joint;
+    SE3_JOINT_TYPEDEF_TEMPLATE;
+
+    using JointModelBase<JointModelDense<_NQ, _NV > >::idx_q;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::idx_v;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::setLowerPositionLimit;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::setUpperPositionLimit;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::setMaxEffortLimit;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::setMaxVelocityLimit;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::setIndexes;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::i_v;
+    using JointModelBase<JointModelDense<_NQ, _NV > >::i_q;
+
+    int nv_dyn,nq_dyn;
+    
+    JointData createData() const
+    {
+      //assert(false && "JointModelDense is read-only, should not createData");
+      return JointData();
+    }
+    void calc( JointData& , 
+     const Eigen::VectorXd &  ) const
+    {
+      assert(false && "JointModelDense is read-only, should not perform any calc");
+    }
+
+    void calc( JointData&  ,
+     const Eigen::VectorXd & , 
+     const Eigen::VectorXd &  ) const
+    {
+      assert(false && "JointModelDense is read-only, should not perform any calc");
+    }
+
+    JointModelDense()
+    {
+      setLowerPositionLimit(Eigen::Matrix<double,NQ,1>(1));
+      setUpperPositionLimit(Eigen::Matrix<double,NQ,1>(1));
+      setMaxEffortLimit(Eigen::Matrix<double,NV,1>(1));
+      setMaxVelocityLimit(Eigen::Matrix<double,NV,1>(1));
+    }
+    JointModelDense(  Index idx,
+                      int idx_q,
+                      int idx_v,
+                      Eigen::Matrix<double,NQ,1> lowPos,
+                      Eigen::Matrix<double,NQ,1> upPos,
+                      Eigen::Matrix<double,NV,1> maxEff,
+                      Eigen::Matrix<double,NV,1> maxVel
+                    )
+    {
+      setIndexes(idx, idx_q, idx_v);
+      setLowerPositionLimit(lowPos);
+      setUpperPositionLimit(upPos);
+      setMaxEffortLimit(maxEff);
+      setMaxVelocityLimit(maxVel);
+    }
+
+    int     nv_impl() const { return nv_dyn; }
+    int     nq_impl() const { return nq_dyn; }
+
+    template<typename D>
+    typename SizeDepType<NQ>::template SegmentReturn<D>::ConstType
+    jointConfigSpace_impl(const Eigen::MatrixBase<D>& a) const { return a.template segment(i_q,nq_dyn); }
+    template<typename D>
+    typename SizeDepType<NQ>::template SegmentReturn<D>::Type
+    jointConfigSpace_impl( Eigen::MatrixBase<D>& a) const { return a.template segment(i_q,nq_dyn); }
+
+    template<typename D>
+    typename SizeDepType<NV>::template SegmentReturn<D>::ConstType
+    jointVelocitySpace_impl(const Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
+    template<typename D>
+    typename SizeDepType<NV>::template SegmentReturn<D>::Type
+    jointVelocitySpace_impl( Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
+
+    template<typename D>
+    typename SizeDepType<NV>::template ColsReturn<D>::ConstType 
+    jointCols_impl(const Eigen::MatrixBase<D>& A) const { return A.template middleCols<NV>(i_v); }
+    template<typename D>
+    typename SizeDepType<NV>::template ColsReturn<D>::Type 
+    jointCols_impl(Eigen::MatrixBase<D>& A) const { return A.template middleCols<NV>(i_v); }
+
+    JointModelDense<_NQ, _NV> toDense_impl() const
+    {
+      assert(false && "Trying to convert a jointModelDense to JointModelDense : useless"); // disapear with release optimizations
+      return *this;
+    }
+
+  }; // struct JointModelDense
+
+  template<>
+  template<typename D>
+  typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::ConstType
+  JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
+  jointConfigSpace_impl(const Eigen::MatrixBase<D>& a) const { return a.segment(i_q,nq_dyn); }
+  template<>
+  template<typename D>
+  typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::Type
+  JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
+  jointConfigSpace_impl(Eigen::MatrixBase<D>& a) const { return a.segment(i_q,nq_dyn); }
+  template<>
+  template<typename D>
+  typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::ConstType
+  JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
+  jointVelocitySpace_impl(const Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
+  template<>
+  template<typename D>
+  typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::Type
+  JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
+  jointVelocitySpace_impl(Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
+
+  template<>
+  template<typename D>
+  typename SizeDepType<Eigen::Dynamic>::template ColsReturn<D>::ConstType 
+  JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
+  jointCols_impl(const Eigen::MatrixBase<D>& A) const { return A.middleCols(i_v,nv_dyn); }
+  template<>
+  template<typename D>
+  typename SizeDepType<Eigen::Dynamic>::template ColsReturn<D>::Type 
+  JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
+  jointCols_impl(Eigen::MatrixBase<D>& A) const { return A.middleCols(i_v,nv_dyn); }
+
+} // namespace se3
+
+#endif // ifndef __se3_joint_dense_hpp__

--- a/src/multibody/joint/joint-dense.hpp
+++ b/src/multibody/joint/joint-dense.hpp
@@ -150,17 +150,17 @@ namespace se3
 
     template<typename D>
     typename SizeDepType<NQ>::template SegmentReturn<D>::ConstType
-    jointConfigSpace_impl(const Eigen::MatrixBase<D>& a) const { return a.template segment(i_q,nq_dyn); }
+    jointConfigSelector_impl(const Eigen::MatrixBase<D>& a) const { return a.template segment(i_q,nq_dyn); }
     template<typename D>
     typename SizeDepType<NQ>::template SegmentReturn<D>::Type
-    jointConfigSpace_impl( Eigen::MatrixBase<D>& a) const { return a.template segment(i_q,nq_dyn); }
+    jointConfigSelector_impl( Eigen::MatrixBase<D>& a) const { return a.template segment(i_q,nq_dyn); }
 
     template<typename D>
     typename SizeDepType<NV>::template SegmentReturn<D>::ConstType
-    jointVelocitySpace_impl(const Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
+    jointVelocitySelector_impl(const Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
     template<typename D>
     typename SizeDepType<NV>::template SegmentReturn<D>::Type
-    jointVelocitySpace_impl( Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
+    jointVelocitySelector_impl( Eigen::MatrixBase<D>& a) const { return a.template segment(i_v,nv_dyn); }
 
     template<typename D>
     typename SizeDepType<NV>::template ColsReturn<D>::ConstType 
@@ -171,7 +171,7 @@ namespace se3
 
     JointModelDense<_NQ, _NV> toDense_impl() const
     {
-      assert(false && "Trying to convert a jointModelDense to JointModelDense : useless"); // disapear with release optimizations
+      assert(false && "Trying to convert a jointModelDense to JointModelDense : useless");
       return *this;
     }
 
@@ -181,22 +181,22 @@ namespace se3
   template<typename D>
   typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::ConstType
   JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointConfigSpace_impl(const Eigen::MatrixBase<D>& a) const { return a.segment(i_q,nq_dyn); }
+  jointConfigSelector_impl(const Eigen::MatrixBase<D>& a) const { return a.segment(i_q,nq_dyn); }
   template<>
   template<typename D>
   typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::Type
   JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointConfigSpace_impl(Eigen::MatrixBase<D>& a) const { return a.segment(i_q,nq_dyn); }
+  jointConfigSelector_impl(Eigen::MatrixBase<D>& a) const { return a.segment(i_q,nq_dyn); }
   template<>
   template<typename D>
   typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::ConstType
   JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointVelocitySpace_impl(const Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
+  jointVelocitySelector_impl(const Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
   template<>
   template<typename D>
   typename SizeDepType<Eigen::Dynamic>::template SegmentReturn<D>::Type
   JointModelDense<Eigen::Dynamic,Eigen::Dynamic>::
-  jointVelocitySpace_impl(Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
+  jointVelocitySelector_impl(Eigen::MatrixBase<D>& a) const { return a.segment(i_v,nv_dyn); }
 
   template<>
   template<typename D>

--- a/src/multibody/joint/joint-free-flyer.hpp
+++ b/src/multibody/joint/joint-free-flyer.hpp
@@ -109,9 +109,7 @@ namespace se3
     { typedef SE3::Matrix6 Type; };
   }
 
-  struct JointFreeFlyer{
-
-  };
+  struct JointFreeFlyer;
 
   template<>
   struct traits<JointFreeFlyer>
@@ -154,7 +152,7 @@ namespace se3
     {
       return JointDataDense<NQ, NV>(S, M, v, c, F);
     }
-  };
+  }; // struct JointDataFreeFlyer
 
   struct JointModelFreeFlyer : public JointModelBase<JointModelFreeFlyer>
   {
@@ -209,7 +207,7 @@ namespace se3
     {
       return true; // TODO ?? used to bind variant in python
     }
-  };
+  }; // struct JointModelFreeFlyer
 
 } // namespace se3
 

--- a/src/multibody/joint/joint-generic.hpp
+++ b/src/multibody/joint/joint-generic.hpp
@@ -20,6 +20,7 @@
 
 #include "pinocchio/exception.hpp"
 #include "pinocchio/multibody/joint/joint-base.hpp"
+#include "pinocchio/multibody/joint/joint-dense.hpp"
 #include "pinocchio/multibody/joint/joint-variant.hpp"
 
 namespace se3

--- a/src/multibody/joint/joint-planar.hpp
+++ b/src/multibody/joint/joint-planar.hpp
@@ -19,6 +19,7 @@
 #define __se3_joint_planar_hpp__
 
 #include "pinocchio/multibody/joint/joint-base.hpp"
+#include "pinocchio/multibody/joint/joint-dense.hpp"
 #include "pinocchio/multibody/constraint.hpp"
 #include "pinocchio/math/sincos.hpp"
 #include "pinocchio/spatial/motion.hpp"

--- a/src/multibody/joint/joint-planar.hpp
+++ b/src/multibody/joint/joint-planar.hpp
@@ -121,6 +121,7 @@ namespace se3
   {
 
     SPATIAL_TYPEDEF_NO_TEMPLATE(ConstraintPlanar);
+    enum { NV = 3, Options = 0 }; // to check
     typedef traits<ConstraintPlanar>::JointMotion JointMotion;
     typedef traits<ConstraintPlanar>::JointForce JointForce;
     typedef traits<ConstraintPlanar>::DenseBase DenseBase;
@@ -128,6 +129,8 @@ namespace se3
 
     Motion operator* (const MotionPlanar & vj) const
     { return vj; }
+
+    int nv_impl() const { return NV; }
 
 
     struct ConstraintTranspose
@@ -264,13 +267,29 @@ namespace se3
     Motion_t v;
     Bias_t c;
 
+    F_t F; // TODO if not used anymore, clean F_t
+
     JointDataPlanar () : M(1) {}
+
+    JointDataDense<NQ, NV> toDense_impl() const
+    {
+      return JointDataDense<NQ, NV>(S, M, v, c, F);
+    }
   }; // struct JointDataPlanar
 
   struct JointModelPlanar : public JointModelBase<JointModelPlanar>
   {
     typedef JointPlanar Joint;
     SE3_JOINT_TYPEDEF;
+
+    using JointModelBase<JointModelPlanar>::id;
+    using JointModelBase<JointModelPlanar>::idx_q;
+    using JointModelBase<JointModelPlanar>::idx_v;
+    using JointModelBase<JointModelPlanar>::lowerPosLimit;
+    using JointModelBase<JointModelPlanar>::upperPosLimit;
+    using JointModelBase<JointModelPlanar>::maxEffortLimit;
+    using JointModelBase<JointModelPlanar>::maxVelocityLimit;
+    using JointModelBase<JointModelPlanar>::setIndexes;
 
     JointData createData() const { return JointData(); }
 
@@ -301,6 +320,23 @@ namespace se3
       data.v.x_dot_ = q_dot(0);
       data.v.y_dot_ = q_dot(1);
       data.v.theta_dot_ = q_dot(2);
+    }
+
+    JointModelDense<NQ, NV> toDense_impl() const
+    {
+      return JointModelDense<NQ, NV>( id(),
+                                      idx_q(),
+                                      idx_v(),
+                                      lowerPosLimit(),
+                                      upperPosLimit(),
+                                      maxEffortLimit(),
+                                      maxVelocityLimit()
+                                    );
+    }
+
+    bool operator == (const JointModelPlanar& /*Ohter*/) const
+    {
+      return true; // TODO ?? used to bind variant in python
     }
   }; // struct JointModelPlanar
 

--- a/src/multibody/joint/joint-prismatic.hpp
+++ b/src/multibody/joint/joint-prismatic.hpp
@@ -154,6 +154,8 @@ namespace se3
      return res;
     }
 
+    int nv_impl() const { return NV; }
+
     struct TransposeConst
     {
       const ConstraintPrismatic & ref; 
@@ -346,6 +348,12 @@ namespace se3
     {
       M.rotation(SE3::Matrix3::Identity());
     }
+
+    JointDataDense<NQ, NV> toDense_impl() const
+    {
+      return JointDataDense<NQ, NV>(S, M, v, c, F);
+    }
+
   }; // struct JointDataPrismatic
 
   template<int axis>
@@ -354,8 +362,13 @@ namespace se3
     typedef JointPrismatic<axis> Joint;
     SE3_JOINT_TYPEDEF_TEMPLATE;
 
+    using JointModelBase<JointModelPrismatic>::id;
     using JointModelBase<JointModelPrismatic>::idx_q;
     using JointModelBase<JointModelPrismatic>::idx_v;
+    using JointModelBase<JointModelPrismatic>::lowerPosLimit;
+    using JointModelBase<JointModelPrismatic>::upperPosLimit;
+    using JointModelBase<JointModelPrismatic>::maxEffortLimit;
+    using JointModelBase<JointModelPrismatic>::maxVelocityLimit;
     using JointModelBase<JointModelPrismatic>::setIndexes;
     
     JointData createData() const { return JointData(); }
@@ -375,6 +388,23 @@ namespace se3
 
       data.M.translation(JointPrismatic<axis>::cartesianTranslation(q));
       data.v.v = v;
+    }
+
+    JointModelDense<NQ, NV> toDense_impl() const
+    {
+      return JointModelDense<NQ, NV>( id(),
+                                      idx_q(),
+                                      idx_v(),
+                                      lowerPosLimit(),
+                                      upperPosLimit(),
+                                      maxEffortLimit(),
+                                      maxVelocityLimit()
+                                    );
+    }
+
+    bool operator == (const JointModelPrismatic& /*Ohter*/) const
+    {
+      return true; // TODO ?? used to bind variant in python
     }
   }; // struct JointModelPrismatic
 

--- a/src/multibody/joint/joint-prismatic.hpp
+++ b/src/multibody/joint/joint-prismatic.hpp
@@ -19,6 +19,7 @@
 #define __se3_joint_prismatic_hpp__
 
 #include "pinocchio/multibody/joint/joint-base.hpp"
+#include "pinocchio/multibody/joint/joint-dense.hpp"
 #include "pinocchio/multibody/constraint.hpp"
 #include "pinocchio/spatial/inertia.hpp"
 

--- a/src/multibody/joint/joint-revolute-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unaligned.hpp
@@ -262,7 +262,7 @@ namespace se3
     {
       return JointDataDense<NQ, NV>(S, M, v, c, F);
     }
-  };
+  }; // struct JointDataRevoluteUnaligned
 
   struct JointModelRevoluteUnaligned : public JointModelBase< JointModelRevoluteUnaligned >
   {
@@ -330,7 +330,7 @@ namespace se3
     {
       return true; // TODO ?? used to bind variant in python
     }
-  };
+  }; // struct JointModelRevoluteUnaligned
 
 } //namespace se3
 

--- a/src/multibody/joint/joint-revolute-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unaligned.hpp
@@ -19,6 +19,7 @@
 #define __se3_joint_revolute_unaligned_hpp__
 
 #include "pinocchio/multibody/joint/joint-base.hpp"
+#include "pinocchio/multibody/joint/joint-dense.hpp"
 #include "pinocchio/multibody/constraint.hpp"
 #include "pinocchio/spatial/inertia.hpp"
 #include "pinocchio/math/sincos.hpp"

--- a/src/multibody/joint/joint-revolute-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unaligned.hpp
@@ -113,6 +113,10 @@ namespace se3
     struct ConstraintRevoluteUnaligned : ConstraintBase < ConstraintRevoluteUnaligned >
     {
       SPATIAL_TYPEDEF_NO_TEMPLATE(ConstraintRevoluteUnaligned);
+      enum { NV = 1, Options = 0 };
+      typedef traits<ConstraintRevoluteUnaligned>::JointMotion JointMotion;
+      typedef traits<ConstraintRevoluteUnaligned>::JointForce JointForce;
+      typedef traits<ConstraintRevoluteUnaligned>::DenseBase DenseBase;
 
       ConstraintRevoluteUnaligned() : axis(Eigen::Vector3d::Constant(NAN)) {}
       ConstraintRevoluteUnaligned(const Motion::Vector3 & _axis) : axis(_axis) {}
@@ -133,6 +137,8 @@ namespace se3
         res.head<3>() = m.translation().cross(res.tail<3>());
         return res;
       }
+
+      int nv_impl() const { return NV; }
 
       struct TransposeConst
       {
@@ -250,6 +256,11 @@ namespace se3
       : M(1),S(axis),v(axis,NAN)
       ,angleaxis(NAN,axis)
     {}
+
+    JointDataDense<NQ, NV> toDense_impl() const
+    {
+      return JointDataDense<NQ, NV>(S, M, v, c, F);
+    }
   };
 
   struct JointModelRevoluteUnaligned : public JointModelBase< JointModelRevoluteUnaligned >
@@ -257,8 +268,13 @@ namespace se3
     typedef JointRevoluteUnaligned Joint;
     SE3_JOINT_TYPEDEF;
 
+    using JointModelBase<JointModelRevoluteUnaligned>::id;
     using JointModelBase<JointModelRevoluteUnaligned>::idx_q;
     using JointModelBase<JointModelRevoluteUnaligned>::idx_v;
+    using JointModelBase<JointModelRevoluteUnaligned>::lowerPosLimit;
+    using JointModelBase<JointModelRevoluteUnaligned>::upperPosLimit;
+    using JointModelBase<JointModelRevoluteUnaligned>::maxEffortLimit;
+    using JointModelBase<JointModelRevoluteUnaligned>::maxVelocityLimit;
     using JointModelBase<JointModelRevoluteUnaligned>::setIndexes;
     
     JointModelRevoluteUnaligned() : axis(Eigen::Vector3d::Constant(NAN))   {}
@@ -296,6 +312,23 @@ namespace se3
     }
 
     Eigen::Vector3d axis;
+
+    JointModelDense<NQ, NV> toDense_impl() const
+    {
+      return JointModelDense<NQ, NV>( id(),
+                                      idx_q(),
+                                      idx_v(),
+                                      lowerPosLimit(),
+                                      upperPosLimit(),
+                                      maxEffortLimit(),
+                                      maxVelocityLimit()
+                                    );
+    }
+
+    bool operator == (const JointModelRevoluteUnaligned& /*Ohter*/) const
+    {
+      return true; // TODO ?? used to bind variant in python
+    }
   };
 
 } //namespace se3

--- a/src/multibody/joint/joint-revolute.hpp
+++ b/src/multibody/joint/joint-revolute.hpp
@@ -18,10 +18,10 @@
 #ifndef __se3_joint_revolute_hpp__
 #define __se3_joint_revolute_hpp__
 
-#include "pinocchio/multibody/joint/joint-base.hpp"
-#include "pinocchio/multibody/constraint.hpp"
-#include "pinocchio/spatial/inertia.hpp"
+// #include "pinocchio/multibody/constraint.hpp"
 #include "pinocchio/math/sincos.hpp"
+#include "pinocchio/spatial/inertia.hpp"
+#include "pinocchio/multibody/joint/joint-base.hpp"
 
 namespace se3
 {
@@ -37,12 +37,11 @@ namespace se3
       double w; 
       CartesianVector3(const double & w) : w(w) {}
       CartesianVector3() : w(1) {}
-      operator Eigen::Vector3d ();
-    }; // struct CartesianVector3
+      operator Eigen::Vector3d (); // { return Eigen::Vector3d(w,0,0); }
+    };
     template<>CartesianVector3<0>::operator Eigen::Vector3d () { return Eigen::Vector3d(w,0,0); }
     template<>CartesianVector3<1>::operator Eigen::Vector3d () { return Eigen::Vector3d(0,w,0); }
     template<>CartesianVector3<2>::operator Eigen::Vector3d () { return Eigen::Vector3d(0,0,w); }
-
     Eigen::Vector3d operator+ (const Eigen::Vector3d & w1,const CartesianVector3<0> & wx)
     { return Eigen::Vector3d(w1[0]+wx.w,w1[1],w1[2]); }
     Eigen::Vector3d operator+ (const Eigen::Vector3d & w1,const CartesianVector3<1> & wy)
@@ -52,6 +51,7 @@ namespace se3
   } // namespace revolute
 
   template<int axis> struct MotionRevolute;
+
   template<int axis>
   struct traits< MotionRevolute < axis > >
   {
@@ -106,6 +106,7 @@ namespace se3
   }
 
   template<int axis> struct ConstraintRevolute;
+
   template<int axis>
   struct traits< ConstraintRevolute<axis> >
   {
@@ -154,6 +155,8 @@ namespace se3
       return res;
     }
 
+    int nv_impl() const { return NV; }
+    
     struct TransposeConst
     {
       const ConstraintRevolute<axis> & ref; 
@@ -182,8 +185,8 @@ namespace se3
      *   - MatrixBase operator* (Constraint::Transpose S, ForceSet::Block)
      *   - SE3::act(ForceSet::Block)
      */
-    operator ConstraintXd () const
-    {
+     operator ConstraintXd () const
+     {
       Eigen::Matrix<double,6,1> S;
       S << Eigen::Vector3d::Zero(), (Eigen::Vector3d)revolute::CartesianVector3<axis>();
       return ConstraintXd(S);
@@ -373,6 +376,11 @@ namespace se3
     {
       M.translation(SE3::Vector3::Zero());
     }
+
+    JointDataDense<NQ, NV> toDense_impl() const
+    {
+      return JointDataDense<NQ, NV>(S, M, v, c, F);
+    }
   }; // struct JointDataRevolute
 
   template<int axis>
@@ -381,8 +389,13 @@ namespace se3
     typedef JointRevolute<axis> Joint;
     SE3_JOINT_TYPEDEF_TEMPLATE;
 
+    using JointModelBase<JointModelRevolute>::id;
     using JointModelBase<JointModelRevolute>::idx_q;
     using JointModelBase<JointModelRevolute>::idx_v;
+    using JointModelBase<JointModelRevolute>::lowerPosLimit;
+    using JointModelBase<JointModelRevolute>::upperPosLimit;
+    using JointModelBase<JointModelRevolute>::maxEffortLimit;
+    using JointModelBase<JointModelRevolute>::maxVelocityLimit;
     using JointModelBase<JointModelRevolute>::setIndexes;
     
     JointData createData() const { return JointData(); }
@@ -404,6 +417,22 @@ namespace se3
       data.v.w = v;
     }
 
+    JointModelDense<NQ, NV> toDense_impl() const
+    {
+      return JointModelDense<NQ, NV>( id(),
+                                      idx_q(),
+                                      idx_v(),
+                                      lowerPosLimit(),
+                                      upperPosLimit(),
+                                      maxEffortLimit(),
+                                      maxVelocityLimit()
+                                    );
+    }
+
+    bool operator == (const JointModelRevolute<axis>& /*Other*/) const
+    {
+      return true; // TODO ??
+    }
 
   }; // struct JointModelRevolute
 

--- a/src/multibody/joint/joint-revolute.hpp
+++ b/src/multibody/joint/joint-revolute.hpp
@@ -22,6 +22,7 @@
 #include "pinocchio/math/sincos.hpp"
 #include "pinocchio/spatial/inertia.hpp"
 #include "pinocchio/multibody/joint/joint-base.hpp"
+#include "pinocchio/multibody/joint/joint-dense.hpp"
 
 namespace se3
 {

--- a/src/multibody/joint/joint-revolute.hpp
+++ b/src/multibody/joint/joint-revolute.hpp
@@ -18,7 +18,6 @@
 #ifndef __se3_joint_revolute_hpp__
 #define __se3_joint_revolute_hpp__
 
-// #include "pinocchio/multibody/constraint.hpp"
 #include "pinocchio/math/sincos.hpp"
 #include "pinocchio/spatial/inertia.hpp"
 #include "pinocchio/multibody/joint/joint-base.hpp"

--- a/src/multibody/joint/joint-spherical-ZYX.hpp
+++ b/src/multibody/joint/joint-spherical-ZYX.hpp
@@ -19,6 +19,7 @@
 #define __se3_joint_spherical_ZYX_hpp__
 #include <iostream>
 #include "pinocchio/multibody/joint/joint-base.hpp"
+#include "pinocchio/multibody/joint/joint-dense.hpp"
 #include "pinocchio/multibody/constraint.hpp"
 #include "pinocchio/math/sincos.hpp"
 #include "pinocchio/spatial/inertia.hpp"

--- a/src/multibody/joint/joint-spherical-ZYX.hpp
+++ b/src/multibody/joint/joint-spherical-ZYX.hpp
@@ -90,13 +90,11 @@ namespace se3
 
     struct ConstraintRotationalSubspace
     {
-    public:
       enum { NV = 3, Options = 0 };
       typedef _Scalar Scalar;
       typedef Eigen::Matrix <_Scalar,3,3,_Options> Matrix3;
       typedef Eigen::Matrix <_Scalar,3,1,_Options> Vector3;
 
-    public:
       Matrix3 S_minimal;
 
       Motion operator* (const MotionSpherical & vj) const
@@ -259,7 +257,7 @@ namespace se3
     {
       return JointDataDense<NQ, NV>(S, M, v, c, F);
     }
-  };
+  }; // strcut JointDataSphericalZYX
 
   struct JointModelSphericalZYX : public JointModelBase<JointModelSphericalZYX>
   {
@@ -347,7 +345,7 @@ namespace se3
       return true; // TODO ?? used to bind variant in python
     }
 
-  };
+  }; // struct JointModelSphericalZYX
 
 } // namespace se3
 

--- a/src/multibody/joint/joint-spherical.hpp
+++ b/src/multibody/joint/joint-spherical.hpp
@@ -19,6 +19,7 @@
 #define __se3_joint_spherical_hpp__
 
 #include "pinocchio/multibody/joint/joint-base.hpp"
+#include "pinocchio/multibody/joint/joint-dense.hpp"
 #include "pinocchio/multibody/constraint.hpp"
 #include "pinocchio/math/sincos.hpp"
 #include "pinocchio/spatial/inertia.hpp"

--- a/src/multibody/joint/joint-translation.hpp
+++ b/src/multibody/joint/joint-translation.hpp
@@ -19,6 +19,7 @@
 #define __se3_joint_translation_hpp__
 
 #include "pinocchio/multibody/joint/joint-base.hpp"
+#include "pinocchio/multibody/joint/joint-dense.hpp"
 #include "pinocchio/multibody/constraint.hpp"
 #include "pinocchio/spatial/inertia.hpp"
 #include "pinocchio/spatial/skew.hpp"

--- a/src/multibody/joint/joint-translation.hpp
+++ b/src/multibody/joint/joint-translation.hpp
@@ -117,6 +117,7 @@ namespace se3
   struct ConstraintTranslationSubspace : ConstraintBase < ConstraintTranslationSubspace >
   {
     SPATIAL_TYPEDEF_NO_TEMPLATE(ConstraintTranslationSubspace);
+    enum { NV = 3, Options = 0 };
     typedef traits<ConstraintTranslationSubspace>::JointMotion JointMotion;
     typedef traits<ConstraintTranslationSubspace>::JointForce JointForce;
     typedef traits<ConstraintTranslationSubspace>::DenseBase DenseBase;
@@ -125,6 +126,7 @@ namespace se3
     Motion operator* (const MotionTranslation & vj) const
     { return Motion (vj (), Motion::Vector3::Zero ()); }
 
+    int nv_impl() const { return NV; }
 
     struct ConstraintTranspose
     {
@@ -235,13 +237,29 @@ namespace se3
     Motion_t v;
     Bias_t c;
 
+    F_t F; // TODO if not used anymore, clean F_t
+
     JointDataTranslation () : M(1) {}
+
+    JointDataDense<NQ, NV> toDense_impl() const
+    {
+      return JointDataDense<NQ, NV>(S, M, v, c, F);
+    }
   }; // struct JointDataTranslation
 
   struct JointModelTranslation : public JointModelBase<JointModelTranslation>
   {
     typedef JointTranslation Joint;
     SE3_JOINT_TYPEDEF;
+
+    using JointModelBase<JointModelTranslation>::id;
+    using JointModelBase<JointModelTranslation>::idx_q;
+    using JointModelBase<JointModelTranslation>::idx_v;
+    using JointModelBase<JointModelTranslation>::lowerPosLimit;
+    using JointModelBase<JointModelTranslation>::upperPosLimit;
+    using JointModelBase<JointModelTranslation>::maxEffortLimit;
+    using JointModelBase<JointModelTranslation>::maxVelocityLimit;
+    using JointModelBase<JointModelTranslation>::setIndexes;
 
     JointData createData() const { return JointData(); }
 
@@ -256,6 +274,23 @@ namespace se3
     {
       data.M.translation (qs.segment<NQ> (idx_q ()));
       data.v () = vs.segment<NQ> (idx_v ());
+    }
+
+    JointModelDense<NQ, NV> toDense_impl() const
+    {
+      return JointModelDense<NQ, NV>( id(),
+                                      idx_q(),
+                                      idx_v(),
+                                      lowerPosLimit(),
+                                      upperPosLimit(),
+                                      maxEffortLimit(),
+                                      maxVelocityLimit()
+                                    );
+    }
+
+    bool operator == (const JointModelTranslation& /*Ohter*/) const
+    {
+      return true; // TODO ?? used to bind variant in python
     }
   }; // struct JointModelTranslation
   

--- a/src/multibody/joint/joint-variant.hpp
+++ b/src/multibody/joint/joint-variant.hpp
@@ -29,8 +29,8 @@
 
 namespace se3
 {
-  typedef boost::variant< JointModelRX, JointModelRY, JointModelRZ, JointModelRevoluteUnaligned, JointModelSpherical, JointModelSphericalZYX, JointModelPX, JointModelPY, JointModelPZ, JointModelFreeFlyer, JointModelPlanar, JointModelTranslation> JointModelVariant;
-  typedef boost::variant< JointDataRX, JointDataRY, JointDataRZ, JointDataRevoluteUnaligned, JointDataSpherical, JointDataSphericalZYX, JointDataPX, JointDataPY, JointDataPZ, JointDataFreeFlyer, JointDataPlanar, JointDataTranslation> JointDataVariant;
+  typedef boost::variant< JointModelRX, JointModelRY, JointModelRZ, JointModelRevoluteUnaligned, JointModelSpherical, JointModelSphericalZYX, JointModelPX, JointModelPY, JointModelPZ, JointModelFreeFlyer, JointModelPlanar, JointModelTranslation,JointModelDense<-1,-1> > JointModelVariant;
+  typedef boost::variant< JointDataRX, JointDataRY, JointDataRZ, JointDataRevoluteUnaligned, JointDataSpherical, JointDataSphericalZYX, JointDataPX, JointDataPY, JointDataPZ, JointDataFreeFlyer, JointDataPlanar, JointDataTranslation,JointDataDense<-1,-1> > JointDataVariant;
 
   typedef std::vector<JointModelVariant> JointModelVector;
   typedef std::vector<JointDataVariant> JointDataVector;

--- a/src/simulation/compute-all-terms.hpp
+++ b/src/simulation/compute-all-terms.hpp
@@ -79,7 +79,7 @@ namespace se3
         data.oMi[i] = data.liMi[i];
       }
 
-      data.J.block(0,jmodel.idx_v(),6,jmodel.nv()) = data.oMi[i].act(jdata.S());
+      jmodel.jointCols(data.J) = data.oMi[i].act(jdata.S());
 
       data.a[i]  = jdata.c() + (data.v[i] ^ jdata.v());
       data.a[i] += data.liMi[i].actInv(data.a[parent]);
@@ -113,7 +113,7 @@ namespace se3
       const Model::Index & parent = model.parents[i];
 
       /* F[1:6,i] = Y*S */
-      data.Fcrb[i].block<6,JointModel::NV>(0,jmodel.idx_v()) = data.Ycrb[i] * jdata.S();
+      jmodel.jointCols(data.Fcrb[i]) = data.Ycrb[i] * jdata.S();
 
       /* M[i,SUBTREE] = S'*F[1:6,SUBTREE] */
       data.M.block(jmodel.idx_v(),jmodel.idx_v(),jmodel.nv(),data.nvSubtree[i])

--- a/src/simulation/compute-all-terms.hpp
+++ b/src/simulation/compute-all-terms.hpp
@@ -120,7 +120,7 @@ namespace se3
       = jdata.S().transpose()*data.Fcrb[i].block(0,jmodel.idx_v(),6,data.nvSubtree[i]);
 
 
-      jmodel.jointForce(data.nle)  = jdata.S().transpose()*data.f[i];
+      jmodel.jointVelocitySpace(data.nle)  = jdata.S().transpose()*data.f[i];
       if(parent>0)
       {
         /*   Yli += liXi Yi */

--- a/src/simulation/compute-all-terms.hpp
+++ b/src/simulation/compute-all-terms.hpp
@@ -120,7 +120,7 @@ namespace se3
       = jdata.S().transpose()*data.Fcrb[i].block(0,jmodel.idx_v(),6,data.nvSubtree[i]);
 
 
-      jmodel.jointVelocitySpace(data.nle)  = jdata.S().transpose()*data.f[i];
+      jmodel.jointVelocitySelector(data.nle)  = jdata.S().transpose()*data.f[i];
       if(parent>0)
       {
         /*   Yli += liXi Yi */

--- a/src/spatial/inertia.hpp
+++ b/src/spatial/inertia.hpp
@@ -184,8 +184,8 @@ namespace se3
     {
       Matrix6 M;
       const Matrix3 & c_cross = (skew(c));
-      M.template block<3,3>(LINEAR, LINEAR ).template setZero ();
-      M.template block<3,3>(LINEAR, LINEAR ).template diagonal ().template fill (m);
+      M.template block<3,3>(LINEAR, LINEAR ).setZero ();
+      M.template block<3,3>(LINEAR, LINEAR ).diagonal ().fill (m);
       M.template block<3,3>(ANGULAR,LINEAR ) = m * c_cross;
       M.template block<3,3>(LINEAR, ANGULAR) = -M.template block<3,3> (ANGULAR, LINEAR);
       M.template block<3,3>(ANGULAR,ANGULAR) = (Matrix3)(I - M.template block<3,3>(ANGULAR, LINEAR) * c_cross);

--- a/unittest/joints.cpp
+++ b/unittest/joints.cpp
@@ -1016,3 +1016,55 @@ BOOST_AUTO_TEST_CASE ( test_merge_body )
 }
 
 BOOST_AUTO_TEST_SUITE_END ()
+
+BOOST_AUTO_TEST_SUITE ( JointDense )
+
+BOOST_AUTO_TEST_CASE ( toJointModelDense )
+{
+  using namespace se3;
+
+
+  JointModelRX jmodel;
+  jmodel.setIndexes (2, 0, 0);
+
+  JointModelDense<JointModelBase<JointModelRX>::NQ, JointModelBase<JointModelRX>::NV> jmd(jmodel.id(), jmodel.idx_q(), jmodel.idx_v(), jmodel.lowerPosLimit(),
+                          jmodel.upperPosLimit(), jmodel.maxEffortLimit(), jmodel.maxVelocityLimit());
+  JointModelDense<JointModelBase<JointModelRX>::NQ, JointModelBase<JointModelRX>::NV> jmd2 = jmodel.toDense();
+  (void)jmd; (void)jmd2;
+
+  assert(jmd.idx_q() == jmodel.idx_q() && "The comparison of the joint index in configuration space failed");
+  assert(jmd.idx_q() == jmd2.idx_q() && "The comparison of the joint index in  configuration space failed");
+
+  assert(jmd.idx_v() == jmodel.idx_v() && "The comparison of the joint index in velocity space failed");
+  assert(jmd.idx_v() == jmd2.idx_v() && "The comparison of the joint index in  velocity space failed");
+
+  assert(jmd.id() == jmodel.id() && "The comparison of the joint index in model's kinematic tree failed");
+  assert(jmd.id() == jmd2.id() && "The comparison of the joint index in model's kinematic tree failed");
+
+}
+
+BOOST_AUTO_TEST_CASE ( toJointDataDense )
+{
+  // using namespace se3;
+
+  // JointModelRX jmodel;
+  // jmodel.setIndexes (2, 0, 0);
+
+  // JointDataRX jdata;
+
+  // JointDataDense< JointDataBase<JointModelRX::JointData>::NQ,
+  //                 JointDataBase<JointModelRX::JointData>::NV
+  //                                                                     > jdd = jdata.toDense(); (void) jdd;
+
+  // asert(jdata.S().nv() == jdd.S().nv() && "");
+
+  
+      // JointDataBase<JointDataDense> & jddb = jdd;
+
+      // std::cout << "S nv: \t" ;
+      // std::cout << jdata.S().nv() << std::endl;
+      // JointDataDense::Transformation_t mm = jdd.M1();
+      // std::cout //<< "M\t" << mm << std::endl;
+                // << jdd.S << std::endl;
+}
+BOOST_AUTO_TEST_SUITE_END ()

--- a/unittest/joints.cpp
+++ b/unittest/joints.cpp
@@ -1045,26 +1045,18 @@ BOOST_AUTO_TEST_CASE ( toJointModelDense )
 
 BOOST_AUTO_TEST_CASE ( toJointDataDense )
 {
-  // using namespace se3;
+  using namespace se3;
 
-  // JointModelRX jmodel;
-  // jmodel.setIndexes (2, 0, 0);
+  JointModelRX jmodel;
+  jmodel.setIndexes (2, 0, 0);
 
-  // JointDataRX jdata;
+  JointDataRX jdata;
 
-  // JointDataDense< JointDataBase<JointModelRX::JointData>::NQ,
-  //                 JointDataBase<JointModelRX::JointData>::NV
-  //                                                                     > jdd = jdata.toDense(); (void) jdd;
+  JointDataDense< JointDataBase<JointModelRX::JointData>::NQ,
+                  JointDataBase<JointModelRX::JointData>::NV
+                                                                      > jdd = jdata.toDense();
 
-  // asert(jdata.S().nv() == jdd.S().nv() && "");
+  assert(jdata.S.nv() == jdd.S.nv() && "");
 
-  
-      // JointDataBase<JointDataDense> & jddb = jdd;
-
-      // std::cout << "S nv: \t" ;
-      // std::cout << jdata.S().nv() << std::endl;
-      // JointDataDense::Transformation_t mm = jdd.M1();
-      // std::cout //<< "M\t" << mm << std::endl;
-                // << jdd.S << std::endl;
 }
 BOOST_AUTO_TEST_SUITE_END ()


### PR DESCRIPTION
Added two classes JointModelDense and JointDataDense.
Their aim is to be as generic as possible and to possibly allow conversion to these types for any joints thanks to the methods toDense(). Cf in tests.
They are given as it with a possible use in C++. 
Thanks to @nmansard , the Joint dense with dynamic size is now available.

Another point : the methods to access segments of fixed size have been reoganized. There were duplicates services with different names. Now jointConfigSpace_impl return a block of size NQ, and jointVelocitySpace_impl a block of size NV.