### PR TITLE
Try to avoid travis killed builds (i.e crashes due to building environment running out of ram)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,17 @@
 language: cpp
 sudo: required
 compiler:
-# - gcc
-- clang
+- gcc
+# - clang
 env:
   global:
     - secure: "SnIBG/xLIHX3CSvUbqqsX8xTVqIqQ7fFS6HWO6KZQVBsT6yugTwYHbyhNiU531JejYJ/I3ZrDhXfYH3qFZiYxnH1sifvwV+fnTtMXpPN7qPZwIymkjcmm6gJF51e0C7VOfUbvKFv0ngwj+ul21rgZSMuoEvxPK0WxtE3/ZSfn9c="
-    - "APT_DEPENDENCIES=doxygen doxygen-latex libboost-all-dev libeigen3-dev liblapack-dev libblas-dev gfortran python-dev python-sphinx"
+    - "APT_DEPENDENCIES=doxygen libeigen3-dev "
     - DEBSIGN_KEYID=5AE5CD75
   matrix:
     # - BUILDTYPE=Release
-    - BUILDTYPE=Debug
+    # - BUILDTYPE=Debug
+    - BUILDTYPE=Minsizerel
 notifications:
 email:
 - hpp-source@laas.fr
@@ -24,6 +25,7 @@ allow_failures:
 - compiler:
 script:
   - export CMAKE_ADDITIONAL_OPTIONS="-DCMAKE_BUILD_TYPE=${BUILDTYPE}"
+  - sudo free -m -t
   - ./.travis/run ../travis_custom/custom_build
 after_success: ./travis/run after_success
 after_failure: ./.travis/run after_failure

--- a/travis_custom/custom_before_install
+++ b/travis_custom/custom_before_install
@@ -8,8 +8,11 @@ set -v
 # Add robotpkg 
 sudo sh -c "echo \"deb http://robotpkg.openrobots.org/packages/debian precise robotpkg\" >> /etc/apt/sources.list "
 
+# show memory usage before install
+sudo free -m -t
+
 # Setup environment variables.
-export APT_DEPENDENCIES="doxygen doxygen-latex libboost-all-dev libeigen3-dev liblapack-dev libblas-dev gfortran python-dev python-sphinx libtinyxml-dev robotpkg-urdfdom "
+export APT_DEPENDENCIES="doxygen libboost-dev libboost-doc libboost-thread-dev libboost-system-dev libboost-test-dev libboost-filesystem-dev libboost-python-dev libboost-program-options-dev libeigen3-dev libtinyxml-dev robotpkg-urdfdom "
 curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | sudo apt-key add -
 . ./.travis/run before_install
 


### PR DESCRIPTION
[travis] Build_type is now MinSizeRel to optimize the comsumption of … RAM during process in order to avoid crashes during travis builds. Display memory during build to track RAM information. Reduce number of dependencies