### PR TITLE
Topic/neutral config

### DIFF
--- a/src/multibody/joint/joint-base.hpp
+++ b/src/multibody/joint/joint-base.hpp
@@ -328,6 +328,15 @@ namespace se3
     double distance(const Eigen::VectorXd & q0,const Eigen::VectorXd & q1) const
     { return derived().distance_impl(q0, q1); }
 
+    /**
+     * @brief      Get neutral configuration of joint
+     *
+     * @return     The joint's neutral configuration
+     */
+    ConfigVector_t neutralConfiguration() const
+    { return derived().neutralConfiguration_impl(); } 
+
+
     JointIndex i_id; // ID of the joint in the multibody list.
     int i_q;    // Index of the joint configuration in the joint configuration vector.
     int i_v;    // Index of the joint velocity in the joint velocity vector.

--- a/src/multibody/joint/joint-basic-visitors.hpp
+++ b/src/multibody/joint/joint-basic-visitors.hpp
@@ -147,6 +147,16 @@ namespace se3
 
   
   /**
+   * @brief       Visit a JointModelVariant through JointNeutralfigurationVisitor to
+   *              get the neutral configuration vector of the joint
+   *
+   * @param[in]  jmodel           The JointModelVariant
+   *
+   * @return     The joint's neutral configuration
+   */
+  inline Eigen::VectorXd neutralConfiguration(const JointModelVariant & jmodel);
+
+  /**
    * @brief      Visit a JointModelVariant through JointNvVisitor to get the dimension of 
    *             the joint tangent space
    *

--- a/src/multibody/joint/joint-basic-visitors.hxx
+++ b/src/multibody/joint/joint-basic-visitors.hxx
@@ -212,6 +212,27 @@ namespace se3
     return JointRandomConfigurationVisitor::run(jmodel, lower_pos_limit, upper_pos_limit);
   }
 
+
+  /**
+   * @brief      JointNeutralConfigurationVisitor visitor
+   */
+  class JointNeutralConfigurationVisitor: public boost::static_visitor<Eigen::VectorXd>
+  {
+  public:
+
+    template<typename D>
+    Eigen::VectorXd operator()(const JointModelBase<D> & jmodel) const
+    { return jmodel.neutralConfiguration(); }
+    
+    static Eigen::VectorXd run(const JointModelVariant & jmodel)
+    { return boost::apply_visitor( JointNeutralConfigurationVisitor(), jmodel ); }
+  };
+  inline Eigen::VectorXd neutralConfiguration(const JointModelVariant & jmodel)
+  {
+    return JointNeutralConfigurationVisitor::run(jmodel);
+  }
+
+
   /**
    * @brief      JointDifferenceVisitor visitor
    */

--- a/src/multibody/joint/joint-dense.hpp
+++ b/src/multibody/joint/joint-dense.hpp
@@ -190,6 +190,13 @@ namespace se3
       return result; 
     }
 
+    ConfigVector_t neutralConfiguration_impl() const
+    { 
+      ConfigVector_t result;
+      assert(false && "JointModelDense is read-only, should not perform any calc");
+      return result; 
+    }
+
     JointModelDense() {}
     JointModelDense(JointIndex idx, int idx_q, int idx_v)
     {

--- a/src/multibody/joint/joint-free-flyer.hpp
+++ b/src/multibody/joint/joint-free-flyer.hpp
@@ -366,6 +366,14 @@ namespace se3
       return difference_impl(q0,q1).norm();
     } 
 
+    ConfigVector_t neutralConfiguration_impl() const
+    { 
+      ConfigVector_t q;
+      q << 0, 0, 0, // translation part
+           0, 0, 0, 1; // quaternion part
+      return q;
+    } 
+
     JointModelDense<NQ, NV> toDense_impl() const
     {
       return JointModelDense<NQ, NV>( id(),

--- a/src/multibody/joint/joint-planar.hpp
+++ b/src/multibody/joint/joint-planar.hpp
@@ -428,6 +428,13 @@ namespace se3
       return (q_1-q_0).norm();
     }
 
+    ConfigVector_t neutralConfiguration_impl() const
+    { 
+      ConfigVector_t q;
+      q << 0, 0, 0;
+      return q;
+    } 
+
     JointModelDense<NQ, NV> toDense_impl() const
     {
       return JointModelDense<NQ, NV>( id(),

--- a/src/multibody/joint/joint-prismatic-unaligned.hpp
+++ b/src/multibody/joint/joint-prismatic-unaligned.hpp
@@ -433,6 +433,12 @@ namespace se3
       return (q_1-q_0);
     }
 
+    ConfigVector_t neutralConfiguration_impl() const
+    { 
+      ConfigVector_t q;
+      q << 0;
+      return q;
+    } 
 
     JointModelDense<NQ, NV> toDense_impl() const
     {

--- a/src/multibody/joint/joint-prismatic.hpp
+++ b/src/multibody/joint/joint-prismatic.hpp
@@ -489,6 +489,13 @@ namespace se3
       return (q_1-q_0);
     }
 
+    ConfigVector_t neutralConfiguration_impl() const
+    { 
+      ConfigVector_t q;
+      q << 0;
+      return q;
+    } 
+
     JointModelDense<NQ, NV> toDense_impl() const
     {
       return JointModelDense<NQ, NV>( id(),

--- a/src/multibody/joint/joint-revolute-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unaligned.hpp
@@ -438,6 +438,13 @@ namespace se3
       return (q_1-q_0);
     }
 
+    ConfigVector_t neutralConfiguration_impl() const
+    { 
+      ConfigVector_t q;
+      q << 0;
+      return q;
+    } 
+
     JointModelDense<NQ, NV> toDense_impl() const
     {
       return JointModelDense<NQ, NV>( id(),

--- a/src/multibody/joint/joint-revolute.hpp
+++ b/src/multibody/joint/joint-revolute.hpp
@@ -523,6 +523,13 @@ namespace se3
       return (q_1-q_0);
     }
 
+    ConfigVector_t neutralConfiguration_impl() const
+    { 
+      ConfigVector_t q;
+      q << 0;
+      return q;
+    } 
+
     JointModelDense<NQ, NV> toDense_impl() const
     {
       return JointModelDense<NQ, NV>( id(),

--- a/src/multibody/joint/joint-spherical-ZYX.hpp
+++ b/src/multibody/joint/joint-spherical-ZYX.hpp
@@ -455,6 +455,13 @@ namespace se3
       return (q_1 - q_0).norm();
     }
     
+    ConfigVector_t neutralConfiguration_impl() const
+    { 
+      ConfigVector_t q;
+      q << 0, 0, 0;
+      return q;
+    } 
+
     JointModelDense<NQ, NV> toDense_impl() const
     {
       return JointModelDense<NQ, NV>( id(),

--- a/src/multibody/joint/joint-spherical.hpp
+++ b/src/multibody/joint/joint-spherical.hpp
@@ -392,6 +392,13 @@ namespace se3
       return difference_impl(q0, q1).norm();
     }
 
+    ConfigVector_t neutralConfiguration_impl() const
+    { 
+      ConfigVector_t q;
+      q << 0, 0, 0, 1;
+      return q;
+    } 
+
     JointModelDense<NQ, NV> toDense_impl() const
     {
       return JointModelDense<NQ, NV>( id(),

--- a/src/multibody/joint/joint-translation.hpp
+++ b/src/multibody/joint/joint-translation.hpp
@@ -367,6 +367,13 @@ namespace se3
       return (q_1 - q_0).norm();
     }
     
+    ConfigVector_t neutralConfiguration_impl() const
+    { 
+      ConfigVector_t q;
+      q << 0,0,0;
+      return q;
+    } 
+
     JointModelDense<NQ, NV> toDense_impl() const
     {
       return JointModelDense<NQ, NV>( id(),

--- a/src/multibody/joint/joint.hpp
+++ b/src/multibody/joint/joint.hpp
@@ -146,6 +146,11 @@ namespace se3
       return ::se3::distance(*this, q0, q1);
     }
 
+    ConfigVector_t neutralConfiguration_impl() const
+    { 
+      return ::se3::neutralConfiguration(*this);
+    } 
+
     JointModel() : JointModelBoostVariant() {}
     JointModel( const JointModelVariant & model_variant ) : JointModelBoostVariant(model_variant)
     {}

--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -83,6 +83,9 @@ namespace se3
     /// \brief Name of joint <i>
     std::vector<std::string> names;
     
+    /// \brief Vector of joint's neutral configurations
+    Eigen::VectorXd neutralConfigurations;
+
     /// \brief Vector of maximal joint torques
     Eigen::VectorXd effortLimit;
     /// \brief Vector of maximal joint velocities

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -93,6 +93,7 @@ namespace se3
     nq += j.nq();
     nv += j.nv();
 
+    neutralConfigurations.conservativeResize(nq);neutralConfigurations.bottomRows<D::NQ>() = j.neutralConfiguration();
     effortLimit.conservativeResize(nv);effortLimit.bottomRows<D::NV>().fill(std::numeric_limits<double>::infinity());
     velocityLimit.conservativeResize(nv);velocityLimit.bottomRows<D::NV>().fill(std::numeric_limits<double>::infinity());
     lowerPositionLimit.conservativeResize(nq);lowerPositionLimit.bottomRows<D::NQ>().fill(-std::numeric_limits<double>::infinity());
@@ -125,6 +126,7 @@ namespace se3
     nq += j.nq();
     nv += j.nv();
 
+    neutralConfigurations.conservativeResize(nq);neutralConfigurations.bottomRows<D::NQ>() = j.neutralConfiguration();
     effortLimit.conservativeResize(nv);effortLimit.bottomRows<D::NV>() = effort;
     velocityLimit.conservativeResize(nv);velocityLimit.bottomRows<D::NV>() = velocity;
     lowerPositionLimit.conservativeResize(nq);lowerPositionLimit.bottomRows<D::NQ>() = lowPos;

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -126,11 +126,25 @@ namespace se3
     nq += j.nq();
     nv += j.nv();
 
-    neutralConfigurations.conservativeResize(nq);neutralConfigurations.bottomRows<D::NQ>() = j.neutralConfiguration();
+    
     effortLimit.conservativeResize(nv);effortLimit.bottomRows<D::NV>() = effort;
     velocityLimit.conservativeResize(nv);velocityLimit.bottomRows<D::NV>() = velocity;
     lowerPositionLimit.conservativeResize(nq);lowerPositionLimit.bottomRows<D::NQ>() = lowPos;
     upperPositionLimit.conservativeResize(nq);upperPositionLimit.bottomRows<D::NQ>() = upPos;
+
+    // Ensure that limits are not inf
+    Eigen::VectorXd neutralConf((lowerPositionLimit.bottomRows<D::NQ>() + upperPositionLimit.bottomRows<D::NQ>())/2 );
+    
+    neutralConfigurations.conservativeResize(nq);
+    if ( std::isfinite(neutralConf.norm()) )
+    {
+      neutralConfigurations.bottomRows<D::NQ>() = neutralConf;
+    }
+    else
+    {
+      assert( false && "One of the position limit is inf or NaN");
+      neutralConfigurations.bottomRows<D::NQ>() = j.neutralConfiguration();
+    }
 
     addFrame((jointName!="")?jointName:random(8), idx, SE3::Identity(), JOINT);
 

--- a/src/multibody/parser/srdf.hpp
+++ b/src/multibody/parser/srdf.hpp
@@ -109,6 +109,89 @@ namespace se3
     
 #endif // ifdef WITH_HPP_FCL
     
+
+    ///
+    /// \brief Get the neutral configuration of a given model associated to a SRDF file.
+    ///        It throws if the SRDF file is incorrect.
+    ///
+    /// \param[in] model The Model for which we want the neutral config
+    /// \param[in] filename The complete path to the SRDF file.
+    /// \param[in] verbose Verbosity mode.
+    ///
+    /// \return The neutral configuration as an eigen vector
+    inline Eigen::VectorXd getNeutralConfigurationFromSrdf(Model & model,
+                                                           const std::string & filename,
+                                                           const bool verbose) throw (std::invalid_argument)
+    {
+      const Eigen::VectorXd neutralConfig(model.nq);
+
+      // Check extension
+      const std::string extension = filename.substr(filename.find_last_of('.')+1);
+      if (extension != "srdf")
+      {
+        const std::string exception_message (filename + " does not have the right extension.");
+        throw std::invalid_argument(exception_message);
+      }
+      
+      // Open file
+      std::ifstream srdf_stream(filename.c_str());
+      if (! srdf_stream.is_open())
+      {
+        const std::string exception_message (filename + " does not seem to be a valid file.");
+        throw std::invalid_argument(exception_message);
+      }
+      
+      // Read xml stream
+      using boost::property_tree::ptree;
+      ptree pt;
+      read_xml(srdf_stream, pt);
+      
+      // Iterate over all tags directly children of robot
+      BOOST_FOREACH(const ptree::value_type & v, pt.get_child("robot"))
+      {
+        // if we encounter a tag group_state
+        if (v.first == "group_state")
+        {
+          const std::string name = v.second.get<std::string>("<xmlattr>.name");
+          std::cout << name << std::endl;
+          // Ensure that it is the half_sitting tag
+          if( name == "half_sitting")
+          {
+            // Iterate over all the joint tags
+            BOOST_FOREACH(const ptree::value_type & joint, v.second)
+            {
+              if (joint.first == "joint")
+              {
+                std::string joint_name = joint.second.get<std::string>("<xmlattr>.name");
+                double joint_config = joint.second.get<double>("<xmlattr>.value");
+                if (verbose)
+                {
+                  std::cout << "(" << joint_name << " , " << joint_config << ")" << std::endl;
+                }
+                // Search in model the joint and its config id
+                Model::JointIndex joint_id = model.getJointId(joint_name);
+                const JointModel & joint = model.joints[joint_id];
+
+                if (joint_id != model.joints.size()) // != model.njoints
+                {
+                  model.neutralConfigurations(joint.idx_q()) = joint_config; // joint with 1 dof
+                  // model.neutralConfigurations.segment(joint.idx_q(),joint.nq()) = joint_config; // joint with more than 1 dof
+                }
+                else
+                {
+                  if (verbose) std::cout << "The Joint " << joint_name << " was not found in model" << std::endl;
+                }
+              }
+            }
+            return neutralConfig;
+          }
+
+          
+        }
+      } // BOOST_FOREACH
+      assert(false && "no half_sitting configuration found in the srdf file"); // Should we throw something here ?  
+      return neutralConfig; // warning : uninitialized vector is returned
+    }
   }
 } // namespace se3
 

--- a/src/python/model.hpp
+++ b/src/python/model.hpp
@@ -125,6 +125,7 @@ namespace se3
 
 
           .add_property("effortLimit", bp::make_function(&ModelPythonVisitor::effortLimit), "Joint max effort")
+          .add_property("neutralConfigurations", bp::make_function(&ModelPythonVisitor::neutralConfigurations), "Joint's neutral configurations")
           .add_property("velocityLimit", bp::make_function(&ModelPythonVisitor::velocityLimit), "Joint max velocity")
           .add_property("lowerPositionLimit", bp::make_function(&ModelPythonVisitor::lowerPositionLimit), "Limit for joint lower position")
           .add_property("upperPositionLimit", bp::make_function(&ModelPythonVisitor::upperPositionLimit), "Limit for joint upper position")
@@ -171,6 +172,7 @@ namespace se3
       }
 
 
+      static Eigen::VectorXd neutralConfigurations(ModelHandler & m) {return m->neutralConfigurations;}
       static Eigen::VectorXd effortLimit(ModelHandler & m) {return m->effortLimit;}
       static Eigen::VectorXd velocityLimit(ModelHandler & m) {return m->velocityLimit;}
       static Eigen::VectorXd lowerPositionLimit(ModelHandler & m) {return m->lowerPositionLimit;}

--- a/src/python/parsers.hpp
+++ b/src/python/parsers.hpp
@@ -37,6 +37,8 @@
   #include "pinocchio/multibody/parser/lua.hpp"
 #endif // #ifdef WITH_LUA
 
+#include "pinocchio/multibody/parser/srdf.hpp"
+
 namespace se3
 {
   namespace python
@@ -122,6 +124,14 @@ namespace se3
       }
 #endif // #ifdef WITH_LUA
 
+      static Eigen::VectorXd getNeutralConfigurationFromSrdf(ModelHandler & model,
+                                                             const std::string & filename,
+                                                             bool verbose
+                                                            )
+      {
+        return se3::srdf::getNeutralConfigurationFromSrdf(*model, filename, verbose);
+      }
+
       /* --- Expose --------------------------------------------------------- */
       static void expose();
     }; // struct ParsersPythonVisitor
@@ -173,6 +183,13 @@ namespace se3
               "Parse the urdf file given in input and return a proper pinocchio model "
               "(remember to create the corresponding data structure).");
 #endif // #ifdef WITH_LUA
+
+      bp::def("getNeutralConfigurationFromSrdf",getNeutralConfigurationFromSrdf,
+              // static_cast <ModelHandler (*) ( const std::string &, bool)> (&ParsersPythonVisitor::getNeutralConfigurationFromSrdf),
+              bp::args("Model for which we want the neutral config","srdf filename (string)", "verbosity"
+                       ),
+              "Get the neutral configuration of a given model associated to a SRDF file");
+
     }
     
   }

--- a/unittest/joint-configurations.cpp
+++ b/unittest/joint-configurations.cpp
@@ -385,6 +385,46 @@ BOOST_AUTO_TEST_CASE ( distance_computation_test )
   BOOST_CHECK_MESSAGE(result.isApprox(expected, 1e-12), "Distance between two configs of full model - wrong results");
 }
 
+BOOST_AUTO_TEST_CASE ( neutral_configuration_test )
+{
+  se3::Model model;
+  
+  using namespace se3;
+
+  model.addJointAndBody(model.getJointId("universe"),JointModelFreeFlyer(),SE3::Identity(),Inertia::Random(),
+                "freeflyer_joint", "freeflyer_body");
+  model.addJointAndBody(model.getJointId("freeflyer_joint"),JointModelSpherical(),SE3::Identity(),Inertia::Random(),
+                "spherical_joint", "spherical_body");
+  model.addJointAndBody(model.getJointId("spherical_joint"),JointModelRX(),SE3::Identity(),Inertia::Random(),
+                "revolute_joint", "revolute_body");
+  model.addJointAndBody(model.getJointId("revolute_joint"),JointModelPX(),SE3::Identity(),Inertia::Random(),
+                "px_joint", "px_body");
+  model.addJointAndBody(model.getJointId("px_joint"),JointModelPrismaticUnaligned(Eigen::Vector3d(1,0,0)),SE3::Identity(),Inertia::Random(),
+                "pu_joint", "pu_body");
+  model.addJointAndBody(model.getJointId("pu_joint"),JointModelRevoluteUnaligned(Eigen::Vector3d(0,0,1)),SE3::Identity(),Inertia::Random(),
+                "ru_joint", "ru_body");
+  model.addJointAndBody(model.getJointId("ru_joint"),JointModelSphericalZYX(),SE3::Identity(),Inertia::Random(),
+                "sphericalZYX_joint", "sphericalZYX_body");
+  model.addJointAndBody(model.getJointId("sphericalZYX_joint"),JointModelTranslation(),SE3::Identity(),Inertia::Random(),
+                "translation_joint", "translation_body");
+  model.addJointAndBody(model.getJointId("translation_joint"),JointModelPlanar(),SE3::Identity(),Inertia::Random(),
+                "planar_joint", "planar_body");
+  
+
+  Eigen::VectorXd expected(model.nq);
+  expected << 0,0,0,0,0,0,1,
+              0,0,0,1,
+              0,
+              0,
+              0,
+              0,
+              0,0,0,
+              0,0,0,
+              0,0,0;
+
+
+  BOOST_CHECK_MESSAGE(model.neutralConfigurations.isApprox(expected, 1e-12), "neutral configurations - wrong results");
+}
 
 BOOST_AUTO_TEST_CASE ( uniform_sampling_test )
 {


### PR DESCRIPTION
Added joints default neural configuration +
neutralConfigurations vector in Model.
Also added srdf parsing to fill the neutralConfigurations vector ( looking for "half_sitting" at the moment, should we change it to "neutral_configuration" ?

Also: in hrp2_14 and romeo srdf files i only meet joints with 1 dof. In the actual status of this PR, joints with more than 1 DoF are not handled, you will see a commented line in parser/srdf. How should it be handled ? ( I mean, can one find the following tag in an srdf file: `<joint name="LARM_JOINT4" value="0.  0.  1." />` )