### PR TITLE
Update hpp-devel

### DIFF
--- a/src/multibody/joint/joint-planar.hpp
+++ b/src/multibody/joint/joint-planar.hpp
@@ -417,8 +417,8 @@ namespace se3
         // else    : S = -Sp
         // S / t = Sp / |t|
         // S * S = - I2
-        // R = I2 + ( 1 - ct) / |t| * S + ( 1 - st / t ) * S * S
-        //   =      ( 1 - ct) / |t| * S +       st / t   * I2
+        // R = I2 + ( 1 - ct) / |t| * S + ( 1 - st / |t| ) * S * S
+        //   =      ( 1 - ct) / |t| * S +       st / |t|   * I2
         //
         // Ru = exp3 (w)
         // tu = R * v = (1 - ct) / |t| * S * v + st / t * v
@@ -498,7 +498,7 @@ namespace se3
       
       TangentVector_t res;
       res.head<2>() = nu.linear().head<2>();
-      res(2) = q_1(2) - q_0(2);
+      res(2) = nu.angular()(2);
       return res;
     } 
 

--- a/src/multibody/joint/joint-planar.hpp
+++ b/src/multibody/joint/joint-planar.hpp
@@ -519,7 +519,7 @@ namespace se3
       Eigen::VectorXd::ConstFixedSegmentReturnType<NQ>::Type & q_1 = q1.segment<NQ> (idx_q ());
       Eigen::VectorXd::ConstFixedSegmentReturnType<NQ>::Type & q_2 = q2.segment<NQ> (idx_q ());
 
-      return q_1.isApprox(q_2, prec);
+      return q_1.head<2>().isApprox(q_2.head<2>(), prec) && std::fmod(std::abs(q_1[2] - q_2[2]), 2*M_PI) < prec;
     }
 
     JointModelDense<NQ, NV> toDense_impl() const

--- a/src/spatial/explog.hpp
+++ b/src/spatial/explog.hpp
@@ -49,7 +49,7 @@ namespace se3
 
   /// \brief Log: SO3 -> so3.
   ///
-  /// Pseudo-inverse of log from SO3 -> { v \in so3, ||v|| < 2pi }.
+  /// Pseudo-inverse of log from \f$ SO3 -> { v \in so3, ||v|| \le pi } \f$.
   ///
   /// \param[in] R The rotation matrix.
   ///
@@ -60,6 +60,9 @@ namespace se3
   {
     EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(D, 3, 3);
     Eigen::AngleAxis<typename D::Scalar> angleAxis(R);
+    assert(0 <= angleAxis.angle() && angleAxis.angle() <= 2 * M_PI);
+    if (angleAxis.angle() > M_PI)
+      return -(2*M_PI - angleAxis.angle()) * angleAxis.axis();
     return angleAxis.axis() * angleAxis.angle();
   }
 


### PR DESCRIPTION
2 main changes (which may need update before going to devel branch) :
- the rotational part of `JointModelPlanar` behaves like an unbounded rotation,
- the `log3` function returns the vector with shortest norm (it avoids doing the big loop).