### PR TITLE
Fix doc of jacobinCenterOfMass

### DIFF
--- a/src/algorithm/center-of-mass.hpp
+++ b/src/algorithm/center-of-mass.hpp
@@ -90,7 +90,7 @@ namespace se3
   ///
   /// \brief Computes both the jacobian and the the center of mass position of a given model according to a particular joint configuration.
   ///        The results are accessible through data.Jcom and data.com[0] and are both expressed in the world frame. In addition, the algorithm also computes the Jacobian of all the joints (\sa se3::computeJacobians).
-  ///        And data.com[i] gives the center of mass of the subtree supported by joint i (expressed in the joint i frame).
+  ///        And data.com[i] gives the center of mass of the subtree supported by joint i (expressed in the world frame).
   ///
   /// \param[in] model The model structure of the rigid body system.
   /// \param[in] data The data structure of the rigid body system.


### PR DESCRIPTION
I lost quite some time looking for a bug caused by this. It may help somebody later.

By the way, I find it a bit confusing that `centerOfMass` and `jacobianCenterOfMass` fills the same data but in different frames.