### PR TITLE
Handle the zero velocity case for spherical joint types

### DIFF
--- a/src/multibody/joint/joint-free-flyer.hpp
+++ b/src/multibody/joint/joint-free-flyer.hpp
@@ -345,12 +345,18 @@ namespace se3
       ConstQuaternionMap_t quat1 (q_1.segment<4>(3).data());
       
       const Motion_t::Quaternion_t quat_relatif (quat1*quat0.conjugate());
-      const Scalar_t theta = 2.*acos(quat_relatif.w());
       
-      if (quat0.dot(quat1) >= 0.)
-        result.tail<3>() << theta * quat_relatif.vec().normalized();
+      if (quat_relatif.vec().norm() < 1e-8) // TODO: The value 1e-8 must be changed according to the precision of the current real.
+        result.tail<3> ().setZero();
       else
-        result.tail<3>() << -(2*PI-theta) * quat_relatif.vec().normalized();
+      {
+        const Scalar_t theta = 2.*acos(quat_relatif.w());
+        
+        if (quat0.dot(quat1) >= 0.)
+          result.tail<3>() << theta * quat_relatif.vec().normalized();
+        else
+          result.tail<3>() << -(2*PI-theta) * quat_relatif.vec().normalized();
+      }
 
       return result;
     } 

--- a/src/multibody/joint/joint-spherical.hpp
+++ b/src/multibody/joint/joint-spherical.hpp
@@ -372,14 +372,20 @@ namespace se3
       ConstQuaternionMap_t quat1 (q1.segment<NQ> (idx_q ()).data());
       
       const Motion_t::Quaternion_t quat_relatif (quat1*quat0.conjugate());
-      Scalar_t theta;
-      if (quat0.dot(quat1) >= 0.)
-        theta = 2.*acos(quat_relatif.w());
-      else
-        theta = -2.*(PI - acos(quat_relatif.w()));
       
-      return theta * quat_relatif.vec().normalized();
-    } 
+      if (quat_relatif.vec().norm() < 1e-8) // TODO: The value 1e-8 must be changed according to the precision of the current real.
+        return TangentVector_t::Zero();
+      else
+      {
+        Scalar_t theta;
+        if (quat0.dot(quat1) >= 0.)
+          theta = 2.*acos(quat_relatif.w());
+        else
+          theta = -2.*(PI - acos(quat_relatif.w()));
+        
+        return theta * quat_relatif.vec().normalized();
+      }
+    }
 
     double distance_impl(const Eigen::VectorXd & q0,const Eigen::VectorXd & q1) const
     { 


### PR DESCRIPTION
Fix bug in the differentiate implementation of joint free flyer and spherical when the two configurations are equal.