### PR TITLE
[C++] Rename spatial scalar type to follow Eigen convention.

### DIFF
--- a/src/multibody/constraint.hpp
+++ b/src/multibody/constraint.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2015-2016 CNRS
+// Copyright (c) 2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -63,7 +64,7 @@ namespace se3
   template<int D, typename T, int U>
   struct traits< ConstraintTpl<D, T, U> >
   {
-    typedef T Scalar_t;
+    typedef T Scalar;
     typedef Eigen::Matrix<T,3,1,U> Vector3;
     typedef Eigen::Matrix<T,4,1,U> Vector4;
     typedef Eigen::Matrix<T,6,1,U> Vector6;
@@ -84,9 +85,9 @@ namespace se3
       LINEAR = 0,
       ANGULAR = 3
     };
-    typedef Eigen::Matrix<Scalar_t,D,1,U> JointMotion;
-    typedef Eigen::Matrix<Scalar_t,D,1,U> JointForce;
-    typedef Eigen::Matrix<Scalar_t,6,D> DenseBase;
+    typedef Eigen::Matrix<Scalar,D,1,U> JointMotion;
+    typedef Eigen::Matrix<Scalar,D,1,U> JointForce;
+    typedef Eigen::Matrix<Scalar,6,D> DenseBase;
 
   }; // traits ConstraintTpl
 

--- a/src/multibody/joint/joint-free-flyer.hpp
+++ b/src/multibody/joint/joint-free-flyer.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2015 CNRS
-// Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
+// Copyright (c) 2015-2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -39,7 +39,7 @@ namespace se3
   template <>
   struct traits< ConstraintIdentity >
   {
-    typedef double Scalar_t;
+    typedef double Scalar;
     typedef Eigen::Matrix<double,3,1,0> Vector3;
     typedef Eigen::Matrix<double,4,1,0> Vector4;
     typedef Eigen::Matrix<double,6,1,0> Vector6;
@@ -60,9 +60,9 @@ namespace se3
       LINEAR = 0,
       ANGULAR = 3
     };
-    typedef Eigen::Matrix<Scalar_t,6,1,0> JointMotion;
-    typedef Eigen::Matrix<Scalar_t,6,1,0> JointForce;
-    typedef Eigen::Matrix<Scalar_t,6,6> DenseBase;
+    typedef Eigen::Matrix<Scalar,6,1,0> JointMotion;
+    typedef Eigen::Matrix<Scalar,6,1,0> JointForce;
+    typedef Eigen::Matrix<Scalar,6,6> DenseBase;
   }; // traits ConstraintRevolute
 
 
@@ -200,7 +200,7 @@ namespace se3
     using JointModelBase<JointModelFreeFlyer>::idx_v;
     using JointModelBase<JointModelFreeFlyer>::setIndexes;
     typedef Motion::Vector3 Vector3;
-    typedef double Scalar_t;
+    typedef double Scalar;
 
     JointDataDerived createData() const { return JointDataDerived(); }
     void calc(JointDataDerived & data,
@@ -305,19 +305,19 @@ namespace se3
           throw std::runtime_error(error.str());
         }
           
-        result[i] = lower_pos_limit[i] + (upper_pos_limit[i] - lower_pos_limit[i]) * (Scalar_t)(rand())/RAND_MAX;
+        result[i] = lower_pos_limit[i] + (upper_pos_limit[i] - lower_pos_limit[i]) * (Scalar)(rand())/RAND_MAX;
       }
           
       // Rotational part
-      const Scalar_t u1 = (Scalar_t)rand() / RAND_MAX;
-      const Scalar_t u2 = (Scalar_t)rand() / RAND_MAX;
-      const Scalar_t u3 = (Scalar_t)rand() / RAND_MAX;
+      const Scalar u1 = (Scalar)rand() / RAND_MAX;
+      const Scalar u2 = (Scalar)rand() / RAND_MAX;
+      const Scalar u3 = (Scalar)rand() / RAND_MAX;
       
-      const Scalar_t mult1 = sqrt (1-u1);
-      const Scalar_t mult2 = sqrt (u1);
+      const Scalar mult1 = sqrt (1-u1);
+      const Scalar mult2 = sqrt (u1);
       
-      Scalar_t s2,c2; SINCOS(2.*PI*u2,&s2,&c2);
-      Scalar_t s3,c3; SINCOS(2.*PI*u3,&s3,&c3);
+      Scalar s2,c2; SINCOS(2.*PI*u2,&s2,&c2);
+      Scalar s3,c3; SINCOS(2.*PI*u3,&s3,&c3);
       
       
       result.segment<4>(3) << mult1 * s2,
@@ -350,7 +350,7 @@ namespace se3
         result.tail<3> ().setZero();
       else
       {
-        const Scalar_t theta = 2.*acos(quat_relatif.w());
+        const Scalar theta = 2.*acos(quat_relatif.w());
         
         if (quat0.dot(quat1) >= 0.)
           result.tail<3>() << theta * quat_relatif.vec().normalized();

--- a/src/multibody/joint/joint-planar.hpp
+++ b/src/multibody/joint/joint-planar.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2015 CNRS
-// Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
+// Copyright (c) 2015-2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -38,7 +38,7 @@ namespace se3
   template <>
   struct traits< MotionPlanar >
   {
-    typedef double Scalar_t;
+    typedef double Scalar;
     typedef Eigen::Matrix<double,3,1,0> Vector3;
     typedef Eigen::Matrix<double,4,1,0> Vector4;
     typedef Eigen::Matrix<double,6,1,0> Vector6;
@@ -66,10 +66,10 @@ namespace se3
     SPATIAL_TYPEDEF_NO_TEMPLATE(MotionPlanar);
 
     MotionPlanar () : x_dot_(NAN), y_dot_(NAN), theta_dot_(NAN)      {}
-    MotionPlanar (Scalar_t x_dot, Scalar_t y_dot, Scalar_t theta_dot) : x_dot_(x_dot), y_dot_(y_dot), theta_dot_(theta_dot)  {}
-    Scalar_t x_dot_;
-    Scalar_t y_dot_;
-    Scalar_t theta_dot_;
+    MotionPlanar (Scalar x_dot, Scalar y_dot, Scalar theta_dot) : x_dot_(x_dot), y_dot_(y_dot), theta_dot_(theta_dot)  {}
+    Scalar x_dot_;
+    Scalar y_dot_;
+    Scalar theta_dot_;
 
     operator Motion() const
     {
@@ -98,7 +98,7 @@ namespace se3
   template <>
   struct traits < ConstraintPlanar >
   {
-    typedef double Scalar_t;
+    typedef double Scalar;
     typedef Eigen::Matrix<double,3,1,0> Vector3;
     typedef Eigen::Matrix<double,4,1,0> Vector4;
     typedef Eigen::Matrix<double,6,1,0> Vector6;
@@ -119,9 +119,9 @@ namespace se3
       LINEAR = 0,
       ANGULAR = 3
     };
-    typedef Eigen::Matrix<Scalar_t,3,1,0> JointMotion;
-    typedef Eigen::Matrix<Scalar_t,3,1,0> JointForce;
-    typedef Eigen::Matrix<Scalar_t,6,3> DenseBase;
+    typedef Eigen::Matrix<Scalar,3,1,0> JointMotion;
+    typedef Eigen::Matrix<Scalar,3,1,0> JointForce;
+    typedef Eigen::Matrix<Scalar,6,3> DenseBase;
   }; // struct traits ConstraintPlanar
 
 
@@ -171,7 +171,7 @@ namespace se3
 
     operator ConstraintXd () const
     {
-      Eigen::Matrix<Scalar_t,6,3> S;
+      Eigen::Matrix<Scalar,6,3> S;
       S.block <3,3> (Inertia::LINEAR, 0).setZero ();
       S.block <3,3> (Inertia::ANGULAR, 0).setZero ();
       S(Inertia::LINEAR + 0,0) = 1.;
@@ -180,7 +180,7 @@ namespace se3
       return ConstraintXd(S);
     }
 
-    Eigen::Matrix <Scalar_t,6,3> se3Action (const SE3 & m) const
+    Eigen::Matrix <Scalar,6,3> se3Action (const SE3 & m) const
     {
       Eigen::Matrix <double,6,3> X_subspace;
       X_subspace.block <3,2> (Motion::LINEAR, 0) = m.rotation ().leftCols <2> ();
@@ -219,9 +219,9 @@ namespace se3
   }
 
   /* [CRBA] ForceSet operator* (Inertia Y,Constraint S) */
-  inline Eigen::Matrix <Inertia::Scalar_t, 6, 3> operator* (const Inertia & Y, const ConstraintPlanar &)
+  inline Eigen::Matrix <Inertia::Scalar, 6, 3> operator* (const Inertia & Y, const ConstraintPlanar &)
   {
-    Eigen::Matrix <Inertia::Scalar_t, 6, 3> M;
+    Eigen::Matrix <Inertia::Scalar, 6, 3> M;
     const double mass = Y.mass ();
     const Inertia::Vector3 & com = Y.lever ();
     const Symmetric3 & inertia = Y.inertia ();
@@ -244,10 +244,10 @@ namespace se3
   /* [ABA] Y*S operator (Inertia Y,Constraint S) */
   //  inline Eigen::Matrix<double,6,1>
   inline
-  Eigen::Matrix<Inertia::Scalar_t, 6, 3>
+  Eigen::Matrix<Inertia::Scalar, 6, 3>
   operator* (const Inertia::Matrix6 & Y, const ConstraintPlanar &)
   {
-    typedef Eigen::Matrix<Inertia::Scalar_t, 6, 3> Matrix63;
+    typedef Eigen::Matrix<Inertia::Scalar, 6, 3> Matrix63;
     Matrix63 IS;
     
     IS.leftCols <2> () = Y.leftCols <2> ();

--- a/src/multibody/joint/joint-prismatic-unaligned.hpp
+++ b/src/multibody/joint/joint-prismatic-unaligned.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2015-2016 CNRS
+// Copyright (c) 2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -36,23 +37,23 @@ namespace se3
   template <>
   struct traits <MotionPrismaticUnaligned>
   {
-    typedef double Scalar_t;
-    typedef Eigen::Matrix<Scalar_t,3,1,0> Vector3;
-    typedef Eigen::Matrix<Scalar_t,4,1,0> Vector4;
-    typedef Eigen::Matrix<Scalar_t,6,1,0> Vector6;
-    typedef Eigen::Matrix<Scalar_t,3,3,0> Matrix3;
-    typedef Eigen::Matrix<Scalar_t,4,4,0> Matrix4;
-    typedef Eigen::Matrix<Scalar_t,6,6,0> Matrix6;
+    typedef double Scalar;
+    typedef Eigen::Matrix<Scalar,3,1,0> Vector3;
+    typedef Eigen::Matrix<Scalar,4,1,0> Vector4;
+    typedef Eigen::Matrix<Scalar,6,1,0> Vector6;
+    typedef Eigen::Matrix<Scalar,3,3,0> Matrix3;
+    typedef Eigen::Matrix<Scalar,4,4,0> Matrix4;
+    typedef Eigen::Matrix<Scalar,6,6,0> Matrix6;
     typedef Vector3 Angular_t;
     typedef Vector3 Linear_t;
     typedef const Vector3 ConstAngular_t;
     typedef const Vector3 ConstLinear_t;
     typedef Matrix6 ActionMatrix_t;
-    typedef Eigen::Quaternion<Scalar_t,0> Quaternion_t;
-    typedef SE3Tpl<Scalar_t,0> SE3;
-    typedef ForceTpl<Scalar_t,0> Force;
-    typedef MotionTpl<Scalar_t,0> Motion;
-    typedef Symmetric3Tpl<Scalar_t,0> Symmetric3;
+    typedef Eigen::Quaternion<Scalar,0> Quaternion_t;
+    typedef SE3Tpl<Scalar,0> SE3;
+    typedef ForceTpl<Scalar,0> Force;
+    typedef MotionTpl<Scalar,0> Motion;
+    typedef Symmetric3Tpl<Scalar,0> Symmetric3;
     enum {
       LINEAR = 0,
       ANGULAR = 3
@@ -64,10 +65,10 @@ namespace se3
     SPATIAL_TYPEDEF_NO_TEMPLATE(MotionPrismaticUnaligned);
 
     MotionPrismaticUnaligned () : axis(Vector3::Constant(NAN)), v(NAN) {}
-    MotionPrismaticUnaligned (const Vector3 & axis, const Scalar_t v) : axis(axis), v(v) {}
+    MotionPrismaticUnaligned (const Vector3 & axis, const Scalar v) : axis(axis), v(v) {}
 
     Vector3 axis;
-    Scalar_t v;
+    Scalar v;
 
     operator Motion() const { return Motion(axis*v, Vector3::Zero());}
   }; // struct MotionPrismaticUnaligned
@@ -84,30 +85,30 @@ namespace se3
   template <>
   struct traits <ConstraintPrismaticUnaligned>
   {
-    typedef double Scalar_t;
-    typedef Eigen::Matrix<Scalar_t,3,1,0> Vector3;
-    typedef Eigen::Matrix<Scalar_t,4,1,0> Vector4;
-    typedef Eigen::Matrix<Scalar_t,6,1,0> Vector6;
-    typedef Eigen::Matrix<Scalar_t,3,3,0> Matrix3;
-    typedef Eigen::Matrix<Scalar_t,4,4,0> Matrix4;
-    typedef Eigen::Matrix<Scalar_t,6,6,0> Matrix6;
+    typedef double Scalar;
+    typedef Eigen::Matrix<Scalar,3,1,0> Vector3;
+    typedef Eigen::Matrix<Scalar,4,1,0> Vector4;
+    typedef Eigen::Matrix<Scalar,6,1,0> Vector6;
+    typedef Eigen::Matrix<Scalar,3,3,0> Matrix3;
+    typedef Eigen::Matrix<Scalar,4,4,0> Matrix4;
+    typedef Eigen::Matrix<Scalar,6,6,0> Matrix6;
     typedef Matrix3 Angular_t;
     typedef Vector3 Linear_t;
     typedef const Matrix3 ConstAngular_t;
     typedef const Vector3 ConstLinear_t;
     typedef Matrix6 ActionMatrix_t;
-    typedef Eigen::Quaternion<Scalar_t,0> Quaternion_t;
-    typedef SE3Tpl<Scalar_t,0> SE3;
-    typedef ForceTpl<Scalar_t,0> Force;
-    typedef MotionTpl<Scalar_t,0> Motion;
-    typedef Symmetric3Tpl<Scalar_t,0> Symmetric3;
+    typedef Eigen::Quaternion<Scalar,0> Quaternion_t;
+    typedef SE3Tpl<Scalar,0> SE3;
+    typedef ForceTpl<Scalar,0> Force;
+    typedef MotionTpl<Scalar,0> Motion;
+    typedef Symmetric3Tpl<Scalar,0> Symmetric3;
     enum {
       LINEAR = 0,
       ANGULAR = 3
     };
-    typedef Eigen::Matrix<Scalar_t,1,1,0> JointMotion;
-    typedef Eigen::Matrix<Scalar_t,1,1,0> JointForce;
-    typedef Eigen::Matrix<Scalar_t,6,1> DenseBase;
+    typedef Eigen::Matrix<Scalar,1,1,0> JointMotion;
+    typedef Eigen::Matrix<Scalar,1,1,0> JointForce;
+    typedef Eigen::Matrix<Scalar,6,1> DenseBase;
   }; // traits ConstraintPrismaticUnaligned
 
     struct ConstraintPrismaticUnaligned : ConstraintBase <ConstraintPrismaticUnaligned>
@@ -142,14 +143,14 @@ namespace se3
 
       struct TransposeConst
       {
-        typedef traits<ConstraintPrismaticUnaligned>::Scalar_t Scalar_t;
+        typedef traits<ConstraintPrismaticUnaligned>::Scalar Scalar;
         typedef traits<ConstraintPrismaticUnaligned>::Force Force;
         typedef traits<ConstraintPrismaticUnaligned>::Vector6 Vector6;
         
       	const ConstraintPrismaticUnaligned & ref; 
       	TransposeConst(const ConstraintPrismaticUnaligned & ref) : ref(ref) {}
         
-      	const Eigen::Matrix<Scalar_t, 1, 1>
+      	const Eigen::Matrix<Scalar, 1, 1>
       	operator* (const Force & f) const
       	{
       	  return ref.axis.transpose()*f.linear();
@@ -319,10 +320,10 @@ namespace se3
     using JointModelBase<JointModelPrismaticUnaligned>::idx_v;
     using JointModelBase<JointModelPrismaticUnaligned>::setIndexes;
     typedef Motion::Vector3 Vector3;
-    typedef double Scalar_t;
+    typedef double Scalar;
     
     JointModelPrismaticUnaligned() : axis(Vector3::Constant(NAN))   {}
-    JointModelPrismaticUnaligned(Scalar_t x, Scalar_t y, Scalar_t z)
+    JointModelPrismaticUnaligned(Scalar x, Scalar y, Scalar z)
     {
       axis << x, y, z ;
       axis.normalize();
@@ -350,8 +351,8 @@ namespace se3
               const Eigen::VectorXd & qs,
               const Eigen::VectorXd & vs) const
     {
-      const Scalar_t & q = qs[idx_q()];
-      const Scalar_t & v = vs[idx_v()];
+      const Scalar & q = qs[idx_q()];
+      const Scalar & v = vs[idx_v()];
 
       /* It should not be necessary to copy axis in jdata, however a current bug
        * in the fusion visitor prevents a proper access to jmodel::axis. A
@@ -373,8 +374,8 @@ namespace se3
 
     ConfigVector_t integrate_impl(const Eigen::VectorXd & qs,const Eigen::VectorXd & vs) const
     {
-      const Scalar_t & q = qs[idx_q()];
-      const Scalar_t & v = vs[idx_v()];
+      const Scalar & q = qs[idx_q()];
+      const Scalar & v = vs[idx_v()];
 
       ConfigVector_t result;
       result << (q + v);
@@ -383,8 +384,8 @@ namespace se3
 
     ConfigVector_t interpolate_impl(const Eigen::VectorXd & q0,const Eigen::VectorXd & q1, const double u) const
     { 
-      const Scalar_t & q_0 = q0[idx_q()];
-      const Scalar_t & q_1 = q1[idx_q()];
+      const Scalar & q_0 = q0[idx_q()];
+      const Scalar & q_1 = q1[idx_q()];
 
       ConfigVector_t result;
       result << ((1-u) * q_0 + u * q_1);
@@ -417,8 +418,8 @@ namespace se3
 
     TangentVector_t difference_impl(const Eigen::VectorXd & q0,const Eigen::VectorXd & q1) const
     { 
-      const Scalar_t & q_0 = q0[idx_q()];
-      const Scalar_t & q_1 = q1[idx_q()];
+      const Scalar & q_0 = q0[idx_q()];
+      const Scalar & q_1 = q1[idx_q()];
 
       ConfigVector_t result;
       result << (q_1 - q_0);
@@ -427,8 +428,8 @@ namespace se3
 
     double distance_impl(const Eigen::VectorXd & q0,const Eigen::VectorXd & q1) const
     { 
-      const Scalar_t & q_0 = q0[idx_q()];
-      const Scalar_t & q_1 = q1[idx_q()];
+      const Scalar & q_0 = q0[idx_q()];
+      const Scalar & q_1 = q1[idx_q()];
 
       return (q_1-q_0);
     }

--- a/src/multibody/joint/joint-prismatic.hpp
+++ b/src/multibody/joint/joint-prismatic.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2015-2016 CNRS
-// Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
+// Copyright (c) 2015-2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -60,7 +60,7 @@ namespace se3
   template<int axis>
   struct traits <MotionPrismatic < axis > >
   {
-    typedef double Scalar_t;
+    typedef double Scalar;
     typedef Eigen::Matrix<double,3,1,0> Vector3;
     typedef Eigen::Matrix<double,4,1,0> Vector4;
     typedef Eigen::Matrix<double,6,1,0> Vector6;
@@ -114,7 +114,7 @@ namespace se3
   template<int axis>
   struct traits< ConstraintPrismatic<axis> >
   {
-    typedef double Scalar_t;
+    typedef double Scalar;
     typedef Eigen::Matrix<double,3,1,0> Vector3;
     typedef Eigen::Matrix<double,4,1,0> Vector4;
     typedef Eigen::Matrix<double,6,1,0> Vector6;
@@ -135,9 +135,9 @@ namespace se3
       LINEAR = 0,
       ANGULAR = 3
     };
-    typedef Eigen::Matrix<Scalar_t,1,1,0> JointMotion;
-    typedef Eigen::Matrix<Scalar_t,1,1,0> JointForce;
-    typedef Eigen::Matrix<Scalar_t,6,1> DenseBase;
+    typedef Eigen::Matrix<Scalar,1,1,0> JointMotion;
+    typedef Eigen::Matrix<Scalar,1,1,0> JointForce;
+    typedef Eigen::Matrix<Scalar,6,1> DenseBase;
   }; // traits ConstraintRevolute
 
   template <int axis>
@@ -396,7 +396,7 @@ namespace se3
     using JointModelBase<JointModelPrismatic>::idx_v;
     using JointModelBase<JointModelPrismatic>::setIndexes;
     typedef Motion::Vector3 Vector3;
-    typedef double Scalar_t;
+    typedef double Scalar;
     
     JointDataDerived createData() const { return JointDataDerived(); }
     void calc( JointDataDerived& data, 
@@ -429,8 +429,8 @@ namespace se3
 
     ConfigVector_t integrate_impl(const Eigen::VectorXd & qs,const Eigen::VectorXd & vs) const
     {
-      const Scalar_t & q = qs[idx_q()];
-      const Scalar_t & v = vs[idx_v()];
+      const Scalar & q = qs[idx_q()];
+      const Scalar & v = vs[idx_v()];
 
       ConfigVector_t result;
       result << (q + v);
@@ -439,8 +439,8 @@ namespace se3
 
     ConfigVector_t interpolate_impl(const Eigen::VectorXd & q0,const Eigen::VectorXd & q1, const double u) const
     { 
-      const Scalar_t & q_0 = q0[idx_q()];
-      const Scalar_t & q_1 = q1[idx_q()];
+      const Scalar & q_0 = q0[idx_q()];
+      const Scalar & q_1 = q1[idx_q()];
 
       ConfigVector_t result;
       result << ((1-u) * q_0 + u * q_1);
@@ -473,8 +473,8 @@ namespace se3
 
     TangentVector_t difference_impl(const Eigen::VectorXd & q0,const Eigen::VectorXd & q1) const
     { 
-      const Scalar_t & q_0 = q0[idx_q()];
-      const Scalar_t & q_1 = q1[idx_q()];
+      const Scalar & q_0 = q0[idx_q()];
+      const Scalar & q_1 = q1[idx_q()];
 
       ConfigVector_t result;
       result << (q_1 - q_0);
@@ -483,8 +483,8 @@ namespace se3
 
     double distance_impl(const Eigen::VectorXd & q0,const Eigen::VectorXd & q1) const
     { 
-      const Scalar_t & q_0 = q0[idx_q()];
-      const Scalar_t & q_1 = q1[idx_q()];
+      const Scalar & q_0 = q0[idx_q()];
+      const Scalar & q_1 = q1[idx_q()];
 
       return (q_1-q_0);
     }

--- a/src/multibody/joint/joint-revolute-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unaligned.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2015-2016 CNRS
-// Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
+// Copyright (c) 2015-2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -36,7 +36,7 @@ namespace se3
   template <>
   struct traits < MotionRevoluteUnaligned >
   {
-    typedef double Scalar_t;
+    typedef double Scalar;
     typedef Eigen::Matrix<double,3,1,0> Vector3;
     typedef Eigen::Matrix<double,4,1,0> Vector4;
     typedef Eigen::Matrix<double,6,1,0> Vector6;
@@ -88,7 +88,7 @@ namespace se3
   template <>
   struct traits < ConstraintRevoluteUnaligned >
   {
-    typedef double Scalar_t;
+    typedef double Scalar;
     typedef Eigen::Matrix<double,3,1,0> Vector3;
     typedef Eigen::Matrix<double,4,1,0> Vector4;
     typedef Eigen::Matrix<double,6,1,0> Vector6;
@@ -109,9 +109,9 @@ namespace se3
       LINEAR = 0,
       ANGULAR = 3
     };
-    typedef Eigen::Matrix<Scalar_t,1,1,0> JointMotion;
-    typedef Eigen::Matrix<Scalar_t,1,1,0> JointForce;
-    typedef Eigen::Matrix<Scalar_t,6,1> DenseBase;
+    typedef Eigen::Matrix<Scalar,1,1,0> JointMotion;
+    typedef Eigen::Matrix<Scalar,1,1,0> JointForce;
+    typedef Eigen::Matrix<Scalar,6,1> DenseBase;
   }; // traits ConstraintRevoluteUnaligned
 
 
@@ -324,7 +324,7 @@ namespace se3
     using JointModelBase<JointModelRevoluteUnaligned>::idx_v;
     using JointModelBase<JointModelRevoluteUnaligned>::setIndexes;
     typedef Motion::Vector3 Vector3;
-    typedef double Scalar_t;
+    typedef double Scalar;
     
     JointModelRevoluteUnaligned() : axis(Eigen::Vector3d::Constant(NAN))   {}
     JointModelRevoluteUnaligned(const double x, const double y, const double z)
@@ -378,8 +378,8 @@ namespace se3
 
     ConfigVector_t integrate_impl(const Eigen::VectorXd & qs,const Eigen::VectorXd & vs) const
     {
-      const Scalar_t & q = qs[idx_q()];
-      const Scalar_t & v = vs[idx_v()];
+      const Scalar & q = qs[idx_q()];
+      const Scalar & v = vs[idx_v()];
 
       ConfigVector_t result;
       result << (q + v);
@@ -388,8 +388,8 @@ namespace se3
 
     ConfigVector_t interpolate_impl(const Eigen::VectorXd & q0,const Eigen::VectorXd & q1, const double u) const
     { 
-      const Scalar_t & q_0 = q0[idx_q()];
-      const Scalar_t & q_1 = q1[idx_q()];
+      const Scalar & q_0 = q0[idx_q()];
+      const Scalar & q_1 = q1[idx_q()];
 
       ConfigVector_t result;
       result << ((1-u) * q_0 + u * q_1);
@@ -422,8 +422,8 @@ namespace se3
 
     TangentVector_t difference_impl(const Eigen::VectorXd & q0,const Eigen::VectorXd & q1) const
     { 
-      const Scalar_t & q_0 = q0[idx_q()];
-      const Scalar_t & q_1 = q1[idx_q()];
+      const Scalar & q_0 = q0[idx_q()];
+      const Scalar & q_1 = q1[idx_q()];
 
       ConfigVector_t result;
       result << (q_1 - q_0);
@@ -432,8 +432,8 @@ namespace se3
 
     double distance_impl(const Eigen::VectorXd & q0,const Eigen::VectorXd & q1) const
     { 
-      const Scalar_t & q_0 = q0[idx_q()];
-      const Scalar_t & q_1 = q1[idx_q()];
+      const Scalar & q_0 = q0[idx_q()];
+      const Scalar & q_1 = q1[idx_q()];
 
       return (q_1-q_0);
     }

--- a/src/multibody/joint/joint-revolute.hpp
+++ b/src/multibody/joint/joint-revolute.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2015-2016 CNRS
-// Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
+// Copyright (c) 2015-2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -63,7 +63,7 @@ namespace se3
   template<int axis>
   struct traits< MotionRevolute < axis > >
   {
-    typedef double Scalar_t;
+    typedef double Scalar;
     typedef Eigen::Matrix<double,3,1,0> Vector3;
     typedef Eigen::Matrix<double,4,1,0> Vector4;
     typedef Eigen::Matrix<double,6,1,0> Vector6;
@@ -118,7 +118,7 @@ namespace se3
   template<int axis>
   struct traits< ConstraintRevolute<axis> >
   {
-    typedef double Scalar_t;
+    typedef double Scalar;
     typedef Eigen::Matrix<double,3,1,0> Vector3;
     typedef Eigen::Matrix<double,4,1,0> Vector4;
     typedef Eigen::Matrix<double,6,1,0> Vector6;
@@ -139,9 +139,9 @@ namespace se3
       LINEAR = 0,
       ANGULAR = 3
     };
-    typedef Eigen::Matrix<Scalar_t,1,1,0> JointMotion;
-    typedef Eigen::Matrix<Scalar_t,1,1,0> JointForce;
-    typedef Eigen::Matrix<Scalar_t,6,1> DenseBase;
+    typedef Eigen::Matrix<Scalar,1,1,0> JointMotion;
+    typedef Eigen::Matrix<Scalar,1,1,0> JointForce;
+    typedef Eigen::Matrix<Scalar,6,1> DenseBase;
   }; // traits ConstraintRevolute
 
   template<int axis>
@@ -430,7 +430,7 @@ namespace se3
     using JointModelBase<JointModelRevolute>::idx_v;
     using JointModelBase<JointModelRevolute>::setIndexes;
     typedef Motion::Vector3 Vector3;
-    typedef double Scalar_t;
+    typedef double Scalar;
     
     JointDataDerived createData() const { return JointDataDerived(); }
     void calc( JointDataDerived& data, 
@@ -463,8 +463,8 @@ namespace se3
 
     ConfigVector_t integrate_impl(const Eigen::VectorXd & qs,const Eigen::VectorXd & vs) const
     {
-      const Scalar_t & q = qs[idx_q()];
-      const Scalar_t & v = vs[idx_v()];
+      const Scalar & q = qs[idx_q()];
+      const Scalar & v = vs[idx_v()];
 
       ConfigVector_t result;
       result << (q + v);
@@ -473,8 +473,8 @@ namespace se3
 
     ConfigVector_t interpolate_impl(const Eigen::VectorXd & q0,const Eigen::VectorXd & q1, const double u) const
     { 
-      const Scalar_t & q_0 = q0[idx_q()];
-      const Scalar_t & q_1 = q1[idx_q()];
+      const Scalar & q_0 = q0[idx_q()];
+      const Scalar & q_1 = q1[idx_q()];
 
       ConfigVector_t result;
       result << ((1-u) * q_0 + u * q_1);
@@ -507,8 +507,8 @@ namespace se3
 
     TangentVector_t difference_impl(const Eigen::VectorXd & q0,const Eigen::VectorXd & q1) const
     { 
-      const Scalar_t & q_0 = q0[idx_q()];
-      const Scalar_t & q_1 = q1[idx_q()];
+      const Scalar & q_0 = q0[idx_q()];
+      const Scalar & q_1 = q1[idx_q()];
 
       ConfigVector_t result;
       result << (q_1 - q_0);
@@ -517,8 +517,8 @@ namespace se3
 
     double distance_impl(const Eigen::VectorXd & q0,const Eigen::VectorXd & q1) const
     { 
-      const Scalar_t & q_0 = q0[idx_q()];
-      const Scalar_t & q_1 = q1[idx_q()];
+      const Scalar & q_0 = q0[idx_q()];
+      const Scalar & q_1 = q1[idx_q()];
 
       return (q_1-q_0);
     }

--- a/src/multibody/joint/joint-spherical-ZYX.hpp
+++ b/src/multibody/joint/joint-spherical-ZYX.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2015-2016 CNRS
-// Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
+// Copyright (c) 2015-2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -293,7 +293,7 @@ namespace se3
     typedef JointSphericalZYX JointDerived;
     SE3_JOINT_TYPEDEF;
 
-    typedef Motion::Scalar_t Scalar;
+    typedef Motion::Scalar Scalar;
 
     typedef Eigen::Matrix<Scalar,6,6> Matrix6;
     typedef Eigen::Matrix<Scalar,3,3> Matrix3;
@@ -329,7 +329,7 @@ namespace se3
     using JointModelBase<JointModelSphericalZYX>::idx_v;
     using JointModelBase<JointModelSphericalZYX>::setIndexes;
     typedef Motion::Vector3 Vector3;
-    typedef double Scalar_t;
+    typedef double Scalar;
 
     JointDataDerived createData() const { return JointDataDerived(); }
 

--- a/src/multibody/joint/joint-spherical.hpp
+++ b/src/multibody/joint/joint-spherical.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2015-2016 CNRS
-// Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
+// Copyright (c) 2015-2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -39,7 +39,7 @@ namespace se3
   template <>
   struct traits< MotionSpherical >
   {
-    typedef double Scalar_t;
+    typedef double Scalar;
     typedef Eigen::Matrix<double,3,1,0> Vector3;
     typedef Eigen::Matrix<double,4,1,0> Vector4;
     typedef Eigen::Matrix<double,6,1,0> Vector6;
@@ -91,7 +91,7 @@ namespace se3
   template <>
   struct traits < struct ConstraintRotationalSubspace >
   {
-    typedef double Scalar_t;
+    typedef double Scalar;
     typedef Eigen::Matrix<double,3,1,0> Vector3;
     typedef Eigen::Matrix<double,4,1,0> Vector4;
     typedef Eigen::Matrix<double,6,1,0> Vector6;
@@ -112,9 +112,9 @@ namespace se3
       LINEAR = 0,
       ANGULAR = 3
     };
-    typedef Eigen::Matrix<Scalar_t,3,1,0> JointMotion;
-    typedef Eigen::Matrix<Scalar_t,3,1,0> JointForce;
-    typedef Eigen::Matrix<Scalar_t,6,3> DenseBase;
+    typedef Eigen::Matrix<Scalar,3,1,0> JointMotion;
+    typedef Eigen::Matrix<Scalar,3,1,0> JointForce;
+    typedef Eigen::Matrix<Scalar,6,3> DenseBase;
   }; // struct traits struct ConstraintRotationalSubspace
 
   struct ConstraintRotationalSubspace
@@ -263,7 +263,7 @@ namespace se3
     using JointModelBase<JointModelSpherical>::idx_v;
     using JointModelBase<JointModelSpherical>::setIndexes;
     typedef Motion::Vector3 Vector3;
-    typedef double Scalar_t;
+    typedef double Scalar;
 
     JointDataDerived createData() const { return JointDataDerived(); }
 
@@ -345,15 +345,15 @@ namespace se3
       ConfigVector_t result;
 
       // Rotational part
-      const Scalar_t u1 = (Scalar_t)rand() / RAND_MAX;
-      const Scalar_t u2 = (Scalar_t)rand() / RAND_MAX;
-      const Scalar_t u3 = (Scalar_t)rand() / RAND_MAX;
+      const Scalar u1 = (Scalar)rand() / RAND_MAX;
+      const Scalar u2 = (Scalar)rand() / RAND_MAX;
+      const Scalar u3 = (Scalar)rand() / RAND_MAX;
       
-      const Scalar_t mult1 = sqrt (1-u1);
-      const Scalar_t mult2 = sqrt (u1);
+      const Scalar mult1 = sqrt (1-u1);
+      const Scalar mult2 = sqrt (u1);
       
-      Scalar_t s2,c2; SINCOS(2.*PI*u2,&s2,&c2);
-      Scalar_t s3,c3; SINCOS(2.*PI*u3,&s3,&c3);
+      Scalar s2,c2; SINCOS(2.*PI*u2,&s2,&c2);
+      Scalar s3,c3; SINCOS(2.*PI*u3,&s3,&c3);
       
       result << mult1 * s2,
                 mult1 * c2,
@@ -377,7 +377,7 @@ namespace se3
         return TangentVector_t::Zero();
       else
       {
-        Scalar_t theta;
+        Scalar theta;
         if (quat0.dot(quat1) >= 0.)
           theta = 2.*acos(quat_relatif.w());
         else

--- a/src/multibody/joint/joint-translation.hpp
+++ b/src/multibody/joint/joint-translation.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2015 CNRS
-// Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
+// Copyright (c) 2015-2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -37,7 +37,7 @@ namespace se3
   template <>
   struct traits < MotionTranslation >
   {
-    typedef double Scalar_t;
+    typedef double Scalar;
     typedef Eigen::Matrix<double,3,1,0> Vector3;
     typedef Eigen::Matrix<double,4,1,0> Vector4;
     typedef Eigen::Matrix<double,6,1,0> Vector6;
@@ -96,7 +96,7 @@ namespace se3
   template <>
   struct traits < ConstraintTranslationSubspace>
   {
-    typedef double Scalar_t;
+    typedef double Scalar;
     typedef Eigen::Matrix<double,3,1,0> Vector3;
     typedef Eigen::Matrix<double,4,1,0> Vector4;
     typedef Eigen::Matrix<double,6,1,0> Vector6;
@@ -117,9 +117,9 @@ namespace se3
       LINEAR = 0,
       ANGULAR = 3
     };
-    typedef Eigen::Matrix<Scalar_t,3,1,0> JointMotion;
-    typedef Eigen::Matrix<Scalar_t,3,1,0> JointForce;
-    typedef Eigen::Matrix<Scalar_t,6,3> DenseBase;
+    typedef Eigen::Matrix<Scalar,3,1,0> JointMotion;
+    typedef Eigen::Matrix<Scalar,3,1,0> JointForce;
+    typedef Eigen::Matrix<Scalar,6,3> DenseBase;
   }; // traits ConstraintTranslationSubspace
 
   struct ConstraintTranslationSubspace : ConstraintBase < ConstraintTranslationSubspace >
@@ -278,7 +278,7 @@ namespace se3
     using JointModelBase<JointModelTranslation>::idx_v;
     using JointModelBase<JointModelTranslation>::setIndexes;
     typedef Motion::Vector3 Vector3;
-    typedef double Scalar_t;
+    typedef double Scalar;
 
     JointDataDerived createData() const { return JointDataDerived(); }
 

--- a/src/multibody/parser/urdf.hxx
+++ b/src/multibody/parser/urdf.hxx
@@ -1,6 +1,6 @@
         //
 // Copyright (c) 2015-2016 CNRS
-// Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
+// Copyright (c) 2015-2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -147,20 +147,20 @@ namespace se3
 
             typedef JointModelFreeFlyer::ConfigVector_t ConfigVector_t;
             typedef JointModelFreeFlyer::TangentVector_t TangentVector_t;
-            typedef ConfigVector_t::Scalar Scalar_t;
+            typedef ConfigVector_t::Scalar Scalar;
 
 
             ConfigVector_t lower_position;
-            lower_position.fill(std::numeric_limits<Scalar_t>::min());
+            lower_position.fill(std::numeric_limits<Scalar>::min());
 
             ConfigVector_t upper_position;
-            upper_position.fill(std::numeric_limits<Scalar_t>::max());
+            upper_position.fill(std::numeric_limits<Scalar>::max());
 
             TangentVector_t max_effort;
-            max_effort.fill(std::numeric_limits<Scalar_t>::max());
+            max_effort.fill(std::numeric_limits<Scalar>::max());
 
             TangentVector_t max_velocity;
-            max_velocity.fill(std::numeric_limits<Scalar_t>::max());
+            max_velocity.fill(std::numeric_limits<Scalar>::max());
 
             model.addJointAndBody(parent_joint_id, JointModelFreeFlyer(), jointPlacement, Y,
               max_effort, max_velocity, lower_position, upper_position,

--- a/src/python/force.hpp
+++ b/src/python/force.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2015-2016 CNRS
+// Copyright (c) 2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -28,7 +29,7 @@ namespace eigenpy
   template<>
   struct UnalignedEquivalent<se3::Force>
   {
-    typedef se3::ForceTpl<se3::Force::Scalar_t,Eigen::DontAlign> type;
+    typedef se3::ForceTpl<se3::Force::Scalar,Eigen::DontAlign> type;
   };
 } // namespace eigenpy
 

--- a/src/python/inertia.hpp
+++ b/src/python/inertia.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2015-2016 CNRS
+// Copyright (c) 2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -28,7 +29,7 @@ namespace eigenpy
   template<>
   struct UnalignedEquivalent<se3::Inertia>
   {
-    typedef se3::InertiaTpl<se3::Inertia::Scalar_t,Eigen::DontAlign> type;
+    typedef se3::InertiaTpl<se3::Inertia::Scalar,Eigen::DontAlign> type;
   };
 
 } // namespace eigenpy
@@ -55,7 +56,7 @@ namespace se3
       typedef typename Inertia_fx::Vector3 Vector3_fx;
       typedef typename Inertia_fx::Motion  Motion_fx ;
       
-      typedef typename Inertia_fx::Scalar_t Scalar_t;
+      typedef typename Inertia_fx::Scalar Scalar;
       
     public:
 
@@ -113,8 +114,8 @@ namespace se3
         ;
 	  }
       
-      static Scalar_t getMass( const Inertia_fx & self ) { return self.mass(); }
-      static void setMass( Inertia_fx & self, Scalar_t mass ) { self.mass() = mass; }
+      static Scalar getMass( const Inertia_fx & self ) { return self.mass(); }
+      static void setMass( Inertia_fx & self, Scalar mass ) { self.mass() = mass; }
       
       static Vector3_fx getLever( const Inertia_fx & self ) { return self.lever(); }
       static void setLever( Inertia_fx & self, const Vector3_fx & lever ) { self.lever() = lever; }

--- a/src/python/motion.hpp
+++ b/src/python/motion.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2015-2016 CNRS
+// Copyright (c) 2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -29,7 +30,7 @@ namespace eigenpy
   template<>
   struct UnalignedEquivalent<se3::Motion>
   {
-    typedef se3::MotionTpl<se3::Motion::Scalar_t,Eigen::DontAlign> type;
+    typedef se3::MotionTpl<se3::Motion::Scalar,Eigen::DontAlign> type;
   };
 } // namespace eigenpy
 

--- a/src/python/se3.hpp
+++ b/src/python/se3.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2015 CNRS
+// Copyright (c) 2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -28,7 +29,7 @@ namespace eigenpy
   template<>
   struct UnalignedEquivalent<se3::SE3>
   {
-    typedef se3::SE3Tpl<se3::SE3::Scalar_t,Eigen::DontAlign> type;
+    typedef se3::SE3Tpl<se3::SE3::Scalar,Eigen::DontAlign> type;
   };
 } // namespace eigenpy
 

--- a/src/spatial/force.hpp
+++ b/src/spatial/force.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2015 CNRS
+// Copyright (c) 2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -62,7 +63,7 @@ namespace se3
     Derived_t operator-() const { return derived().__minus__(); }
     Derived_t operator-(const Derived_t & phi) const { return derived().__minus__(phi); }
     
-    Scalar_t dot(const Motion & m) const { return static_cast<Derived_t*>(this)->dot(m); }
+    Scalar dot(const Motion & m) const { return static_cast<Derived_t*>(this)->dot(m); }
 
     Derived_t se3Action(const SE3 & m) const { return derived().se3Action_impl(m); }
     Derived_t se3ActionInverse(const SE3 & m) const { return derived().se3ActionInverse_impl(m); }
@@ -80,7 +81,7 @@ namespace se3
   template<typename T, int U>
   struct traits< ForceTpl<T, U> >
   {
-    typedef T Scalar_t;
+    typedef T Scalar;
     typedef Eigen::Matrix<T,3,1,U> Vector3;
     typedef Eigen::Matrix<T,4,1,U> Vector4;
     typedef Eigen::Matrix<T,6,1,U> Vector6;
@@ -200,7 +201,7 @@ namespace se3
     Linear_t linear_impl() { return data.template segment<3> (LINEAR);}
     void linear_impl(const Vector3 & f) { data.template segment<3> (LINEAR) = f; }
     
-    Scalar_t dot(const Motion & m) const { return data.dot(m.toVector()); }
+    Scalar dot(const Motion & m) const { return data.dot(m.toVector()); }
 
   protected:
     Vector6 data;

--- a/src/spatial/fwd.hpp
+++ b/src/spatial/fwd.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2015-2016 CNRS
+// Copyright (c) 2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -31,7 +32,7 @@ namespace se3
   template<class C> struct traits {};
 
   #define SPATIAL_TYPEDEF_TEMPLATE(derived)              \
-    typedef typename traits<derived>::Scalar_t Scalar_t; \
+    typedef typename traits<derived>::Scalar Scalar; \
     typedef typename traits<derived>::Vector3 Vector3; \
     typedef typename traits<derived>::Vector4 Vector4; \
     typedef typename traits<derived>::Vector6 Vector6; \
@@ -54,7 +55,7 @@ namespace se3
     }
 
   #define SPATIAL_TYPEDEF_NO_TEMPLATE(derived)              \
-    typedef traits<derived>::Scalar_t Scalar_t; \
+    typedef traits<derived>::Scalar Scalar; \
     typedef traits<derived>::Vector3 Vector3; \
     typedef traits<derived>::Vector4 Vector4; \
     typedef traits<derived>::Vector6 Vector6; \

--- a/src/spatial/inertia.hpp
+++ b/src/spatial/inertia.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2015-2016 CNRS
+// Copyright (c) 2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -41,8 +42,8 @@ namespace se3
     Derived_t & derived() { return *static_cast<Derived_t*>(this); }
     const Derived_t & derived() const { return *static_cast<const Derived_t*>(this); }
 
-    Scalar_t           mass()    const { return static_cast<const Derived_t*>(this)->mass(); }
-    Scalar_t &         mass() { return static_cast<const Derived_t*>(this)->mass(); }
+    Scalar           mass()    const { return static_cast<const Derived_t*>(this)->mass(); }
+    Scalar &         mass() { return static_cast<const Derived_t*>(this)->mass(); }
     const Vector3 &    lever()   const { return static_cast<const Derived_t*>(this)->lever(); }
     Vector3 &          lever() { return static_cast<const Derived_t*>(this)->lever(); }
     const Symmetric3 & inertia() const { return static_cast<const Derived_t*>(this)->inertia(); }
@@ -57,7 +58,7 @@ namespace se3
     Derived_t operator+(const Derived_t & Yb) const { return derived().__plus__(Yb); }
     Force operator*(const Motion & v) const    { return derived().__mult__(v); }
 
-    Scalar_t vtiv(const Motion & v) const { return derived().vtiv_impl(v); }
+    Scalar vtiv(const Motion & v) const { return derived().vtiv_impl(v); }
 
     void setZero() { derived().setZero(); }
     void setIdentity() { derived().setIdentity(); }
@@ -82,7 +83,7 @@ namespace se3
   template<typename T, int U>
   struct traits< InertiaTpl<T, U> >
   {
-    typedef T Scalar_t;
+    typedef T Scalar;
     typedef Eigen::Matrix<T,3,1,U> Vector3;
     typedef Eigen::Matrix<T,4,1,U> Vector4;
     typedef Eigen::Matrix<T,6,1,U> Vector6;
@@ -117,7 +118,7 @@ namespace se3
     // Constructors
     InertiaTpl() : m(), c(), I() {}
 
-    InertiaTpl(const Scalar_t m_, const Vector3 &c_, const Matrix3 &I_)
+    InertiaTpl(const Scalar m_, const Vector3 &c_, const Matrix3 &I_)
     : m(m_), c(c_), I(I_)
     {}
     
@@ -135,7 +136,7 @@ namespace se3
       I = Symmetric3(I3);
     }
 
-    InertiaTpl(Scalar_t _m, 
+    InertiaTpl(Scalar _m, 
      const Vector3 &_c, 
      const Symmetric3 &_I)
     : m(_m),
@@ -183,41 +184,41 @@ namespace se3
     static InertiaTpl Random()
     {
         // We have to shoot "I" definite positive and not only symmetric.
-      return InertiaTpl(Eigen::internal::random<Scalar_t>()+1,
+      return InertiaTpl(Eigen::internal::random<Scalar>()+1,
                         Vector3::Random(),
                         Symmetric3::RandomPositive());
     }
 
     static InertiaTpl FromEllipsoid(
-        const Scalar_t m, const Scalar_t x, const Scalar_t y, const Scalar_t z)
+        const Scalar m, const Scalar x, const Scalar y, const Scalar z)
     {
-      Scalar_t a = m * (y*y + z*z) / 5;
-      Scalar_t b = m * (x*x + z*z) / 5;
-      Scalar_t c = m * (y*y + x*x) / 5;
+      Scalar a = m * (y*y + z*z) / 5;
+      Scalar b = m * (x*x + z*z) / 5;
+      Scalar c = m * (y*y + x*x) / 5;
       return InertiaTpl(m, Vector3::Zero(), Symmetric3(a, 0, b, 0, 0, c));
     }
 
     static InertiaTpl FromCylinder(
-        const Scalar_t m, const Scalar_t r, const Scalar_t l)
+        const Scalar m, const Scalar r, const Scalar l)
     {
-      Scalar_t a = m * (r*r / 4 + l*l / 12);
-      Scalar_t c = m * (r*r / 2);
+      Scalar a = m * (r*r / 4 + l*l / 12);
+      Scalar c = m * (r*r / 2);
       return InertiaTpl(m, Vector3::Zero(), Symmetric3(a, 0, a, 0, 0, c));
     }
 
     static InertiaTpl FromBox(
-        const Scalar_t m, const Scalar_t x, const Scalar_t y, const Scalar_t z)
+        const Scalar m, const Scalar x, const Scalar y, const Scalar z)
     {
-      Scalar_t a = m * (y*y + z*z) / 12;
-      Scalar_t b = m * (x*x + z*z) / 12;
-      Scalar_t c = m * (y*y + x*x) / 12;
+      Scalar a = m * (y*y + z*z) / 12;
+      Scalar b = m * (x*x + z*z) / 12;
+      Scalar c = m * (y*y + x*x) / 12;
       return InertiaTpl(m, Vector3::Zero(), Symmetric3(a, 0, b, 0, 0, c));
     }
 
     
     void setRandom()
     {
-      m = static_cast<Scalar_t> (std::rand()) / static_cast<Scalar_t> (RAND_MAX);
+      m = static_cast<Scalar> (std::rand()) / static_cast<Scalar> (RAND_MAX);
       c.setRandom(); I.setRandom();
     }
 
@@ -280,10 +281,10 @@ namespace se3
       return f;
     }
     
-    Scalar_t vtiv_impl(const Motion & v) const
+    Scalar vtiv_impl(const Motion & v) const
     {
       const Vector3 cxw (c.cross(v.angular()));
-      Scalar_t res = m * (v.linear().squaredNorm() - 2.*v.linear().dot(cxw));
+      Scalar res = m * (v.linear().squaredNorm() - 2.*v.linear().dot(cxw));
       const Vector3 mcxcxw (-m*c.cross(cxw));
       res += v.angular().dot(mcxcxw);
       res += I.vtiv(v.angular());
@@ -292,11 +293,11 @@ namespace se3
     }
 
     // Getters
-    Scalar_t           mass()    const { return m; }
+    Scalar           mass()    const { return m; }
     const Vector3 &    lever()   const { return c; }
     const Symmetric3 & inertia() const { return I; }
     
-    Scalar_t &   mass()    { return m; }
+    Scalar &   mass()    { return m; }
     Vector3 &    lever()   { return c; }
     Symmetric3 & inertia() { return I; }
 
@@ -335,7 +336,7 @@ namespace se3
     }
 
   protected:
-    Scalar_t m;
+    Scalar m;
     Vector3 c;
     Symmetric3 I;
     

--- a/src/spatial/motion.hpp
+++ b/src/spatial/motion.hpp
@@ -1,6 +1,6 @@
 //
 // Copyright (c) 2015-2016 CNRS
-// Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
+// Copyright (c) 2015-2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -65,7 +65,7 @@ namespace se3
     Derived_t se3Action(const SE3 & m) const { return derived().se3Action_impl(m); }
     Derived_t se3ActionInverse(const SE3 & m) const { return derived().se3ActionInverse_impl(m); }
     
-    Scalar_t dot(const Force & f) const { return static_cast<Derived_t*>(this)->dot(f); }
+    Scalar dot(const Force & f) const { return static_cast<Derived_t*>(this)->dot(f); }
 
     void disp(std::ostream & os) const { derived().disp_impl(os); }
     friend std::ostream & operator << (std::ostream & os, const MotionBase<Derived_t> & mv)
@@ -80,7 +80,7 @@ namespace se3
   template<typename T, int U>
   struct traits< MotionTpl<T, U> >
   {
-    typedef T Scalar_t;
+    typedef T Scalar;
     typedef Eigen::Matrix<T,3,1,U> Vector3;
     typedef Eigen::Matrix<T,4,1,U> Vector4;
     typedef Eigen::Matrix<T,6,1,U> Vector6;
@@ -189,7 +189,7 @@ namespace se3
     MotionTpl __minus__(const MotionTpl & v2) const { return MotionTpl(data - v2.data); }
     MotionTpl& __pequ__(const MotionTpl & v2) { data += v2.data; return *this; }
     
-    Scalar_t dot(const Force & f) const { return data.dot(f.toVector()); }
+    Scalar dot(const Force & f) const { return data.dot(f.toVector()); }
 
     MotionTpl cross(const MotionTpl& v2) const
     {
@@ -256,7 +256,7 @@ namespace se3
   template<>
   struct traits< BiasZero >
   {
-    typedef double Scalar_t;
+    typedef double Scalar;
     typedef Eigen::Matrix<double,3,1,0> Vector3;
     typedef Eigen::Matrix<double,4,1,0> Vector4;
     typedef Eigen::Matrix<double,6,1,0> Vector6;

--- a/src/spatial/se3.hpp
+++ b/src/spatial/se3.hpp
@@ -1,5 +1,6 @@
 //
 // Copyright (c) 2015-2016 CNRS
+// Copyright (c) 2016 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -109,7 +110,7 @@ namespace se3
         return derived().__equal__(other);
       }
 
-      bool isApprox (const Derived_t & other, const Scalar_t & prec = Eigen::NumTraits<Scalar_t>::dummy_precision()) const
+      bool isApprox (const Derived_t & other, const Scalar & prec = Eigen::NumTraits<Scalar>::dummy_precision()) const
       {
         return derived().isApprox_impl(other, prec);
       }
@@ -126,7 +127,7 @@ namespace se3
   template<typename T, int U>
   struct traits< SE3Tpl<T, U> >
   {
-    typedef T Scalar_t;
+    typedef T Scalar;
     typedef Eigen::Matrix<T,3,1,U> Vector3;
     typedef Eigen::Matrix<T,4,1,U> Vector4;
     typedef Eigen::Matrix<T,6,1,U> Vector6;
@@ -282,7 +283,7 @@ namespace se3
       return (rotation_impl() == m2.rotation() && translation_impl() == m2.translation());
     }
 
-    bool isApprox_impl (const SE3Tpl & m2, const Scalar_t & prec = Eigen::NumTraits<Scalar_t>::dummy_precision()) const
+    bool isApprox_impl (const SE3Tpl & m2, const Scalar & prec = Eigen::NumTraits<Scalar>::dummy_precision()) const
     {
       return rot.isApprox(m2.rot, prec) && trans.isApprox(m2.trans, prec);
     }


### PR DESCRIPTION
* Rename Scalar_t to Scalar.
* This allows applying Eigen-compatible template operations to
  se3::spatial objects.