### PR TITLE
[Python][hpp-fcl] Provide temporary operator== for DistanceResult.

### DIFF
--- a/bindings/python/geometry-data.hpp
+++ b/bindings/python/geometry-data.hpp
@@ -28,6 +28,20 @@
 #include "pinocchio/bindings/python/data.hpp"
 #include "pinocchio/bindings/python/geometry-model.hpp"
 
+namespace fcl
+{
+  // This operator is defined here temporary, as it is needed by vector_indexing_suite
+  // It has also been defined in hpp-fcl in a pending pull request.
+  // Once it has been integrated in releases of hpp-fcl, please remove this operator
+  inline bool operator ==(const DistanceResult & dr1, const DistanceResult& dr2)
+  {
+    return dr1.min_distance == dr2.min_distance
+        && dr1.o1 == dr2.o1
+        && dr1.o2 == dr2.o2
+        && dr1.nearest_points[0] == dr2.nearest_points[0]
+        && dr1.nearest_points[1] == dr2.nearest_points[1];
+  }
+}
 namespace se3
 {
   namespace python


### PR DESCRIPTION
Previous PR has been merged before i pushed this commit.
As we don't know yet if hpp-fcl will integrate the operator== for DistanceResult, i've put it where it is needed in Pinocchio