### PR TITLE
[C++][Python][Major] Replaced the way collisions and visuals are stored

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
 script:
   - export CMAKE_ADDITIONAL_OPTIONS="-DCMAKE_BUILD_TYPE=${BUILDTYPE}"
   - sudo free -m -t
-  - travis_wait 30 ./.travis/run ../travis_custom/custom_build
+  - travis_wait 40 ./.travis/run ../travis_custom/custom_build
 after_failure: ./.travis/run after_failure
 after_success:
   - ./.travis/run after_success

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,6 +180,7 @@ SET(${PROJECT_NAME}_PYTHON_HEADERS
 
 IF(HPP_FCL_FOUND)
   LIST(APPEND ${PROJECT_NAME}_PYTHON_HEADERS
+      python/geometry-object.hpp
       python/geometry-model.hpp
       python/geometry-data.hpp
     )

--- a/src/algorithm/collisions.hpp
+++ b/src/algorithm/collisions.hpp
@@ -29,7 +29,7 @@ namespace se3
 
 
   ///
-  /// \brief Apply a forward kinematics and update the placement of the collision objects.
+  /// \brief Apply a forward kinematics and update the placement of the geometry objects (both collision's and visual's one).
   ///
   /// \param[in] model The model structure of the rigid body system.
   /// \param[in] data The data structure of the rigid body system.
@@ -45,7 +45,7 @@ namespace se3
                                        );
   
   ///
-  /// \brief Update the placement of the collision objects according to the current joint placements contained in data.
+  /// \brief Update the placement of the geometry objects according to the current joint placements contained in data. (both collision's and visual's one)
   ///
   /// \param[in] model The model structure of the rigid body system.
   /// \param[in] data The data structure of the rigid body system.
@@ -102,11 +102,16 @@ namespace se3
                                        GeometryData & data_geom
                                        )
   {
-    for (GeometryData::GeomIndex i=0; i < (GeometryData::GeomIndex) data_geom.model_geom.ngeom; ++i)
+    for (GeometryData::GeomIndex i=0; i < (GeometryData::GeomIndex) data_geom.model_geom.ncollisions; ++i)
     {
-      const Model::JointIndex & parent = model_geom.geom_parents[i];
-      data_geom.oMg[i] =  (data.oMi[parent] * model_geom.geometryPlacement[i]);
-      data_geom.oMg_fcl[i] =  toFclTransform3f(data_geom.oMg[i]);
+      const Model::JointIndex & parent = model_geom.collision_objects[i].parent;
+      data_geom.oMg_collisions[i] =  (data.oMi[parent] * model_geom.collision_objects[i].placement);
+      data_geom.oMg_fcl_collisions[i] =  toFclTransform3f(data_geom.oMg_collisions[i]);
+    }
+    for (GeometryData::GeomIndex i=0; i < (GeometryData::GeomIndex) data_geom.model_geom.nvisuals; ++i)
+    {
+      const Model::JointIndex & parent = model_geom.visual_objects[i].parent;
+      data_geom.oMg_visuals[i] =  (data.oMi[parent] * model_geom.visual_objects[i].placement);
     }
   }
   

--- a/src/multibody/geometry.hpp
+++ b/src/multibody/geometry.hpp
@@ -157,6 +157,13 @@ namespace se3
 
   }; // struct CollisionResult
 
+/// \brief Return true if the intrinsic geometry of the two CollisionObject is the same
+bool operator == (const fcl::CollisionObject & lhs, const fcl::CollisionObject & rhs)
+{
+  return lhs.collisionGeometry() == rhs.collisionGeometry()
+          && lhs.getAABB().min_ == rhs.getAABB().min_
+          && lhs.getAABB().max_ == rhs.getAABB().max_;
+}
 enum GeometryType
 {
   VISUAL,
@@ -216,7 +223,7 @@ struct GeometryObject
   {
     return (lhs.type == rhs.type && lhs.name == rhs.name
                                && lhs.parent == rhs.parent
-                               // && lhs.collision_object == rhs.collision_object
+                               && lhs.collision_object == rhs.collision_object
                                && lhs.placement == rhs.placement
                                && lhs.mesh_path ==  rhs.mesh_path
                                );
@@ -224,12 +231,12 @@ struct GeometryObject
 
   inline std::ostream & operator<< (std::ostream & os, const GeometryObject & geom_object)
   {
-    os  << "Type: \t" << geom_object.type
-        << "Name: \t" << geom_object.name
-        << "Parent ID: \t" << geom_object.parent
-        // << "collision object: \t" << geom_object.collision_object
-        << "Position in parent frame: \t" << geom_object.placement
-        << "Absolute path to mesh file: \t" << geom_object.mesh_path
+    os  << "Type: \t \n" << geom_object.type << "\n"
+        << "Name: \t \n" << geom_object.name << "\n"
+        << "Parent ID: \t \n" << geom_object.parent << "\n"
+        // << "collision object: \t \n" << geom_object.collision_object << "\n"
+        << "Position in parent frame: \t \n" << geom_object.placement << "\n"
+        << "Absolute path to mesh file: \t \n" << geom_object.mesh_path << "\n"
         << std::endl;
     return os;
   }

--- a/src/multibody/parser/urdf-with-geometry.hpp
+++ b/src/multibody/parser/urdf-with-geometry.hpp
@@ -35,15 +35,18 @@ namespace se3
 
 
     /**
-     * @brief      Get a CollisionObject from an urdf link, searching
+     * @brief      Get a fcl::CollisionObject from an urdf geometry, searching
      *             for it in specified package directories
      *
-     * @param[in]  link          The input urdf link
-     * @param[in]  package_dirs  A vector containing the different directories where to search for packages
+     * @param[in]  urdf_geometry  The input urdf geometry
+     * @param[in]  package_dirs   A vector containing the different directories where to search for packages
+     * @param[out] mesh_path      The Absolute path of the mesh currently read
      *
-     * @return     The mesh converted as a fcl::CollisionObject
+     * @return     The geometry converted as a fcl::CollisionObject
      */
-    inline fcl::CollisionObject retrieveCollisionGeometry (const ::urdf::LinkConstPtr & link, const std::vector < std::string > & package_dirs);
+    inline fcl::CollisionObject retrieveCollisionGeometry(const boost::shared_ptr < ::urdf::Geometry > urdf_geometry,
+                                                          const std::vector < std::string > & package_dirs,
+                                                          std::string & mesh_path);
 
     
     /**

--- a/src/python/geometry-data.hpp
+++ b/src/python/geometry-data.hpp
@@ -94,10 +94,14 @@ namespace se3
         
         .add_property("nCollisionPairs", &GeometryDataPythonVisitor::nCollisionPairs)
         
-        .add_property("oMg",
-                      bp::make_function(&GeometryDataPythonVisitor::oMg,
+        .add_property("oMg_collisions",
+                      bp::make_function(&GeometryDataPythonVisitor::oMg_collisions,
                                         bp::return_internal_reference<>()),
                       "Vector of collision objects placement relative to the world.")
+        .add_property("oMg_visuals",
+                      bp::make_function(&GeometryDataPythonVisitor::oMg_visuals,
+                                        bp::return_internal_reference<>()),
+                      "Vector of visual objects placement relative to the world.")
         .add_property("collision_pairs",
                       bp::make_function(&GeometryDataPythonVisitor::collision_pairs,
                                         bp::return_internal_reference<>()),
@@ -165,7 +169,8 @@ namespace se3
 
       static Index nCollisionPairs(const GeometryDataHandler & m ) { return m->nCollisionPairs; }
       
-      static std::vector<SE3> & oMg(GeometryDataHandler & m) { return m->oMg; }
+      static std::vector<SE3> & oMg_collisions(GeometryDataHandler & m) { return m->oMg_collisions; }
+      static std::vector<SE3> & oMg_visuals(GeometryDataHandler & m) { return m->oMg_visuals; }
       static std::vector<CollisionPair_t> & collision_pairs( GeometryDataHandler & m ) { return m->collision_pairs; }
       static std::vector<DistanceResult> & distance_results( GeometryDataHandler & m ) { return m->distance_results; }
       static std::vector<CollisionResult> & collision_results( GeometryDataHandler & m ) { return m->collision_results; }

--- a/src/python/geometry-model.hpp
+++ b/src/python/geometry-model.hpp
@@ -63,19 +63,22 @@ namespace se3
       void visit(PyClass& cl) const 
       {
 	cl
-    .add_property("ngeom", &GeometryModelPythonVisitor::ngeom)
+    .add_property("ncollisions", &GeometryModelPythonVisitor::ncollisions)
+    .add_property("nvisuals", &GeometryModelPythonVisitor::nvisuals)
 
-    .def("getGeomId",&GeometryModelPythonVisitor::getGeomId)
+    .def("getCollisionId",&GeometryModelPythonVisitor::getCollisionId)
+    .def("getVisualId",&GeometryModelPythonVisitor::getVisualId)
+    .def("existCollisionName",&GeometryModelPythonVisitor::existCollisionName)
+    .def("existVisualName",&GeometryModelPythonVisitor::existVisualName)
+    .def("getCollisionName",&GeometryModelPythonVisitor::getCollisionName)
+    .def("getVisualName",&GeometryModelPythonVisitor::getVisualName)
+    .add_property("collision_objects",
+      bp::make_function(&GeometryModelPythonVisitor::collision_objects,
+            bp::return_internal_reference<>())  )
+    .add_property("visual_objects",
+      bp::make_function(&GeometryModelPythonVisitor::visual_objects,
+            bp::return_internal_reference<>())  )
 
-    .add_property("geometryPlacement",
-      bp::make_function(&GeometryModelPythonVisitor::geometryPlacement,
-            bp::return_internal_reference<>())  )
-    .add_property("geom_parents", 
-      bp::make_function(&GeometryModelPythonVisitor::geom_parents,
-            bp::return_internal_reference<>())  )
-    .add_property("geom_names",
-      bp::make_function(&GeometryModelPythonVisitor::geom_names,
-            bp::return_internal_reference<>())  )
 
     .def("__str__",&GeometryModelPythonVisitor::toString)
 
@@ -84,14 +87,26 @@ namespace se3
 	  ;
       }
 
-      static GeometryModel::Index ngeom( GeometryModelHandler & m ) { return m->ngeom; }
+      static GeometryModel::Index ncollisions( GeometryModelHandler & m ) { return m->ncollisions; }
+      static GeometryModel::Index nvisuals( GeometryModelHandler & m ) { return m->nvisuals; }
 
-      static Model::GeomIndex getGeomId( const GeometryModelHandler & gmodelPtr, const std::string & name )
-      { return  gmodelPtr->getGeomId(name); }
+      static std::vector<GeometryObject> & collision_objects( GeometryModelHandler & m ) { return m->collision_objects; }
+      static std::vector<GeometryObject> & visual_objects( GeometryModelHandler & m ) { return m->visual_objects; }
       
-      static std::vector<SE3> & geometryPlacement( GeometryModelHandler & m ) { return m->geometryPlacement; }
-      static std::vector<Model::JointIndex> & geom_parents( GeometryModelHandler & m ) { return m->geom_parents; }
-      static std::vector<std::string> & geom_names ( GeometryModelHandler & m ) { return m->geom_names; }
+      static Model::GeomIndex getCollisionId( const GeometryModelHandler & gmodelPtr, const std::string & name )
+      { return  gmodelPtr->getCollisionId(name); }
+      static Model::GeomIndex getVisualId( const GeometryModelHandler & gmodelPtr, const std::string & name )
+      { return  gmodelPtr->getVisualId(name); }
+      static bool existCollisionName(const GeometryModelHandler & gmodelPtr, const std::string & name)
+      { return gmodelPtr->existCollisionName(name);}
+      static bool existVisualName(const GeometryModelHandler & gmodelPtr, const std::string & name)
+      { return gmodelPtr->existVisualName(name);}
+      static std::string getCollisionName(const GeometryModelHandler & gmodelPtr, const GeomIndex index)
+      { return gmodelPtr->getCollisionName(index);}
+      static std::string getVisualName(const GeometryModelHandler & gmodelPtr, const GeomIndex index)
+      { return gmodelPtr->getVisualName(index);}
+      // static std::vector<Model::JointIndex> & geom_parents( GeometryModelHandler & m ) { return m->geom_parents; }
+      // static std::vector<std::string> & geom_names ( GeometryModelHandler & m ) { return m->geom_names; }
 
       
 

--- a/src/python/geometry-object.hpp
+++ b/src/python/geometry-object.hpp
@@ -52,22 +52,18 @@ namespace se3
       void visit(PyClass& cl) const 
       {
         cl
-          .add_property("name", &GeometryObjectPythonVisitor::getName, &GeometryObjectPythonVisitor::setName)
-          .add_property("parent_id", &GeometryObjectPythonVisitor::getParentId, &GeometryObjectPythonVisitor::setParentId)
-          .add_property("placement", &GeometryObjectPythonVisitor::getPlacementWrtParentJoint, &GeometryObjectPythonVisitor::setMeshPath)
-          .add_property("mesh_path", &GeometryObjectPythonVisitor::getMeshPath, &GeometryObjectPythonVisitor::setMeshPath)
+          .def_readwrite("name", &GeometryObject::name, "Name of the GeometryObject")
+          .def_readwrite("parent", &GeometryObject::parent, "Index of the parent joint")
+          .add_property("placement", &GeometryObjectPythonVisitor::getPlacementWrtParentJoint,
+                                      &GeometryObjectPythonVisitor::setPlacementWrtParentJoint,
+                                      "Position of geometry object in parent joint's frame")
+          .def_readonly("mesh_path", &GeometryObject::mesh_path, "Absolute path to the mesh file")
           ;
       }
 
-
-      static std::string getName( const GeometryObject & self) { return self.name; }
-      static void setName(GeometryObject & self, const std::string & name) { self.name = name; }
-      static JointIndex getParentId( const GeometryObject & self) { return self.parent; }
-      static void setParentId(GeometryObject & self, const JointIndex parent) { self.parent = parent; }
       static SE3_fx getPlacementWrtParentJoint( const GeometryObject & self) { return self.placement; }
       static void setPlacementWrtParentJoint(GeometryObject & self, const SE3_fx & placement) { self.placement = placement; }
-      static std::string getMeshPath( const GeometryObject & self) { return self.mesh_path; }
-      static void setMeshPath(GeometryObject & self, const std::string & mesh_path) { self.mesh_path = mesh_path; }
+
 
       static void expose()
       {
@@ -78,8 +74,6 @@ namespace se3
 	                       .def(GeometryObjectPythonVisitor())
 	                       ;
     
-        // bp::to_python_converter< GeometryObject,GeometryObjectPythonVisitor >();
-
         bp::class_< std::vector<GeometryObject> >("StdVec_GeometryObject")
         .def(bp::vector_indexing_suite< std::vector<GeometryObject> >());
       }

--- a/src/python/geometry-object.hpp
+++ b/src/python/geometry-object.hpp
@@ -1,0 +1,95 @@
+//
+// Copyright (c) 2016 CNRS
+//
+// This file is part of Pinocchio
+// Pinocchio is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// Pinocchio is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// Pinocchio If not, see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef __se3_python_geometry_object_hpp__
+#define __se3_python_geometry_object_hpp__
+
+#include <eigenpy/exception.hpp>
+#include <eigenpy/eigenpy.hpp>
+
+#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+
+#include "pinocchio/multibody/model.hpp"
+#include "pinocchio/multibody/geometry.hpp"
+
+
+namespace se3
+{
+  namespace python
+  {
+    namespace bp = boost::python;
+
+    struct GeometryObjectPythonVisitor
+      : public boost::python::def_visitor< GeometryObjectPythonVisitor >
+    {
+      typedef eigenpy::UnalignedEquivalent<SE3>::type SE3_fx;
+      typedef Model::Index Index;
+      typedef Model::JointIndex JointIndex;
+      typedef Model::FrameIndex FrameIndex;
+
+    public:
+
+      static PyObject* convert(Frame const& f)
+      {
+        return boost::python::incref(boost::python::object(f).ptr());
+      }
+
+      template<class PyClass>
+      void visit(PyClass& cl) const 
+      {
+        cl
+          .add_property("name", &GeometryObjectPythonVisitor::getName, &GeometryObjectPythonVisitor::setName)
+          .add_property("parent_id", &GeometryObjectPythonVisitor::getParentId, &GeometryObjectPythonVisitor::setParentId)
+          .add_property("placement", &GeometryObjectPythonVisitor::getPlacementWrtParentJoint, &GeometryObjectPythonVisitor::setMeshPath)
+          .add_property("mesh_path", &GeometryObjectPythonVisitor::getMeshPath, &GeometryObjectPythonVisitor::setMeshPath)
+          ;
+      }
+
+
+      static std::string getName( const GeometryObject & self) { return self.name; }
+      static void setName(GeometryObject & self, const std::string & name) { self.name = name; }
+      static JointIndex getParentId( const GeometryObject & self) { return self.parent; }
+      static void setParentId(GeometryObject & self, const JointIndex parent) { self.parent = parent; }
+      static SE3_fx getPlacementWrtParentJoint( const GeometryObject & self) { return self.placement; }
+      static void setPlacementWrtParentJoint(GeometryObject & self, const SE3_fx & placement) { self.placement = placement; }
+      static std::string getMeshPath( const GeometryObject & self) { return self.mesh_path; }
+      static void setMeshPath(GeometryObject & self, const std::string & mesh_path) { self.mesh_path = mesh_path; }
+
+      static void expose()
+      {
+        bp::class_<GeometryObject>("GeometryObject",
+                           "A wrapper on a collision geometry including its parent joint, placement in parent frame.\n\n",
+	                         bp::no_init
+                         )
+	                       .def(GeometryObjectPythonVisitor())
+	                       ;
+    
+        // bp::to_python_converter< GeometryObject,GeometryObjectPythonVisitor >();
+
+        bp::class_< std::vector<GeometryObject> >("StdVec_GeometryObject")
+        .def(bp::vector_indexing_suite< std::vector<GeometryObject> >());
+      }
+
+
+    };
+    
+
+  } // namespace python
+} // namespace se3
+
+#endif // ifndef __se3_python_geometry_object_hpp__
+

--- a/src/python/python.cpp
+++ b/src/python/python.cpp
@@ -32,6 +32,7 @@
 #include "pinocchio/python/explog.hpp"
 
 #ifdef WITH_HPP_FCL
+#include "pinocchio/python/geometry-object.hpp"
 #include "pinocchio/python/geometry-model.hpp"
 #include "pinocchio/python/geometry-data.hpp"
 #endif
@@ -69,7 +70,8 @@ namespace se3
       FramePythonVisitor::expose();
       ModelPythonVisitor::expose();
       DataPythonVisitor::expose();
-#ifdef WITH_HPP_FCL      
+#ifdef WITH_HPP_FCL
+      GeometryObjectPythonVisitor::expose();      
       CollisionPairPythonVisitor::expose();
       GeometryModelPythonVisitor::expose();
       GeometryDataPythonVisitor::expose();

--- a/unittest/geom.cpp
+++ b/unittest/geom.cpp
@@ -129,12 +129,12 @@ struct Distance_t
 #endif
 std::ostream& operator<<(std::ostream& os, const std::pair < se3::Model, se3::GeometryModel >& robot)
 {
-  os << "Nb collision objects = " << robot.second.ngeom << std::endl;
+  os << "Nb collision objects = " << robot.second.ncollisions << std::endl;
   
-  for(se3::GeometryModel::Index i=0;i<(se3::GeometryModel::Index)(robot.second.ngeom);++i)
+  for(se3::GeometryModel::Index i=0;i<(se3::GeometryModel::Index)(robot.second.ncollisions);++i)
   {
-    os  << "Object n " << i << " : " << robot.second.geom_names[i] << ": attached to joint = " << robot.second.geom_parents[i]
-        << "=" << robot.first.getJointName(robot.second.geom_parents[i]) << std::endl;
+    os  << "Object n " << i << " : " << robot.second.collision_objects[i].name << ": attached to joint = " << robot.second.collision_objects[i].parent
+        << "=" << robot.first.getJointName(robot.second.collision_objects[i].parent) << std::endl;
   }
   return os;
 } 
@@ -156,11 +156,11 @@ BOOST_AUTO_TEST_CASE ( simple_boxes )
   
   boost::shared_ptr<fcl::Box> Sample(new fcl::Box(1));
   fcl::CollisionObject box1(Sample, fcl::Transform3f());
-  model_geom.addGeomObject(model.getJointId("planar1_joint"),box1, SE3::Identity(),  "ff1_collision_object");
+  model_geom.addCollisionObject(model.getJointId("planar1_joint"),box1, SE3::Identity(),  "ff1_collision_object", "");
   
   boost::shared_ptr<fcl::Box> Sample2(new fcl::Box(1));
   fcl::CollisionObject box2(Sample, fcl::Transform3f());
-  model_geom.addGeomObject(model.getJointId("planar2_joint"),box2, SE3::Identity(),  "ff2_collision_object");
+  model_geom.addCollisionObject(model.getJointId("planar2_joint"),box2, SE3::Identity(),  "ff2_collision_object", "");
 
   se3::Data data(model);
   se3::GeometryData data_geom(data, model_geom);
@@ -448,9 +448,9 @@ JointPositionsMap_t fillPinocchioJointPositions(const se3::Data & data)
 GeometryPositionsMap_t fillPinocchioGeometryPositions(const se3::GeometryData & data_geom)
 {
   GeometryPositionsMap_t result;
-  for (std::size_t i = 0; i < data_geom.model_geom.ngeom ; ++i)
+  for (std::size_t i = 0; i < data_geom.model_geom.ncollisions ; ++i)
   {
-    result[data_geom.model_geom.getGeomName(i)] = data_geom.oMg[i];
+    result[data_geom.model_geom.getCollisionName(i)] = data_geom.oMg_collisions[i];
   }
   return result;
 }


### PR DESCRIPTION
ed in GeometryModel. Now it is two lists of GeometryObject (one for collisions, one for visuals) aggregating information instead of multiple vectors. Now handle multiple collisions/visuals for one link when parsing urdf file and keep track of the mesh absolute path. Changed binding accordingly.