### PR TITLE
Handle recent compilers as gcc5 or gcc6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,9 @@ SET(PROJECT_URL "http://github.com/stack-of-tasks/pinocchio")
 
 SET(DOXYGEN_USE_MATHJAX YES)
 
+# We follows c++03 standard
+ADD_DEFINITIONS(-std=c++03)
+
 IF(APPLE)
   SET(CMAKE_MACOSX_RPATH TRUE)
   SET(CMAKE_SKIP_BUILD_RPATH  FALSE)


### PR DESCRIPTION
Recent compilers use c++11 as default standard. We must inform that we are currently following the c++03 standard.
