### PR TITLE
Replacement Joint{Model,Data} with Joint{Model,Data}Variant in JointModelComposite

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,7 @@ SET(${PROJECT_NAME}_SPATIAL_HEADERS
   )
 
 SET(${PROJECT_NAME}_MULTIBODY_JOINT_HEADERS
+  multibody/joint/fwd.hpp
   multibody/joint/joint-base.hpp
   multibody/joint/joint-dense.hpp
   multibody/joint/joint-revolute.hpp

--- a/bindings/python/joint.hpp
+++ b/bindings/python/joint.hpp
@@ -20,7 +20,7 @@
 
 #include <eigenpy/exception.hpp>
 #include <eigenpy/eigenpy.hpp>
-#include "pinocchio/multibody/joint/joint-composite.hpp"
+#include "pinocchio/multibody/joint/joint.hpp"
 
 namespace se3
 {

--- a/src/multibody/joint/fwd.hpp
+++ b/src/multibody/joint/fwd.hpp
@@ -15,29 +15,19 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_multibody_fwd_hpp__
-#define __se3_multibody_fwd_hpp__
-
-# include <cstddef> // std::size_t
+#ifndef __se3_joint_fwd_hpp__
+#define __se3_joint_fwd_hpp__
 
 namespace se3
 {
-  typedef std::size_t Index;
-  typedef Index JointIndex;
-  typedef Index GeomIndex;
-  typedef Index FrameIndex;
-  typedef Index PairIndex;
+  enum { MAX_JOINT_NV = 6 };
   
-  struct Frame;
-  struct Model;
-  struct Data;
-  struct GeometryModel;
-  struct GeometryData;
+  struct JointModelComposite;
+  struct JointDataComposite;
+  
+  struct JointModel;
+  struct JointData;
+  
+}
 
-
-  // Forward declaration needed for Model::check
-  template<class D> struct AlgorithmCheckerBase;
-
-} // namespace se3
-
-#endif // #ifndef __se3_multibody_fwd_hpp__
+#endif // ifndef __se3_joint_fwd_hpp__

--- a/src/multibody/joint/joint-composite.hpp
+++ b/src/multibody/joint/joint-composite.hpp
@@ -19,12 +19,10 @@
 #define __se3_joint_composite_hpp__
 
 #include "pinocchio/assert.hpp"
-#include "pinocchio/multibody/joint/joint.hpp"
+#include "pinocchio/multibody/joint/joint-variant.hpp"
+#include "pinocchio/multibody/joint/joint-basic-visitors.hpp"
 
 #include <Eigen/StdVector>
-
-EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(se3::SE3)
-EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(se3::Motion)
 
 namespace se3
 {
@@ -67,6 +65,7 @@ namespace se3
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     
     typedef JointComposite Joint;
+    typedef JointDataVariant JointData;
     typedef std::vector<JointData, Eigen::aligned_allocator<JointData> > JointDataVector;
     SE3_JOINT_TYPEDEF;
 
@@ -74,7 +73,7 @@ namespace se3
     int nq_composite,nv_composite;
 
     Constraint_t S;
-    std::vector<Transformation_t> ljMj;
+    std::vector<Transformation_t, Eigen::aligned_allocator<Transformation_t> > ljMj;
     Transformation_t M;
     Motion_t v;
     Bias_t c;
@@ -110,7 +109,12 @@ namespace se3
     typedef JointComposite Joint;
     SE3_JOINT_TYPEDEF;
     SE3_JOINT_USE_INDEXES;
+    
+    typedef JointModelVariant JointModel;
     typedef std::vector<JointModel, Eigen::aligned_allocator<JointModel> > JointModelVector;
+    
+    typedef JointDataVariant JointData;
+    typedef std::vector<JointData, Eigen::aligned_allocator<JointData> > JointDataVector;
     
     using JointModelBase<JointModelComposite>::id;
     using JointModelBase<JointModelComposite>::setIndexes;
@@ -475,15 +479,16 @@ namespace se3
   };
   
 
-    inline std::ostream & operator << (std::ostream & os, const JointModelComposite & jmodel)
+  inline std::ostream & operator << (std::ostream & os, const JointModelComposite & jmodel)
+  {
+    typedef JointModelComposite::JointModelVector JointModelVector;
+    os << "JointModelComposite containing following models:\n" ;
+    for (JointModelVector::const_iterator i = jmodel.joints.begin(); i != jmodel.joints.end(); ++i)
     {
-      os << "JointModelComposite containing following models:\n" ;
-      for (JointModelVector::const_iterator i = jmodel.joints.begin(); i != jmodel.joints.end(); ++i)
-      {
-        os << shortname(*i) << std::endl;
-      }
-      return os;
+      os << shortname(*i) << std::endl;
     }
+    return os;
+  }
 
 } // namespace se3
 

--- a/src/multibody/joint/joint-variant.hpp
+++ b/src/multibody/joint/joint-variant.hpp
@@ -18,7 +18,7 @@
 #ifndef __se3_joint_variant_hpp__
 #define __se3_joint_variant_hpp__
 
-#include "pinocchio/multibody/joint/joint-base.hpp"
+#include "pinocchio/multibody/joint/fwd.hpp"
 #include "pinocchio/multibody/joint/joint-dense.hpp"
 #include "pinocchio/multibody/joint/joint-free-flyer.hpp"
 #include "pinocchio/multibody/joint/joint-planar.hpp"
@@ -36,12 +36,7 @@
 
 namespace se3
 {
-  enum { MAX_JOINT_NV = 6 };
-
-  struct JointComposite;
-  struct JointModelComposite;
-  struct JointDataComposite;
-
+  
   // The JointModelComposite contains several JointModel (which are JointModelVariant). Hence there is a circular
   // dependency between JointModelComposite and JointModelVariant that can be resolved with the use of boost::recursive_variant
   // For more details, see http://www.boost.org/doc/libs/1_58_0/doc/html/variant/tutorial.html#variant.tutorial.recursive 

--- a/src/multibody/joint/joint.hpp
+++ b/src/multibody/joint/joint.hpp
@@ -150,12 +150,9 @@ namespace se3
     void setIndexes(JointIndex id,int nq,int nv) { ::se3::setIndexes(*this,id, nq, nv); }
   };
   
-  typedef std::vector<JointData> JointDataVector;
-  typedef std::vector<JointModel> JointModelVector;
+  typedef std::vector<JointData, Eigen::aligned_allocator<JointData> > JointDataVector;
+  typedef std::vector<JointModel, Eigen::aligned_allocator<JointModel> > JointModelVector;
 
 } // namespace se3
-
-EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(se3::JointModel)
-EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(se3::JointData)
 
 #endif // ifndef __se3_joint_model_hpp__

--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -26,7 +26,7 @@
 #include "pinocchio/spatial/inertia.hpp"
 #include "pinocchio/multibody/fwd.hpp"
 #include "pinocchio/multibody/frame.hpp"
-#include "pinocchio/multibody/joint/joint-composite.hpp"
+#include "pinocchio/multibody/joint/joint.hpp"
 #include "pinocchio/deprecated.hh"
 #include "pinocchio/tools/string-generator.hpp"
 


### PR DESCRIPTION
Related to #336.
The circular inclusion is removed. One just relies on `pinocchio/multi body/joint/joint.hpp`to get access to all the joints.