### PR TITLE
Throw exception when parsing meshes instead of runtime error

### DIFF
--- a/src/multibody/parser/from-collada-to-fcl.hpp
+++ b/src/multibody/parser/from-collada-to-fcl.hpp
@@ -135,7 +135,7 @@ inline void buildMesh (const ::urdf::Vector3 & scale,
  * @param[in]  name   File (ressource) transformed into an assimp scene in loa
  * @param[in]  scale  Scale to apply when reading the ressource
  * @param[in]  scene  Pointer to the assimp scene
- * @param[in]  mesh   The mesh that must be built
+ * @param[out] mesh  The mesh that must be built
  */
 inline void meshFromAssimpScene (const std::string & name,
                                  const ::urdf::Vector3 & scale,
@@ -174,7 +174,7 @@ inline void meshFromAssimpScene (const std::string & name,
  *
  * @param[in]  resource_path  Path to the ressource mesh file to be read
  * @param[in]  scale          Scale to apply when reading the ressource
- * @param[in]  polyhedron     The resulted polyhedron
+ * @param[out] polyhedron     The resulted polyhedron
  */
 inline void loadPolyhedronFromResource (const std::string & resource_path,
                                         const ::urdf::Vector3 & scale,

--- a/src/multibody/parser/from-collada-to-fcl.hpp
+++ b/src/multibody/parser/from-collada-to-fcl.hpp
@@ -32,14 +32,13 @@
 #include <assimp/Importer.hpp>
 #include <assimp/postprocess.h>
 
-
 #include <hpp/fcl/BV/OBBRSS.h>
 #include <hpp/fcl/BVH/BVH_model.h>
 
 #include <exception>
 
 typedef fcl::BVHModel< fcl::OBBRSS > PolyhedronType;
-typedef boost::shared_ptr <PolyhedronType> PolyhedronPtrType;
+typedef boost::shared_ptr <PolyhedronType> Polyhedron_ptr;
 
 struct TriangleAndVertices
 {
@@ -67,7 +66,7 @@ inline void buildMesh (const ::urdf::Vector3 & scale,
                        const aiScene* scene,
                        const aiNode* node,
                        std::vector<unsigned> & subMeshIndexes,
-                       const PolyhedronPtrType & mesh,
+                       const Polyhedron_ptr & mesh,
                        TriangleAndVertices & tv)
 {
   if (!node) return;
@@ -89,8 +88,8 @@ inline void buildMesh (const ::urdf::Vector3 & scale,
   {
     aiMesh* input_mesh = scene->mMeshes[node->mMeshes[i]];
 
-    unsigned oldNbPoints = mesh->num_vertices;
-    unsigned oldNbTriangles = mesh->num_tris;
+    unsigned oldNbPoints = (unsigned) mesh->num_vertices;
+    unsigned oldNbTriangles = (unsigned) mesh->num_tris;
 
     // Add the vertices
     for (uint32_t j = 0; j < input_mesh->mNumVertices; j++)
@@ -204,7 +203,8 @@ inline void loadPolyhedronFromResource (const std::string & resource_path,
  *
  * @return     The absolute path to the mesh file
  */
-inline std::string fromURDFMeshPathToAbsolutePath(const std::string & urdf_mesh_path, const std::string & meshRootDir)
+inline std::string fromURDFMeshPathToAbsolutePath(const std::string & urdf_mesh_path,
+                                                  const std::string & meshRootDir)
 { 
 
   std::string absolutePath = std::string(meshRootDir +  

--- a/src/multibody/parser/from-collada-to-fcl.hpp
+++ b/src/multibody/parser/from-collada-to-fcl.hpp
@@ -36,6 +36,8 @@
 #include <hpp/fcl/BV/OBBRSS.h>
 #include <hpp/fcl/BVH/BVH_model.h>
 
+#include <exception>
+
 typedef fcl::BVHModel< fcl::OBBRSS > PolyhedronType;
 typedef boost::shared_ptr <PolyhedronType> PolyhedronPtrType;
 
@@ -138,13 +140,13 @@ inline void buildMesh (const ::urdf::Vector3 & scale,
 inline void meshFromAssimpScene (const std::string & name,
                                  const ::urdf::Vector3 & scale,
                                  const aiScene* scene,
-                                 const PolyhedronPtrType & mesh)
+                                 const Polyhedron_ptr & mesh) throw (std::invalid_argument)
   {
     TriangleAndVertices tv;
 
     if (!scene->HasMeshes())
     {
-      throw std::runtime_error (std::string ("No meshes found in file ")+
+      throw std::invalid_argument (std::string ("No meshes found in file ")+
         name);
     }
 
@@ -176,7 +178,7 @@ inline void meshFromAssimpScene (const std::string & name,
  */
 inline void loadPolyhedronFromResource (const std::string & resource_path,
                                         const ::urdf::Vector3 & scale,
-                                        const PolyhedronPtrType & polyhedron)
+                                        const Polyhedron_ptr & polyhedron) throw (std::invalid_argument)
 {
   Assimp::Importer importer;
   const aiScene* scene = importer.ReadFile(resource_path.c_str(), aiProcess_SortByPType| aiProcess_GenNormals|
@@ -184,8 +186,10 @@ inline void loadPolyhedronFromResource (const std::string & resource_path,
                                                           aiProcess_FlipUVs);
   if (!scene)
   {
-    throw std::runtime_error (std::string ("Could not load resource ") + resource_path + std::string ("\n") +
-                              importer.GetErrorString ());
+    const std::string exception_message (std::string ("Could not load resource ") + resource_path + std::string("\n") +
+                                         importer.GetErrorString () + std::string("\n") +
+                                         "Hint: the mesh directory may be wrong.");
+    throw std::invalid_argument(exception_message);
   }
 
   meshFromAssimpScene (resource_path, scale, scene, polyhedron);

--- a/src/multibody/parser/urdf-with-geometry.hxx
+++ b/src/multibody/parser/urdf-with-geometry.hxx
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2015 CNRS
+// Copyright (c) 2015-2016 CNRS
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -32,13 +32,11 @@
 
 #include <exception>
 
-
 namespace se3
 {
   namespace urdf
   {
-
-
+    
     inline fcl::CollisionObject retrieveCollisionGeometry (const ::urdf::LinkConstPtr & link, const std::string & meshRootDir)
     {
       boost::shared_ptr < ::urdf::Collision> collision = link->collision;
@@ -55,7 +53,7 @@ namespace se3
         ::urdf::Vector3 scale = collisionGeometry->scale;
 
         // Create FCL mesh by parsing Collada file.
-        PolyhedronPtrType  polyhedron (new PolyhedronType);
+        Polyhedron_ptr polyhedron (new PolyhedronType);
 
         loadPolyhedronFromResource (full_path, scale, polyhedron);
         geometry = polyhedron;


### PR DESCRIPTION
Runtime error killed python when meshes were not found.