### PR TITLE
Rework center of mass algo + Python API

### DIFF
--- a/benchmark/timings.cpp
+++ b/benchmark/timings.cpp
@@ -144,7 +144,7 @@ int main(int argc, const char ** argv)
   timer.tic();
   SMOOTH(NBT)
   {
-    centerOfMassAcceleration(model,data,qs[_smooth], qdots[_smooth], qddots[_smooth], false);
+    centerOfMass(model,data,qs[_smooth], qdots[_smooth], qddots[_smooth], false);
   }
   std::cout << "COM+vCOM+aCOM = \t"; timer.toc(std::cout,NBT);
 

--- a/src/algorithm/center-of-mass.hpp
+++ b/src/algorithm/center-of-mass.hpp
@@ -75,7 +75,7 @@ namespace se3
   ///
   /// \return The jacobian of center of mass position of the rigid body system expressed in the world frame (matrix 3 x model.nv).
   ///
-  inline const Eigen::Matrix<double,3,Eigen::Dynamic> &
+  inline const Data::Matrix3x &
   jacobianCenterOfMass(const Model & model, Data & data,
                        const Eigen::VectorXd & q,
                        const bool computeSubtreeComs = true);
@@ -92,7 +92,7 @@ namespace se3
   ///
   /// \return The center of mass position of the rigid body system expressed in the world frame (vector 3).
   ///
-  inline const Eigen::Vector3d &
+  inline const SE3::Vector3 &
   getComFromCrba(const Model & model, Data & data);
   
   ///
@@ -104,7 +104,7 @@ namespace se3
   ///
   /// \return The jacobian of the CoM expressed in the world frame (matrix 3 x model.nv).
   ///
-  inline const Eigen::Matrix<double,3,Eigen::Dynamic> &
+  inline const Data::Matrix3x &
   getJacobianComFromCrba(const Model & model, Data & data);
   
 } // namespace se3 

--- a/src/algorithm/center-of-mass.hpp
+++ b/src/algorithm/center-of-mass.hpp
@@ -35,11 +35,32 @@ namespace se3
   /// \param[in] computeSubtreeComs If true, the algorithm computes also the center of mass of the subtrees.
   /// \param[in] updateKinematics If true, the algorithm updates first the geometry of the tree. Otherwise, it uses the current kinematics stored in data.
   ///
-  /// \return The center of mass position of the rigid body system expressed in the world frame (vector 3).
+  /// \return The center of mass position of the full rigid body system expressed in the world frame.
   ///
-  inline const Eigen::Vector3d &
-  centerOfMass(const Model & model, Data& data,
+  inline const SE3::Vector3 &
+  centerOfMass(const Model & model, Data & data,
                const Eigen::VectorXd & q,
+               const bool computeSubtreeComs = true,
+               const bool updateKinematics = true);
+  
+  ///
+  /// \brief Computes the center of mass position, velocity and acceleration of a given model according to a particular joint configuration, velocity and acceleration.
+  ///        The result is accessible throw data.com[0], data.vcom[0], data.acom[0] for the full body com position, velocity and acceleation.
+  ///        And data.com[i], data.vcom[i] and data.acom[i] for the subtree supported by joint i (expressed in the joint i frame).
+  ///
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  /// \param[in] q The joint configuration vector (dim model.nq).
+  /// \param[in] v The joint velocity vector (dim model.nv).
+  /// \param[in] computeSubtreeComs If true, the algorithm computes also the center of mass of the subtrees.
+  /// \param[in] updateKinematics If true, the algorithm updates first the second order kinematics of the tree. Otherwise, it uses the current kinematics stored in data.
+  ///
+  /// \return The center of mass position of the full rigid body system expressed in the world frame.
+  ///
+  inline const SE3::Vector3 &
+  centerOfMass(const Model & model, Data & data,
+               const Eigen::VectorXd & q,
+               const Eigen::VectorXd & v,
                const bool computeSubtreeComs = true,
                const bool updateKinematics = true);
   
@@ -56,12 +77,15 @@ namespace se3
   /// \param[in] computeSubtreeComs If true, the algorithm computes also the center of mass of the subtrees.
   /// \param[in] updateKinematics If true, the algorithm updates first the second order kinematics of the tree. Otherwise, it uses the current kinematics stored in data.
   ///
-  inline void centerOfMassAcceleration(const Model & model, Data & data,
-                                       const Eigen::VectorXd & q,
-                                       const Eigen::VectorXd & v,
-                                       const Eigen::VectorXd & a,
-                                       const bool computeSubtreeComs = true,
-                                       const bool updateKinematics = true);
+  /// \return The center of mass position of the full rigid body system expressed in the world frame.
+  ///
+  inline const SE3::Vector3 &
+  centerOfMass(const Model & model, Data & data,
+               const Eigen::VectorXd & q,
+               const Eigen::VectorXd & v,
+               const Eigen::VectorXd & a,
+               const bool computeSubtreeComs = true,
+               const bool updateKinematics = true);
   
   ///
   /// \brief Computes both the jacobian and the the center of mass position of a given model according to a particular joint configuration.

--- a/src/algorithm/center-of-mass.hxx
+++ b/src/algorithm/center-of-mass.hxx
@@ -128,7 +128,8 @@ namespace se3
     data.acom[0] /= data.mass[0];
   }
 
-  inline const Eigen::Vector3d & getComFromCrba(const Model &, Data & data)
+  inline const SE3::Vector3 &
+  getComFromCrba(const Model &, Data & data)
   {
     return data.com[0] = data.liMi[1].act(data.Ycrb[1].lever());
   }
@@ -216,7 +217,7 @@ namespace se3
 
   };
 
-  inline const Eigen::Matrix<double,3,Eigen::Dynamic> &
+  inline const Data::Matrix3x &
   jacobianCenterOfMass(const Model & model, Data & data,
                        const Eigen::VectorXd & q,
                        const bool computeSubtreeComs)
@@ -241,7 +242,7 @@ namespace se3
     return data.Jcom;
   }
 
-  inline const Eigen::Matrix<double,3,Eigen::Dynamic> &
+  inline const Data::Matrix3x &
   getJacobianComFromCrba(const Model & model, Data & data)
   {
     const SE3 & oM1 = data.liMi[1];

--- a/src/python/algorithms.hpp
+++ b/src/python/algorithms.hpp
@@ -75,21 +75,46 @@ namespace se3
   return data->M;
       }
 
-      static Eigen::VectorXd com_proxy( const ModelHandler& model, 
-          DataHandler & data,
-          const VectorXd_fx & q )
-      { return centerOfMass(*model,*data,q); }
+      static SE3::Vector3
+      com_0_proxy(const ModelHandler& model,
+                DataHandler & data,
+                const VectorXd_fx & q,
+                const bool updateKinematics = true)
+      {
+        return centerOfMass(*model,*data,q,
+                            true,
+                            updateKinematics);
+      }
       
-      static void com_acceleration_proxy(const ModelHandler& model,
-                                         DataHandler & data,
-                                         const VectorXd_fx & q,
-                                         const VectorXd_fx & v,
-                                         const VectorXd_fx & a)
-      { return centerOfMassAcceleration(*model,*data,q,v,a); }
+      static SE3::Vector3
+      com_1_proxy(const ModelHandler& model,
+                  DataHandler & data,
+                  const VectorXd_fx & q,
+                  const VectorXd_fx & v,
+                  const bool updateKinematics = true)
+      {
+        return centerOfMass(*model,*data,q,v,
+                            true,
+                            updateKinematics);
+      }
+      
+      static SE3::Vector3
+      com_2_proxy(const ModelHandler & model,
+                             DataHandler & data,
+                             const VectorXd_fx & q,
+                             const VectorXd_fx & v,
+                             const VectorXd_fx & a,
+                             const bool updateKinematics = true)
+      {
+        return centerOfMass(*model,*data,q,v,a,
+                            true,
+                            updateKinematics);
+      }
 
-      static Eigen::MatrixXd Jcom_proxy( const ModelHandler& model, 
-           DataHandler & data,
-           const VectorXd_fx & q )
+      static Data::Matrix3x
+      Jcom_proxy(const ModelHandler& model,
+                 DataHandler & data,
+                 const VectorXd_fx & q)
       { return jacobianCenterOfMass(*model,*data,q); }
 
       static Data::Matrix6x jacobian_proxy( const ModelHandler& model, 
@@ -250,28 +275,58 @@ namespace se3
       /* --- Expose --------------------------------------------------------- */
       static void expose()
       {
-  bp::def("rnea",rnea_proxy,
-    bp::args("Model","Data",
-       "Configuration q (size Model::nq)",
-       "Velocity qdot (size Model::nv)",
-       "Acceleration qddot (size Model::nv)"),
-    "Compute the RNEA, put the result in Data and return it.");
+        bp::def("rnea",rnea_proxy,
+                bp::args("Model","Data",
+                         "Configuration q (size Model::nq)",
+                         "Velocity v (size Model::nv)",
+                         "Acceleration a (size Model::nv)"),
+                "Compute the RNEA, put the result in Data and return it.");
+        
+        bp::def("nle",nle_proxy,
+                bp::args("Model","Data",
+                         "Configuration q (size Model::nq)",
+                         "Velocity v (size Model::nv)"),
+                "Compute the Non Linear Effects (coriolis, centrifugal and gravitational effects), put the result in Data and return it.");
+        
+        bp::def("crba",crba_proxy,
+                bp::args("Model","Data",
+                         "Configuration q (size Model::nq)"),
+                "Compute CRBA, put the result in Data and return it.");
+        
+        bp::def("centerOfMass",com_0_proxy,
+                bp::args("Model","Data",
+                         "Configuration q (size Model::nq)",
+                         "Update kinematics"),
+                "Compute the center of mass, putting the result in Data and return it.");
+        
+        bp::def("centerOfMass",com_1_proxy,
+                bp::args("Model","Data",
+                         "Configuration q (size Model::nq)",
+                         "Velocity v (size Model::nv)",
+                         "Update kinematics"),
+                "Compute the center of mass position and velocuty by storing the result in Data"
+                "and return the center of mass position of the full model expressed in the world frame.");
+        
+        bp::def("centerOfMass",com_2_proxy,
+                bp::args("Model","Data",
+                         "Configuration q (size Model::nq)",
+                         "Velocity v (size Model::nv)",
+                         "Acceleration a (size Model::nv)",
+                         "Update kinematics"),
+                "Compute the center of mass position, velocity and acceleration by storing the result in Data"
+                "and return the center of mass position of the full model expressed in the world frame.");
 
-  bp::def("nle",nle_proxy,
-    bp::args("Model","Data",
-        "Configuration q (size Model::nq)",
-        "Velocity qdot (size Model::nv)"),
-        "Compute the Non Linear Effects (coriolis, centrifugal and gravitational effects), put the result in Data and return it.");
-
-  bp::def("crba",crba_proxy,
-    bp::args("Model","Data",
-       "Configuration q (size Model::nq)"),
-    "Compute CRBA, put the result in Data and return it.");
-
-  bp::def("centerOfMass",com_proxy,
-    bp::args("Model","Data",
-       "Configuration q (size Model::nq)"),
-    "Compute the center of mass, putting the result in Data and return it.");
+        bp::def("jacobianCenterOfMass",Jcom_proxy,
+                bp::args("Model","Data",
+                         "Configuration q (size Model::nq)"),
+                "Compute the jacobian of the center of mass, put the result in Data and return it.");
+        
+        
+        bp::def("framesKinematics",frames_fk_0_proxy,
+                bp::args("Model","Data",
+                         "Configuration q (size Model::nq)"),
+                "Compute the placements and spatial velocities of all the operational frames "
+                "and put the results in data.");
         
   bp::def("centerOfMassAcceleration",com_acceleration_proxy,
     bp::args("Model","Data",

--- a/src/python/algorithms.hpp
+++ b/src/python/algorithms.hpp
@@ -159,16 +159,16 @@ namespace se3
       }
       
       static void fk_0_proxy(const ModelHandler & model,
-                           DataHandler & data,
-                           const VectorXd_fx & q)
+                             DataHandler & data,
+                             const VectorXd_fx & q)
       {
         forwardKinematics(*model,*data,q);
       }
 
-      static void fk_1_proxy( const ModelHandler& model,
-                           DataHandler & data,
-                           const VectorXd_fx & q,
-                           const VectorXd_fx & qdot )
+      static void fk_1_proxy(const ModelHandler& model,
+                             DataHandler & data,
+                             const VectorXd_fx & q,
+                             const VectorXd_fx & qdot )
       {
         forwardKinematics(*model,*data,q,qdot);
       }
@@ -183,10 +183,10 @@ namespace se3
       }
 
       static void fk_2_proxy(const ModelHandler& model,
-                           DataHandler & data,
-                           const VectorXd_fx & q,
-                           const VectorXd_fx & v,
-                           const VectorXd_fx & a)
+                             DataHandler & data,
+                             const VectorXd_fx & q,
+                             const VectorXd_fx & v,
+                             const VectorXd_fx & a)
       {
         forwardKinematics(*model,*data,q,v,a);
       }
@@ -328,39 +328,20 @@ namespace se3
                 "Compute the placements and spatial velocities of all the operational frames "
                 "and put the results in data.");
         
-  bp::def("centerOfMassAcceleration",com_acceleration_proxy,
-    bp::args("Model","Data",
-    "Configuration q (size Model::nq)",
-    "Velocity v (size Model::nv)",
-    "Acceleration a (size Model::nv)"),
-    "Compute the center of mass position, velocity and acceleration andputting the result in Data.");
-
-  bp::def("jacobianCenterOfMass",Jcom_proxy,
-    bp::args("Model","Data",
-       "Configuration q (size Model::nq)"),
-    "Compute the jacobian of the center of mass, put the result in Data and return it.");
-
-  bp::def("kinematics",fk_1_proxy,
-    bp::args("Model","Data",
-       "Configuration q (size Model::nq)",
-       "Velocity v (size Model::nv)"),
-    "Compute the placements and spatial velocities of all the frames of the kinematic "
-    "tree and put the results in data.");
-
-
-  bp::def("framesKinematics",frames_fk_0_proxy,
-    bp::args("Model","Data",
-       "Configuration q (size Model::nq)"),
-    "Compute the placements and spatial velocities of all the operational frames "
-    "and put the results in data.");
-
-  bp::def("geometry",fk_0_proxy,
-    bp::args("Model","Data",
-        "Configuration q (size Model::nq)"),
-        "Compute the placements of all the frames of the kinematic "
-        "tree and put the results in data.");
+        bp::def("forwardKinematics",fk_0_proxy,
+                bp::args("Model","Data",
+                         "Configuration q (size Model::nq)"),
+                "Compute the placements of all the frames of the kinematic "
+                "tree and put the results in data.");
         
-        bp::def("dynamics",fk_2_proxy,
+        bp::def("forwardKinematics",fk_1_proxy,
+                bp::args("Model","Data",
+                         "Configuration q (size Model::nq)",
+                         "Velocity v (size Model::nv)"),
+                "Compute the placements and spatial velocities of all the frames of the kinematic "
+                "tree and put the results in data.");
+        
+        bp::def("forwardKinematics",fk_2_proxy,
                 bp::args("Model","Data",
                          "Configuration q (size Model::nq)",
                          "Velocity v (size Model::nv)",

--- a/src/python/data.hpp
+++ b/src/python/data.hpp
@@ -94,7 +94,7 @@ namespace se3
     .ADD_DATA_PROPERTY(std::vector<Vector3>,vcom,"Subtree com velocity.")
     .ADD_DATA_PROPERTY(std::vector<Vector3>,acom,"Subtree com acceleration.")
 	  .ADD_DATA_PROPERTY(std::vector<double>,mass,"Subtree total mass.")
-	  .ADD_DATA_PROPERTY(Matrix3x,Jcom,"Jacobian of center of mass.")
+	  .ADD_DATA_PROPERTY_CONST(Matrix3x,Jcom,"Jacobian of center of mass.")
 
     .ADD_DATA_PROPERTY_CONST(Eigen::VectorXd,effortLimit,"Joint max effort")
     .ADD_DATA_PROPERTY_CONST(Eigen::VectorXd,velocityLimit,"Joint max velocity")
@@ -132,7 +132,7 @@ namespace se3
       IMPL_DATA_PROPERTY(std::vector<Vector3>,vcom,"Subtree com velocity.")
       IMPL_DATA_PROPERTY(std::vector<Vector3>,acom,"Subtree com acceleration.")
       IMPL_DATA_PROPERTY(std::vector<double>,mass,"Subtree total mass.")
-      IMPL_DATA_PROPERTY(Matrix3x,Jcom,"Jacobian of center of mass.")
+      IMPL_DATA_PROPERTY_CONST(Matrix3x,Jcom,"Jacobian of center of mass.")
 
       IMPL_DATA_PROPERTY_CONST(Eigen::VectorXd,effortLimit,"Joint max effort")
       IMPL_DATA_PROPERTY_CONST(Eigen::VectorXd,velocityLimit,"Joint max velocity")

--- a/src/python/geometry-data.hpp
+++ b/src/python/geometry-data.hpp
@@ -231,8 +231,8 @@ namespace se3
         .def(bp::vector_indexing_suite< std::vector<CollisionResult> >());
 
         bp::class_<GeometryDataHandler>("GeometryData",
-                                 "Geometry data linked to a geometry model",
-                                 bp::no_init)
+                                        "Geometry data linked to a geometry model and data struct.",
+                                        bp::no_init)
         .def(GeometryDataPythonVisitor());
      
         bp::to_python_converter< GeometryDataHandler::SmartPtr_t,GeometryDataPythonVisitor >();

--- a/src/python/robot_wrapper.py
+++ b/src/python/robot_wrapper.py
@@ -102,26 +102,31 @@ class RobotWrapper:
     def gravity(self,q):
         return se3.rnea(self.model,self.data,q,self.v0,self.v0)
     
-    def geometry(self,q):
-        se3.geometry(self.model, self.data, q)
-    def kinematics(self,q,v):
-        se3.kinematics(self.model, self.data, q, v)
-    def dynamics(self,q,v,a):
-        se3.dynamics(self.model, self.data, q, v, a)
+    def forwardKinematics(self,*args):
+        q = args[0]
+        if len(args) >= 2:
+            v = args[1]
+            if len(args) == 3:
+                a = args[2]
+                se3.forwardKinematics(self.model, self.data, q, v, a)
+            else:
+                se3.forwardKinematics(self.model, self.data, q, v)
+        else:
+            se3.forwardKinematics(self.model, self.data, q)
 
     def position(self,q,index, update_geometry = True):
         if update_geometry:
-            se3.geometry(self.model,self.data,q)
+            se3.forwardKinematics(self.model,self.data,q)
 
         return self.data.oMi[index]
     def velocity(self,q,v,index, update_kinematics = True):
         if update_kinematics:
-            se3.kinematics(self.model,self.data,q,v)
+            se3.forwardKinematics(self.model,self.data,q,v)
 
         return self.data.v[index]
     def acceleration(self,q,v,a,index, update_acceleration = True):
         if update_acceleration:
-          se3.dynamics(self.model,self.data,q,v,a)
+          se3.forwardKinematics(self.model,self.data,q,v,a)
         return self.data.a[index]
     def jacobian(self,q,index, update_geometry = True):
         return se3.jacobian(self.model,self.data,q,index,True,update_geometry)

--- a/src/python/robot_wrapper.py
+++ b/src/python/robot_wrapper.py
@@ -69,13 +69,28 @@ class RobotWrapper:
         return self.model.nv
 
     def com(self,*args):
-        if len(args) == 3:
-            q = args[0]
-            v = args[1]
-            a = args[2]
-            se3.centerOfMassAcceleration(self.model,self.data,q,v,a)
-            return self.data.com[0], self.data.vcom[0], self.data.acom[0]
-        return se3.centerOfMass(self.model,self.data,args[0])
+        q = args[0]
+        update_kinematics = True
+        if len(args)>=2:
+            if isinstance(args[1], bool):
+                update_kinematics = args[1]
+                return se3.centerOfMass(self.model,self.data,q,update_kinematics)
+            else:
+                v = args[1]
+        
+                if len(args) >= 3:
+                    if isinstance(args[2], bool):
+                        update_kinematics = args[2]
+                        se3.centerOfMass(self.model,self.data,q,v,update_kinematics)
+                        return self.data.com[0], self.data.vcom[0]
+                    else:
+                        a = args[2]
+                        if len(args) == 4:
+                            update_kinematics = args[3]
+                        se3.centerOfMass(self.model,self.data,q,v,a,update_kinematics)
+                        return self.data.com[0], self.data.vcom[0], data.acom[0]
+        else:
+            return se3.centerOfMass(self.model,self.data,q,update_kinematics)
 
     def Jcom(self,q):
         return se3.jacobianCenterOfMass(self.model,self.data,q)

--- a/src/simulation/compute-all-terms.hpp
+++ b/src/simulation/compute-all-terms.hpp
@@ -165,7 +165,7 @@ namespace se3
     }
     
     getJacobianComFromCrba(model, data);
-    centerOfMassAcceleration(model, data, q, v, v, true, false);
+    centerOfMass(model, data, q, v, true, false);
 
   }
 } // namespace se3

--- a/unittest/com.cpp
+++ b/unittest/com.cpp
@@ -64,13 +64,13 @@ BOOST_AUTO_TEST_CASE ( test_com )
   BOOST_CHECK(com.isApprox(data.com[0], 1e-12));
 
 	/* Test COM against Jcom (both use different way of compute the COM. */
-  centerOfMassAcceleration(model,data,q,v,a);
+  centerOfMass(model,data,q,v,a);
   BOOST_CHECK(com.isApprox(data.com[0], 1e-12));
 
   /* Test vCoM againt nle algorithm without gravity field */
   a.setZero();
   model.gravity.setZero();
-  centerOfMassAcceleration(model,data,q,v,a);
+  centerOfMass(model,data,q,v,a);
   nonLinearEffects(model, data, q, v);
   
   se3::SE3::Vector3 acom_from_nle (data.nle.head <3> ()/data.mass[0]);
@@ -80,6 +80,11 @@ BOOST_AUTO_TEST_CASE ( test_com )
   Eigen::MatrixXd Jcom = jacobianCenterOfMass(model,data,q);
   BOOST_CHECK(data.Jcom.isApprox(getJacobianComFromCrba(model,data), 1e-12));
 
+  /* Test CoM vecolity againt jacobianCenterOfMass */
+  BOOST_CHECK((Jcom * v).isApprox(data.vcom[0], 1e-12));
+  
+  
+  centerOfMass(model,data,q,v);
   /* Test CoM vecolity againt jacobianCenterOfMass */
   BOOST_CHECK((Jcom * v).isApprox(data.vcom[0], 1e-12));
 


### PR DESCRIPTION
There is now only one name for center of mass computations which is centerOfMass with different signatures.
The Python is now changed to follow the same standard of a unique method name for forwardKinematics with several signatures.