### PR TITLE
Set default initialization of variables + expose spatial quantities methods + correct bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,13 @@ ENDIF(WIN32)
 
 # --- OPTIONS ----------------------------------------
 OPTION (BUILD_BENCHMARK "Build the benchmarks" OFF)
+OPTION (INITIALIZE_WITH_NAN "Initialize Eigen entries with NaN" OFF)
+
+IF (INITIALIZE_WITH_NAN)
+  MESSAGE (STATUS "Initialize with NaN all the Eigen entries")
+  ADD_DEFINITIONS(-DEIGEN_INITIALIZE_MATRICES_BY_NAN)
+  #LIST(APPEND CMAKE_CXX_FLAGS "-DEIGEN_INITIALIZE_MATRICES_BY_NAN")
+ENDIF (INITIALIZE_WITH_NAN)
 
 # ----------------------------------------------------
 # --- DEPENDANCIES -----------------------------------

--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -347,12 +347,12 @@ namespace se3
     ,lowerPositionLimit(ref.nq)
     ,upperPositionLimit(ref.nq)
   {
+    /* Create data strcture associated to the joints */
     for(Model::Index i=0;i<(Model::Index)(model.nbody);++i) 
       joints.push_back(CreateJointData::run(model.joints[i]));
 
     /* Init for CRBA */
-    M.fill(NAN);    
-    for(Model::Index i=0;i<(Model::Index)(ref.nbody);++i ) { Fcrb[i].resize(6,model.nv); Fcrb[i].fill(NAN); }
+    for(Model::Index i=0;i<(Model::Index)(ref.nbody);++i ) { Fcrb[i].resize(6,model.nv); }
     computeLastChild(ref);
 
     /* Init for Cholesky */
@@ -361,6 +361,14 @@ namespace se3
 
     /* Init Jacobian */
     J.fill(0);
+    
+    /* Init universe states relatively to itself */
+    
+    a[0].setZero();
+    v[0].setZero();
+    f[0].setZero();
+    oMi[0].setIdentity();
+    liMi[0].setIdentity();
   }
 
   inline void Data::computeLastChild(const Model& model)

--- a/src/multibody/parser/urdf.hpp
+++ b/src/multibody/parser/urdf.hpp
@@ -74,7 +74,7 @@ namespace se3
     }
 
 
-void parseTree( ::urdf::LinkConstPtr link, Model & model,SE3 placementOffset = SE3::Identity())
+    void parseTree( ::urdf::LinkConstPtr link, Model & model, const SE3 & placementOffset = SE3::Identity()) 
 {
 
 
@@ -249,7 +249,7 @@ void parseTree( ::urdf::LinkConstPtr link, Model & model,SE3 placementOffset = S
 }
 
     template <typename D>
-    void parseTree( ::urdf::LinkConstPtr link, Model & model,SE3 placementOffset , const JointModelBase<D> &  root_joint  )
+    void parseTree( ::urdf::LinkConstPtr link, Model & model, const SE3 & placementOffset , const JointModelBase<D> &  root_joint  )
     {
       const Inertia & Y = (link->inertial) ?
       convertFromUrdf(*link->inertial)

--- a/src/python/inertia.hpp
+++ b/src/python/inertia.hpp
@@ -54,6 +54,9 @@ namespace se3
       typedef typename Inertia_fx::Vector6 Vector6_fx;
       typedef typename Inertia_fx::Vector3 Vector3_fx;
       typedef typename Inertia_fx::Motion  Motion_fx ;
+      
+      typedef typename Inertia_fx::Scalar_t Scalar_t;
+      
     public:
 
       static PyObject* convert(Inertia const& m)
@@ -72,9 +75,9 @@ namespace se3
 	   			    (bp::arg("mass"),bp::arg("lever"),bp::arg("inertia"))),
 	       "Initialize from mass, lever and 3d inertia.")
 
-	  .add_property("mass",&Inertia_fx::mass)
-	  .add_property("lever",&InertiaPythonVisitor::lever)
-	  .add_property("inertia",&InertiaPythonVisitor::inertia)
+      .add_property("mass", &InertiaPythonVisitor::getMass, &InertiaPythonVisitor::setMass)
+	  .add_property("lever", &InertiaPythonVisitor::getLever, &InertiaPythonVisitor::setLever)
+	  .add_property("inertia", &InertiaPythonVisitor::getInertia, &InertiaPythonVisitor::setInertia)
 
 	  .def("matrix",&Inertia_fx::matrix)
 	  .def("se3Action",&Inertia_fx::se3Action)
@@ -93,6 +96,15 @@ namespace se3
 	  .staticmethod("Random")
 	  ;
 	  }
+      
+      static Scalar_t getMass( const Inertia_fx & self ) { return self.mass(); }
+      static void setMass( Inertia_fx & self, Scalar_t mass ) { self.mass() = mass; }
+      
+      static Vector3_fx getLever( const Inertia_fx & self ) { return self.lever(); }
+      static void setLever( Inertia_fx & self, const Vector3_fx & lever ) { self.lever() = lever; }
+      
+      static Matrix3_fx getInertia( const Inertia_fx & self ) { return self.inertia().matrix(); }
+      static void setInertia( Inertia_fx & self, const Vector6_fx & minimal_inertia ) { self.inertia().data() = minimal_inertia; }
 
       static Inertia_fx* makeFromMCI(const double & mass,
 				     const Vector3_fx & lever,
@@ -106,8 +118,6 @@ namespace se3
 	  throw eigenpy::Exception("The 3d inertia should be positive.");
 	return new Inertia_fx(mass,lever,inertia); 
       }
-      static Matrix3_fx inertia(const Inertia_fx& Y) { return Y.inertia().matrix(); }
-      static Vector3_fx lever(const Inertia_fx& Y) { return Y.lever(); }
       static std::string toString(const Inertia_fx& m) 
       {	  std::ostringstream s; s << m; return s.str();       }
 
@@ -124,7 +134,7 @@ namespace se3
     }
 
 
-    };
+    }; // struct InertiaPythonVisitor
     
 
 

--- a/src/python/model.hpp
+++ b/src/python/model.hpp
@@ -201,7 +201,7 @@ namespace se3
       /// \param[in] v The value of to look for in the vector.
       ///
       /// \return The index of the matching element of the vector. If
-      ///         no element is found, return -1.
+      ///         no element is found, return the size of the vector.
       ///
       template<typename T>
       static Model::Index index(std::vector<T> const& x,
@@ -215,7 +215,7 @@ namespace se3
             return i;
           }
         }
-        return -1;
+        return x.size();
       }
 
       /* --- Expose --------------------------------------------------------- */

--- a/src/spatial/inertia.hpp
+++ b/src/spatial/inertia.hpp
@@ -245,9 +245,10 @@ namespace se3
     Scalar_t           mass()    const { return m; }
     const Vector3 &    lever()   const { return c; }
     const Symmetric3 & inertia() const { return I; }
-
-
-
+    
+    Scalar_t &   mass()    { return m; }
+    Vector3 &    lever()   { return c; }
+    Symmetric3 & inertia() { return I; }
 
     /// aI = aXb.act(bI)
     InertiaTpl se3Action_impl(const SE3 & M) const
@@ -283,7 +284,7 @@ namespace se3
       << "I = [\n" << (Matrix3)I << "];";
     }
 
-  private:
+  protected:
     Scalar_t m;
     Vector3 c;
     Symmetric3 I;

--- a/src/spatial/symmetric3.hpp
+++ b/src/spatial/symmetric3.hpp
@@ -60,6 +60,16 @@ namespace se3
     /* Requiered by Inertia::operator== */
     bool operator== (const Symmetric3Tpl & S2 ) { return data_ == S2.data_; }
     
+    void setIdentity()
+    {
+      data_[0] = data_[2] = data_[5] = 1.;
+      data_[1] = data_[3] = data_[4] = 0.;
+    }
+    
+    void setZero() { data_.fill(0); }
+    
+    void fill(Scalar value) { data_.fill(value); }
+    
     struct SkewSquare
     {
       const Vector3 & v;

--- a/unittest/com.cpp
+++ b/unittest/com.cpp
@@ -22,6 +22,7 @@
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/algorithm/jacobian.hpp"
 #include "pinocchio/algorithm/crba.hpp"
+#include "pinocchio/algorithm/non-linear-effects.hpp"
 #include "pinocchio/algorithm/center-of-mass.hpp"
 #include "pinocchio/tools/timer.hpp"
 #include "pinocchio/multibody/parser/sample-models.hpp"
@@ -50,6 +51,7 @@ BOOST_AUTO_TEST_CASE ( test_com )
   VectorXd v = VectorXd::Ones(model.nv);
   VectorXd a = VectorXd::Ones(model.nv);
   data.M.fill(0);  crba(model,data,q);
+  
 
 	/* Test COM against CRBA*/
   Vector3d com = centerOfMass(model,data,q);
@@ -63,6 +65,14 @@ BOOST_AUTO_TEST_CASE ( test_com )
 	/* Test COM against Jcom (both use different way of compute the COM. */
   centerOfMassAcceleration(model,data,q,v,a);
   is_matrix_absolutely_closed(com, data.com[0], 1e-12);
+  
+  /* Test vCoM againt nle algorithm without gravity field */
+  a.setZero();
+  model.gravity.setZero();
+  centerOfMassAcceleration(model,data,q,v,a);
+  nonLinearEffects(model, data, q, v);
+  
+  is_matrix_absolutely_closed(data.nle.head <3> ()/data.mass[0], data.acom[0], 1e-12);
 
 	/* Test Jcom against CRBA  */
   Eigen::MatrixXd Jcom = jacobianCenterOfMass(model,data,q);


### PR DESCRIPTION
This PR provides different improvements:
1. Initialize with NaN all the kinematics and dynamics quantities in Debug mode (useful for python users) (solves #62) 
2. Expose some methods of spatial quantities for easier modifications
3. Correct a bug for the returning index