### PR TITLE
Enforce (again) One Definition Rule

### DIFF
--- a/src/multibody/joint/joint-prismatic.hpp
+++ b/src/multibody/joint/joint-prismatic.hpp
@@ -428,7 +428,7 @@ namespace se3
   typedef JointDataPrismatic<0> JointDataPX;
   typedef JointModelPrismatic<0> JointModelPX;
 
-  template<>
+  template<> inline
   const std::string JointModelPrismatic<0>::shortname()
   {
     return std::string("JointModelPX");
@@ -438,7 +438,7 @@ namespace se3
   typedef JointDataPrismatic<1> JointDataPY;
   typedef JointModelPrismatic<1> JointModelPY;
 
-  template<>
+  template<> inline
   const std::string JointModelPrismatic<1>::shortname()
   {
     return std::string("JointModelPY");
@@ -448,7 +448,7 @@ namespace se3
   typedef JointDataPrismatic<2> JointDataPZ;
   typedef JointModelPrismatic<2> JointModelPZ;
 
-  template<>
+  template<> inline
   const std::string JointModelPrismatic<2>::shortname()
   {
     return std::string("JointModelPZ");

--- a/src/multibody/joint/joint-revolute.hpp
+++ b/src/multibody/joint/joint-revolute.hpp
@@ -455,7 +455,7 @@ namespace se3
   typedef JointDataRevolute<0> JointDataRX;
   typedef JointModelRevolute<0> JointModelRX;
 
-  template<>
+  template<> inline
   const std::string JointModelRevolute<0>::shortname()
   {
     return std::string("JointModelRX") ;
@@ -465,7 +465,7 @@ namespace se3
   typedef JointDataRevolute<1> JointDataRY;
   typedef JointModelRevolute<1> JointModelRY;
 
-  template<>
+  template<> inline
   const std::string JointModelRevolute<1>::shortname()
   {
     return std::string("JointModelRY") ;
@@ -475,7 +475,7 @@ namespace se3
   typedef JointDataRevolute<2> JointDataRZ;
   typedef JointModelRevolute<2> JointModelRZ;
 
-  template<>
+  template<> inline
   const std::string JointModelRevolute<2>::shortname()
   {
     return std::string("JointModelRZ") ;


### PR DESCRIPTION
@fvalenza You should always inline full template specializations.
I think this type of error can be easily checked if you build the benchmark in travis.