### PR TITLE
Set default SINCOS for architecture with no sincos function

### DIFF
--- a/src/math/sincos.hpp
+++ b/src/math/sincos.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2015 CNRS
+// Copyright (c) 2015-2016 CNRS
 // Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
@@ -22,11 +22,11 @@
 #include <cmath>
 
 #ifdef __linux__
-#define SINCOS sincos
+  #define SINCOS sincos
 #elif __APPLE__
-#define SINCOS __sincos
-#elif __QNXNTO__
-#define SINCOS(a,sa,ca) (*sa) = std::sin(a); (*ca) = std::cos(a)
+  #define SINCOS __sincos
+#else // if sincos specialization does not exist
+  #define SINCOS(a,sa,ca) (*sa) = std::sin(a); (*ca) = std::cos(a)
 #endif
 
 #endif //#ifndef __math_sincos_hpp__


### PR DESCRIPTION
This feature is needed for OS having no sincos function.