### PR TITLE
[C++] Add missing forward declaration.

### DIFF
--- a/src/multibody/fwd.hpp
+++ b/src/multibody/fwd.hpp
@@ -25,6 +25,13 @@ namespace se3
   typedef Index GeomIndex;
   typedef Index FrameIndex;
   
+  struct Frame;
+  struct Model;
+  struct Data;
+  struct GeometryModel;
+  struct GeometryData;
+  struct JointModel;
+  struct JointData;
 } // namespace se3
 
 #endif // #ifndef __se3_multibody_fwd_hpp__

--- a/src/spatial/force.hpp
+++ b/src/spatial/force.hpp
@@ -208,8 +208,6 @@ namespace se3
 
   }; // class ForceTpl
 
-  typedef ForceTpl<double,0> Force;
-
 } // namespace se3
 
 #endif // ifndef __se3_force_hpp__

--- a/src/spatial/fwd.hpp
+++ b/src/spatial/fwd.hpp
@@ -29,6 +29,12 @@ namespace se3
   template<typename _Scalar, int _Options=0> class InertiaTpl;
   template<typename _Scalar, int _Options=0> class Symmetric3Tpl;
 
+  typedef SE3Tpl        <double,0> SE3;
+  typedef MotionTpl     <double,0> Motion;
+  typedef ForceTpl      <double,0> Force;
+  typedef InertiaTpl    <double,0> Inertia;
+  typedef Symmetric3Tpl <double,0> Symmetric3;
+
   template<class C> struct traits {};
 
   #define SPATIAL_TYPEDEF_TEMPLATE(derived)              \

--- a/src/spatial/inertia.hpp
+++ b/src/spatial/inertia.hpp
@@ -341,8 +341,6 @@ namespace se3
     Symmetric3 I;
     
   }; // class InertiaTpl
-
-  typedef InertiaTpl<double,0> Inertia;
     
 } // namespace se3
 

--- a/src/spatial/motion.hpp
+++ b/src/spatial/motion.hpp
@@ -247,8 +247,6 @@ namespace se3
   template<typename S,int O>
   ForceTpl<S,O> operator^( const MotionTpl<S,O> &m, const ForceTpl<S,O> &f ) { return m.cross(f); }
 
-  typedef MotionTpl<double,0> Motion;
-
 
   ///////////////   BiasZero  ///////////////
   struct BiasZero;

--- a/src/spatial/se3.hpp
+++ b/src/spatial/se3.hpp
@@ -301,8 +301,6 @@ namespace se3
     
   }; // class SE3Tpl
 
-  typedef SE3Tpl<double,0> SE3;
-
 } // namespace se3
 
 #endif // ifndef __se3_se3_hpp__

--- a/src/spatial/symmetric3.hpp
+++ b/src/spatial/symmetric3.hpp
@@ -337,8 +337,6 @@ namespace se3
     
   };
 
-  typedef Symmetric3Tpl<double,0> Symmetric3;
-
 } // namespace se3
 
 #endif // ifndef __se3__symmetric3_hpp__


### PR DESCRIPTION
This decreases headers inter-dependency. It helps reducing compilation time of libraries downstream.