### PR TITLE
Fix bug in parsing of ROS_PACKAGE_PATH variable

### DIFF
--- a/src/tools/file-explorer.hpp
+++ b/src/tools/file-explorer.hpp
@@ -41,6 +41,8 @@ namespace se3
     if (env_var_value != NULL)
     {
       std::string policyStr (env_var_value);
+      // Add a separator at the end so that last path is also retrieved
+      policyStr += std::string (":");
       size_t lastOffset = 0;
       
       while(true)


### PR DESCRIPTION
Last path was not retrieved. I locally added a separator ":" at the end of ROS_PACKAGE_PATH environment variable to fix the bug.