### PR TITLE
[C++][Python]Exposed in Python GeometryModel method::addGeometryObjec…

### DIFF
--- a/bindings/python/geometry-model.hpp
+++ b/bindings/python/geometry-model.hpp
@@ -70,6 +70,10 @@ namespace se3
                         bp::make_function(&GeometryModelPythonVisitor::geometryObjects,
                                           bp::return_internal_reference<>())  )
           .def("__str__",&GeometryModelPythonVisitor::toString)
+	  .def("addEmptyGeometryObject",&GeometryModelPythonVisitor::addEmptyGeometryObject,
+               bp::args("parent (index)","placement (SE3)","geom_name (string)","mesh_path (string)"),
+               "Add geometry object with no collision to the GeometryModel.")
+
 #ifdef WITH_HPP_FCL
           .add_property("collision_pairs",
                         bp::make_function(&GeometryModelPythonVisitor::collision_pairs,
@@ -110,6 +114,8 @@ namespace se3
       { return gmodelPtr->getGeometryName(index);}
       
       static std::vector<GeometryObject> & geometryObjects( GeometryModelHandler & m ) { return m->geometryObjects; }
+      static GeomIndex addEmptyGeometryObject( GeometryModelHandler & gmodelPtr, const JointIndex & parent, const SE3_fx & placement, const std::string & geom_name, const std::string & mesh_path)
+      { return  gmodelPtr->addGeometryObject(parent, placement, geom_name, mesh_path); }
 #ifdef WITH_HPP_FCL      
       static std::vector<CollisionPair> & collision_pairs( GeometryModelHandler & m ) 
       { return m->collisionPairs; }

--- a/src/multibody/geometry.hpp
+++ b/src/multibody/geometry.hpp
@@ -86,7 +86,19 @@ namespace se3
                                        const SE3 & placement, const std::string & geom_name = "",
                                        const std::string & mesh_path = "") throw(std::invalid_argument);
 
-
+    /**
+     * @brief      Add a geometry object to a GeometryModel
+     *
+     * @param[in]  parent     Index of the parent joint
+     * @param[in]  placement  The relative placement regarding to the parent frame
+     * @param[in]  geom_name  The name of the Geometry Object
+     * @param[in]  mesh_path  The absolute path to the mesh
+     *
+     * @return     The index of the new added GeometryObject in geometryObjects
+     */
+    inline GeomIndex addGeometryObject(const JointIndex parent, 
+                                       const SE3 & placement, const std::string & geom_name = "",
+                                       const std::string & mesh_path = "") throw(std::invalid_argument);
 
     /**
      * @brief      Return the index of a GeometryObject given by its name.

--- a/src/multibody/geometry.hxx
+++ b/src/multibody/geometry.hxx
@@ -47,6 +47,20 @@ namespace se3
     return idx;
   }
 
+  inline GeomIndex GeometryModel::addGeometryObject(const JointIndex parent,                                                    
+                                                    const SE3 & placement,
+                                                    const std::string & geom_name,
+                                                    const std::string & mesh_path) throw(std::invalid_argument)
+  {
+
+    Index idx = (Index) (ngeoms ++);
+    const boost::shared_ptr<fcl::CollisionGeometry> geometry(new fcl::CollisionGeometry());
+    geometryObjects.push_back(GeometryObject( geom_name, parent, geometry,
+                                               placement, mesh_path));
+    addInnerObject(parent, idx);
+    return idx;
+  }
+
 
   inline GeomIndex GeometryModel::getGeometryId(const std::string & name) const
   {


### PR DESCRIPTION
One can now add geometry objects to a python GeometryModel one by one. Previously it was only possible parsing a urdf file.

Peer programming with @fvalenza 