### PR TITLE
se3::computeDistances return the index of the shortest distance.

### DIFF
--- a/src/algorithm/geometry.hpp
+++ b/src/algorithm/geometry.hpp
@@ -70,14 +70,14 @@ namespace se3
                                 const bool stopAtFirstCollision = false
                                 );
 
-  inline void computeDistances(GeometryData & data_geom);
+  inline std::size_t computeDistances(GeometryData & data_geom);
 
-  inline void computeDistances(const Model & model,
-                              Data & data,
-                              const GeometryModel & model_geom,
-                              GeometryData & data_geom,
-                              const Eigen::VectorXd & q
-                              );
+  inline std::size_t computeDistances(const Model & model,
+                                      Data & data,
+                                      const GeometryModel & model_geom,
+                                      GeometryData & data_geom,
+                                      const Eigen::VectorXd & q
+                                      );
 
   inline void computeBodyRadius(const Model &         model,
                                 const GeometryModel & geomModel,

--- a/src/algorithm/geometry.hpp
+++ b/src/algorithm/geometry.hpp
@@ -70,8 +70,18 @@ namespace se3
                                 const bool stopAtFirstCollision = false
                                 );
 
+  /// Compute the distances of all collision pairs
+  ///
+  /// \param ComputeShortest default to true.
+  /// \param data_geom
+  /// \return When ComputeShortest is true, the index of the collision pair which has the shortest distance.
+  ///         When ComputeShortest is false, the number of collision pairs.
+  template <bool ComputeShortest>
   inline std::size_t computeDistances(GeometryData & data_geom);
 
+  /// Compute the forward kinematics, update the goemetry placements and
+  /// calls computeDistances(GeometryData&).
+  template <bool ComputeShortest>
   inline std::size_t computeDistances(const Model & model,
                                       Data & data,
                                       const GeometryModel & model_geom,

--- a/src/algorithm/geometry.hxx
+++ b/src/algorithm/geometry.hxx
@@ -78,7 +78,14 @@ namespace se3
     
     return computeCollisions(data_geom, stopAtFirstCollision);
   }
+
+  // Required to have a default template argument on templated free function
+  inline std::size_t computeDistances(GeometryData & data_geom)
+  {
+    return computeDistances<true>(data_geom);
+  }
   
+  template <bool ComputeShortest>
   inline std::size_t computeDistances(GeometryData & data_geom)
   {
     double min_dist = std::numeric_limits<double>::infinity();
@@ -87,7 +94,7 @@ namespace se3
     {
       data_geom.distance_results[cpt] = data_geom.computeDistance(data_geom.collision_pairs[cpt].first,
                                                                   data_geom.collision_pairs[cpt].second);
-      if (data_geom.distance_results[cpt].distance() < min_dist) {
+      if (ComputeShortest && data_geom.distance_results[cpt].distance() < min_dist) {
         min_index = cpt;
         min_dist = data_geom.distance_results[cpt].distance();
       }
@@ -95,6 +102,18 @@ namespace se3
     return min_index;
   }
   
+  // Required to have a default template argument on templated free function
+  inline std::size_t computeDistances(const Model & model,
+                               Data & data,
+                               const GeometryModel & model_geom,
+                               GeometryData & data_geom,
+                               const Eigen::VectorXd & q
+                               )
+  {
+    return computeDistances<true>(model, data, model_geom, data_geom, q);
+  }
+
+  template <bool ComputeShortest>
   inline std::size_t computeDistances(const Model & model,
                                Data & data,
                                const GeometryModel & model_geom,
@@ -103,7 +122,7 @@ namespace se3
                                )
   {
     updateGeometryPlacements (model, data, model_geom, data_geom, q);
-    return computeDistances(data_geom);
+    return computeDistances<ComputeShortest>(data_geom);
   }
 
   /// Given p1..3 being either "min" or "max", return one of the corners of the 

--- a/src/algorithm/geometry.hxx
+++ b/src/algorithm/geometry.hxx
@@ -79,15 +79,23 @@ namespace se3
     return computeCollisions(data_geom, stopAtFirstCollision);
   }
   
-  
-  inline void computeDistances(GeometryData & data_geom)
+  inline std::size_t computeDistances(GeometryData & data_geom)
   {
+    double min_dist = std::numeric_limits<double>::infinity();
+    std::size_t min_index = data_geom.collision_pairs.size();
     for (std::size_t cpt = 0; cpt < data_geom.collision_pairs.size(); ++cpt)
+    {
       data_geom.distance_results[cpt] = data_geom.computeDistance(data_geom.collision_pairs[cpt].first,
                                                                   data_geom.collision_pairs[cpt].second);
+      if (data_geom.distance_results[cpt].distance() < min_dist) {
+        min_index = cpt;
+        min_dist = data_geom.distance_results[cpt].distance();
+      }
+    }
+    return min_index;
   }
   
-  inline void computeDistances(const Model & model,
+  inline std::size_t computeDistances(const Model & model,
                                Data & data,
                                const GeometryModel & model_geom,
                                GeometryData & data_geom,
@@ -95,7 +103,7 @@ namespace se3
                                )
   {
     updateGeometryPlacements (model, data, model_geom, data_geom, q);
-    computeDistances(data_geom);
+    return computeDistances(data_geom);
   }
 
   /// Given p1..3 being either "min" or "max", return one of the corners of the 


### PR DESCRIPTION
For a rather cheap update, we can have `computeDistances` returning the index corresponding to the shortest distance.

I hesitated between this version and a templatized version like `computeDistances<ReturnShortest>(...)`. As the shortest distance is rather cheap to compute, I think it does not matter do always do it.