### PR TITLE
[C++][Bug] Enforce One Definition Rule in template instantiations.

### DIFF
--- a/src/multibody/joint/joint-free-flyer.hpp
+++ b/src/multibody/joint/joint-free-flyer.hpp
@@ -89,7 +89,7 @@ namespace se3
 
 
   /* [CRBA] ForceSet operator* (Inertia Y,Constraint S) */
-  Inertia::Matrix6 operator*( const Inertia& Y,const ConstraintIdentity & )
+  inline Inertia::Matrix6 operator*( const Inertia& Y,const ConstraintIdentity & )
   {
     return Y.matrix();
   }

--- a/src/multibody/joint/joint-planar.hpp
+++ b/src/multibody/joint/joint-planar.hpp
@@ -73,11 +73,11 @@ namespace se3
 
   }; // struct MotionPlanar
 
-  const MotionPlanar operator+ (const MotionPlanar & m, const BiasZero &)
+  inline const MotionPlanar operator+ (const MotionPlanar & m, const BiasZero &)
   { return m; }
 
   
-  Motion operator+ (const MotionPlanar & m1, const Motion & m2)
+  inline Motion operator+ (const MotionPlanar & m1, const Motion & m2)
   {
     Motion result (m2);
     result.linear ()[0] += m1.x_dot_;
@@ -197,7 +197,7 @@ namespace se3
   }
 
 
-  Motion operator^ (const Motion & m1, const MotionPlanar & m2)
+  inline Motion operator^ (const Motion & m1, const MotionPlanar & m2)
   {
     Motion result;
 
@@ -211,7 +211,7 @@ namespace se3
   }
 
   /* [CRBA] ForceSet operator* (Inertia Y,Constraint S) */
-  Eigen::Matrix <Inertia::Scalar_t, 6, 3> operator* (const Inertia & Y, const ConstraintPlanar &)
+  inline Eigen::Matrix <Inertia::Scalar_t, 6, 3> operator* (const Inertia & Y, const ConstraintPlanar &)
   {
     Eigen::Matrix <Inertia::Scalar_t, 6, 3> M;
     const double mass = Y.mass ();

--- a/src/multibody/joint/joint-prismatic.hpp
+++ b/src/multibody/joint/joint-prismatic.hpp
@@ -39,15 +39,15 @@ namespace se3
       CartesianVector3() : v(NAN) {}
       operator Eigen::Vector3d () const; 
     }; // struct CartesianVector3
-    template<>CartesianVector3<0>::operator Eigen::Vector3d () const { return Eigen::Vector3d(v,0,0); }
-    template<>CartesianVector3<1>::operator Eigen::Vector3d () const { return Eigen::Vector3d(0,v,0); }
-    template<>CartesianVector3<2>::operator Eigen::Vector3d () const { return Eigen::Vector3d(0,0,v); }
+    template<> inline CartesianVector3<0>::operator Eigen::Vector3d () const { return Eigen::Vector3d(v,0,0); }
+    template<> inline CartesianVector3<1>::operator Eigen::Vector3d () const { return Eigen::Vector3d(0,v,0); }
+    template<> inline CartesianVector3<2>::operator Eigen::Vector3d () const { return Eigen::Vector3d(0,0,v); }
     
-    Eigen::Vector3d operator+ (const Eigen::Vector3d & v1,const CartesianVector3<0> & vx)
+    inline Eigen::Vector3d operator+ (const Eigen::Vector3d & v1,const CartesianVector3<0> & vx)
     { return Eigen::Vector3d(v1[0]+vx.v,v1[1],v1[2]); }
-    Eigen::Vector3d operator+ (const Eigen::Vector3d & v1,const CartesianVector3<1> & vy)
+    inline Eigen::Vector3d operator+ (const Eigen::Vector3d & v1,const CartesianVector3<1> & vy)
     { return Eigen::Vector3d(v1[0],v1[1]+vy.v,v1[2]); }
-    Eigen::Vector3d operator+ (const Eigen::Vector3d & v1,const CartesianVector3<2> & vz)
+    inline Eigen::Vector3d operator+ (const Eigen::Vector3d & v1,const CartesianVector3<2> & vz)
     { return Eigen::Vector3d(v1[0],v1[1],v1[2]+vz.v); }
   } // namespace prismatic
 
@@ -203,7 +203,7 @@ namespace se3
     static Eigen::Vector3d cartesianTranslation(const double & shift); 
   };
 
-  Motion operator^( const Motion& m1, const MotionPrismatic<0>& m2)
+  inline Motion operator^( const Motion& m1, const MotionPrismatic<0>& m2)
   {
     /* nu1^nu2    = ( v1^w2+w1^v2, w1^w2 )
      * nu1^(v2,0) = ( w1^v2      , 0 )
@@ -216,7 +216,7 @@ namespace se3
        Motion::Vector3::Zero());
    }
 
-   Motion operator^( const Motion& m1, const MotionPrismatic<1>& m2)
+   inline Motion operator^( const Motion& m1, const MotionPrismatic<1>& m2)
    {
     /* nu1^nu2    = ( v1^w2+w1^v2, w1^w2 )
      * nu1^(v2,0) = ( w1^v2      , 0 )
@@ -229,7 +229,7 @@ namespace se3
        Motion::Vector3::Zero());
    }
 
-   Motion operator^( const Motion& m1, const MotionPrismatic<2>& m2)
+   inline Motion operator^( const Motion& m1, const MotionPrismatic<2>& m2)
    {
     /* nu1^nu2    = ( v1^w2+w1^v2, w1^w2 )
      * nu1^(v2,0) = ( w1^v2      , 0 )
@@ -242,24 +242,24 @@ namespace se3
        Motion::Vector3::Zero());
    }
 
-  template<>
+  template<> inline
   Eigen::Vector3d JointPrismatic<0>::cartesianTranslation(const double & shift) 
   {
     return Motion::Vector3(shift,0,0);
   }
-  template<>
+  template<> inline
   Eigen::Vector3d JointPrismatic<1>::cartesianTranslation(const double & shift) 
   {
     return Motion::Vector3(0,shift,0);
   }
-  template<>
+  template<> inline
   Eigen::Vector3d JointPrismatic<2>::cartesianTranslation(const double & shift) 
   {
     return Motion::Vector3(0,0,shift);
   }
 
   /* [CRBA] ForceSet operator* (Inertia Y,Constraint S) */
-  Eigen::Matrix<double,6,1>
+  inline Eigen::Matrix<double,6,1>
   operator*( const Inertia& Y,const ConstraintPrismatic<0> & )
   { 
     /* Y(:,0) = ( 1,0, 0, 0 , z , -y ) */
@@ -274,7 +274,7 @@ namespace se3
     return res;
   }
   /* [CRBA] ForceSet operator* (Inertia Y,Constraint S) */
-  Eigen::Matrix<double,6,1>
+  inline Eigen::Matrix<double,6,1>
   operator*( const Inertia& Y,const ConstraintPrismatic<1> & )
   { 
     /* Y(:,1) = ( 0,1, 0, -z , 0 , x) */
@@ -289,7 +289,7 @@ namespace se3
     return res;
   }
   /* [CRBA] ForceSet operator* (Inertia Y,Constraint S) */
-  Eigen::Matrix<double,6,1>
+  inline Eigen::Matrix<double,6,1>
   operator*( const Inertia& Y,const ConstraintPrismatic<2> & )
   { 
     /* Y(:,2) = ( 0,0, 1, y , -x , 0) */

--- a/src/multibody/joint/joint-revolute-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unaligned.hpp
@@ -71,11 +71,11 @@ namespace se3
                     axis*w);
     }
   }; // struct MotionRevoluteUnaligned
-  
-  const MotionRevoluteUnaligned& operator+ (const MotionRevoluteUnaligned& m, const BiasZero&)
+
+  inline const MotionRevoluteUnaligned& operator+ (const MotionRevoluteUnaligned& m, const BiasZero&)
   { return m; }
 
-  Motion operator+ (const MotionRevoluteUnaligned& m1, const Motion& m2)
+  inline Motion operator+ (const MotionRevoluteUnaligned& m1, const Motion& m2)
   {
     return Motion( m2.linear(), m1.w*m1.axis+m2.angular() );
   }
@@ -185,7 +185,7 @@ namespace se3
     }; // struct ConstraintRevoluteUnaligned
 
 
-    Motion operator^( const Motion& m1, const MotionRevoluteUnaligned & m2)
+    inline Motion operator^( const Motion& m1, const MotionRevoluteUnaligned & m2)
     {
       /* m1xm2 = [ v1xw2 + w1xv2; w1xw2 ] = [ v1xw2; w1xw2 ] */
       const Motion::Vector3& v1 = m1.linear();
@@ -195,7 +195,7 @@ namespace se3
     }
 
     /* [CRBA] ForceSet operator* (Inertia Y,Constraint S) */
-    Eigen::Matrix<double,6,1>
+    inline Eigen::Matrix<double,6,1>
     operator*( const Inertia& Y,const ConstraintRevoluteUnaligned & cru)
     { 
       /* YS = [ m -mcx ; mcx I-mcxcx ] [ 0 ; w ] = [ mcxw ; Iw -mcxcxw ] */

--- a/src/multibody/joint/joint-revolute.hpp
+++ b/src/multibody/joint/joint-revolute.hpp
@@ -39,14 +39,14 @@ namespace se3
       CartesianVector3() : w(1) {}
       operator Eigen::Vector3d (); // { return Eigen::Vector3d(w,0,0); }
     };
-    template<>CartesianVector3<0>::operator Eigen::Vector3d () { return Eigen::Vector3d(w,0,0); }
-    template<>CartesianVector3<1>::operator Eigen::Vector3d () { return Eigen::Vector3d(0,w,0); }
-    template<>CartesianVector3<2>::operator Eigen::Vector3d () { return Eigen::Vector3d(0,0,w); }
-    Eigen::Vector3d operator+ (const Eigen::Vector3d & w1,const CartesianVector3<0> & wx)
+    template<> inline CartesianVector3<0>::operator Eigen::Vector3d () { return Eigen::Vector3d(w,0,0); }
+    template<> inline CartesianVector3<1>::operator Eigen::Vector3d () { return Eigen::Vector3d(0,w,0); }
+    template<> inline CartesianVector3<2>::operator Eigen::Vector3d () { return Eigen::Vector3d(0,0,w); }
+    inline Eigen::Vector3d operator+ (const Eigen::Vector3d & w1,const CartesianVector3<0> & wx)
     { return Eigen::Vector3d(w1[0]+wx.w,w1[1],w1[2]); }
-    Eigen::Vector3d operator+ (const Eigen::Vector3d & w1,const CartesianVector3<1> & wy)
+    inline Eigen::Vector3d operator+ (const Eigen::Vector3d & w1,const CartesianVector3<1> & wy)
     { return Eigen::Vector3d(w1[0],w1[1]+wy.w,w1[2]); }
-    Eigen::Vector3d operator+ (const Eigen::Vector3d & w1,const CartesianVector3<2> & wz)
+    inline Eigen::Vector3d operator+ (const Eigen::Vector3d & w1,const CartesianVector3<2> & wz)
     { return Eigen::Vector3d(w1[0],w1[1],w1[2]+wz.w); }
   } // namespace revolute
 
@@ -198,7 +198,7 @@ namespace se3
       static Eigen::Matrix3d cartesianRotation(const double & angle); 
   };
 
-  Motion operator^( const Motion& m1, const MotionRevolute<0>& m2)
+  inline Motion operator^( const Motion& m1, const MotionRevolute<0>& m2)
   {
     /* nu1^nu2    = ( v1^w2+w1^v2, w1^w2 )
      * nu1^(0,w2) = ( v1^w2      , w1^w2 )
@@ -213,7 +213,7 @@ namespace se3
                  );
   }
 
-  Motion operator^( const Motion& m1, const MotionRevolute<1>& m2)
+  inline Motion operator^( const Motion& m1, const MotionRevolute<1>& m2)
   {
     /* nu1^nu2    = ( v1^w2+w1^v2, w1^w2 )
      * nu1^(0,w2) = ( v1^w2      , w1^w2 )
@@ -228,7 +228,7 @@ namespace se3
                  );
   }
 
-  Motion operator^( const Motion& m1, const MotionRevolute<2>& m2)
+  inline Motion operator^( const Motion& m1, const MotionRevolute<2>& m2)
   {
     /* nu1^nu2    = ( v1^w2+w1^v2, w1^w2 )
      * nu1^(0,w2) = ( v1^w2      , w1^w2 )
@@ -243,7 +243,7 @@ namespace se3
                  );
     }
 
-  template<>
+  template<> inline
   Eigen::Matrix3d JointRevolute<0>::cartesianRotation(const double & angle) 
   {
     Eigen::Matrix3d R3; 
@@ -255,7 +255,7 @@ namespace se3
     return R3;
   }
 
-  template<>
+  template<> inline
   Eigen::Matrix3d JointRevolute<1>::cartesianRotation(const double & angle)
   {
     Eigen::Matrix3d R3; 
@@ -267,7 +267,7 @@ namespace se3
     return R3;
   }
 
-  template<>
+  template<> inline
   Eigen::Matrix3d JointRevolute<2>::cartesianRotation(const double & angle) 
   {
     Eigen::Matrix3d R3; 
@@ -280,7 +280,7 @@ namespace se3
   }
 
   /* [CRBA] ForceSet operator* (Inertia Y,Constraint S) */
-  Eigen::Matrix<double,6,1>
+  Eigen::Matrix<double,6,1> inline
   operator*( const Inertia& Y,const ConstraintRevolute<0> & )
   { 
     /* Y(:,3) = ( 0,-z, y,  I00+yy+zz,  I01-xy   ,  I02-xz   ) */
@@ -297,7 +297,7 @@ namespace se3
     return res;
   }
   /* [CRBA] ForceSet operator* (Inertia Y,Constraint S) */
-  Eigen::Matrix<double,6,1>
+  Eigen::Matrix<double,6,1> inline
   operator*( const Inertia& Y,const ConstraintRevolute<1> & )
   { 
     /* Y(:,4) = ( z, 0,-x,  I10-xy   ,  I11+xx+zz,  I12-yz   ) */
@@ -314,7 +314,7 @@ namespace se3
     return res;
   }
   /* [CRBA] ForceSet operator* (Inertia Y,Constraint S) */
-  Eigen::Matrix<double,6,1>
+  Eigen::Matrix<double,6,1> inline
   operator*( const Inertia& Y,const ConstraintRevolute<2> & )
   { 
     /* Y(:,5) = (-y, x, 0,  I20-xz   ,  I21-yz   ,  I22+xx+yy) */

--- a/src/multibody/joint/joint-spherical-ZYX.hpp
+++ b/src/multibody/joint/joint-spherical-ZYX.hpp
@@ -60,8 +60,8 @@ namespace se3
 
     }; // struct BiasSpherical
 
-    friend const Motion operator+ (const Motion & v, const BiasSpherical & c) { return Motion (v.linear (), v.angular () + c ()); }
-    friend const Motion operator+ (const BiasSpherical & c, const Motion & v) { return Motion (v.linear (), v.angular () + c ()); }
+    inline friend const Motion operator+ (const Motion & v, const BiasSpherical & c) { return Motion (v.linear (), v.angular () + c ()); }
+    inline friend const Motion operator+ (const BiasSpherical & c, const Motion & v) { return Motion (v.linear (), v.angular () + c ()); }
 
     struct MotionSpherical
     {
@@ -79,7 +79,7 @@ namespace se3
       }
     }; // struct MotionSpherical
 
-    friend const MotionSpherical operator+ (const MotionSpherical & m, const BiasSpherical & c)
+    inline friend const MotionSpherical operator+ (const MotionSpherical & m, const BiasSpherical & c)
     { return MotionSpherical (m.w + c.c_J); }
 
     friend MotionTpl<_Scalar,_Options> operator+ (const MotionSpherical & m1, 
@@ -180,7 +180,7 @@ namespace se3
 
   typedef JointSphericalZYXTpl<double,0> JointSphericalZYX;
 
-  Motion operator^ (const Motion & m1, const JointSphericalZYX::MotionSpherical & m2)
+  inline Motion operator^ (const Motion & m1, const JointSphericalZYX::MotionSpherical & m2)
   {
 //    const Motion::Matrix3 m2_cross (skew (Motion::Vector3 (-m2.w)));
 //    return Motion(m2_cross * m1.linear (), m2_cross * m1.angular ());

--- a/src/multibody/joint/joint-spherical.hpp
+++ b/src/multibody/joint/joint-spherical.hpp
@@ -73,10 +73,10 @@ namespace se3
     }
   }; // struct MotionSpherical
 
-  const MotionSpherical operator+ (const MotionSpherical & m, const BiasZero & )
+  inline const MotionSpherical operator+ (const MotionSpherical & m, const BiasZero & )
   { return m; }
 
-  Motion operator+ (const MotionSpherical & m1, const Motion & m2)
+  inline Motion operator+ (const MotionSpherical & m1, const Motion & m2)
   {
     return Motion( m2.linear(), m2.angular() + m1.w);
   }
@@ -167,13 +167,13 @@ namespace se3
   }
 
 
-  Motion operator^ (const Motion & m1, const MotionSpherical & m2)
+  inline Motion operator^ (const Motion & m1, const MotionSpherical & m2)
   {
     return Motion(m1.linear ().cross (m2.w), m1.angular ().cross (m2.w));
   }
 
   /* [CRBA] ForceSet operator* (Inertia Y,Constraint S) */
-  Eigen::Matrix <double, 6, 3> operator* (const Inertia & Y, const ConstraintRotationalSubspace & )
+  inline Eigen::Matrix <double, 6, 3> operator* (const Inertia & Y, const ConstraintRotationalSubspace & )
   {
     Eigen::Matrix <double, 6, 3> M;
     //    M.block <3,3> (Inertia::LINEAR, 0) = - Y.mass () * skew(Y.lever ());

--- a/src/multibody/joint/joint-translation.hpp
+++ b/src/multibody/joint/joint-translation.hpp
@@ -79,10 +79,10 @@ namespace se3
     }
   }; // struct MotionTranslation
 
-  const MotionTranslation operator+ (const MotionTranslation & m, const BiasZero &)
+  inline const MotionTranslation operator+ (const MotionTranslation & m, const BiasZero &)
   { return m; }
 
-  Motion operator+ (const MotionTranslation & m1, const Motion & m2)
+  inline Motion operator+ (const MotionTranslation & m1, const Motion & m2)
   {
     return Motion (m2.linear () + m1.v, m2.angular ());
   }
@@ -179,13 +179,13 @@ namespace se3
   }
 
 
-  Motion operator^ (const Motion & m1, const MotionTranslation & m2)
+  inline Motion operator^ (const Motion & m1, const MotionTranslation & m2)
   {
     return Motion (m1.angular ().cross (m2.v), Motion::Vector3::Zero ());
   }
 
   /* [CRBA] ForceSet operator* (Inertia Y,Constraint S) */
-  Eigen::Matrix <double, 6, 3> operator* (const Inertia & Y, const ConstraintTranslationSubspace &)
+  inline Eigen::Matrix <double, 6, 3> operator* (const Inertia & Y, const ConstraintTranslationSubspace &)
   {
     Eigen::Matrix <double, 6, 3> M;
     M.block <3,3> (Inertia::ANGULAR, 0) = alphaSkew(Y.mass (), Y.lever ());

--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -169,7 +169,7 @@ namespace se3
 /* --- Details -------------------------------------------------------------- */
 namespace se3
 {
-  std::ostream& operator<< ( std::ostream & os, const Model& model )
+  inline std::ostream& operator<< ( std::ostream & os, const Model& model )
   {
     os << "Nb bodies = " << model.nbody << " (nq="<< model.nq<<",nv="<<model.nv<<")" << std::endl;
     for(Model::Index i=0;i<(Model::Index)(model.nbody);++i)
@@ -181,7 +181,7 @@ namespace se3
     return os;
   }
 
-  std::string random(const int len)
+  inline std::string random(const int len)
   {
     std::string res;
     static const char alphanum[] =
@@ -253,10 +253,10 @@ namespace se3
     return idx;
   }
 
-  Model::Index Model::addFixedBody( Index lastMovingParent,
-                                    const SE3 & placementFromLastMoving,
-                                    const std::string & bodyName,
-                                    bool visual )
+  inline Model::Index Model::addFixedBody( Index lastMovingParent,
+                                           const SE3 & placementFromLastMoving,
+                                           const std::string & bodyName,
+                                           bool visual )
   {
 
     Model::Index idx = (Model::Index) (nFixBody++);
@@ -267,13 +267,13 @@ namespace se3
     return idx;
   }
 
-  void Model::mergeFixedBody(Index parent, const SE3 & placement, const Inertia & Y)
+  inline void Model::mergeFixedBody(Index parent, const SE3 & placement, const Inertia & Y)
   {
     const Inertia & iYf = Y.se3Action(placement); //TODO
     inertias[parent] += iYf;
   }
 
-  Model::Index Model::getBodyId( const std::string & name ) const
+  inline Model::Index Model::getBodyId( const std::string & name ) const
   {
     std::vector<std::string>::iterator::difference_type
       res = std::find(names.begin(),names.end(),name) - names.begin();
@@ -281,20 +281,20 @@ namespace se3
     assert( (res>=0)&&(res<nbody)&&"The body name you asked do not exist" );
     return Model::Index(res);
   }
-  bool Model::existBodyName( const std::string & name ) const
+  inline bool Model::existBodyName( const std::string & name ) const
   {
     std::vector<std::string>::iterator::difference_type
       res = std::find(names.begin(),names.end(),name) - names.begin();
     return (res>=0)&&(res<nbody);
   }
   
-  const std::string& Model::getBodyName( Model::Index index ) const
+  inline const std::string& Model::getBodyName( Model::Index index ) const
   {
     assert( index < (Model::Index)nbody );
     return names[index];
   }  
 
-  Data::Data( const Model& ref )
+  inline Data::Data( const Model& ref )
     :model(ref)
     ,joints(0)
     ,a((std::size_t)ref.nbody)
@@ -342,7 +342,7 @@ namespace se3
     J.fill(0);
   }
 
-  void Data::computeLastChild(const Model& model)
+  inline void Data::computeLastChild(const Model& model)
   {
     typedef Model::Index Index;
     std::fill(lastChild.begin(),lastChild.end(),-1);
@@ -358,7 +358,7 @@ namespace se3
       }
   }
 
-  void Data::computeParents_fromRow( const Model& model )
+  inline void Data::computeParents_fromRow( const Model& model )
   {
     for( Model::Index joint=1;joint<(Model::Index)(model.nbody);joint++)
       {

--- a/src/spatial/motion.hpp
+++ b/src/spatial/motion.hpp
@@ -335,8 +335,8 @@ namespace se3
     operator Motion () const { return Motion::Zero(); }
   }; // struct BiasZero
 
-const Motion & operator+( const Motion& v, const BiasZero&) { return v; }
-const Motion & operator+ ( const BiasZero&,const Motion& v) { return v; }
+inline const Motion & operator+( const Motion& v, const BiasZero&) { return v; }
+inline const Motion & operator+ ( const BiasZero&,const Motion& v) { return v; }
 
 } // namespace se3
 


### PR DESCRIPTION
  * Add inline specifier where needed.
  * This is done to avoid multiple definition when using the pinocchio
    library as a dependency.

  * This should **partly** solve #47 