### PR TITLE
rework model (joints/bodies) + fix RobotWrapper link to viewer

### DIFF
--- a/python/bindings_geometry_object.py
+++ b/python/bindings_geometry_object.py
@@ -26,13 +26,13 @@ class TestGeometryObjectBindings(unittest.TestCase):
 
     def test_name_get_set(self):
         col = self.robot.geometry_model.collision_objects[1]
-        self.assertTrue(col.name == '') # See in parser why name is empty
+        self.assertTrue(col.name == 'LHipPitchLink')
         col.name = 'new_collision_name'
         self.assertTrue(col.name == 'new_collision_name')
 
     def test_parent_get_set(self):
         col = self.robot.geometry_model.collision_objects[1]
-        self.assertTrue(col.parent == 3)
+        self.assertTrue(col.parent == 4)
         col.parent = 5
         self.assertTrue(col.parent == 5)
 

--- a/python/tests.py
+++ b/python/tests.py
@@ -7,7 +7,7 @@ from bindings_SE3 import TestSE3Bindings
 from bindings_force import TestForceBindings
 from bindings_motion import TestMotionBindings
 from bindings_inertia import TestInertiaBindings
-from bindings_frame import TestFrameBindings # No geometry module yet on travis
+from bindings_frame import TestFrameBindings
 from bindings_geometry_object import TestGeometryObjectBindings  # Python Class RobotWrapper needs geometry module to not raise Exception
 from explog import TestExpLog  # noqa
 from model import TestModel  # noqa

--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -62,7 +62,7 @@ namespace se3
     /// \brief Number of joints .
     int njoint;
 
-    /// \brief Number of bodies (= number of joints + 1).
+    /// \brief Number of bodies .
     int nbody;
     
     
@@ -133,11 +133,11 @@ namespace se3
     ~Model() {} // std::cout << "Destroy model" << std::endl; }
     
     ///
-    /// \brief Add a body to the kinematic tree.
+    /// \brief Add a Joint along with body to the kinematic tree.
     ///
     /// \param[in] parent Index of the parent joint.
     /// \param[in] j The joint model.
-    /// \param[in] placement The relative placement of the joint j regarding to the parent joint.
+    /// \param[in] jointPlacement The relative placement of the joint j regarding to the parent joint.
     /// \param[in] Y Spatial inertia of the body.
     /// \param[in] jointName Name of the joint.
     /// \param[in] bodyName Name of the body.
@@ -145,16 +145,16 @@ namespace se3
     /// \return The index of the new added joint.
     ///
     template<typename D>
-    JointIndex addJointAndBody(JointIndex parent, const JointModelBase<D> & j, const SE3 & placement,
+    JointIndex addJointAndBody(JointIndex parent, const JointModelBase<D> & j, const SE3 & jointPlacement,
                                const Inertia & Y, const std::string & jointName = "",
                                const std::string & bodyName = "");
     
     ///
-    /// \brief Add a body to the kinematic tree.
+    /// \brief Add a Joint along with body to the kinematic tree, specifying limits
     ///
     /// \param[in] parent Index of the parent joint.
     /// \param[in] j The joint model.
-    /// \param[in] placement The relative placement of the joint j regarding to the parent joint.
+    /// \param[in] jointPlacement The relative placement of the joint j regarding to the parent joint.
     /// \param[in] Y Spatial inertia of the body.
     /// \param[in] effort Maximal joint torque.
     /// \param[in] velocity Maximal joint velocity.
@@ -166,7 +166,7 @@ namespace se3
     /// \return The index of the new added joint.
     ///
     template<typename D>
-    JointIndex addJointAndBody(JointIndex parent,const JointModelBase<D> & j,const SE3 & placement,
+    JointIndex addJointAndBody(JointIndex parent,const JointModelBase<D> & j,const SE3 & jointPlacement,
                                const Inertia & Y,
                                const Eigen::VectorXd & effort, const Eigen::VectorXd & velocity,
                                const Eigen::VectorXd & lowPos, const Eigen::VectorXd & upPos,
@@ -177,21 +177,21 @@ namespace se3
     ///
     /// \param[in] parent Index of the parent joint.
     /// \param[in] j The joint model.
-    /// \param[in] placement The relative placement of the joint j regarding to the parent joint.
+    /// \param[in] jointPlacement The relative placement of the joint j regarding to the parent joint.
     /// \param[in] jointName Name of the joint.
     ///
     /// \return The index of the new added joint.
     ///
     template<typename D>
-    JointIndex addJoint(JointIndex parent,const JointModelBase<D> & j,const SE3 & placement,
+    JointIndex addJoint(JointIndex parent,const JointModelBase<D> & j,const SE3 & jointPlacement,
                         const std::string & jointName = "");
 
     ///
-    /// \brief Add a Joint with no body (Zero inertia) to the kinematic tree.
+    /// \brief Add a Joint with no body (Zero inertia) to the kinematic tree, specifying limits
     ///
     /// \param[in] parent Index of the parent joint.
     /// \param[in] j The joint model.
-    /// \param[in] placement The relative placement of the joint j regarding to the parent joint.
+    /// \param[in] jointPlacement The relative placement of the joint j regarding to the parent joint.
     /// \param[in] effort Maximal joint torque.
     /// \param[in] velocity Maximal joint velocity.
     /// \param[in] lowPos Lower joint configuration.
@@ -201,7 +201,7 @@ namespace se3
     /// \return The index of the new added joint.
     ///
     template<typename D>
-    JointIndex addJoint(JointIndex parent,const JointModelBase<D> & j,const SE3 & placement,
+    JointIndex addJoint(JointIndex parent,const JointModelBase<D> & j,const SE3 & jointPlacement,
                        const Eigen::VectorXd & effort, const Eigen::VectorXd & velocity,
                        const Eigen::VectorXd & lowPos, const Eigen::VectorXd & upPos,
                        const std::string & jointName = "");
@@ -212,12 +212,12 @@ namespace se3
     /// \brief Append a body to a given Joint of the kinematic tree.
     ///
     /// \param[in] parent Index of the parent joint.
-    /// \param[in] placement The relative placement of the body regarding to the parent joint.
+    /// \param[in] bodyPlacement The relative placement of the body regarding to the parent joint.
     /// \param[in] Y Spatial inertia of the body.
     /// \param[in] bodyName Name of the body.
     ///
     ///
-    void appendBodyToJoint (const JointIndex parent, const SE3 & placement, const Inertia & Y,
+    void appendBodyToJoint (const JointIndex parent, const SE3 & bodyPlacement, const Inertia & Y,
                             const std::string & bodyName = "");
 
     

--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -59,6 +59,9 @@ namespace se3
     /// \brief Dimension of the velocity vector space.
     int nv;
     
+    /// \brief Number of joints .
+    int njoint;
+
     /// \brief Number of bodies (= number of joints + 1).
     int nbody;
     
@@ -73,12 +76,18 @@ namespace se3
     
     /// \brief Placement (SE3) of the input of joint <i> regarding to the parent joint output <li>.
     std::vector<SE3> jointPlacements;
+
+    /// \brief Placement (SE3) of the body <i> regarding to the parent joint output <li>.
+    std::vector<SE3> bodyPlacements;
     
     /// \brief Model of joint <i>.
     JointModelVector joints;
     
     /// \brief Joint parent of joint <i>, denoted <li> (li==parents[i]).
     std::vector<JointIndex> parents;
+
+    /// \brief Joint parent of body <i>
+    std::vector<JointIndex> bodyParents;
     
     /// \brief Name of joint <i>
     std::vector<std::string> names;
@@ -123,6 +132,7 @@ namespace se3
     Model()
       : nq(0)
       , nv(0)
+      , njoint(1)
       , nbody(1)
       , nFixBody(0)
       , nOperationalFrames(0)
@@ -149,15 +159,13 @@ namespace se3
     /// \param[in] Y Spatial inertia of the body.
     /// \param[in] jointName Name of the joint.
     /// \param[in] bodyName Name of the body.
-    /// \param[in] visual Inform if the current body has a visual or not.
     ///
     /// \return The index of the new added joint.
     ///
     template<typename D>
-    JointIndex addBody(JointIndex parent, const JointModelBase<D> & j, const SE3 & placement,
-                       const Inertia & Y,
-                       const std::string & jointName = "", const std::string & bodyName = "",
-                       bool visual = false);
+    JointIndex addJointAndBody(JointIndex parent, const JointModelBase<D> & j, const SE3 & placement,
+                               const Inertia & Y, const std::string & jointName = "",
+                               const std::string & bodyName = "");
     
     ///
     /// \brief Add a body to the kinematic tree.
@@ -172,18 +180,64 @@ namespace se3
     /// \param[in] upPos Upper joint configuration.
     /// \param[in] jointName Name of the joint.
     /// \param[in] bodyName Name of the body.
-    /// \param[in] visual Inform if the current body has a visual or not.
     ///
     /// \return The index of the new added joint.
     ///
     template<typename D>
-    JointIndex addBody(JointIndex parent,const JointModelBase<D> & j,const SE3 & placement,
-                       const Inertia & Y,
+    JointIndex addJointAndBody(JointIndex parent,const JointModelBase<D> & j,const SE3 & placement,
+                               const Inertia & Y,
+                               const Eigen::VectorXd & effort, const Eigen::VectorXd & velocity,
+                               const Eigen::VectorXd & lowPos, const Eigen::VectorXd & upPos,
+                               const std::string & jointName = "", const std::string & bodyName = "");
+    
+    ///
+    /// \brief Add a Joint with no body (Zero inertia) to the kinematic tree.
+    ///
+    /// \param[in] parent Index of the parent joint.
+    /// \param[in] j The joint model.
+    /// \param[in] placement The relative placement of the joint j regarding to the parent joint.
+    /// \param[in] jointName Name of the joint.
+    ///
+    /// \return The index of the new added joint.
+    ///
+    template<typename D>
+    JointIndex addJoint(JointIndex parent,const JointModelBase<D> & j,const SE3 & placement,
+                        const std::string & jointName = "");
+
+    ///
+    /// \brief Add a Joint with no body (Zero inertia) to the kinematic tree.
+    ///
+    /// \param[in] parent Index of the parent joint.
+    /// \param[in] j The joint model.
+    /// \param[in] placement The relative placement of the joint j regarding to the parent joint.
+    /// \param[in] effort Maximal joint torque.
+    /// \param[in] velocity Maximal joint velocity.
+    /// \param[in] lowPos Lower joint configuration.
+    /// \param[in] upPos Upper joint configuration.
+    /// \param[in] jointName Name of the joint.
+    ///
+    /// \return The index of the new added joint.
+    ///
+    template<typename D>
+    JointIndex addJoint(JointIndex parent,const JointModelBase<D> & j,const SE3 & placement,
                        const Eigen::VectorXd & effort, const Eigen::VectorXd & velocity,
                        const Eigen::VectorXd & lowPos, const Eigen::VectorXd & upPos,
-                       const std::string & jointName = "", const std::string & bodyName = "",
-                       bool visual = false);
-    
+                       const std::string & jointName = "");
+
+
+
+    ///
+    /// \brief Append a body to a given Joint of the kinematic tree.
+    ///
+    /// \param[in] parent Index of the parent joint.
+    /// \param[in] placement The relative placement of the body regarding to the parent joint.
+    /// \param[in] Y Spatial inertia of the body.
+    /// \param[in] bodyName Name of the body.
+    ///
+    ///
+    void appendBodyToJoint (const JointIndex parent, const SE3 & placement, const Inertia & Y,
+                            const std::string & bodyName = "");
+
     /// Need modifications
     /// \brief Add a body to the kinematic tree.
     ///
@@ -199,14 +253,6 @@ namespace se3
                             const std::string & jointName = "",
                             bool visual=false);
     
-    ///
-    /// \brief Merge a body to a parent body in the kinematic tree.
-    ///
-    /// \param[in] parent Index of the parent body to merge with.
-    /// \param[in] placement Relative placement between the body and its parent body.
-    /// \param[in] Y Spatial inertia of the body.
-    ///
-    void mergeFixedBody(const JointIndex parent, const SE3 & placement, const Inertia & Y);
     
     ///
     /// \brief Return the index of a body given by its name.

--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -122,6 +122,7 @@ namespace se3
       , jointPlacements(1)
       , joints(1)
       , parents(1)
+      , bodyParents(1)
       , names(1)
       , bodyNames(1)
       , gravity( gravity981,Eigen::Vector3d::Zero() )

--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -65,8 +65,6 @@ namespace se3
     /// \brief Number of bodies (= number of joints + 1).
     int nbody;
     
-    /// \brief Number of fixed-bodies (= number of fixed-joints).
-    int nFixBody;
     
     /// \brief Number of operational frames.
     int nOperationalFrames;
@@ -105,21 +103,6 @@ namespace se3
     /// \brief Upper joint configuration limit
     Eigen::VectorXd upperPositionLimit;
 
-    /// \brief True iff body <i> has a visual mesh.
-    std::vector<bool> hasVisual;
-
-    /// \brief Fixed-body relative placement (wrt last moving parent)
-    std::vector<SE3> fix_lmpMi;
-    
-    /// \brief Fixed-body index of the last moving parent
-    std::vector<Model::JointIndex> fix_lastMovingParent;
-    
-    /// \brief True iff fixed-body <i> has a visual mesh.
-    std::vector<bool> fix_hasVisual;
-    
-    /// \brief Name of fixed-joint <i>.
-    std::vector<std::string> fix_bodyNames;
-
     /// \brief Vector of operational frames registered on the model.
     std::vector<Frame> operational_frames;
 
@@ -134,7 +117,6 @@ namespace se3
       , nv(0)
       , njoint(1)
       , nbody(1)
-      , nFixBody(0)
       , nOperationalFrames(0)
       , inertias(1)
       , jointPlacements(1)
@@ -142,7 +124,6 @@ namespace se3
       , parents(1)
       , names(1)
       , bodyNames(1)
-      , hasVisual(1)
       , gravity( gravity981,Eigen::Vector3d::Zero() )
     {
       names[0]     = "universe";     // Should be "universe joint (trivial)"
@@ -238,21 +219,6 @@ namespace se3
     void appendBodyToJoint (const JointIndex parent, const SE3 & placement, const Inertia & Y,
                             const std::string & bodyName = "");
 
-    /// Need modifications
-    /// \brief Add a body to the kinematic tree.
-    ///
-    /// \param[in] fix_lastMovingParent Index of the closest movable parent joint.
-    /// \param[in] placementFromLastMoving Placement regarding to the closest movable parent joint.
-    /// \param[in] jointName Name of the joint.
-    /// \param[in] visual Inform if the current body has a visual or not.
-    ///
-    /// \return The index of the new added joint.
-    ///
-    JointIndex addFixedBody(JointIndex fix_lastMovingParent,
-                            const SE3 & placementFromLastMoving,
-                            const std::string & jointName = "",
-                            bool visual=false);
-    
     
     ///
     /// \brief Return the index of a body given by its name.

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -48,24 +48,24 @@ namespace se3
 
 
   template<typename D>
-  Model::JointIndex Model::addJointAndBody(JointIndex parent, const JointModelBase<D> & j, const SE3 & placement,
+  Model::JointIndex Model::addJointAndBody(JointIndex parent, const JointModelBase<D> & j, const SE3 & jointPlacement,
                                            const Inertia & Y, const std::string & jointName,
                                            const std::string & bodyName)
   {
-    JointIndex idx = addJoint(parent,j,placement,jointName);
+    JointIndex idx = addJoint(parent,j,jointPlacement,jointName);
     appendBodyToJoint(idx, SE3::Identity(), Y, bodyName);
     return idx;
   }
 
   template<typename D>
-  Model::JointIndex Model::addJointAndBody(JointIndex parent, const JointModelBase<D> & j, const SE3 & placement,
+  Model::JointIndex Model::addJointAndBody(JointIndex parent, const JointModelBase<D> & j, const SE3 & jointPlacement,
                                            const Inertia & Y,
                                            const Eigen::VectorXd & effort, const Eigen::VectorXd & velocity,
                                            const Eigen::VectorXd & lowPos, const Eigen::VectorXd & upPos,
                                            const std::string & jointName,
                                            const std::string & bodyName)
   {
-    JointIndex idx = addJoint(parent,j,placement,
+    JointIndex idx = addJoint(parent,j,jointPlacement,
                               effort, velocity, lowPos, upPos,
                               jointName);
     appendBodyToJoint(idx, SE3::Identity(), Y, bodyName);
@@ -74,7 +74,7 @@ namespace se3
 
 
   template<typename D>
-  Model::JointIndex Model::addJoint(JointIndex parent, const JointModelBase<D> & j, const SE3 & placement,
+  Model::JointIndex Model::addJoint(JointIndex parent, const JointModelBase<D> & j, const SE3 & jointPlacement,
                                     const std::string & jointName)
   {
     assert( (njoint==(int)joints.size())&&(njoint==(int)inertias.size())
@@ -88,7 +88,7 @@ namespace se3
 
     inertias       .push_back(Inertia::Zero());
     parents        .push_back(parent);
-    jointPlacements.push_back(placement);
+    jointPlacements.push_back(jointPlacement);
     names          .push_back( (jointName!="")?jointName:random(8) );
     nq += j.nq();
     nv += j.nv();
@@ -101,7 +101,7 @@ namespace se3
   }
 
   template<typename D>
-  Model::JointIndex Model::addJoint(JointIndex parent,const JointModelBase<D> & j,const SE3 & placement,
+  Model::JointIndex Model::addJoint(JointIndex parent,const JointModelBase<D> & j,const SE3 & jointPlacement,
                      const Eigen::VectorXd & effort, const Eigen::VectorXd & velocity,
                      const Eigen::VectorXd & lowPos, const Eigen::VectorXd & upPos,
                      const std::string & jointName)
@@ -110,6 +110,9 @@ namespace se3
       &&(njoint==(int)parents.size())&&(njoint==(int)jointPlacements.size()) );
     assert( (j.nq()>=0)&&(j.nv()>=0) );
 
+    assert( effort.size() == j.nv() && velocity.size() == j.nv()
+           && lowPos.size() == j.nq() && upPos.size() == j.nq() );
+
     Model::JointIndex idx = (Model::JointIndex) (njoint ++);
 
     joints         .push_back(j.derived()); 
@@ -117,7 +120,7 @@ namespace se3
 
     inertias       .push_back(Inertia::Zero());
     parents        .push_back(parent);
-    jointPlacements.push_back(placement);
+    jointPlacements.push_back(jointPlacement);
     names          .push_back( (jointName!="")?jointName:random(8) );
     nq += j.nq();
     nv += j.nv();
@@ -130,14 +133,14 @@ namespace se3
   }
 
 
-  inline void Model::appendBodyToJoint(const JointIndex parent, const SE3 & placement, const Inertia & Y,
+  inline void Model::appendBodyToJoint(const JointIndex parent, const SE3 & bodyPlacement, const Inertia & Y,
                                        const std::string & bodyName)
   {
-    const Inertia & iYf = Y.se3Action(placement);
+    const Inertia & iYf = Y.se3Action(bodyPlacement);
     inertias[parent] += iYf;
 
     bodyParents.push_back(parent);
-    bodyPlacements.push_back(SE3::Identity());
+    bodyPlacements.push_back(bodyPlacement);
     bodyNames.push_back( (bodyName!="")?bodyName:random(8));
 
     nbody ++;

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -137,7 +137,7 @@ namespace se3
     inertias[parent] += iYf;
 
     bodyParents.push_back(parent);
-    bodyPlacements.push_back(placement);
+    bodyPlacements.push_back(SE3::Identity());
     bodyNames.push_back( (bodyName!="")?bodyName:random(8));
 
     nbody ++;

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -39,8 +39,7 @@ namespace se3
     os << "Nb bodies = " << model.nbody << " (nq="<< model.nq<<",nv="<<model.nv<<")" << std::endl;
     for(Model::Index i=0;i<(Model::Index)(model.nbody);++i)
       {
-	os << "  Joint "<<model.names[i] << ": parent=" << model.parents[i] 
-	   << ( model.hasVisual[i] ? " (has visual) " : "(doesnt have visual)" ) << std::endl;
+	os << "  Joint "<<model.names[i] << ": parent=" << model.parents[i]  << std::endl;
       }
 
     return os;
@@ -145,20 +144,7 @@ namespace se3
   }
 
 
-  inline Model::JointIndex Model::addFixedBody (JointIndex lastMovingParent,
-                                           const SE3 & placementFromLastMoving,
-                                           const std::string & bodyName,
-                                           bool visual)
-  {
-
-    Model::JointIndex idx = (Model::JointIndex) (nFixBody++);
-    fix_lastMovingParent.push_back(lastMovingParent);
-    fix_lmpMi      .push_back(placementFromLastMoving);
-    fix_hasVisual  .push_back(visual);
-    fix_bodyNames  .push_back( (bodyName!="")?bodyName:random(8));
-    return idx;
-  }
-
+ 
 
 
   inline Model::JointIndex Model::getBodyId (const std::string & name) const

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -45,29 +45,52 @@ namespace se3
 
     return os;
   }
-
   
 
+
   template<typename D>
-  Model::JointIndex Model::addBody (JointIndex parent, const JointModelBase<D> & j, const SE3 & placement,
-                               const Inertia & Y, const std::string & jointName,
-                               const std::string & bodyName, bool visual)
+  Model::JointIndex Model::addJointAndBody(JointIndex parent, const JointModelBase<D> & j, const SE3 & placement,
+                                           const Inertia & Y, const std::string & jointName,
+                                           const std::string & bodyName)
   {
-    assert( (nbody==(int)joints.size())&&(nbody==(int)inertias.size())
-      &&(nbody==(int)parents.size())&&(nbody==(int)jointPlacements.size()) );
+    JointIndex idx = addJoint(parent,j,placement,jointName);
+    appendBodyToJoint(idx, SE3::Identity(), Y, bodyName);
+    return idx;
+  }
+
+  template<typename D>
+  Model::JointIndex Model::addJointAndBody(JointIndex parent, const JointModelBase<D> & j, const SE3 & placement,
+                                           const Inertia & Y,
+                                           const Eigen::VectorXd & effort, const Eigen::VectorXd & velocity,
+                                           const Eigen::VectorXd & lowPos, const Eigen::VectorXd & upPos,
+                                           const std::string & jointName,
+                                           const std::string & bodyName)
+  {
+    JointIndex idx = addJoint(parent,j,placement,
+                              effort, velocity, lowPos, upPos,
+                              jointName);
+    appendBodyToJoint(idx, SE3::Identity(), Y, bodyName);
+    return idx;
+  }
+
+
+  template<typename D>
+  Model::JointIndex Model::addJoint(JointIndex parent, const JointModelBase<D> & j, const SE3 & placement,
+                                    const std::string & jointName)
+  {
+    assert( (njoint==(int)joints.size())&&(njoint==(int)inertias.size())
+      &&(njoint==(int)parents.size())&&(njoint==(int)jointPlacements.size()) );
     assert( (j.nq()>=0)&&(j.nv()>=0) );
 
-    Model::JointIndex idx = (Model::JointIndex) (nbody ++);
+    Model::JointIndex idx = (Model::JointIndex) (njoint ++);
 
     joints         .push_back(j.derived()); 
     boost::get<D>(joints.back()).setIndexes(idx,nq,nv);
 
-    inertias       .push_back(Y);
+    inertias       .push_back(Inertia::Zero());
     parents        .push_back(parent);
     jointPlacements.push_back(placement);
     names          .push_back( (jointName!="")?jointName:random(8) );
-    hasVisual      .push_back(visual);
-    bodyNames      .push_back( (bodyName!="")?bodyName:random(8));
     nq += j.nq();
     nv += j.nv();
 
@@ -79,33 +102,24 @@ namespace se3
   }
 
   template<typename D>
-  Model::JointIndex Model::addBody (JointIndex parent, const JointModelBase<D> & j, const SE3 & placement,
-                               const Inertia & Y,
-                               const Eigen::VectorXd & effort, const Eigen::VectorXd & velocity,
-                               const Eigen::VectorXd & lowPos, const Eigen::VectorXd & upPos,
-                               const std::string & jointName,
-                               const std::string & bodyName, bool visual)
+  Model::JointIndex Model::addJoint(JointIndex parent,const JointModelBase<D> & j,const SE3 & placement,
+                     const Eigen::VectorXd & effort, const Eigen::VectorXd & velocity,
+                     const Eigen::VectorXd & lowPos, const Eigen::VectorXd & upPos,
+                     const std::string & jointName)
   {
-    assert( (nbody==(int)joints.size())&&(nbody==(int)inertias.size())
-	    &&(nbody==(int)parents.size())&&(nbody==(int)jointPlacements.size()) );
+    assert( (njoint==(int)joints.size())&&(njoint==(int)inertias.size())
+      &&(njoint==(int)parents.size())&&(njoint==(int)jointPlacements.size()) );
     assert( (j.nq()>=0)&&(j.nv()>=0) );
-    
-    assert( effort.size() == j.nv() && velocity.size() == j.nv()
-      && lowPos.size() == j.nq() && upPos.size() == j.nq() );
 
-
-    Model::JointIndex idx = (Model::JointIndex) (nbody ++);
+    Model::JointIndex idx = (Model::JointIndex) (njoint ++);
 
     joints         .push_back(j.derived()); 
     boost::get<D>(joints.back()).setIndexes(idx,nq,nv);
 
-
-    inertias       .push_back(Y);
+    inertias       .push_back(Inertia::Zero());
     parents        .push_back(parent);
     jointPlacements.push_back(placement);
     names          .push_back( (jointName!="")?jointName:random(8) );
-    hasVisual      .push_back(visual);
-    bodyNames      .push_back( (bodyName!="")?bodyName:random(8));
     nq += j.nq();
     nv += j.nv();
 
@@ -115,6 +129,21 @@ namespace se3
     upperPositionLimit.conservativeResize(nq);upperPositionLimit.bottomRows<D::NQ>() = upPos;
     return idx;
   }
+
+
+  inline void Model::appendBodyToJoint(const JointIndex parent, const SE3 & placement, const Inertia & Y,
+                                       const std::string & bodyName)
+  {
+    const Inertia & iYf = Y.se3Action(placement);
+    inertias[parent] += iYf;
+
+    bodyParents.push_back(parent);
+    bodyPlacements.push_back(placement);
+    bodyNames.push_back( (bodyName!="")?bodyName:random(8));
+
+    nbody ++;
+  }
+
 
   inline Model::JointIndex Model::addFixedBody (JointIndex lastMovingParent,
                                            const SE3 & placementFromLastMoving,
@@ -130,11 +159,7 @@ namespace se3
     return idx;
   }
 
-  inline void Model::mergeFixedBody (const JointIndex parent, const SE3 & placement, const Inertia & Y)
-  {
-    const Inertia & iYf = Y.se3Action(placement); //TODO
-    inertias[parent] += iYf;
-  }
+
 
   inline Model::JointIndex Model::getBodyId (const std::string & name) const
   {

--- a/src/multibody/parser/lua.cpp
+++ b/src/multibody/parser/lua.cpp
@@ -233,43 +233,43 @@ namespace se3
         bool is_body_fixed = false;
         if (joint_type == "JointTypeRevoluteX")
         {
-          body_id = model.addBody (parent_id, JointModelRX (), global_placement, Y, joint_name, body_name, false);
+          body_id = model.addJointAndBody (parent_id, JointModelRX (), global_placement, Y, joint_name, body_name);
         }
         else if (joint_type == "JointTypeRevoluteY")
         {
-          body_id = model.addBody (parent_id, JointModelRY (), global_placement, Y, joint_name, body_name, false);
+          body_id = model.addJointAndBody (parent_id, JointModelRY (), global_placement, Y, joint_name, body_name);
         }
         else if (joint_type == "JointTypeRevoluteZ")
         {
-          body_id = model.addBody (parent_id, JointModelRZ (), global_placement, Y, joint_name, body_name, false);
+          body_id = model.addJointAndBody (parent_id, JointModelRZ (), global_placement, Y, joint_name, body_name);
         }
         else if (joint_type == "JointTypePrismaticX")
         {
-          body_id = model.addBody (parent_id, JointModelPX (), global_placement, Y, joint_name, body_name, false);
+          body_id = model.addJointAndBody (parent_id, JointModelPX (), global_placement, Y, joint_name, body_name);
         }
         else if (joint_type == "JointTypePrismaticY")
         {
-          body_id = model.addBody (parent_id, JointModelPY (), global_placement, Y, joint_name, body_name, false);
+          body_id = model.addJointAndBody (parent_id, JointModelPY (), global_placement, Y, joint_name, body_name);
         }
         else if (joint_type == "JointTypePrismaticZ")
         {
-          body_id = model.addBody (parent_id, JointModelPZ (), global_placement, Y, joint_name, body_name, false);
+          body_id = model.addJointAndBody (parent_id, JointModelPZ (), global_placement, Y, joint_name, body_name);
         }
         else if (joint_type == "JointTypeFloatingBase" || joint_type == "JointTypeFloatbase")
         {
-          body_id = model.addBody (parent_id, JointModelFreeFlyer (), global_placement, Y, joint_name, body_name, false);
+          body_id = model.addJointAndBody (parent_id, JointModelFreeFlyer (), global_placement, Y, joint_name, body_name);
         }
         else if (joint_type == "JointTypeSpherical")
         {
-          body_id = model.addBody (parent_id, JointModelSpherical (), global_placement, Y, joint_name, body_name, false);
+          body_id = model.addJointAndBody (parent_id, JointModelSpherical (), global_placement, Y, joint_name, body_name);
         }
         else if (joint_type == "JointTypeEulerZYX")
         {
-          body_id = model.addBody (parent_id, JointModelSphericalZYX (), global_placement, Y, joint_name, body_name, false);
+          body_id = model.addJointAndBody (parent_id, JointModelSphericalZYX (), global_placement, Y, joint_name, body_name);
         }
         else if (joint_type == "JointTypeFixed")
         {
-          model.mergeFixedBody(parent_id, global_placement, Y);
+          model.appendBodyToJoint(parent_id, global_placement, Y, "");
 
           fixed_body_table_id_map[body_name] = parent_id;
           fixed_placement_map[body_name] = global_placement;

--- a/src/multibody/parser/lua.cpp
+++ b/src/multibody/parser/lua.cpp
@@ -270,7 +270,7 @@ namespace se3
         {
           model.appendBodyToJoint(parent_id, global_placement, Y, "");
 
-          body_id = model.nbody;
+          body_id = (Model::JointIndex)model.nbody;
           
           fixed_body_table_id_map[body_name] = parent_id;
           fixed_placement_map[body_name] = global_placement;

--- a/src/multibody/parser/lua.cpp
+++ b/src/multibody/parser/lua.cpp
@@ -230,7 +230,6 @@ namespace se3
 
 
         Model::JointIndex body_id;
-        bool is_body_fixed = false;
         if (joint_type == "JointTypeRevoluteX")
         {
           body_id = model.addJointAndBody (parent_id, JointModelRX (), global_placement, Y, joint_name, body_name);
@@ -271,11 +270,11 @@ namespace se3
         {
           model.appendBodyToJoint(parent_id, global_placement, Y, "");
 
+          body_id = model.nbody;
+          
           fixed_body_table_id_map[body_name] = parent_id;
           fixed_placement_map[body_name] = global_placement;
 
-          body_id = model.addFixedBody(parent_id, global_placement, body_name, false);
-          is_body_fixed = true;
         }
         else
         {
@@ -288,10 +287,7 @@ namespace se3
         if (verbose) {
           std::cout << "==== Added Body ====" << std::endl;
           std::cout << "  body name  : " << body_name << std::endl;
-          if (! is_body_fixed)
-            std::cout << "  body id    : " << body_id << std::endl;
-          else
-            std::cout << "  fixed body id    : " << body_id << std::endl;
+          std::cout << "  body id    : " << body_id << std::endl;
           std::cout << "  closest parent id  : " << parent_id << std::endl;
           std::cout << "  joint frame:\n" << joint_placement << std::endl;
           std::cout << "  joint type : " << joint_type << std::endl;

--- a/src/multibody/parser/sample-models.cpp
+++ b/src/multibody/parser/sample-models.cpp
@@ -29,34 +29,34 @@ namespace se3
 
     void humanoid2d(Model& model)
     {
-      model.addBody(model.getBodyId("universe"),JointModelRX(),SE3::Identity(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("universe"),JointModelRX(),SE3::Identity(),Inertia::Random(),
                     "ff1_joint", "ff1_body");
-      model.addBody(model.getBodyId("ff1_body"),JointModelRY(),SE3::Identity(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("ff1_body"),JointModelRY(),SE3::Identity(),Inertia::Random(),
                     "root_joint", "root_body");
 
-      model.addBody(model.getBodyId("root_body"),JointModelRZ(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("root_body"),JointModelRZ(),SE3::Random(),Inertia::Random(),
                     "lleg1_joint", "lleg1_body");
-      model.addBody(model.getBodyId("lleg1_body"),JointModelRY(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("lleg1_body"),JointModelRY(),SE3::Random(),Inertia::Random(),
                     "lleg2_joint", "lleg2_body");
 
-      model.addBody(model.getBodyId("root_body"),JointModelRZ(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("root_body"),JointModelRZ(),SE3::Random(),Inertia::Random(),
                     "rleg1_joint", "rleg1_body");
-      model.addBody(model.getBodyId("rleg1_body"),JointModelRY(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("rleg1_body"),JointModelRY(),SE3::Random(),Inertia::Random(),
                     "rleg2_joint", "rleg2_body");
 
-      model.addBody(model.getBodyId("root_body"),JointModelRY(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("root_body"),JointModelRY(),SE3::Random(),Inertia::Random(),
                     "torso1_joint", "torso1_body");
-      model.addBody(model.getBodyId("torso1_body"),JointModelRZ(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("torso1_body"),JointModelRZ(),SE3::Random(),Inertia::Random(),
                     "chest_joint", "chest_body");
 
-      model.addBody(model.getBodyId("chest_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("chest_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     "rarm1_joint", "rarm1_body");
-      model.addBody(model.getBodyId("rarm1_body"),JointModelRZ(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("rarm1_body"),JointModelRZ(),SE3::Random(),Inertia::Random(),
                     "rarm2_joint", "rarm2_body");
 
-      model.addBody(model.getBodyId("chest_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("chest_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     "larm1_joint", "larm1_body");
-      model.addBody(model.getBodyId("larm1_body"),JointModelRZ(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("larm1_body"),JointModelRZ(),SE3::Random(),Inertia::Random(),
                     "larm2_joint", "larm2_body");
     }
 
@@ -64,22 +64,22 @@ namespace se3
     {
       if(! usingFF )
       {
-        model.addBody(model.getBodyId("universe"),JointModelRX(),SE3::Identity(),Inertia::Random(),
+        model.addJointAndBody(model.getBodyId("universe"),JointModelRX(),SE3::Identity(),Inertia::Random(),
                       "ff1_joint", "ff1_body");
-        model.addBody(model.getBodyId("ff1_body"),JointModelRY(),SE3::Identity(),Inertia::Random(),
+        model.addJointAndBody(model.getBodyId("ff1_body"),JointModelRY(),SE3::Identity(),Inertia::Random(),
                       "ff2_joint", "ff2_body");
-        model.addBody(model.getBodyId("ff2_body"),JointModelRZ(),SE3::Identity(),Inertia::Random(),
+        model.addJointAndBody(model.getBodyId("ff2_body"),JointModelRZ(),SE3::Identity(),Inertia::Random(),
                       "ff3_joint", "ff3_body");
-        model.addBody(model.getBodyId("ff3_body"),JointModelRZ(),SE3::Random(),Inertia::Random(),
+        model.addJointAndBody(model.getBodyId("ff3_body"),JointModelRZ(),SE3::Random(),Inertia::Random(),
                       "ff4_joint", "ff4_body");
-        model.addBody(model.getBodyId("ff4_body"),JointModelRY(),SE3::Identity(),Inertia::Random(),
+        model.addJointAndBody(model.getBodyId("ff4_body"),JointModelRY(),SE3::Identity(),Inertia::Random(),
                       "ff5_joint", "ff5_body");
-        model.addBody(model.getBodyId("ff5_body"),JointModelRX(),SE3::Identity(),Inertia::Random(),
+        model.addJointAndBody(model.getBodyId("ff5_body"),JointModelRX(),SE3::Identity(),Inertia::Random(),
                       "root_joint", "root_body");
       }
       else
       {
-        model.addBody(model.getBodyId("universe"),JointModelFreeFlyer(),
+        model.addJointAndBody(model.getBodyId("universe"),JointModelFreeFlyer(),
                       SE3::Identity(),Inertia::Random(),
                       Eigen::VectorXd::Zero(6), 1e3 * (Eigen::VectorXd::Random(6).array() + 1),
                       1e3 * (Eigen::VectorXd::Random(7).array() - 1),
@@ -87,111 +87,111 @@ namespace se3
                       "root_joint", "root_body");
       }
 
-      model.addBody(model.getBodyId("root_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("root_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "lleg1_joint", "lleg1_body");
-      model.addBody(model.getBodyId("lleg1_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("lleg1_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "lleg2_joint", "lleg2_body");
-      model.addBody(model.getBodyId("lleg2_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("lleg2_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "lleg3_joint", "lleg3_body");
-      model.addBody(model.getBodyId("lleg3_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("lleg3_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "lleg4_joint", "lleg4_body");
-      model.addBody(model.getBodyId("lleg4_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("lleg4_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "lleg5_joint", "lleg5_body");
-      model.addBody(model.getBodyId("lleg5_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("lleg5_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "lleg6_joint", "lleg6_body");
 
-      model.addBody(model.getBodyId("root_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("root_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "rleg1_joint", "rleg1_body");
-      model.addBody(model.getBodyId("rleg1_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("rleg1_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "rleg2_joint", "rleg2_body");
-      model.addBody(model.getBodyId("rleg2_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("rleg2_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "rleg3_joint", "rleg3_body");
-      model.addBody(model.getBodyId("rleg3_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("rleg3_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "rleg4_joint", "rleg4_body");
-      model.addBody(model.getBodyId("rleg4_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("rleg4_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "rleg5_joint", "rleg5_body");
-      model.addBody(model.getBodyId("rleg5_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("rleg5_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "rleg6_joint", "rleg6_body");
 
-      model.addBody(model.getBodyId("root_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("root_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "torso1_joint", "torso1_body");
-      model.addBody(model.getBodyId("torso1_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("torso1_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "chest_joint", "chest_body");
 
-      model.addBody(model.getBodyId("chest_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("chest_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "rarm1_joint", "rarm1_body");
-      model.addBody(model.getBodyId("rarm1_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("rarm1_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "rarm2_joint", "rarm2_body");
-      model.addBody(model.getBodyId("rarm2_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("rarm2_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "rarm3_joint", "rarm3_body");
-      model.addBody(model.getBodyId("rarm3_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("rarm3_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "rarm4_joint", "rarm4_body");
-      model.addBody(model.getBodyId("rarm4_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("rarm4_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "rarm5_joint", "rarm5_body");
-      model.addBody(model.getBodyId("rarm5_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("rarm5_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "rarm6_joint", "rarm6_body");
 
-      model.addBody(model.getBodyId("chest_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("chest_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "larm1_joint", "larm1_body");
-      model.addBody(model.getBodyId("larm1_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("larm1_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "larm2_joint", "larm2_body");
-      model.addBody(model.getBodyId("larm2_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("larm2_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "larm3_joint", "larm3_body");
-      model.addBody(model.getBodyId("larm3_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("larm3_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "larm4_joint", "larm4_body");
-      model.addBody(model.getBodyId("larm4_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("larm4_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "larm5_joint", "larm5_body");
-      model.addBody(model.getBodyId("larm5_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
+      model.addJointAndBody(model.getBodyId("larm5_body"),JointModelRX(),SE3::Random(),Inertia::Random(),
                     Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                     Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                     "larm6_joint", "larm6_body");

--- a/src/multibody/parser/urdf-with-geometry.hxx
+++ b/src/multibody/parser/urdf-with-geometry.hxx
@@ -124,8 +124,8 @@ namespace se3
         {
           fcl::CollisionObject collision_object = retrieveCollisionGeometry((*i)->geometry, package_dirs, mesh_path);
           SE3 geomPlacement = convertFromUrdf((*i)->origin);
-          std::string collision_object_name = (*i)->name ;
-          geom_model.addCollisionObject(model.parents[model.getBodyId(link_name)], collision_object, geomPlacement, collision_object_name, mesh_path); 
+          std::string collision_object_name = link_name;
+          geom_model.addCollisionObject(model.bodyParents[model.getBodyId(link_name)], collision_object, geomPlacement, collision_object_name, mesh_path); 
           
         }
       } // if(link->collision)
@@ -143,8 +143,8 @@ namespace se3
         {
           fcl::CollisionObject visual_object = retrieveCollisionGeometry((*i)->geometry, package_dirs, mesh_path);
           SE3 geomPlacement = convertFromUrdf((*i)->origin);
-          std::string visual_object_name = (*i)->name ;
-          geom_model.addVisualObject(model.parents[model.getBodyId(link_name)], visual_object, geomPlacement, visual_object_name, mesh_path); 
+          std::string visual_object_name = link_name;
+          geom_model.addVisualObject(model.bodyParents[model.getBodyId(link_name)], visual_object, geomPlacement, visual_object_name, mesh_path); 
           
         }
       } // if(link->visual)

--- a/src/multibody/parser/urdf.hxx
+++ b/src/multibody/parser/urdf.hxx
@@ -369,8 +369,6 @@ namespace se3
           //transformation of the current placement offset
           nextPlacementOffset = jointPlacement;
           
-          //add the fixed Body in the model for the viewer
-          model.addFixedBody(parent_joint_id, nextPlacementOffset, link->name);
 
           // Add a frame in the model to keep trace of this fixed joint
           model.addFrame(joint->name, parent_joint_id, nextPlacementOffset);

--- a/src/multibody/parser/urdf.hxx
+++ b/src/multibody/parser/urdf.hxx
@@ -103,7 +103,6 @@ namespace se3
         const Inertia & Y = (link->inertial) ? convertFromUrdf(*link->inertial) :
         Inertia::Zero();
 
-        const bool has_visual = (link->visual) ? true : false;
 
         switch(joint->type)
         {
@@ -128,9 +127,9 @@ namespace se3
             TangentVector_t max_velocity;
             max_velocity.fill(std::numeric_limits<Scalar_t>::max());
 
-            model.addBody(parent_joint_id, JointModelFreeFlyer(), jointPlacement, Y,
+            model.addJointAndBody(parent_joint_id, JointModelFreeFlyer(), jointPlacement, Y,
               max_effort, max_velocity, lower_position, upper_position,
-              joint->name, link->name, has_visual);
+              joint->name, link->name);
             break;
           }
           case ::urdf::Joint::REVOLUTE:
@@ -160,21 +159,21 @@ namespace se3
             {
               case AXIS_X:
               joint_info += " along X";
-              model.addBody(  parent_joint_id, JointModelRX(), jointPlacement, Y,
+              model.addJointAndBody(  parent_joint_id, JointModelRX(), jointPlacement, Y,
                 max_effort, max_velocity, lower_position, upper_position,
-                joint->name,link->name, has_visual );
+                joint->name,link->name );
               break;
               case AXIS_Y:
               joint_info += " along Y";
-              model.addBody(  parent_joint_id, JointModelRY(), jointPlacement, Y,
+              model.addJointAndBody(  parent_joint_id, JointModelRY(), jointPlacement, Y,
                 max_effort, max_velocity, lower_position, upper_position,
-                joint->name,link->name, has_visual );
+                joint->name,link->name );
               break;
               case AXIS_Z:
               joint_info += " along Z";
-              model.addBody(  parent_joint_id, JointModelRZ(), jointPlacement, Y,
+              model.addJointAndBody(  parent_joint_id, JointModelRZ(), jointPlacement, Y,
                 max_effort, max_velocity, lower_position, upper_position,
-                joint->name,link->name, has_visual );
+                joint->name,link->name );
               break;
               case AXIS_UNALIGNED:
               {
@@ -185,10 +184,10 @@ namespace se3
 
                 jointAxis = Eigen::Vector3d( joint->axis.x,joint->axis.y,joint->axis.z );
                 jointAxis.normalize();
-                model.addBody(  parent_joint_id, JointModelRevoluteUnaligned(jointAxis),
+                model.addJointAndBody(  parent_joint_id, JointModelRevoluteUnaligned(jointAxis),
                   jointPlacement, Y,
                   max_effort, max_velocity, lower_position, upper_position,
-                  joint->name,link->name, has_visual );
+                  joint->name,link->name );
                 break;
               }
               default:
@@ -224,21 +223,21 @@ namespace se3
           {
             case AXIS_X:
             joint_info += " along X";
-            model.addBody(  parent_joint_id, JointModelRX(), jointPlacement, Y,
+            model.addJointAndBody(  parent_joint_id, JointModelRX(), jointPlacement, Y,
               max_effort, max_velocity, lower_position, upper_position,
-              joint->name,link->name, has_visual );
+              joint->name,link->name );
             break;
             case AXIS_Y:
             joint_info += " along Y";
-            model.addBody(  parent_joint_id, JointModelRY(), jointPlacement, Y,
+            model.addJointAndBody(  parent_joint_id, JointModelRY(), jointPlacement, Y,
               max_effort, max_velocity, lower_position, upper_position,
-              joint->name,link->name, has_visual );
+              joint->name,link->name );
             break;
             case AXIS_Z:
             joint_info += " along Z";
-            model.addBody(  parent_joint_id, JointModelRZ(), jointPlacement, Y,
+            model.addJointAndBody(  parent_joint_id, JointModelRZ(), jointPlacement, Y,
               max_effort, max_velocity, lower_position, upper_position,
-              joint->name,link->name, has_visual );
+              joint->name,link->name );
             break;
             case AXIS_UNALIGNED:
             {
@@ -249,10 +248,10 @@ namespace se3
               
               jointAxis = Eigen::Vector3d( joint->axis.x,joint->axis.y,joint->axis.z );
               jointAxis.normalize();
-              model.addBody(  parent_joint_id, JointModelRevoluteUnaligned(jointAxis),
+              model.addJointAndBody(  parent_joint_id, JointModelRevoluteUnaligned(jointAxis),
                 jointPlacement, Y,
                 max_effort, max_velocity, lower_position, upper_position,
-                joint->name,link->name, has_visual );
+                joint->name,link->name );
               break;
             }
             default:
@@ -286,21 +285,21 @@ namespace se3
           {
             case AXIS_X:
             joint_info += " along X";
-            model.addBody(  parent_joint_id, JointModelPX(), jointPlacement, Y,
+            model.addJointAndBody(  parent_joint_id, JointModelPX(), jointPlacement, Y,
               max_effort, max_velocity, lower_position, upper_position,
-              joint->name,link->name, has_visual );
+              joint->name,link->name );
             break;
             case AXIS_Y:
             joint_info += " along Y";
-            model.addBody(  parent_joint_id, JointModelPY(), jointPlacement, Y,
+            model.addJointAndBody(  parent_joint_id, JointModelPY(), jointPlacement, Y,
               max_effort, max_velocity, lower_position, upper_position,
-              joint->name,link->name, has_visual );
+              joint->name,link->name );
             break;
             case AXIS_Z:
             joint_info += " along Z";
-            model.addBody(  parent_joint_id, JointModelPZ(), jointPlacement, Y,
+            model.addJointAndBody(  parent_joint_id, JointModelPZ(), jointPlacement, Y,
               max_effort, max_velocity, lower_position, upper_position,
-              joint->name,link->name, has_visual );
+              joint->name,link->name );
             break;
             case AXIS_UNALIGNED:
             {
@@ -311,10 +310,10 @@ namespace se3
     
               Eigen::Vector3d jointAxis(Eigen::Vector3d(joint->axis.x,joint->axis.y,joint->axis.z));
               jointAxis.normalize();
-              model.addBody(parent_joint_id, JointModelPrismaticUnaligned(jointAxis),
+              model.addJointAndBody(parent_joint_id, JointModelPrismaticUnaligned(jointAxis),
                             jointPlacement, Y,
                             max_effort, max_velocity, lower_position, upper_position,
-                            joint->name,link->name, has_visual);
+                            joint->name,link->name);
               
               break;
             }
@@ -345,9 +344,9 @@ namespace se3
           }
           
 
-          model.addBody(parent_joint_id, JointModelPlanar(), jointPlacement, Y,
+          model.addJointAndBody(parent_joint_id, JointModelPlanar(), jointPlacement, Y,
                         max_effort, max_velocity, lower_position, upper_position,
-                        joint->name,link->name, has_visual );
+                        joint->name,link->name );
 
           break;
         }
@@ -364,14 +363,14 @@ namespace se3
           joint_info = "fixed joint";
           if (link->inertial)
           {
-            model.mergeFixedBody(parent_joint_id, jointPlacement, Y); //Modify the parent inertia in the model
+            model.appendBodyToJoint(parent_joint_id, jointPlacement, Y, ""); //Modify the parent inertia in the model
           }
           
           //transformation of the current placement offset
           nextPlacementOffset = jointPlacement;
           
           //add the fixed Body in the model for the viewer
-          model.addFixedBody(parent_joint_id, nextPlacementOffset, link->name, has_visual);
+          model.addFixedBody(parent_joint_id, nextPlacementOffset, link->name);
 
           // Add a frame in the model to keep trace of this fixed joint
           model.addFrame(joint->name, parent_joint_id, nextPlacementOffset);
@@ -429,8 +428,7 @@ namespace se3
       {
         ::urdf::LinkPtr child_link = link->child_links[0];
         const Inertia & Y = convertFromUrdf(*child_link->inertial);
-        const bool has_visual = (child_link->visual) ? true : false;
-        model.addBody(0, root_joint, placementOffset, Y, "root_joint", child_link->name, has_visual);
+        model.addJointAndBody(0, root_joint, placementOffset, Y, "root_joint", child_link->name);
       
         // Change the name of the parent joint
         child_link->parent_joint->name = "root_joint";
@@ -450,8 +448,7 @@ namespace se3
     else
     {
       const Inertia & Y = convertFromUrdf(*link->inertial);
-      const bool has_visual = (link->visual) ? true : false;
-      model.addBody(0, root_joint, placementOffset, Y , "root_joint", link->name, has_visual);
+      model.addJointAndBody(0, root_joint, placementOffset, Y , "root_joint", link->name);
     
       BOOST_FOREACH(::urdf::LinkConstPtr child, link->child_links)
       {

--- a/src/multibody/parser/urdf.hxx
+++ b/src/multibody/parser/urdf.hxx
@@ -363,7 +363,7 @@ namespace se3
           joint_info = "fixed joint";
           if (link->inertial)
           {
-            model.appendBodyToJoint(parent_joint_id, jointPlacement, Y, ""); //Modify the parent inertia in the model
+            model.appendBodyToJoint(parent_joint_id, jointPlacement, Y, link->name); //Modify the parent inertia in the model
           }
           
           //transformation of the current placement offset

--- a/src/python/model.hpp
+++ b/src/python/model.hpp
@@ -49,7 +49,7 @@ namespace se3
       typedef eigenpy::UnalignedEquivalent<SE3>::type SE3_fx;
       typedef eigenpy::UnalignedEquivalent<Inertia>::type Inertia_fx;
 
-      struct add_body_visitor : public boost::static_visitor<Model::Index>
+      struct add_joint_and_body_visitor : public boost::static_visitor<Model::Index>
       {
         ModelHandler & _model;
         Model::JointIndex & _index_parent;
@@ -57,24 +57,22 @@ namespace se3
         const Inertia_fx & _inertia;
         const std::string & _jName;
         const std::string & _bName;
-        bool _visual;
 
-        add_body_visitor( ModelHandler & model,
+        add_joint_and_body_visitor( ModelHandler & model,
                           Model::JointIndex & idx, const SE3_fx & placement,
                           const Inertia_fx & Y, const std::string & jointName,
-                          const std::string & bodyName, bool visual)
+                          const std::string & bodyName)
                         : _model(model)
                         , _index_parent(idx)
                         , _placement(placement)
                         , _inertia(Y)
                         , _jName(jointName)
                         , _bName(bodyName)
-                        , _visual(visual)
         {}
 
         template <typename T> Model::Index operator()( T & operand ) const
         {
-          return _model->addJointAndBody(_index_parent, operand, _placement, _inertia, _jName, _bName, _visual);
+          return _model->addJointAndBody(_index_parent, operand, _placement, _inertia, _jName, _bName);
         }
       };
 
@@ -104,12 +102,16 @@ namespace se3
 
           .add_property("nq", &ModelPythonVisitor::nq)
           .add_property("nv", &ModelPythonVisitor::nv)
+          .add_property("njoint", &ModelPythonVisitor::njoint)
           .add_property("nbody", &ModelPythonVisitor::nbody)
           .add_property("inertias",
             bp::make_function(&ModelPythonVisitor::inertias,
                   bp::return_internal_reference<>())  )
           .add_property("jointPlacements",
             bp::make_function(&ModelPythonVisitor::jointPlacements,
+                  bp::return_internal_reference<>())  )
+          .add_property("bodyPlacements",
+            bp::make_function(&ModelPythonVisitor::bodyPlacements,
                   bp::return_internal_reference<>())  )
           .add_property("joints",
             bp::make_function(&ModelPythonVisitor::joints,
@@ -123,17 +125,8 @@ namespace se3
           .add_property("bodyNames",
             bp::make_function(&ModelPythonVisitor::bodyNames,
                   bp::return_internal_reference<>())  )
-          .add_property("hasVisual",
-            bp::make_function(&ModelPythonVisitor::hasVisual,
-                  bp::return_internal_reference<>())  )
+          .def("addJointAndBody",&ModelPythonVisitor::addJointAndBodyToModel)
 
-          .def("addJointAndBody",&ModelPythonVisitor::addJointToModel)
-
-          .add_property("nFixBody", &ModelPythonVisitor::nFixBody)
-          .add_property("fix_lmpMi", bp::make_function(&ModelPythonVisitor::fix_lmpMi, bp::return_internal_reference<>()) )
-          .add_property("fix_lastMovingParent",bp::make_function(&ModelPythonVisitor::fix_lastMovingParent,bp::return_internal_reference<>()) )
-          .add_property("fix_hasVisual", bp::make_function(&ModelPythonVisitor::fix_hasVisual, bp::return_internal_reference<>())  )
-          .add_property("fix_bodyNames", bp::make_function(&ModelPythonVisitor::fix_bodyNames, bp::return_internal_reference<>())  )
 
           .add_property("effortLimit", bp::make_function(&ModelPythonVisitor::effortLimit), "Joint max effort")
           .add_property("velocityLimit", bp::make_function(&ModelPythonVisitor::velocityLimit), "Joint max velocity")
@@ -162,32 +155,27 @@ namespace se3
       
       static int nq( ModelHandler & m ) { return m->nq; }
       static int nv( ModelHandler & m ) { return m->nv; }
+      static int njoint( ModelHandler & m ) { return m->njoint; }
       static int nbody( ModelHandler & m ) { return m->nbody; }
       static std::vector<Inertia> & inertias( ModelHandler & m ) { return m->inertias; }
       static std::vector<SE3> & jointPlacements( ModelHandler & m ) { return m->jointPlacements; }
+      static std::vector<SE3> & bodyPlacements( ModelHandler & m ) { return m->bodyPlacements; }
       static JointModelVector & joints( ModelHandler & m ) { return m->joints; }
       static std::vector<Model::JointIndex> & parents( ModelHandler & m ) { return m->parents; }
       static std::vector<std::string> & names ( ModelHandler & m ) { return m->names; }
       static std::vector<std::string> & bodyNames ( ModelHandler & m ) { return m->bodyNames; }
-      static std::vector<bool> & hasVisual ( ModelHandler & m ) { return m->hasVisual; }
 
-      static Model::Index addJointToModel(ModelHandler & modelPtr,
+      static Model::Index addJointAndBodyToModel(ModelHandler & modelPtr,
                                           Model::JointIndex idx, bp::object joint,
                                           const SE3_fx & placement,
                                           const Inertia_fx & Y,
                                           const std::string & jointName,
-                                          const std::string & bodyName,
-                                          bool visual=false)
+                                          const std::string & bodyName)
       { 
         JointModelVariant variant = bp::extract<JointModelVariant> (joint);
-        return boost::apply_visitor(add_body_visitor(modelPtr, idx, placement, Y, jointName, bodyName, visual), variant);
+        return boost::apply_visitor(add_joint_and_body_visitor(modelPtr, idx, placement, Y, jointName, bodyName), variant);
       }
 
-      static int nFixBody( ModelHandler & m )                                     { return m->nFixBody; }
-      static std::vector<SE3>          & fix_lmpMi           ( ModelHandler & m ) { return m->fix_lmpMi; }
-      static std::vector<Model::JointIndex> & fix_lastMovingParent( ModelHandler & m ) { return m->fix_lastMovingParent; }
-      static std::vector<bool> & fix_hasVisual ( ModelHandler & m ) { return m->fix_hasVisual; }
-      static std::vector<std::string> & fix_bodyNames ( ModelHandler & m ) { return m->fix_bodyNames; }
 
       static Eigen::VectorXd effortLimit(ModelHandler & m) {return m->effortLimit;}
       static Eigen::VectorXd velocityLimit(ModelHandler & m) {return m->velocityLimit;}

--- a/src/python/model.hpp
+++ b/src/python/model.hpp
@@ -119,6 +119,9 @@ namespace se3
           .add_property("parents", 
             bp::make_function(&ModelPythonVisitor::parents,
                   bp::return_internal_reference<>())  )
+          .add_property("bodyParents",
+            bp::make_function(&ModelPythonVisitor::bodyParents,
+                  bp::return_internal_reference<>())  )
           .add_property("names",
             bp::make_function(&ModelPythonVisitor::names,
                   bp::return_internal_reference<>())  )
@@ -162,6 +165,7 @@ namespace se3
       static std::vector<SE3> & bodyPlacements( ModelHandler & m ) { return m->bodyPlacements; }
       static JointModelVector & joints( ModelHandler & m ) { return m->joints; }
       static std::vector<Model::JointIndex> & parents( ModelHandler & m ) { return m->parents; }
+      static std::vector<Model::JointIndex> & bodyParents( ModelHandler & m ) { return m->bodyParents; }
       static std::vector<std::string> & names ( ModelHandler & m ) { return m->names; }
       static std::vector<std::string> & bodyNames ( ModelHandler & m ) { return m->bodyNames; }
 

--- a/src/python/model.hpp
+++ b/src/python/model.hpp
@@ -74,7 +74,7 @@ namespace se3
 
         template <typename T> Model::Index operator()( T & operand ) const
         {
-          return _model->addBody(_index_parent, operand, _placement, _inertia, _jName, _bName, _visual);
+          return _model->addJointAndBody(_index_parent, operand, _placement, _inertia, _jName, _bName, _visual);
         }
       };
 
@@ -127,7 +127,7 @@ namespace se3
             bp::make_function(&ModelPythonVisitor::hasVisual,
                   bp::return_internal_reference<>())  )
 
-          .def("addBody",&ModelPythonVisitor::addJointToModel)
+          .def("addJointAndBody",&ModelPythonVisitor::addJointToModel)
 
           .add_property("nFixBody", &ModelPythonVisitor::nFixBody)
           .add_property("fix_lmpMi", bp::make_function(&ModelPythonVisitor::fix_lmpMi, bp::return_internal_reference<>()) )

--- a/src/python/robot_wrapper.py
+++ b/src/python/robot_wrapper.py
@@ -125,7 +125,7 @@ class RobotWrapper(object):
         return [i for i, n in enumerate(self.model.names) if n == name][0]
 
     # --- VIEWER ---
-    # For each joint/body index, returns the corresponding name of the node in Gepetto-viewer.
+    # For each visual object, returns the corresponding name of the node in Gepetto-viewer.
     def viewerNodeNames(self, visual):
         return self.viewerRootNodeName + '/' + visual.name
 
@@ -163,9 +163,7 @@ class RobotWrapper(object):
             self.viewer.gui.createGroup(nodeName)
             # iterate over visuals and create the meshes in the viewer
             for visual in self.geometry_model.visual_objects :
-                print visual.mesh_path
-                meshName = nodeName  + '/' + visual.name 
-                # meshName = self.viewerNodeNames(visual)                                                                                                                  
+                meshName = self.viewerNodeNames(visual)                                                                                                                  
                 meshPath = visual.mesh_path
                 self.viewer.gui.addMesh(meshName, meshPath)
 

--- a/src/python/robot_wrapper.py
+++ b/src/python/robot_wrapper.py
@@ -115,6 +115,10 @@ class RobotWrapper(object):
     def computeJacobians(self, q):
         return se3.computeJacobians(self.model, self.data, q)
 
+    def updateGeometryPlacements(self, q):
+        se3.updateGeometryPlacements(self.model, self.data, self.geometry_model, self.geometry_data, q)
+
+
     # --- ACCESS TO NAMES ----
     # Return the index of the joint whose name is given in argument.
     def index(self, name):
@@ -122,13 +126,9 @@ class RobotWrapper(object):
 
     # --- VIEWER ---
     # For each joint/body index, returns the corresponding name of the node in Gepetto-viewer.
-    def viewerNodeNames(self, index):
-        assert self.model.hasVisual[index]
-        return self.viewerRootNodeName + '/' + self.model.bodyNames[index]
+    def viewerNodeNames(self, visual):
+        return self.viewerRootNodeName + '/' + visual.name
 
-    def viewerFixedNodeNames(self, index):
-        assert self.model.fix_hasVisual[index]
-        return self.viewerRootNodeName + '/' + self.model.fix_bodyNames[index]
 
     def initDisplay(self, viewerRootNodeName="world/pinocchio", loadModel=False):
         import gepetto.corbaserver
@@ -144,43 +144,49 @@ class RobotWrapper(object):
             print "Check wheter gepetto-viewer is properly started"
 
     # Create the scene displaying the robot meshes in gepetto-viewer
-    def loadDisplayModel(self, nodeName, windowName="pinocchio", meshDir=None):
+    def loadDisplayModel(self, nodeName, windowName="pinocchio"):
         import os
+        # Open a window for displaying your model.
         try:
+            # If the window already exists, do not do anything.
             self.windowID = self.viewer.gui.getWindowID(windowName)
             print "Warning: window '%s' already created. Cannot (re-)load the model." % windowName
             return
         except:
+             # Otherwise, create the empty window.
             self.windowID = self.viewer.gui.createWindow(windowName)
-            if not meshDir:
-                meshDir = os.path.dirname(self.model_filename) + "/"
+
+            # Start a new "scene" in this window, named "world", with just a floor.
             self.viewer.gui.createSceneWithFloor("world")
             self.viewer.gui.addSceneToWindow("world", self.windowID)
-            self.viewer.gui.addURDF(nodeName, self.model_filename, meshDir)
+
+            self.viewer.gui.createGroup(nodeName)
+            # iterate over visuals and create the meshes in the viewer
+            for visual in self.geometry_model.visual_objects :
+                print visual.mesh_path
+                meshName = nodeName  + '/' + visual.name 
+                # meshName = self.viewerNodeNames(visual)                                                                                                                  
+                meshPath = visual.mesh_path
+                self.viewer.gui.addMesh(meshName, meshPath)
+
+            # Finally, refresh the layout to obtain your first rendering.
+            self.viewer.gui.refresh()
+
 
     # Display in gepetto-view the robot at configuration q, by placing all the bodies.
     def display(self, q):
         if 'viewer' not in self.__dict__:
             return
-        # Update the robot geometry.
-        se3.forwardKinematics(self.model, self.data, q)
-        # Iteratively place the moving robot bodies.
-        for i in range(1, self.model.nbody):
-            if self.model.hasVisual[i]:
-                M = self.data.oMi[i]
-                pinocchioConf = utils.se3ToXYZQUAT(M)
-                viewerConf = utils.XYZQUATToViewerConfiguration(pinocchioConf)
-                self.viewer.gui.applyConfiguration(self.viewerNodeNames(i), viewerConf)
-        # Iteratively place the fixed robot bodies.
-        for i in range(self.model.nFixBody):
-            if self.model.fix_hasVisual[i]:
-                index_last_movable = self.model.fix_lastMovingParent[i]
-                oMlmp = self.data.oMi[index_last_movable]
-                lmpMi = self.model.fix_lmpMi[i]
-                M = oMlmp * lmpMi
-                pinocchioConf = utils.se3ToXYZQUAT(M)
-                viewerConf = utils.XYZQUATToViewerConfiguration(pinocchioConf)
-                self.viewer.gui.applyConfiguration(self.viewerFixedNodeNames(i), viewerConf)
+        # Update the robot kinematics and geometry.
+        self.updateGeometryPlacements(q)
+
+
+        for visual in self.geometry_model.visual_objects :
+            M = self.geometry_data.oMg_visuals[self.geometry_model.getVisualId(visual.name)]
+            pinocchioConf = utils.se3ToXYZQUAT(M)
+            viewerConf = utils.XYZQUATToViewerConfiguration(pinocchioConf)
+            self.viewer.gui.applyConfiguration(self.viewerNodeNames(visual), viewerConf)
+
         self.viewer.gui.refresh()
 
     def play(self, q_trajectory, dt):

--- a/unittest/geom.cpp
+++ b/unittest/geom.cpp
@@ -149,9 +149,9 @@ BOOST_AUTO_TEST_CASE ( simple_boxes )
   
   using namespace se3;
 
-  model.addBody(model.getBodyId("universe"),JointModelPlanar(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("universe"),JointModelPlanar(),SE3::Identity(),Inertia::Random(),
                 "planar1_joint", "planar1_body");
-  model.addBody(model.getBodyId("universe"),JointModelPlanar(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("universe"),JointModelPlanar(),SE3::Identity(),Inertia::Random(),
                 "planar2_joint", "planar2_body");
   
   boost::shared_ptr<fcl::Box> Sample(new fcl::Box(1));

--- a/unittest/joint-accessor.cpp
+++ b/unittest/joint-accessor.cpp
@@ -88,7 +88,7 @@ void test_joint_methods (T & jmodel, typename T::JointData & jdata)
 struct TestJointAccessor{
 
   template <typename T>
-  void operator()(const T t) const
+  void operator()(const T ) const
   {
     T jmodel;
     jmodel.setIndexes(0,0,0);

--- a/unittest/joint-configurations.cpp
+++ b/unittest/joint-configurations.cpp
@@ -70,23 +70,23 @@ BOOST_AUTO_TEST_CASE ( integration_test )
   
   using namespace se3;
 
-  model.addBody(model.getBodyId("universe"),JointModelFreeFlyer(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("universe"),JointModelFreeFlyer(),SE3::Identity(),Inertia::Random(),
                 "freeflyer_joint", "freeflyer_body");
-  model.addBody(model.getBodyId("freeflyer_body"),JointModelSpherical(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("freeflyer_body"),JointModelSpherical(),SE3::Identity(),Inertia::Random(),
                 "spherical_joint", "spherical_body");
-  model.addBody(model.getBodyId("spherical_body"),JointModelRX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("spherical_body"),JointModelRX(),SE3::Identity(),Inertia::Random(),
                 "revolute_joint", "revolute_body");
-  model.addBody(model.getBodyId("revolute_body"),JointModelPX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("revolute_body"),JointModelPX(),SE3::Identity(),Inertia::Random(),
                 "px_joint", "px_body");
-  model.addBody(model.getBodyId("px_body"),JointModelPrismaticUnaligned(Eigen::Vector3d(1,0,0)),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("px_body"),JointModelPrismaticUnaligned(Eigen::Vector3d(1,0,0)),SE3::Identity(),Inertia::Random(),
                 "pu_joint", "pu_body");
-  model.addBody(model.getBodyId("pu_body"),JointModelRevoluteUnaligned(Eigen::Vector3d(0,0,1)),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("pu_body"),JointModelRevoluteUnaligned(Eigen::Vector3d(0,0,1)),SE3::Identity(),Inertia::Random(),
                 "ru_joint", "ru_body");
-  model.addBody(model.getBodyId("ru_body"),JointModelSphericalZYX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("ru_body"),JointModelSphericalZYX(),SE3::Identity(),Inertia::Random(),
                 "sphericalZYX_joint", "sphericalZYX_body");
-  model.addBody(model.getBodyId("sphericalZYX_body"),JointModelTranslation(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("sphericalZYX_body"),JointModelTranslation(),SE3::Identity(),Inertia::Random(),
                 "translation_joint", "translation_body");
-  model.addBody(model.getBodyId("translation_body"),JointModelPlanar(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("translation_body"),JointModelPlanar(),SE3::Identity(),Inertia::Random(),
                 "planar_joint", "planar_body");
   
   se3::Data data(model);
@@ -122,23 +122,23 @@ BOOST_AUTO_TEST_CASE ( interpolation_test )
   
   using namespace se3;
 
-  model.addBody(model.getBodyId("universe"),JointModelFreeFlyer(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("universe"),JointModelFreeFlyer(),SE3::Identity(),Inertia::Random(),
                 "freeflyer_joint", "freeflyer_body");
-  model.addBody(model.getBodyId("freeflyer_body"),JointModelSpherical(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("freeflyer_body"),JointModelSpherical(),SE3::Identity(),Inertia::Random(),
                 "spherical_joint", "spherical_body");
-  model.addBody(model.getBodyId("spherical_body"),JointModelRX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("spherical_body"),JointModelRX(),SE3::Identity(),Inertia::Random(),
                 "revolute_joint", "revolute_body");
-  model.addBody(model.getBodyId("revolute_body"),JointModelPX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("revolute_body"),JointModelPX(),SE3::Identity(),Inertia::Random(),
                 "px_joint", "px_body");
-  model.addBody(model.getBodyId("px_body"),JointModelPrismaticUnaligned(Eigen::Vector3d(1,0,0)),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("px_body"),JointModelPrismaticUnaligned(Eigen::Vector3d(1,0,0)),SE3::Identity(),Inertia::Random(),
                 "pu_joint", "pu_body");
-  model.addBody(model.getBodyId("pu_body"),JointModelRevoluteUnaligned(Eigen::Vector3d(0,0,1)),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("pu_body"),JointModelRevoluteUnaligned(Eigen::Vector3d(0,0,1)),SE3::Identity(),Inertia::Random(),
                 "ru_joint", "ru_body");
-  model.addBody(model.getBodyId("ru_body"),JointModelSphericalZYX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("ru_body"),JointModelSphericalZYX(),SE3::Identity(),Inertia::Random(),
                 "sphericalZYX_joint", "sphericalZYX_body");
-  model.addBody(model.getBodyId("sphericalZYX_body"),JointModelTranslation(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("sphericalZYX_body"),JointModelTranslation(),SE3::Identity(),Inertia::Random(),
                 "translation_joint", "translation_body");
-  model.addBody(model.getBodyId("translation_body"),JointModelPlanar(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("translation_body"),JointModelPlanar(),SE3::Identity(),Inertia::Random(),
                 "planar_joint", "planar_body");
   
   se3::Data data(model);
@@ -233,23 +233,23 @@ BOOST_AUTO_TEST_CASE ( differentiation_test )
   
   using namespace se3;
 
-  model.addBody(model.getBodyId("universe"),JointModelFreeFlyer(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("universe"),JointModelFreeFlyer(),SE3::Identity(),Inertia::Random(),
                 "freeflyer_joint", "freeflyer_body");
-  model.addBody(model.getBodyId("freeflyer_body"),JointModelSpherical(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("freeflyer_body"),JointModelSpherical(),SE3::Identity(),Inertia::Random(),
                 "spherical_joint", "spherical_body");
-  model.addBody(model.getBodyId("spherical_body"),JointModelRX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("spherical_body"),JointModelRX(),SE3::Identity(),Inertia::Random(),
                 "revolute_joint", "revolute_body");
-  model.addBody(model.getBodyId("revolute_body"),JointModelPX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("revolute_body"),JointModelPX(),SE3::Identity(),Inertia::Random(),
                 "px_joint", "px_body");
-  model.addBody(model.getBodyId("px_body"),JointModelPrismaticUnaligned(Eigen::Vector3d(1,0,0)),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("px_body"),JointModelPrismaticUnaligned(Eigen::Vector3d(1,0,0)),SE3::Identity(),Inertia::Random(),
                 "pu_joint", "pu_body");
-  model.addBody(model.getBodyId("pu_body"),JointModelRevoluteUnaligned(Eigen::Vector3d(0,0,1)),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("pu_body"),JointModelRevoluteUnaligned(Eigen::Vector3d(0,0,1)),SE3::Identity(),Inertia::Random(),
                 "ru_joint", "ru_body");
-  model.addBody(model.getBodyId("ru_body"),JointModelSphericalZYX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("ru_body"),JointModelSphericalZYX(),SE3::Identity(),Inertia::Random(),
                 "sphericalZYX_joint", "sphericalZYX_body");
-  model.addBody(model.getBodyId("sphericalZYX_body"),JointModelTranslation(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("sphericalZYX_body"),JointModelTranslation(),SE3::Identity(),Inertia::Random(),
                 "translation_joint", "translation_body");
-  model.addBody(model.getBodyId("translation_body"),JointModelPlanar(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("translation_body"),JointModelPlanar(),SE3::Identity(),Inertia::Random(),
                 "planar_joint", "planar_body");
   
   se3::Data data(model);
@@ -310,23 +310,23 @@ BOOST_AUTO_TEST_CASE ( distance_computation_test )
   
   using namespace se3;
 
-  model.addBody(model.getBodyId("universe"),JointModelFreeFlyer(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("universe"),JointModelFreeFlyer(),SE3::Identity(),Inertia::Random(),
                 "freeflyer_joint", "freeflyer_body");
-  model.addBody(model.getBodyId("freeflyer_body"),JointModelSpherical(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("freeflyer_body"),JointModelSpherical(),SE3::Identity(),Inertia::Random(),
                 "spherical_joint", "spherical_body");
-  model.addBody(model.getBodyId("spherical_body"),JointModelRX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("spherical_body"),JointModelRX(),SE3::Identity(),Inertia::Random(),
                 "revolute_joint", "revolute_body");
-  model.addBody(model.getBodyId("revolute_body"),JointModelPX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("revolute_body"),JointModelPX(),SE3::Identity(),Inertia::Random(),
                 "px_joint", "px_body");
-  model.addBody(model.getBodyId("px_body"),JointModelPrismaticUnaligned(Eigen::Vector3d(1,0,0)),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("px_body"),JointModelPrismaticUnaligned(Eigen::Vector3d(1,0,0)),SE3::Identity(),Inertia::Random(),
                 "pu_joint", "pu_body");
-  model.addBody(model.getBodyId("pu_body"),JointModelRevoluteUnaligned(Eigen::Vector3d(0,0,1)),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("pu_body"),JointModelRevoluteUnaligned(Eigen::Vector3d(0,0,1)),SE3::Identity(),Inertia::Random(),
                 "ru_joint", "ru_body");
-  model.addBody(model.getBodyId("ru_body"),JointModelSphericalZYX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("ru_body"),JointModelSphericalZYX(),SE3::Identity(),Inertia::Random(),
                 "sphericalZYX_joint", "sphericalZYX_body");
-  model.addBody(model.getBodyId("sphericalZYX_body"),JointModelTranslation(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("sphericalZYX_body"),JointModelTranslation(),SE3::Identity(),Inertia::Random(),
                 "translation_joint", "translation_body");
-  model.addBody(model.getBodyId("translation_body"),JointModelPlanar(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("translation_body"),JointModelPlanar(),SE3::Identity(),Inertia::Random(),
                 "planar_joint", "planar_body");
   
   se3::Data data(model);
@@ -393,41 +393,41 @@ BOOST_AUTO_TEST_CASE ( uniform_sampling_test )
   
   using namespace se3;
 
-  model.addBody(model.getBodyId("universe"),JointModelFreeFlyer(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("universe"),JointModelFreeFlyer(),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Zero(6), 1e3 * (Eigen::VectorXd::Random(6).array() + 1),
                 1e3 * (Eigen::VectorXd::Random(7).array() - 1),
                 1e3 * (Eigen::VectorXd::Random(7).array() + 1),
                 "freeflyer_joint", "freeflyer_body");
-  model.addBody(model.getBodyId("freeflyer_body"),JointModelSpherical(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("freeflyer_body"),JointModelSpherical(),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Zero(3), 1e3 * (Eigen::VectorXd::Random(3).array() + 1),
                 1e3 * (Eigen::VectorXd::Random(4).array() - 1),
                 1e3 * (Eigen::VectorXd::Random(4).array() + 1),
                 "spherical_joint", "spherical_body");
-  model.addBody(model.getBodyId("spherical_body"),JointModelRX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("spherical_body"),JointModelRX(),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                 Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                 "revolute_joint", "revolute_body");
-  model.addBody(model.getBodyId("revolute_body"),JointModelPX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("revolute_body"),JointModelPX(),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                 Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                 "px_joint", "px_body");
-  model.addBody(model.getBodyId("px_body"),JointModelPrismaticUnaligned(Eigen::Vector3d(1,0,0)),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("px_body"),JointModelPrismaticUnaligned(Eigen::Vector3d(1,0,0)),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                 Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                 "pu_joint", "pu_body");
-  model.addBody(model.getBodyId("pu_body"),JointModelRevoluteUnaligned(Eigen::Vector3d(0,0,1)),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("pu_body"),JointModelRevoluteUnaligned(Eigen::Vector3d(0,0,1)),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                 Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                 "ru_joint", "ru_body");
-  model.addBody(model.getBodyId("ru_body"),JointModelSphericalZYX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("ru_body"),JointModelSphericalZYX(),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Random(3).array() + 1, Eigen::VectorXd::Random(3).array() + 1,
                 Eigen::VectorXd::Random(3).array() - 1, Eigen::VectorXd::Random(3).array() + 1,
                 "sphericalZYX_joint", "sphericalZYX_body");
-  model.addBody(model.getBodyId("sphericalZYX_body"),JointModelTranslation(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("sphericalZYX_body"),JointModelTranslation(),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Random(3).array() + 1, Eigen::VectorXd::Random(3).array() + 1,
                 Eigen::VectorXd::Random(3).array() - 1, Eigen::VectorXd::Random(3).array() + 1,
                 "translation_joint", "translation_body");
-  model.addBody(model.getBodyId("translation_body"),JointModelPlanar(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("translation_body"),JointModelPlanar(),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Random(3).array() + 1, Eigen::VectorXd::Random(3).array() + 1,
                 Eigen::VectorXd::Random(3).array() - 1, Eigen::VectorXd::Random(3).array() + 1,
                 "planar_joint", "planar_body");
@@ -450,41 +450,41 @@ BOOST_AUTO_TEST_CASE ( integrate_difference_test )
   
   using namespace se3;
 
-  model.addBody(model.getBodyId("universe"),JointModelFreeFlyer(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("universe"),JointModelFreeFlyer(),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Zero(6), 1e3 * (Eigen::VectorXd::Random(6).array() + 1),
                 1e3 * (Eigen::VectorXd::Random(7).array() - 1),
                 1e3 * (Eigen::VectorXd::Random(7).array() + 1),
                 "freeflyer_joint", "freeflyer_body");
-  model.addBody(model.getBodyId("freeflyer_body"),JointModelSpherical(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("freeflyer_body"),JointModelSpherical(),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Zero(3), 1e3 * (Eigen::VectorXd::Random(3).array() + 1),
                 1e3 * (Eigen::VectorXd::Random(4).array() - 1),
                 1e3 * (Eigen::VectorXd::Random(4).array() + 1),
                 "spherical_joint", "spherical_body");
-  model.addBody(model.getBodyId("spherical_body"),JointModelRX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("spherical_body"),JointModelRX(),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                 Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                 "revolute_joint", "revolute_body");
-  model.addBody(model.getBodyId("revolute_body"),JointModelPX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("revolute_body"),JointModelPX(),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                 Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                 "px_joint", "px_body");
-  model.addBody(model.getBodyId("px_body"),JointModelPrismaticUnaligned(Eigen::Vector3d(1,0,0)),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("px_body"),JointModelPrismaticUnaligned(Eigen::Vector3d(1,0,0)),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                 Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                 "pu_joint", "pu_body");
-  model.addBody(model.getBodyId("pu_body"),JointModelRevoluteUnaligned(Eigen::Vector3d(0,0,1)),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("pu_body"),JointModelRevoluteUnaligned(Eigen::Vector3d(0,0,1)),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Random(1).array() + 1, Eigen::VectorXd::Random(1).array() + 1,
                 Eigen::VectorXd::Random(1).array() - 1, Eigen::VectorXd::Random(1).array() + 1,
                 "ru_joint", "ru_body");
-  model.addBody(model.getBodyId("ru_body"),JointModelSphericalZYX(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("ru_body"),JointModelSphericalZYX(),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Random(3).array() + 1, Eigen::VectorXd::Random(3).array() + 1,
                 Eigen::VectorXd::Random(3).array() - 1, Eigen::VectorXd::Random(3).array() + 1,
                 "sphericalZYX_joint", "sphericalZYX_body");
-  model.addBody(model.getBodyId("sphericalZYX_body"),JointModelTranslation(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("sphericalZYX_body"),JointModelTranslation(),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Random(3).array() + 1, Eigen::VectorXd::Random(3).array() + 1,
                 Eigen::VectorXd::Random(3).array() - 1, Eigen::VectorXd::Random(3).array() + 1,
                 "translation_joint", "translation_body");
-  model.addBody(model.getBodyId("translation_body"),JointModelPlanar(),SE3::Identity(),Inertia::Random(),
+  model.addJointAndBody(model.getBodyId("translation_body"),JointModelPlanar(),SE3::Identity(),Inertia::Random(),
                 Eigen::VectorXd::Random(3).array() + 1, Eigen::VectorXd::Random(3).array() + 1,
                 Eigen::VectorXd::Random(3).array() - 1, Eigen::VectorXd::Random(3).array() + 1,
                 "planar_joint", "planar_body");

--- a/unittest/joints.cpp
+++ b/unittest/joints.cpp
@@ -87,8 +87,8 @@ BOOST_AUTO_TEST_CASE (vsRX)
   SE3 pos(1); pos.translation() = SE3::Linear_t(1.,0.,0.);
 
   JointModelRevoluteUnaligned joint_model_RU(axis);
-  modelRX.addBody (0, JointModelRX (), pos, inertia, "rx");
-  modelRevoluteUnaligned.addBody(0, joint_model_RU ,pos, inertia, "revolute-unaligne");
+  modelRX.addJointAndBody (0, JointModelRX (), pos, inertia, "rx");
+  modelRevoluteUnaligned.addJointAndBody(0, joint_model_RU ,pos, inertia, "revolute-unaligne");
 
   Data dataRX(modelRX);
   Data dataRevoluteUnaligned(modelRevoluteUnaligned);
@@ -169,8 +169,8 @@ BOOST_AUTO_TEST_CASE (vsPX)
   SE3 pos(1); pos.translation() = SE3::Linear_t(1.,0.,0.);
 
   JointModelPrismaticUnaligned joint_model_PU(axis);
-  modelPX.addBody (0, JointModelPX (), pos, inertia, "px");
-  modelPrismaticUnaligned.addBody(0, joint_model_PU ,pos, inertia, "prismatic-unaligne");
+  modelPX.addJointAndBody (0, JointModelPX (), pos, inertia, "px");
+  modelPrismaticUnaligned.addJointAndBody(0, joint_model_PU ,pos, inertia, "prismatic-unaligne");
 
   Data dataPX(modelPX);
   Data dataPrismaticUnaligned(modelPrismaticUnaligned);
@@ -249,8 +249,8 @@ BOOST_AUTO_TEST_CASE (vsFreeFlyer)
   SE3 pos(1); pos.translation() = SE3::Linear_t(1.,0.,0.);
 
 
-  modelSpherical.addBody (0, JointModelSpherical (), pos, inertia, "spherical");
-  modelFreeflyer.addBody(0, JointModelFreeFlyer(),pos, inertia, "ff");
+  modelSpherical.addJointAndBody (0, JointModelSpherical (), pos, inertia, "spherical");
+  modelFreeflyer.addJointAndBody(0, JointModelFreeFlyer(),pos, inertia, "ff");
 
   Data dataSpherical(modelSpherical);
   Data dataFreeFlyer(modelFreeflyer);
@@ -345,8 +345,8 @@ BOOST_AUTO_TEST_CASE (vsFreeFlyer)
   SE3 pos(1); pos.translation() = SE3::Linear_t(1.,0.,0.);
 
 
-  modelSphericalZYX.addBody (0, JointModelSphericalZYX (), pos, inertia, "spherical");
-    modelFreeflyer.addBody(0, JointModelFreeFlyer(),pos, inertia, "ff");
+  modelSphericalZYX.addJointAndBody (0, JointModelSphericalZYX (), pos, inertia, "spherical");
+    modelFreeflyer.addJointAndBody(0, JointModelFreeFlyer(),pos, inertia, "ff");
 
   Data dataSphericalZYX(modelSphericalZYX);
   Data dataFreeFlyer(modelFreeflyer);
@@ -386,7 +386,7 @@ BOOST_AUTO_TEST_CASE ( test_rnea )
   Model model;
   Inertia inertia (1., Vector3 (0.5, 0., 0.0), Matrix3::Identity ());
 
-  model.addBody (model.getBodyId("universe"), JointModelSphericalZYX (), SE3::Identity (), inertia, "root");
+  model.addJointAndBody (model.getBodyId("universe"), JointModelSphericalZYX (), SE3::Identity (), inertia, "root");
 
   Data data (model);
 
@@ -428,7 +428,7 @@ BOOST_AUTO_TEST_CASE ( test_crba )
   Model model;
   Inertia inertia (1., Vector3 (0.5, 0., 0.0), Matrix3::Identity ());
 
-  model.addBody (model.getBodyId("universe"), JointModelSphericalZYX (), SE3::Identity (), inertia, "root");
+  model.addJointAndBody (model.getBodyId("universe"), JointModelSphericalZYX (), SE3::Identity (), inertia, "root");
 
   Data data (model);
 
@@ -527,7 +527,7 @@ BOOST_AUTO_TEST_CASE ( test_rnea )
   Model model;
   Inertia inertia (1., Vector3 (0.5, 0., 0.0), Matrix3::Identity ());
 
-  model.addBody (model.getBodyId("universe"), JointModelPX(), SE3::Identity (), inertia, "root");
+  model.addJointAndBody (model.getBodyId("universe"), JointModelPX(), SE3::Identity (), inertia, "root");
 
   Data data (model);
 
@@ -572,7 +572,7 @@ BOOST_AUTO_TEST_CASE ( test_crba )
   Model model;
   Inertia inertia (1., Vector3 (0.5, 0., 0.0), Matrix3::Identity ());
 
-  model.addBody (model.getBodyId("universe"), JointModelPX (), SE3::Identity (), inertia, "root");
+  model.addJointAndBody (model.getBodyId("universe"), JointModelPX (), SE3::Identity (), inertia, "root");
 
   Data data (model);
 
@@ -660,8 +660,8 @@ BOOST_AUTO_TEST_CASE (vsFreeFlyer)
   SE3 pos(1); pos.translation() = SE3::Linear_t(1.,0.,0.);
 
 
-  modelPlanar.addBody (0, JointModelPlanar (), pos, inertia, "planar");
-  modelFreeflyer.addBody(0, JointModelFreeFlyer(),pos, inertia, "ff");
+  modelPlanar.addJointAndBody (0, JointModelPlanar (), pos, inertia, "planar");
+  modelFreeflyer.addJointAndBody(0, JointModelFreeFlyer(),pos, inertia, "ff");
 
   Data dataPlanar(modelPlanar);
   Data dataFreeFlyer(modelFreeflyer);
@@ -758,8 +758,8 @@ BOOST_AUTO_TEST_CASE (vsFreeFlyer)
   SE3 pos(1); pos.translation() = SE3::Linear_t(1.,0.,0.);
 
 
-  modelTranslation.addBody (0, JointModelTranslation (), pos, inertia, "translation");
-  modelFreeflyer.addBody(0, JointModelFreeFlyer(),pos, inertia, "ff");
+  modelTranslation.addJointAndBody (0, JointModelTranslation (), pos, inertia, "translation");
+  modelFreeflyer.addJointAndBody(0, JointModelFreeFlyer(),pos, inertia, "ff");
 
   Data dataTranslation(modelTranslation);
   Data dataFreeFlyer(modelFreeflyer);


### PR DESCRIPTION
- Make the separation between bodies and joints and do modifications according to.
- Fixed RobotWrapper display : now correctly get the visuals from the geometrymodel/data, update it and display. The meshes are loaded in the viewer one by one thanks to the mesh_path stored by the GeometryObject itself. Removed some useless informations such as _has_visual_ and _fixedBodies_ that were informations related to visual stuff.

Related to #126 , #161 