### PR TITLE
[travis] Give travis more time for executing full build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ allow_failures:
 script:
   - export CMAKE_ADDITIONAL_OPTIONS="-DCMAKE_BUILD_TYPE=${BUILDTYPE}"
   - sudo free -m -t
-  - ./.travis/run ../travis_custom/custom_build
+  - travis_wait ./.travis/run ../travis_custom/custom_build
 after_success: ./travis/run after_success
 after_failure: ./.travis/run after_failure
 before_install: ./travis_custom/custom_before_install


### PR DESCRIPTION
With the command travis_wait we give 20 minutes instead of 10 minutes before killing the build.
With this, issue #48  should be now fixed ( we need to  do more testing but i had 5/5 build success).

(travis_wait can take in argument the time we allow to wait. If no time is stated, then it is  20 minutes)