### PR TITLE
[C++] Move space operation to new class LieGroup and inherited classes.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,15 @@ SET(${PROJECT_NAME}_MULTIBODY_JOINT_HEADERS
   multibody/joint/joint-composite.hpp
   ) 
 
+SET(${PROJECT_NAME}_MULTIBODY_LIEGROUP_HEADERS
+  multibody/liegroup/liegroup.hpp
+  multibody/liegroup/operation-base.hpp
+  multibody/liegroup/vector-space.hpp
+  multibody/liegroup/cartesian-product.hpp
+  multibody/liegroup/special-orthogonal.hpp
+  multibody/liegroup/special-euclidean.hpp
+  ) 
+
 SET(${PROJECT_NAME}_MULTIBODY_HEADERS
   multibody/fwd.hpp
   multibody/constraint.hpp
@@ -281,6 +290,7 @@ SET(HEADERS
   ${${PROJECT_NAME}_TOOLS_HEADERS}
   ${${PROJECT_NAME}_SPATIAL_HEADERS}
   ${${PROJECT_NAME}_MULTIBODY_JOINT_HEADERS}
+  ${${PROJECT_NAME}_MULTIBODY_LIEGROUP_HEADERS}
   ${${PROJECT_NAME}_MULTIBODY_HEADERS}
   ${${PROJECT_NAME}_PARSERS_HEADERS}
   ${${PROJECT_NAME}_ALGORITHM_HEADERS}
@@ -295,6 +305,7 @@ MAKE_DIRECTORY("${${PROJECT_NAME}_BINARY_DIR}/include/pinocchio/math")
 MAKE_DIRECTORY("${${PROJECT_NAME}_BINARY_DIR}/include/pinocchio/spatial")
 MAKE_DIRECTORY("${${PROJECT_NAME}_BINARY_DIR}/include/pinocchio/multibody")
 MAKE_DIRECTORY("${${PROJECT_NAME}_BINARY_DIR}/include/pinocchio/multibody/joint")
+MAKE_DIRECTORY("${${PROJECT_NAME}_BINARY_DIR}/include/pinocchio/multibody/liegroup")
 MAKE_DIRECTORY("${${PROJECT_NAME}_BINARY_DIR}/include/pinocchio/parsers/lua")
 MAKE_DIRECTORY("${${PROJECT_NAME}_BINARY_DIR}/include/pinocchio/parsers")
 MAKE_DIRECTORY("${${PROJECT_NAME}_BINARY_DIR}/include/pinocchio/parsers/urdf")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -192,6 +192,7 @@ SET(${PROJECT_NAME}_MULTIBODY_JOINT_HEADERS
 SET(${PROJECT_NAME}_MULTIBODY_LIEGROUP_HEADERS
   multibody/liegroup/liegroup.hpp
   multibody/liegroup/operation-base.hpp
+  multibody/liegroup/operation-base.hxx
   multibody/liegroup/vector-space.hpp
   multibody/liegroup/cartesian-product.hpp
   multibody/liegroup/special-orthogonal.hpp

--- a/bindings/python/algorithm/expose-joints.cpp
+++ b/bindings/python/algorithm/expose-joints.cpp
@@ -78,10 +78,11 @@ namespace se3
               "return the configuration normalized ");
       
       bp::def("isSameConfiguration",
-              (bool (*)(const Model &, const VectorXd &, const VectorXd &))&isSameConfiguration,
+              (bool (*)(const Model &, const VectorXd &, const VectorXd &, const double&))&isSameConfiguration,
               bp::args("Model",
                        "Configuration q1 (size Model::nq)",
-                       "Configuration q2 (size Model::nq)"),
+                       "Configuration q2 (size Model::nq)",
+                       "Precision"),
               "Return true if two configurations are equivalent");
     }
     

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -134,13 +134,15 @@ namespace se3
    * @param[in]     model      Model
    * @param[in]     q1        The first configuraiton to compare
    * @param[in]     q2        The Second configuraiton to compare
+   * @param[in]     prec      precision of the comparison
    *
    * @return     Wheter the configurations are equivalent or not
    */
   template<typename LieGroup_t>
   inline bool isSameConfiguration(const Model & model,
                                   const Eigen::VectorXd & q1,
-                                  const Eigen::VectorXd & q2);
+                                  const Eigen::VectorXd & q2,
+                                  const double & prec = Eigen::NumTraits<double>::dummy_precision());
 } // namespace se3
 
 /* --- Details -------------------------------------------------------------------- */
@@ -504,11 +506,12 @@ namespace se3
   {
     typedef boost::fusion::vector<bool &,
                                   const Eigen::VectorXd &,
-                                  const Eigen::VectorXd &> ArgsType;
+                                  const Eigen::VectorXd &,
+                                  const double&> ArgsType;
 
     JOINT_MODEL_VISITOR_INIT(IsSameConfigurationStep);
 
-    SE3_DETAILS_VISITOR_METHOD_ALGO_3(IsSameConfigurationStepAlgo, LieGroup_t)
+    SE3_DETAILS_VISITOR_METHOD_ALGO_4(IsSameConfigurationStepAlgo, LieGroup_t)
   };
 
   template<typename LieGroup_t, typename JointModel>
@@ -516,24 +519,27 @@ namespace se3
     static void run(const se3::JointModelBase<JointModel> & jmodel,
                     bool & isSame,
                     const Eigen::VectorXd & q1,
-                    const Eigen::VectorXd & q2)
+                    const Eigen::VectorXd & q2,
+                    const double prec)
     {
       isSame = isSame && LieGroup_t::template operation<JointModel>::type
         ::isSameConfiguration(jmodel.jointConfigSelector(q1),
-                              jmodel.jointConfigSelector(q2));
+                              jmodel.jointConfigSelector(q2),
+                              prec);
     }
   };
 
-  SE3_DETAILS_DISPATCH_JOINT_COMPOSITE_3(IsSameConfigurationStep, IsSameConfigurationStepAlgo);
+  SE3_DETAILS_DISPATCH_JOINT_COMPOSITE_4(IsSameConfigurationStep, IsSameConfigurationStepAlgo);
 
   template<typename LieGroup_t>
   inline bool
   isSameConfiguration(const Model & model,
                       const Eigen::VectorXd & q1,
-                      const Eigen::VectorXd & q2)
+                      const Eigen::VectorXd & q2,
+                      const double& prec)
   {
     bool result = true;
-    typename IsSameConfigurationStep<LieGroup_t>::ArgsType args (result, q1, q2);
+    typename IsSameConfigurationStep<LieGroup_t>::ArgsType args (result, q1, q2, prec);
     for( Model::JointIndex i=1; i<(Model::JointIndex) model.njoints; ++i )
     {
       IsSameConfigurationStep<LieGroup_t>::run(model.joints[i], args);
@@ -546,9 +552,10 @@ namespace se3
   inline bool
   isSameConfiguration(const Model & model,
                       const Eigen::VectorXd & q1,
-                      const Eigen::VectorXd & q2)
+                      const Eigen::VectorXd & q2,
+                      const double& prec = Eigen::NumTraits<double>::dummy_precision())
   {
-    return isSameConfiguration<LieGroupTpl>(model, q1, q2);
+    return isSameConfiguration<LieGroupTpl>(model, q1, q2, prec);
   }
 
 

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -20,7 +20,9 @@
 
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/multibody/model.hpp"
-  
+
+#include "pinocchio/multibody/liegroup/liegroup.hpp"
+
 namespace se3
 {
 
@@ -32,10 +34,14 @@ namespace se3
    * @param[in]  v       Velocity (size model.nv)
    * @return     The integrated configuration (size model.nq)
    */
+  template<typename LieGroup_t>
   inline Eigen::VectorXd integrate(const Model & model,
                                    const Eigen::VectorXd & q,
                                    const Eigen::VectorXd & v);
-
+  // TODO remove me
+  // inline Eigen::VectorXd integrate(const Model & model,
+                                   // const Eigen::VectorXd & q,
+                                   // const Eigen::VectorXd & v);
 
   /**
    * @brief      Interpolate the model between two configurations
@@ -46,11 +52,16 @@ namespace se3
    * @param[in]  u       u in [0;1] position along the interpolation.
    * @return     The interpolated configuration (q0 if u = 0, q1 if u = 1)
    */
+  template<typename LieGroup_t>
   inline Eigen::VectorXd interpolate(const Model & model,
                                      const Eigen::VectorXd & q0,
                                      const Eigen::VectorXd & q1,
                                      const double u);
-
+  // TODO remove me
+  // inline Eigen::VectorXd interpolate(const Model & model,
+                                     // const Eigen::VectorXd & q0,
+                                     // const Eigen::VectorXd & q1,
+                                     // const double u);
 
   /**
    * @brief      Compute the tangent vector that must be integrated during one unit time to go from q0 to q1
@@ -60,35 +71,37 @@ namespace se3
    * @param[in]  q1      Wished configuration (size model.nq)
    * @return     The corresponding velocity (size model.nv)
    */
+  template<typename LieGroup_t>
   inline Eigen::VectorXd differentiate(const Model & model,
                                        const Eigen::VectorXd & q0,
                                        const Eigen::VectorXd & q1);
 
 
   /**
-   * @brief      Distance between two configuration vectors
+   * @brief      Squared distance between two configuration vectors
    *
    * @param[in]  model      Model we want to compute the distance
    * @param[in]  q0         Configuration 0 (size model.nq)
    * @param[in]  q1         Configuration 1 (size model.nq)
-   * @return     The corresponding distances for each joint (size model.njoints-1 = number of joints)
+   * @return     The corresponding squared distances for each joint (size model.njoints-1 = number of joints)
    */
-  inline Eigen::VectorXd distance(const Model & model,
-                                  const Eigen::VectorXd & q0,
-                                  const Eigen::VectorXd & q1);
-
+  template<typename LieGroup_t>
+  inline Eigen::VectorXd squaredDistance(const Model & model,
+                                         const Eigen::VectorXd & q0,
+                                         const Eigen::VectorXd & q1);
 
   /**
    * @brief      Generate a configuration vector uniformly sampled among provided limits.
    *
    *\warning     If limits are infinite, exceptions may be thrown in the joint implementation of uniformlySample
-   *             
+   *
    * @param[in]  model        Model we want to generate a configuration vector of
    * @param[in]  lowerLimits  Joints lower limits
    * @param[in]  upperLimits  Joints upper limits
    *
    * @return     The resulted configuration vector (size model.nq)
    */
+  template<typename LieGroup_t>
   inline Eigen::VectorXd randomConfiguration(const Model & model,
                                              const Eigen::VectorXd & lowerLimits,
                                              const Eigen::VectorXd & upperLimits);
@@ -98,10 +111,11 @@ namespace se3
    *
    *\warning     If limits are infinite (no one specified when adding a body or no modification directly in my_model.{lowerPositionLimit,upperPositionLimit},
    *             exceptions may be thrown in the joint implementation of uniformlySample
-   *             
+   *
    * @param[in]  model   Model we want to generate a configuration vector of
    * @return     The resulted configuration vector (size model.nq)
    */
+  template<typename LieGroup_t>
   inline Eigen::VectorXd randomConfiguration(const Model & model);
 
   /**
@@ -116,22 +130,66 @@ namespace se3
   /**
    * @brief         Return true if the given configurations are equivalents
    * \warning       Two configurations can be equivalent but not equally coefficient wise (e.g for quaternions)
-   * 
+   *
    * @param[in]     model      Model
    * @param[in]     q1        The first configuraiton to compare
    * @param[in]     q2        The Second configuraiton to compare
-   * 
+   *
    * @return     Wheter the configurations are equivalent or not
    */
+  template<typename LieGroup_t>
   inline bool isSameConfiguration(const Model & model,
                                   const Eigen::VectorXd & q1,
                                   const Eigen::VectorXd & q2);
-} // namespace se3 
+} // namespace se3
 
 /* --- Details -------------------------------------------------------------------- */
-namespace se3 
+namespace se3
 {
-  struct IntegrateStep : public fusion::JointModelVisitor<IntegrateStep>
+  namespace details
+  {
+    template<typename Algo> struct Dispatch {
+      static void run (const JointModelComposite& jmodel, typename Algo::ArgsType args)
+      {
+        for (size_t i = 0; i < jmodel.joints.size(); ++i)
+          Algo::run(jmodel.joints[i], args);
+      }
+    };
+
+#define SE3_DETAILS_WRITE_ARGS_0(JM)                               const JointModelBase<JM> & jmodel
+#define SE3_DETAILS_WRITE_ARGS_1(JM) SE3_DETAILS_WRITE_ARGS_0(JM), typename boost::fusion::result_of::at_c<ArgsType, 0>::type a0
+#define SE3_DETAILS_WRITE_ARGS_2(JM) SE3_DETAILS_WRITE_ARGS_1(JM), typename boost::fusion::result_of::at_c<ArgsType, 1>::type a1
+#define SE3_DETAILS_WRITE_ARGS_3(JM) SE3_DETAILS_WRITE_ARGS_2(JM), typename boost::fusion::result_of::at_c<ArgsType, 2>::type a2
+#define SE3_DETAILS_WRITE_ARGS_4(JM) SE3_DETAILS_WRITE_ARGS_3(JM), typename boost::fusion::result_of::at_c<ArgsType, 3>::type a3
+
+#define SE3_DETAILS_DISPATCH_JOINT_COMPOSITE_3(Visitor, Algo)                 \
+    template <typename LieGroup_t> struct Algo <LieGroup_t, JointModelComposite> {                                         \
+      typedef typename Visitor<LieGroup_t>::ArgsType ArgsType;                 \
+      static void run (SE3_DETAILS_WRITE_ARGS_3(JointModelComposite))         \
+      { ::se3::details::Dispatch< Visitor<LieGroup_t> >::run(jmodel.derived(), ArgsType(a0, a1, a2)); } \
+    }
+#define SE3_DETAILS_DISPATCH_JOINT_COMPOSITE_4(Visitor, Algo)                 \
+    template <typename LieGroup_t> struct Algo <LieGroup_t, JointModelComposite> {                                         \
+      typedef typename Visitor<LieGroup_t>::ArgsType ArgsType;                 \
+      static void run (SE3_DETAILS_WRITE_ARGS_4(JointModelComposite))         \
+      { ::se3::details::Dispatch< Visitor<LieGroup_t> >::run(jmodel.derived(), ArgsType(a0, a1, a2, a3)); } \
+    }
+
+#define SE3_DETAILS_VISITOR_METHOD_ALGO_3(Algo, TplParam)                      \
+    template<typename JointModel>                                              \
+    static void algo(SE3_DETAILS_WRITE_ARGS_3(JointModel))                     \
+    { Algo<TplParam, JointModel>::run(jmodel, a0, a1, a2); }
+#define SE3_DETAILS_VISITOR_METHOD_ALGO_4(Algo, TplParam)                      \
+    template<typename JointModel>                                              \
+    static void algo(SE3_DETAILS_WRITE_ARGS_4(JointModel))                     \
+    { Algo<TplParam, JointModel>::run(jmodel, a0, a1, a2, a3); }
+
+  } // namespace details
+
+  template<typename LieGroup_t, typename JointModel> struct IntegrateStepAlgo;
+
+  template<typename LieGroup_t>
+  struct IntegrateStep : public fusion::JointModelVisitor<IntegrateStep<LieGroup_t> >
   {
     typedef boost::fusion::vector<const Eigen::VectorXd &,
                                   const Eigen::VectorXd &,
@@ -140,34 +198,52 @@ namespace se3
 
     JOINT_MODEL_VISITOR_INIT(IntegrateStep);
 
-    template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     const Eigen::VectorXd & q,
-                     const Eigen::VectorXd & v,
-                     Eigen::VectorXd & result) 
-    {
-      jmodel.jointConfigSelector(result) = jmodel.integrate(q, v);
-    }
-
+    SE3_DETAILS_VISITOR_METHOD_ALGO_3(IntegrateStepAlgo, LieGroup_t)
   };
+
+  template<typename LieGroup_t, typename JointModel>
+  struct IntegrateStepAlgo {
+    static void run(const se3::JointModelBase<JointModel> & jmodel,
+                    const Eigen::VectorXd & q,
+                    const Eigen::VectorXd & v,
+                    Eigen::VectorXd & result)
+    {
+      LieGroup_t::template operation<JointModel>::type
+        ::integrate (jmodel.jointConfigSelector  (q),
+                     jmodel.jointVelocitySelector(v),
+                     jmodel.jointConfigSelector  (result));
+    }
+  };
+
+  SE3_DETAILS_DISPATCH_JOINT_COMPOSITE_3(IntegrateStep, IntegrateStepAlgo);
 
   inline Eigen::VectorXd
   integrate(const Model & model,
-                 const Eigen::VectorXd & q,
-                 const Eigen::VectorXd & v)
+            const Eigen::VectorXd & q,
+            const Eigen::VectorXd & v)
+  {
+    return integrate<LieGroupTpl>(model, q, v);
+  }
+
+  template<typename LieGroup_t>
+  inline Eigen::VectorXd
+  integrate(const Model & model,
+            const Eigen::VectorXd & q,
+            const Eigen::VectorXd & v)
   {
     Eigen::VectorXd integ(model.nq);
+    typename IntegrateStep<LieGroup_t>::ArgsType args(q, v, integ);
     for( Model::JointIndex i=1; i<(Model::JointIndex) model.njoints; ++i )
     {
-      IntegrateStep::run(model.joints[i],
-                          IntegrateStep::ArgsType (q, v, integ)
-                          );
+      IntegrateStep<LieGroup_t>::run (model.joints[i], args);
     }
     return integ;
   }
 
+  template<typename LieGroup_t, typename JointModel> struct InterpolateStepAlgo;
 
-  struct InterpolateStep : public fusion::JointModelVisitor<InterpolateStep>
+  template<typename LieGroup_t>
+  struct InterpolateStep : public fusion::JointModelVisitor<InterpolateStep<LieGroup_t> >
   {
     typedef boost::fusion::vector<const Eigen::VectorXd &,
                                   const Eigen::VectorXd &,
@@ -177,18 +253,37 @@ namespace se3
 
     JOINT_MODEL_VISITOR_INIT(InterpolateStep);
 
-    template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     const Eigen::VectorXd & q0,
-                     const Eigen::VectorXd & q1,
-                     const double u,
-                     Eigen::VectorXd & result) 
-    {
-      jmodel.jointConfigSelector(result) = jmodel.interpolate(q0, q1, u);
-    }
-
+    SE3_DETAILS_VISITOR_METHOD_ALGO_4(InterpolateStepAlgo, LieGroup_t)
   };
 
+  template<typename LieGroup_t, typename JointModel>
+  struct InterpolateStepAlgo {
+    static void run(const se3::JointModelBase<JointModel> & jmodel,
+                    const Eigen::VectorXd & q0,
+                    const Eigen::VectorXd & q1,
+                    const double u,
+                    Eigen::VectorXd & result)
+    {
+      LieGroup_t::template operation<JointModel>::type
+        ::interpolate (jmodel.jointConfigSelector(q0),
+                       jmodel.jointConfigSelector(q1),
+                       u,
+                       jmodel.jointConfigSelector(result));
+    }
+  };
+
+  SE3_DETAILS_DISPATCH_JOINT_COMPOSITE_4(InterpolateStep, InterpolateStepAlgo);
+
+  inline Eigen::VectorXd
+  interpolate(const Model & model,
+               const Eigen::VectorXd & q0,
+               const Eigen::VectorXd & q1,
+               const double u)
+  {
+    return interpolate<LieGroupTpl>(model, q0, q1, u);
+  }
+
+  template<typename LieGroup_t>
   inline Eigen::VectorXd
   interpolate(const Model & model,
                const Eigen::VectorXd & q0,
@@ -198,14 +293,16 @@ namespace se3
     Eigen::VectorXd interp(model.nq);
     for( Model::JointIndex i=1; i<(Model::JointIndex) model.njoints; ++i )
     {
-      InterpolateStep::run(model.joints[i],
-                            InterpolateStep::ArgsType (q0, q1, u, interp)
-                            );
+      InterpolateStep<LieGroup_t>::run
+        (model.joints[i], typename InterpolateStep<LieGroup_t>::ArgsType (q0, q1, u, interp));
     }
     return interp;
   }
 
-  struct DifferentiateStep : public fusion::JointModelVisitor<DifferentiateStep>
+  template<typename LieGroup_t, typename JointModel> struct DifferentiateStepAlgo;
+
+  template<typename LieGroup_t>
+  struct DifferentiateStep : public fusion::JointModelVisitor<DifferentiateStep<LieGroup_t> >
   {
     typedef boost::fusion::vector<const Eigen::VectorXd &,
                                   const Eigen::VectorXd &,
@@ -214,33 +311,52 @@ namespace se3
 
     JOINT_MODEL_VISITOR_INIT(DifferentiateStep);
 
-    template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     const Eigen::VectorXd & q0,
-                     const Eigen::VectorXd & q1,
-                     Eigen::VectorXd & result) 
-    {
-      jmodel.jointVelocitySelector(result) = jmodel.difference(q0, q1);
-    }
-
+    SE3_DETAILS_VISITOR_METHOD_ALGO_3(DifferentiateStepAlgo, LieGroup_t)
   };
 
+  template<typename LieGroup_t, typename JointModel>
+  struct DifferentiateStepAlgo {
+    static void run(const se3::JointModelBase<JointModel> & jmodel,
+                     const Eigen::VectorXd & q0,
+                     const Eigen::VectorXd & q1,
+                     Eigen::VectorXd & result)
+    {
+      LieGroup_t::template operation<JointModel>::type
+        ::difference (jmodel.jointConfigSelector(q0),
+                      jmodel.jointConfigSelector(q1),
+                      jmodel.jointVelocitySelector(result));
+    }
+  };
+
+  SE3_DETAILS_DISPATCH_JOINT_COMPOSITE_3(DifferentiateStep, DifferentiateStepAlgo);
+
+  template<typename LieGroup_t>
   inline Eigen::VectorXd
   differentiate(const Model & model,
                      const Eigen::VectorXd & q0,
                      const Eigen::VectorXd & q1)
   {
     Eigen::VectorXd diff(model.nv);
+    typename DifferentiateStep<LieGroup_t>::ArgsType args(q0, q1, diff);
     for( Model::JointIndex i=1; i<(Model::JointIndex) model.njoints; ++i )
     {
-      DifferentiateStep::run(model.joints[i],
-                              DifferentiateStep::ArgsType (q0, q1, diff)
-                              );
+      DifferentiateStep<LieGroup_t>::run(model.joints[i], args);
     }
     return diff;
   }
 
-  struct DistanceStep : public fusion::JointModelVisitor<DistanceStep>
+  inline Eigen::VectorXd
+  differentiate(const Model & model,
+                     const Eigen::VectorXd & q0,
+                     const Eigen::VectorXd & q1)
+  {
+    return differentiate<LieGroupTpl>(model, q0, q1);
+  }
+
+  template<typename LieGroup_t, typename JointModel> struct SquaredDistanceStepAlgo;
+
+  template<typename LieGroup_t>
+  struct SquaredDistanceStep : public fusion::JointModelVisitor<SquaredDistanceStep<LieGroup_t> >
   {
     typedef boost::fusion::vector<const Model::JointIndex,
                                   const Eigen::VectorXd &,
@@ -248,75 +364,112 @@ namespace se3
                                   Eigen::VectorXd &
                                   > ArgsType;
 
-    JOINT_MODEL_VISITOR_INIT(DistanceStep);
+    JOINT_MODEL_VISITOR_INIT(SquaredDistanceStep);
 
-    template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     const Model::JointIndex i,
-                     const Eigen::VectorXd & q0,
-                     const Eigen::VectorXd & q1,
-                     Eigen::VectorXd & distances) 
-    {
-      distances[(long)i] = jmodel.distance(q0, q1);
-    }
-
+    SE3_DETAILS_VISITOR_METHOD_ALGO_4(SquaredDistanceStepAlgo, LieGroup_t)
   };
 
+  template<typename LieGroup_t, typename JointModel>
+  struct SquaredDistanceStepAlgo {
+    static void run(const se3::JointModelBase<JointModel> & jmodel,
+                    const Model::JointIndex i,
+                    const Eigen::VectorXd & q0,
+                    const Eigen::VectorXd & q1,
+                    Eigen::VectorXd & distances)
+    {
+      distances[(long)i] +=
+        LieGroup_t::template operation<JointModel>::type::squaredDistance(
+            jmodel.jointConfigSelector(q0),
+            jmodel.jointConfigSelector(q1));
+    }
+  };
+
+  SE3_DETAILS_DISPATCH_JOINT_COMPOSITE_4(SquaredDistanceStep, SquaredDistanceStepAlgo);
+
+  template<typename LieGroup_t>
   inline Eigen::VectorXd
-  distance(const Model & model,
-               const Eigen::VectorXd & q0,
-               const Eigen::VectorXd & q1)
+  squaredDistance(const Model & model,
+                  const Eigen::VectorXd & q0,
+                  const Eigen::VectorXd & q1)
   {
-    Eigen::VectorXd distances(model.njoints-1);
+    Eigen::VectorXd distances(Eigen::VectorXd::Zero(model.njoints-1));
     for( Model::JointIndex i=1; i<(Model::JointIndex) model.njoints; ++i )
     {
-      DistanceStep::run(model.joints[i],
-                        DistanceStep::ArgsType (i-1, q0, q1, distances)
-                        );
+      typename SquaredDistanceStep<LieGroup_t>::ArgsType args(i-1, q0, q1, distances);
+      SquaredDistanceStep<LieGroup_t>::run(model.joints[i], args);
     }
     return distances;
   }
 
+  inline Eigen::VectorXd
+  squaredDistance(const Model & model,
+                  const Eigen::VectorXd & q0,
+                  const Eigen::VectorXd & q1)
+  {
+    return squaredDistance<LieGroupTpl>(model, q0, q1);
+  }
 
-  struct RandomConfiguration : public fusion::JointModelVisitor<RandomConfiguration>
+  template<typename LieGroup_t, typename JointModel> struct RandomConfigurationStepAlgo;
+
+  template<typename LieGroup_t>
+  struct RandomConfigurationStep : public fusion::JointModelVisitor<RandomConfigurationStep<LieGroup_t> >
   {
     typedef boost::fusion::vector<Eigen::VectorXd &,
                                   const Eigen::VectorXd &,
                                   const Eigen::VectorXd &
                                   > ArgsType;
 
-    JOINT_MODEL_VISITOR_INIT(RandomConfiguration);
+    JOINT_MODEL_VISITOR_INIT(RandomConfigurationStep);
 
-    template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     Eigen::VectorXd & q,
-                     const Eigen::VectorXd & lowerLimits,
-                     const Eigen::VectorXd & upperLimits) 
-    {
-      jmodel.jointConfigSelector(q) = jmodel.randomConfiguration(jmodel.jointConfigSelector(lowerLimits),
-                                                                  jmodel.jointConfigSelector(upperLimits)
-                                                                  );
-    }
-
+    SE3_DETAILS_VISITOR_METHOD_ALGO_3(RandomConfigurationStepAlgo, LieGroup_t)
   };
 
+  template<typename LieGroup_t, typename JointModel>
+  struct RandomConfigurationStepAlgo {
+    static void run(const se3::JointModelBase<JointModel> & jmodel,
+                    Eigen::VectorXd & q,
+                    const Eigen::VectorXd & lowerLimits,
+                    const Eigen::VectorXd & upperLimits)
+    {
+      LieGroup_t::template operation<JointModel>::type
+        ::randomConfiguration(jmodel.jointConfigSelector(lowerLimits),
+                              jmodel.jointConfigSelector(upperLimits),
+                              jmodel.jointConfigSelector(q));
+    }
+  };
+
+  SE3_DETAILS_DISPATCH_JOINT_COMPOSITE_3(RandomConfigurationStep, RandomConfigurationStepAlgo);
+
+  template<typename LieGroup_t>
   inline Eigen::VectorXd
   randomConfiguration(const Model & model, const Eigen::VectorXd & lowerLimits, const Eigen::VectorXd & upperLimits)
   {
     Eigen::VectorXd q(model.nq);
+    typename RandomConfigurationStep<LieGroup_t>::ArgsType args(q, lowerLimits, upperLimits);
     for( Model::JointIndex i=1; i<(Model::JointIndex) model.njoints; ++i )
     {
-      RandomConfiguration::run(model.joints[i],
-                               RandomConfiguration::ArgsType ( q, lowerLimits, upperLimits)
-                               );
+      RandomConfigurationStep<LieGroup_t>::run(model.joints[i], args);
     }
     return q;
   }
 
   inline Eigen::VectorXd
+  randomConfiguration(const Model & model, const Eigen::VectorXd & lowerLimits, const Eigen::VectorXd & upperLimits)
+  {
+    return randomConfiguration<LieGroupTpl>(model, lowerLimits, upperLimits);
+  }
+
+  template<typename LieGroup_t>
+  inline Eigen::VectorXd
   randomConfiguration(const Model & model)
   {
-    return randomConfiguration(model, model.lowerPositionLimit, model.upperPositionLimit);
+    return randomConfiguration<LieGroup_t>(model, model.lowerPositionLimit, model.upperPositionLimit);
+  }
+
+  inline Eigen::VectorXd
+  randomConfiguration(const Model & model)
+  {
+    return randomConfiguration<LieGroupTpl>(model);
   }
 
   struct NormalizeStep : public fusion::JointModelVisitor<NormalizeStep>
@@ -344,8 +497,10 @@ namespace se3
     }
   }
 
+  template<typename LieGroup_t, typename JointModel> struct IsSameConfigurationStepAlgo;
 
-  struct IsSameConfigurationStep : public fusion::JointModelVisitor<IsSameConfigurationStep>
+  template<typename LieGroup_t>
+  struct IsSameConfigurationStep : public fusion::JointModelVisitor<IsSameConfigurationStep<LieGroup_t> >
   {
     typedef boost::fusion::vector<bool &,
                                   const Eigen::VectorXd &,
@@ -353,29 +508,47 @@ namespace se3
 
     JOINT_MODEL_VISITOR_INIT(IsSameConfigurationStep);
 
-    template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     bool & isSame,
-                     const Eigen::VectorXd & q1,
-                     const Eigen::VectorXd & q2)
+    SE3_DETAILS_VISITOR_METHOD_ALGO_3(IsSameConfigurationStepAlgo, LieGroup_t)
+  };
+
+  template<typename LieGroup_t, typename JointModel>
+  struct IsSameConfigurationStepAlgo {
+    static void run(const se3::JointModelBase<JointModel> & jmodel,
+                    bool & isSame,
+                    const Eigen::VectorXd & q1,
+                    const Eigen::VectorXd & q2)
     {
-      isSame = jmodel.isSameConfiguration(q1,q2);
+      isSame = isSame && LieGroup_t::template operation<JointModel>::type
+        ::isSameConfiguration(jmodel.jointConfigSelector(q1),
+                              jmodel.jointConfigSelector(q2));
     }
   };
+
+  SE3_DETAILS_DISPATCH_JOINT_COMPOSITE_3(IsSameConfigurationStep, IsSameConfigurationStepAlgo);
+
+  template<typename LieGroup_t>
+  inline bool
+  isSameConfiguration(const Model & model,
+                      const Eigen::VectorXd & q1,
+                      const Eigen::VectorXd & q2)
+  {
+    bool result = true;
+    typename IsSameConfigurationStep<LieGroup_t>::ArgsType args (result, q1, q2);
+    for( Model::JointIndex i=1; i<(Model::JointIndex) model.njoints; ++i )
+    {
+      IsSameConfigurationStep<LieGroup_t>::run(model.joints[i], args);
+      if( !result )
+        return false;
+    }
+    return true;
+  }
 
   inline bool
   isSameConfiguration(const Model & model,
                       const Eigen::VectorXd & q1,
                       const Eigen::VectorXd & q2)
   {
-    bool result = false;
-    for( Model::JointIndex i=1; i<(Model::JointIndex) model.njoints; ++i )
-    {
-      IsSameConfigurationStep::run(model.joints[i], IsSameConfigurationStep::ArgsType (result,q1,q2)); 
-      if( !result )
-        return false;
-    }
-    return true;
+    return isSameConfiguration<LieGroupTpl>(model, q1, q2);
   }
 
 

--- a/src/math/quaternion.hpp
+++ b/src/math/quaternion.hpp
@@ -56,9 +56,10 @@ namespace se3
   ///
   template <typename Derived, typename otherDerived>
   bool defineSameRotation(const Eigen::QuaternionBase<Derived> & q1,
-                          const Eigen::QuaternionBase<otherDerived> & q2)
+                          const Eigen::QuaternionBase<otherDerived> & q2,
+                          const typename Derived::RealScalar & prec = Eigen::NumTraits<typename Derived::Scalar>::dummy_precision())
   {
-    return (q1.coeffs().isApprox(q2.coeffs()) || q1.coeffs().isApprox(-q2.coeffs()) );
+    return (q1.coeffs().isApprox(q2.coeffs(), prec) || q1.coeffs().isApprox(-q2.coeffs(), prec) );
   }
 
   /// Approximately normalize by applying the first order limited development

--- a/src/math/quaternion.hpp
+++ b/src/math/quaternion.hpp
@@ -18,7 +18,7 @@
 #ifndef __math_quaternion_hpp__
 #define __math_quaternion_hpp__
 
-#include <boost/math/constants/constants.hpp>
+#include <pinocchio/math/fwd.hpp>
 
 namespace se3
 {

--- a/src/multibody/joint/fwd.hpp
+++ b/src/multibody/joint/fwd.hpp
@@ -21,7 +21,37 @@
 namespace se3
 {
   enum { MAX_JOINT_NV = 6 };
-  
+
+  template<int axis> struct JointModelRevolute;
+  template<int axis> struct JointDataRevolute;
+
+  struct JointModelRevoluteUnaligned;
+  struct JointDataRevoluteUnaligned;
+
+  template<int axis> struct JointModelRevoluteUnbounded;
+  template<int axis> struct JointDataRevoluteUnbounded;
+
+  struct JointModelSpherical;
+  struct JointDataSpherical;
+
+  struct JointModelSphericalZYX;
+  struct JointDataSphericalZYX;
+
+  template<int axis> struct JointModelPrismatic;
+  template<int axis> struct JointDataPrismatic;
+
+  struct JointModelPrismaticUnaligned;
+  struct JointDataPrismaticUnaligned;
+
+  struct JointModelFreeFlyer;
+  struct JointDataFreeFlyer;
+
+  struct JointModelPlanar;
+  struct JointDataPlanar;
+
+  struct JointModelTranslation;
+  struct JointDataTranslation;
+
   struct JointModelComposite;
   struct JointDataComposite;
   

--- a/src/multibody/joint/joint-base.hpp
+++ b/src/multibody/joint/joint-base.hpp
@@ -20,6 +20,7 @@
 #define __se3_joint_base_hpp__
 
 #include "pinocchio/multibody/fwd.hpp"
+#include "pinocchio/multibody/joint/fwd.hpp"
 
 #include <Eigen/Core>
 #include <limits>

--- a/src/multibody/joint/joint-free-flyer.hpp
+++ b/src/multibody/joint/joint-free-flyer.hpp
@@ -31,9 +31,6 @@
 namespace se3
 {
 
-  struct JointDataFreeFlyer;
-  struct JointModelFreeFlyer;
-
   struct ConstraintIdentity;
 
   template <>

--- a/src/multibody/joint/joint-planar.hpp
+++ b/src/multibody/joint/joint-planar.hpp
@@ -30,9 +30,6 @@
 namespace se3
 {
 
-  struct JointDataPlanar;
-  struct JointModelPlanar;
-
   struct MotionPlanar;
   template <>
   struct traits< MotionPlanar >

--- a/src/multibody/joint/joint-planar.hpp
+++ b/src/multibody/joint/joint-planar.hpp
@@ -468,7 +468,7 @@ namespace se3
     { 
       ConfigVector_t result;
       result.head<2>().setRandom();
-      const Scalar angle = PI * ((Scalar)(-1 + 2 * rand()) / (Scalar) RAND_MAX);
+      const Scalar angle = PI * (-1 + 2 * ((Scalar)rand()) / RAND_MAX);
       SINCOS(angle, &result[3], &result[2]);
       return result;
     } 
@@ -488,7 +488,7 @@ namespace se3
         }
         result[i] = lower_pos_limit[i] + ( upper_pos_limit[i] - lower_pos_limit[i]) * rand()/RAND_MAX;
       }
-      const Scalar angle = PI * ((Scalar)(-1 + 2 * rand()) / (Scalar) RAND_MAX);
+      const Scalar angle = PI * (-1 + 2 * ((Scalar)rand()) / RAND_MAX);
       SINCOS(angle, &result[3], &result[2]);
       return result;
     } 

--- a/src/multibody/joint/joint-prismatic-unaligned.hpp
+++ b/src/multibody/joint/joint-prismatic-unaligned.hpp
@@ -28,9 +28,6 @@
 namespace se3
 {
 
-  struct JointDataPrismaticUnaligned;
-  struct JointModelPrismaticUnaligned;
-
   struct MotionPrismaticUnaligned;
   
   template <>

--- a/src/multibody/joint/joint-prismatic.hpp
+++ b/src/multibody/joint/joint-prismatic.hpp
@@ -27,9 +27,6 @@
 
 namespace se3
 {
-
-  template<int axis> struct JointDataPrismatic;
-  template<int axis> struct JointModelPrismatic;
   
   namespace prismatic
   {

--- a/src/multibody/joint/joint-revolute-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unaligned.hpp
@@ -28,9 +28,6 @@
 namespace se3
 {
 
-  struct JointDataRevoluteUnaligned;
-  struct JointModelRevoluteUnaligned;
-
   struct MotionRevoluteUnaligned;
   template <>
   struct traits < MotionRevoluteUnaligned >

--- a/src/multibody/joint/joint-revolute-unbounded.hpp
+++ b/src/multibody/joint/joint-revolute-unbounded.hpp
@@ -31,10 +31,6 @@ namespace se3
 
   template<int axis> struct JointRevoluteUnbounded;
 
-  template<int axis> struct JointDataRevoluteUnbounded;
-  template<int axis> struct JointModelRevoluteUnbounded;
-
-
   template<int axis>
   struct traits< JointRevoluteUnbounded<axis> >
   {

--- a/src/multibody/joint/joint-revolute.hpp
+++ b/src/multibody/joint/joint-revolute.hpp
@@ -29,9 +29,6 @@
 namespace se3
 {
 
-  template<int axis> struct JointDataRevolute;
-  template<int axis> struct JointModelRevolute;
-  
   template<int axis> struct SE3Revolute;
   template<int axis> struct MotionRevolute;
 

--- a/src/multibody/joint/joint-spherical-ZYX.hpp
+++ b/src/multibody/joint/joint-spherical-ZYX.hpp
@@ -29,9 +29,6 @@
 
 namespace se3
 {
-
-  struct JointDataSphericalZYX;
-  struct JointModelSphericalZYX;
   
   template <typename _Scalar, int _Options>
   struct JointSphericalZYXTpl

--- a/src/multibody/joint/joint-spherical.hpp
+++ b/src/multibody/joint/joint-spherical.hpp
@@ -31,9 +31,6 @@
 namespace se3
 {
 
-  struct JointDataSpherical;
-  struct JointModelSpherical;
-
   struct MotionSpherical;
   template <>
   struct traits< MotionSpherical >

--- a/src/multibody/joint/joint-translation.hpp
+++ b/src/multibody/joint/joint-translation.hpp
@@ -29,9 +29,6 @@
 namespace se3
 {
 
-  struct JointDataTranslation;
-  struct JointModelTranslation;
-
   struct MotionTranslation;
   template <>
   struct traits < MotionTranslation >

--- a/src/multibody/liegroup/cartesian-product.hpp
+++ b/src/multibody/liegroup/cartesian-product.hpp
@@ -81,11 +81,11 @@ namespace se3
     static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & lower,
                                          const Eigen::MatrixBase<ConfigR_t> & upper,
                                          const Eigen::MatrixBase<ConfigOut_t> & qout)
-    { 
+    {
       ConfigOut_t& out = const_cast< Eigen::MatrixBase<ConfigOut_t>& > (qout).derived();
       LieGroup1::randomConfiguration(lower.template head<LieGroup1::NQ>(), upper.template head<LieGroup1::NQ>(), out.template head<LieGroup1::NQ>());
       LieGroup2::randomConfiguration(lower.template tail<LieGroup2::NQ>(), upper.template tail<LieGroup2::NQ>(), out.template tail<LieGroup2::NQ>());
-    } 
+    }
 
     template <class ConfigL_t, class ConfigR_t>
     static bool isSameConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & q0,

--- a/src/multibody/liegroup/cartesian-product.hpp
+++ b/src/multibody/liegroup/cartesian-product.hpp
@@ -1,0 +1,102 @@
+//
+// Copyright (c) 2016 CNRS
+//
+// This file is part of Pinocchio
+// Pinocchio is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// Pinocchio is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// Pinocchio If not, see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef __se3_cartesian_product_operation_hpp__
+#define __se3_cartesian_product_operation_hpp__
+
+#include <pinocchio/multibody/liegroup/operation-base.hpp>
+
+namespace se3
+{
+  template<typename LieGroup1, typename LieGroup2>
+  struct CartesianProductOperation;
+  template<typename LieGroup1, typename LieGroup2>
+  struct traits<CartesianProductOperation<LieGroup1, LieGroup2> > {
+    typedef double Scalar;
+    enum {
+      NQ = LieGroup1::NQ + LieGroup2::NQ,
+      NV = LieGroup1::NV + LieGroup2::NV
+    };
+    typedef Eigen::Matrix<Scalar,NQ,1> ConfigVector_t;
+    typedef Eigen::Matrix<Scalar,NV,1> TangentVector_t;
+  };
+
+  template<typename LieGroup1, typename LieGroup2>
+  struct CartesianProductOperation : public LieGroupOperationBase <CartesianProductOperation<LieGroup1, LieGroup2> >
+  {
+    typedef CartesianProductOperation<LieGroup1, LieGroup2>  LieGroupDerived;
+    SE3_LIE_GROUP_TYPEDEF;
+
+    template <class ConfigL_t, class ConfigR_t, class Tangent_t>
+    static void difference_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                const Eigen::MatrixBase<ConfigR_t> & q1,
+                                const Eigen::MatrixBase<Tangent_t> & d)
+    {
+      Tangent_t& out = const_cast< Eigen::MatrixBase<Tangent_t>& > (d).derived();
+      LieGroup1::difference(q0.template head<LieGroup1::NQ>(), q1.template head<LieGroup1::NQ>(), out.template head<LieGroup1::NV>());
+      LieGroup2::difference(q0.template tail<LieGroup2::NQ>(), q1.template tail<LieGroup2::NQ>(), out.template tail<LieGroup2::NV>());
+    }
+
+    template <class ConfigIn_t, class Velocity_t, class ConfigOut_t>
+    static void integrate_impl(const Eigen::MatrixBase<ConfigIn_t> & q,
+                               const Eigen::MatrixBase<Velocity_t> & v,
+                               const Eigen::MatrixBase<ConfigOut_t> & qout)
+    {
+      ConfigOut_t& out = const_cast< Eigen::MatrixBase<ConfigOut_t>& > (qout).derived();
+      LieGroup1::integrate(q.template head<LieGroup1::NQ>(), v.template head<LieGroup1::NV>(), out.template head<LieGroup1::NQ>());
+      LieGroup2::integrate(q.template tail<LieGroup2::NQ>(), v.template tail<LieGroup2::NV>(), out.template tail<LieGroup2::NQ>());
+    }
+
+    template <class ConfigL_t, class ConfigR_t>
+    static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                       const Eigen::MatrixBase<ConfigR_t> & q1)
+    {
+      return LieGroup1::squaredDistance(q0.template head<LieGroup1::NQ>(), q1.template head<LieGroup1::NQ>())
+        +    LieGroup2::squaredDistance(q0.template tail<LieGroup2::NQ>(), q1.template tail<LieGroup2::NQ>());
+    }
+
+    template <class Config_t>
+    static void random_impl (const Eigen::MatrixBase<Config_t>& qout)
+    {
+      Config_t& out = const_cast< Eigen::MatrixBase<Config_t>& > (qout).derived();
+      LieGroup1::random(out.template head<LieGroup1::NQ>());
+      LieGroup2::random(out.template tail<LieGroup2::NQ>());
+    }
+
+    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & lower,
+                                         const Eigen::MatrixBase<ConfigR_t> & upper,
+                                         const Eigen::MatrixBase<ConfigOut_t> & qout)
+    { 
+      ConfigOut_t& out = const_cast< Eigen::MatrixBase<ConfigOut_t>& > (qout).derived();
+      LieGroup1::randomConfiguration(lower.template head<LieGroup1::NQ>(), upper.template head<LieGroup1::NQ>(), out.template head<LieGroup1::NQ>());
+      LieGroup2::randomConfiguration(lower.template tail<LieGroup2::NQ>(), upper.template tail<LieGroup2::NQ>(), out.template tail<LieGroup2::NQ>());
+    } 
+
+    template <class ConfigL_t, class ConfigR_t>
+    static bool isSameConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                         const Eigen::MatrixBase<ConfigR_t> & q1,
+                                         const Scalar & prec)
+    {
+      return LieGroup1::isSameConfiguration(q0.template head<LieGroup1::NQ>(), q1.template head<LieGroup1::NQ>(), prec)
+        +    LieGroup2::isSameConfiguration(q0.template tail<LieGroup2::NQ>(), q1.template tail<LieGroup2::NQ>(), prec);
+    }
+  }; // struct CartesianProductOperation
+
+} // namespace se3
+
+#endif // ifndef __se3_cartesian_product_operation_hpp__

--- a/src/multibody/liegroup/liegroup.hpp
+++ b/src/multibody/liegroup/liegroup.hpp
@@ -24,7 +24,7 @@
 #include "pinocchio/multibody/liegroup/special-orthogonal.hpp"
 #include "pinocchio/multibody/liegroup/special-euclidean.hpp"
 
-// #include "pinocchio/multibody/joint/joint.hpp"
+#include "pinocchio/multibody/joint/fwd.hpp"
 
 namespace se3 {
   struct LieGroupTpl {

--- a/src/multibody/liegroup/liegroup.hpp
+++ b/src/multibody/liegroup/liegroup.hpp
@@ -39,16 +39,16 @@ namespace se3 {
 
   template<> struct LieGroupTpl::operation <JointModelComposite> {};
   template<> struct LieGroupTpl::operation <JointModelSpherical> {
-    typedef SpecialOrthogonalOperation type;
+    typedef SpecialOrthogonalOperation<3> type;
   };
   template<> struct LieGroupTpl::operation <JointModelFreeFlyer> {
-    typedef SpecialEuclideanOperation type;
+    typedef SpecialEuclideanOperation<3> type;
   };
   template<> struct LieGroupTpl::operation <JointModelPlanar> {
-    typedef SpecialEuclidean1Operation type;
+    typedef SpecialEuclideanOperation<2> type;
   };
   template<int Axis> struct LieGroupTpl::operation <JointModelRevoluteUnbounded<Axis> > {
-    typedef SpecialOrthogonal1Operation type;
+    typedef SpecialOrthogonalOperation<2> type;
   };
 
   // TODO REMOVE: For testing purposes only

--- a/src/multibody/liegroup/liegroup.hpp
+++ b/src/multibody/liegroup/liegroup.hpp
@@ -27,27 +27,33 @@
 // #include "pinocchio/multibody/joint/joint.hpp"
 
 namespace se3 {
-  template<typename Joint>
+  struct LieGroupTpl {
+    template<typename JointModel> struct operation {
+      typedef VectorSpaceOperation<JointModel::NQ> type;
+    };
+  };
+  template<typename JointModel>
   struct LieGroup {
-    typedef VectorSpaceOperation<Joint::NQ> type;
+    typedef typename LieGroupTpl::operation<JointModel>::type type;
   };
 
-  template<> struct LieGroup <JointModelSpherical> {
+  template<> struct LieGroupTpl::operation <JointModelComposite> {};
+  template<> struct LieGroupTpl::operation <JointModelSpherical> {
     typedef SpecialOrthogonalOperation type;
   };
-  template<> struct LieGroup <JointModelFreeFlyer> {
+  template<> struct LieGroupTpl::operation <JointModelFreeFlyer> {
     typedef SpecialEuclideanOperation type;
   };
-  template<> struct LieGroup <JointModelPlanar> {
+  template<> struct LieGroupTpl::operation <JointModelPlanar> {
     typedef SpecialEuclidean1Operation type;
   };
-  template<int Axis> struct LieGroup <JointModelRevoluteUnbounded<Axis> > {
+  template<int Axis> struct LieGroupTpl::operation <JointModelRevoluteUnbounded<Axis> > {
     typedef SpecialOrthogonal1Operation type;
   };
 
   // TODO REMOVE: For testing purposes only
   // template<>
-  // struct LieGroup <JointModelTranslation> {
+  // struct LieGroupTpl::operation <JointModelTranslation> {
     // typedef CartesianProductOperation<
       // CartesianProductOperation<typename LieGroup<JointModelPX>::type, typename LieGroup<JointModelPY>::type>,
       // typename LieGroup<JointModelPZ>::type

--- a/src/multibody/liegroup/liegroup.hpp
+++ b/src/multibody/liegroup/liegroup.hpp
@@ -1,0 +1,58 @@
+//
+// Copyright (c) 2016 CNRS
+//
+// This file is part of Pinocchio
+// Pinocchio is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// Pinocchio is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// Pinocchio If not, see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef __se3_lie_group_hpp__
+#define __se3_lie_group_hpp__
+
+#include "pinocchio/assert.hpp"
+#include "pinocchio/multibody/liegroup/vector-space.hpp"
+#include "pinocchio/multibody/liegroup/cartesian-product.hpp"
+#include "pinocchio/multibody/liegroup/special-orthogonal.hpp"
+#include "pinocchio/multibody/liegroup/special-euclidean.hpp"
+
+// #include "pinocchio/multibody/joint/joint.hpp"
+
+namespace se3 {
+  template<typename Joint>
+  struct LieGroup {
+    typedef VectorSpaceOperation<Joint::NQ> type;
+  };
+
+  template<> struct LieGroup <JointModelSpherical> {
+    typedef SpecialOrthogonalOperation type;
+  };
+  template<> struct LieGroup <JointModelFreeFlyer> {
+    typedef SpecialEuclideanOperation type;
+  };
+  template<> struct LieGroup <JointModelPlanar> {
+    typedef SpecialEuclidean1Operation type;
+  };
+  template<int Axis> struct LieGroup <JointModelRevoluteUnbounded<Axis> > {
+    typedef SpecialOrthogonal1Operation type;
+  };
+
+  // TODO REMOVE: For testing purposes only
+  // template<>
+  // struct LieGroup <JointModelTranslation> {
+    // typedef CartesianProductOperation<
+      // CartesianProductOperation<typename LieGroup<JointModelPX>::type, typename LieGroup<JointModelPY>::type>,
+      // typename LieGroup<JointModelPZ>::type
+      // > type;
+  // };
+}
+
+#endif // ifndef __se3_lie_group_hpp__

--- a/src/multibody/liegroup/operation-base.hpp
+++ b/src/multibody/liegroup/operation-base.hpp
@@ -118,6 +118,9 @@ namespace se3
                           const Eigen::MatrixBase<Tangent_t>  & v,
                           const Eigen::MatrixBase<ConfigOut_t>& qout)
     {
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigIn_t , ConfigVector_t);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Tangent_t  , TangentVector_t);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigOut_t, ConfigVector_t);
       Derived::integrate_impl(q, v, qout);
     }
 
@@ -149,7 +152,9 @@ namespace se3
                             const Scalar& u,
                             const Eigen::MatrixBase<ConfigOut_t>& qout)
     {
-      // assert(is_config_vector_size(q0) && is_config_vector_size(q1));
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigL_t  , ConfigVector_t);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigR_t  , ConfigVector_t);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigOut_t, ConfigVector_t);
       Derived::interpolate_impl(q0, q1, u, qout);
     }
 
@@ -205,7 +210,12 @@ namespace se3
     static void randomConfiguration(const Eigen::MatrixBase<ConfigL_t> & lower_pos_limit,
                                     const Eigen::MatrixBase<ConfigR_t> & upper_pos_limit,
                                     const Eigen::MatrixBase<ConfigOut_t> & qout)
-    { Derived::randomConfiguration_impl(lower_pos_limit, upper_pos_limit, qout); }
+    {
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigL_t  , ConfigVector_t);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigR_t  , ConfigVector_t);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigOut_t, ConfigVector_t);
+      Derived::randomConfiguration_impl(lower_pos_limit, upper_pos_limit, qout);
+    }
 
     /**
      * @brief      the tangent vector that must be integrated during one unit time to go from q0 to q1
@@ -229,7 +239,9 @@ namespace se3
                            const Eigen::MatrixBase<ConfigR_t> & q1,
                            const Eigen::MatrixBase<Tangent_t>& d)
     {
-      // assert(is_config_vector_size(q0) && is_config_vector_size(q1));
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigL_t, ConfigVector_t);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigR_t, ConfigVector_t);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Tangent_t, TangentVector_t);
       Derived::difference_impl(q0, q1, d);
     }
 
@@ -244,7 +256,11 @@ namespace se3
     template <class ConfigL_t, class ConfigR_t>
     static double squaredDistance(const Eigen::MatrixBase<ConfigL_t> & q0,
                                   const Eigen::MatrixBase<ConfigR_t> & q1)
-    { return Derived::squaredDistance_impl(q0, q1); }
+    {
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigL_t, ConfigVector_t);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigR_t, ConfigVector_t);
+      return Derived::squaredDistance_impl(q0, q1);
+    }
 
     template <class ConfigL_t, class ConfigR_t>
     static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
@@ -299,7 +315,11 @@ namespace se3
     static bool isSameConfiguration(const Eigen::MatrixBase<ConfigL_t> & q0,
                                     const Eigen::MatrixBase<ConfigR_t> & q1,
                                     const Scalar & prec = Eigen::NumTraits<Scalar>::dummy_precision())
-    { return Derived::isSameConfiguration_impl(q0,q1, prec); }
+    {
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigL_t, ConfigVector_t);
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigR_t, ConfigVector_t);
+      return Derived::isSameConfiguration_impl(q0, q1, prec);
+    }
 
     template <class ConfigL_t, class ConfigR_t>
     static bool isSameConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & q0,

--- a/src/multibody/liegroup/operation-base.hpp
+++ b/src/multibody/liegroup/operation-base.hpp
@@ -1,0 +1,324 @@
+//
+// Copyright (c) 2016 CNRS
+//
+// This file is part of Pinocchio
+// Pinocchio is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// Pinocchio is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// Pinocchio If not, see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef __se3_lie_group_operation_base_hpp__
+#define __se3_lie_group_operation_base_hpp__
+
+#include "pinocchio/spatial/fwd.hpp" // struct traits
+
+#include <Eigen/Core>
+#include <limits>
+
+namespace se3
+{
+#ifdef __clang__
+
+#define SE3_LIE_GROUP_TYPEDEF_ARG(prefix)              \
+   typedef prefix traits<LieGroupDerived>::Scalar Scalar;    \
+   enum {                  \
+    NQ = traits<LieGroupDerived>::NQ,              \
+    NV = traits<LieGroupDerived>::NV               \
+  };                        \
+  typedef prefix traits<LieGroupDerived>::ConfigVector_t ConfigVector_t;        \
+  typedef prefix traits<LieGroupDerived>::TangentVector_t TangentVector_t
+
+#define SE3_LIE_GROUP_TYPEDEF SE3_LIE_GROUP_TYPEDEF_ARG()
+#define SE3_LIE_GROUP_TYPEDEF_TEMPLATE SE3_LIE_GROUP_TYPEDEF_ARG(typename)
+
+#elif (__GNUC__ == 4) && (__GNUC_MINOR__ == 4) && (__GNUC_PATCHLEVEL__ == 2)
+
+#define SE3_LIE_GROUP_TYPEDEF_NOARG()       \
+  typedef int Index;            \
+  typedef traits<LieGroupDerived>::Scalar Scalar;    \
+  enum {              \
+    NQ = traits<LieGroupDerived>::NQ,         \
+    NV = traits<LieGroupDerived>::NV          \
+  };                        \
+  typedef traits<LieGroupDerived>::ConfigVector_t ConfigVector_t;        \
+  typedef traits<LieGroupDerived>::TangentVector_t TangentVector_t
+
+#define SE3_LIE_GROUP_TYPEDEF_ARG(prefix)         \
+  typedef int Index;              \
+  typedef prefix traits<LieGroupDerived>::Scalar Scalar;           \
+  enum {                \
+    NQ = traits<LieGroupDerived>::NQ,           \
+    NV = traits<LieGroupDerived>::NV            \
+  };                        \
+  typedef prefix traits<LieGroupDerived>::ConfigVector_t ConfigVector_t;        \
+  typedef prefix traits<LieGroupDerived>::TangentVector_t TangentVector_t
+
+#define SE3_LIE_GROUP_TYPEDEF SE3_LIE_GROUP_TYPEDEF_NOARG()
+#define SE3_LIE_GROUP_TYPEDEF_TEMPLATE SE3_LIE_GROUP_TYPEDEF_ARG(typename)
+
+#else
+
+#define SE3_LIE_GROUP_TYPEDEF_ARG()              \
+  typedef int Index;                 \
+  typedef typename traits<LieGroupDerived>::Scalar Scalar;    \
+  enum {                   \
+    NQ = traits<LieGroupDerived>::NQ,              \
+    NV = traits<LieGroupDerived>::NV               \
+  };                        \
+  typedef typename traits<LieGroupDerived>::ConfigVector_t ConfigVector_t;        \
+  typedef typename traits<LieGroupDerived>::TangentVector_t TangentVector_t
+
+#define SE3_LIE_GROUP_TYPEDEF SE3_LIE_GROUP_TYPEDEF_ARG()
+#define SE3_LIE_GROUP_TYPEDEF_TEMPLATE SE3_LIE_GROUP_TYPEDEF_ARG()
+
+#endif
+
+  template<typename Derived>
+  struct LieGroupOperationBase
+  {
+    typedef Derived LieGroupDerived;
+    SE3_LIE_GROUP_TYPEDEF_TEMPLATE;
+
+    ///
+    /// \brief Return the resolution of the finite differerence increment according to the Scalar type
+    /// \remark Ideally, this function must depend on the value of q
+    ///
+    /// \returns The finite difference increment.
+    ///
+    // typename ConfigVector_t::Scalar finiteDifferenceIncrement() const
+    // { return derived().finiteDifferenceIncrement(); }
+
+    /**
+     * @brief      Integrate joint's configuration for a tangent vector during one unit time
+     *
+     * @param[in]  q     initatial configuration  (size full model.nq)
+     * @param[in]  v     joint velocity (size full model.nv)
+     *
+     * @return     The configuration integrated
+     */
+    template <class Config_t, class Tangent_t>
+    static ConfigVector_t integrate(const Eigen::MatrixBase<Config_t>  & q,
+                                   const Eigen::MatrixBase<Tangent_t> & v)
+    {
+      ConfigVector_t qout;
+      integrate(q, v, qout);
+      return qout;
+    }
+
+    template <class ConfigIn_t, class Tangent_t, class ConfigOut_t>
+    static void integrate(const Eigen::MatrixBase<ConfigIn_t> & q,
+                          const Eigen::MatrixBase<Tangent_t>  & v,
+                          const Eigen::MatrixBase<ConfigOut_t>& qout)
+    {
+      Derived::integrate_impl(q, v, qout);
+    }
+
+
+    /**
+     * @brief      Interpolation between two joint's configurations
+     *
+     * @param[in]  q0    Initial configuration to interpolate
+     * @param[in]  q1    Final configuration to interpolate
+     * @param[in]  u     u in [0;1] position along the interpolation.
+     *
+     * @return     The interpolated configuration (q0 if u = 0, q1 if u = 1)
+     */
+    // ConfigVector_t interpolate(const Eigen::VectorXd & q0,const Eigen::VectorXd & q1, double u) const
+    // { return derived().interpolate_impl(q0, q1, u); }
+    template <class ConfigL_t, class ConfigR_t>
+    static ConfigVector_t interpolate(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                      const Eigen::MatrixBase<ConfigR_t> & q1,
+                                      const Scalar& u)
+    {
+      ConfigVector_t qout;
+      interpolate(q0, q1, u, qout);
+      return qout;
+    }
+
+    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    static void interpolate(const Eigen::MatrixBase<ConfigL_t> & q0,
+                            const Eigen::MatrixBase<ConfigR_t> & q1,
+                            const Scalar& u,
+                            const Eigen::MatrixBase<ConfigOut_t>& qout)
+    {
+      // assert(is_config_vector_size(q0) && is_config_vector_size(q1));
+      Derived::interpolate_impl(q0, q1, u, qout);
+    }
+
+    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                 const Eigen::MatrixBase<ConfigR_t> & q1,
+                                 const Scalar& u,
+                                 const Eigen::MatrixBase<ConfigOut_t>& qout)
+    {
+      if     (u == 0) const_cast<Eigen::MatrixBase<ConfigOut_t>&>(qout) = q0;
+      else if(u == 1) const_cast<Eigen::MatrixBase<ConfigOut_t>&>(qout) = q1;
+      else integrate(q0, u * difference(q0, q1), qout);
+    }
+
+    /**
+     * @brief      Generate a random joint configuration, normalizing quaternions when necessary.
+     *
+     * \warning    Do not take into account the joint limits. To shoot a configuration uniformingly
+     *             depending on joint limits, see uniformySample
+     *
+     * @return     The joint configuration
+     */
+    static ConfigVector_t random()
+    {
+      ConfigVector_t qout;
+      random(qout);
+      return qout;
+    }
+
+    template <class Config_t>
+    static void random (const Eigen::MatrixBase<Config_t>& qout)
+    { return Derived::random_impl (qout); }
+
+    /**
+     * @brief      Generate a configuration vector uniformly sampled among
+     *             provided limits.
+     *
+     * @param[in]  lower_pos_limit  lower joint limit
+     * @param[in]  upper_pos_limit  upper joint limit
+     *
+     * @return     The joint configuration
+     */
+    template <class ConfigL_t, class ConfigR_t>
+    static ConfigVector_t randomConfiguration(const Eigen::MatrixBase<ConfigL_t> & lower_pos_limit,
+                                              const Eigen::MatrixBase<ConfigR_t> & upper_pos_limit)
+    {
+      ConfigVector_t qout;
+      randomConfiguration(lower_pos_limit, upper_pos_limit, qout);
+      return qout;
+    }
+
+    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    static void randomConfiguration(const Eigen::MatrixBase<ConfigL_t> & lower_pos_limit,
+                                    const Eigen::MatrixBase<ConfigR_t> & upper_pos_limit,
+                                    const Eigen::MatrixBase<ConfigOut_t> & qout)
+    { Derived::randomConfiguration_impl(lower_pos_limit, upper_pos_limit, qout); }
+
+    /**
+     * @brief      the tangent vector that must be integrated during one unit time to go from q0 to q1
+     *
+     * @param[in]  q0    Initial configuration
+     * @param[in]  q1    Wished configuration
+     *
+     * @return     The corresponding velocity
+     */
+    template <class ConfigL_t, class ConfigR_t>
+    static TangentVector_t difference(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                      const Eigen::MatrixBase<ConfigR_t> & q1)
+    {
+      TangentVector_t diff;
+      difference(q0, q1, diff);
+      return diff;
+    }
+
+    template <class ConfigL_t, class ConfigR_t, class Tangent_t>
+    static void difference(const Eigen::MatrixBase<ConfigL_t> & q0,
+                           const Eigen::MatrixBase<ConfigR_t> & q1,
+                           const Eigen::MatrixBase<Tangent_t>& d)
+    {
+      // assert(is_config_vector_size(q0) && is_config_vector_size(q1));
+      Derived::difference_impl(q0, q1, d);
+    }
+
+    /**
+     * @brief      Squared distance between two configurations of the joint
+     *
+     * @param[in]  q0    Configuration 1
+     * @param[in]  q1    Configuration 2
+     *
+     * @return     The corresponding distance
+     */
+    template <class ConfigL_t, class ConfigR_t>
+    static double squaredDistance(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                  const Eigen::MatrixBase<ConfigR_t> & q1)
+    { return Derived::squaredDistance_impl(q0, q1); }
+
+    template <class ConfigL_t, class ConfigR_t>
+    static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                       const Eigen::MatrixBase<ConfigR_t> & q1)
+    {
+      TangentVector_t t;
+      difference(q0, q1, t);
+      return t.squaredNorm();
+    }
+
+    /**
+     * @brief      Distance between two configurations of the joint
+     *
+     * @param[in]  q0    Configuration 1
+     * @param[in]  q1    Configuration 2
+     *
+     * @return     The corresponding distance
+     */
+    template <class ConfigL_t, class ConfigR_t>
+    static double distance(const Eigen::MatrixBase<ConfigL_t> & q0,
+                           const Eigen::MatrixBase<ConfigR_t> & q1)
+    { return sqrt(squaredDistance(q0, q1)); }
+
+    /**
+     * @brief      Get neutral configuration of joint
+     *
+     * @return     The joint's neutral configuration
+     */
+    // ConfigVector_t neutralConfiguration() const
+    // { return derived().neutralConfiguration_impl(); }
+
+    /**
+     * @brief      Normalize a configuration
+     *
+     * @param[in,out]  q     Configuration to normalize (size full model.nq)
+     */
+    // void normalize(Eigen::VectorXd & q) const
+    // { return derived().normalize_impl(q); }
+
+    /**
+     * @brief      Default implementation of normalize
+     */
+    // void normalize_impl(Eigen::VectorXd &) const { }
+
+    /**
+     * @brief      Check if two configurations are equivalent within the given precision
+     *
+     * @param[in]  q0    Configuration 0
+     * @param[in]  q1    Configuration 1
+     */
+    template <class ConfigL_t, class ConfigR_t>
+    static bool isSameConfiguration(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                    const Eigen::MatrixBase<ConfigR_t> & q1,
+                                    const Scalar & prec = Eigen::NumTraits<Scalar>::dummy_precision())
+    { return Derived::isSameConfiguration_impl(q0,q1, prec); }
+
+    template <class ConfigL_t, class ConfigR_t>
+    static bool isSameConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                         const Eigen::MatrixBase<ConfigR_t> & q1,
+                                         const Scalar & prec)
+    { return q0.isApprox(q1, prec); }
+
+  protected:
+    /// Default constructor.
+    /// 
+    /// Prevent the construction of derived class.
+    LieGroupOperationBase() {}
+    
+    /// Copy constructor
+    ///
+    /// Prevent the copy of derived class.
+    LieGroupOperationBase( const LieGroupOperationBase& clone) {}
+  }; // struct LieGroupOperationBase
+
+} // namespace se3
+
+#endif // ifndef __se3_lie_group_operation_base_hpp__

--- a/src/multibody/liegroup/operation-base.hpp
+++ b/src/multibody/liegroup/operation-base.hpp
@@ -309,10 +309,10 @@ namespace se3
 
   protected:
     /// Default constructor.
-    /// 
+    ///
     /// Prevent the construction of derived class.
     LieGroupOperationBase() {}
-    
+
     /// Copy constructor
     ///
     /// Prevent the copy of derived class.

--- a/src/multibody/liegroup/operation-base.hpp
+++ b/src/multibody/liegroup/operation-base.hpp
@@ -87,14 +87,8 @@ namespace se3
     typedef Derived LieGroupDerived;
     SE3_LIE_GROUP_TYPEDEF_TEMPLATE;
 
-    ///
-    /// \brief Return the resolution of the finite differerence increment according to the Scalar type
-    /// \remark Ideally, this function must depend on the value of q
-    ///
-    /// \returns The finite difference increment.
-    ///
-    // typename ConfigVector_t::Scalar finiteDifferenceIncrement() const
-    // { return derived().finiteDifferenceIncrement(); }
+    /// \name API with return value as argument
+    /// \{
 
     /**
      * @brief      Integrate joint's configuration for a tangent vector during one unit time
@@ -104,26 +98,10 @@ namespace se3
      *
      * @return     The configuration integrated
      */
-    template <class Config_t, class Tangent_t>
-    static ConfigVector_t integrate(const Eigen::MatrixBase<Config_t>  & q,
-                                   const Eigen::MatrixBase<Tangent_t> & v)
-    {
-      ConfigVector_t qout;
-      integrate(q, v, qout);
-      return qout;
-    }
-
     template <class ConfigIn_t, class Tangent_t, class ConfigOut_t>
     static void integrate(const Eigen::MatrixBase<ConfigIn_t> & q,
                           const Eigen::MatrixBase<Tangent_t>  & v,
-                          const Eigen::MatrixBase<ConfigOut_t>& qout)
-    {
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigIn_t , ConfigVector_t);
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Tangent_t  , TangentVector_t);
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigOut_t, ConfigVector_t);
-      Derived::integrate_impl(q, v, qout);
-    }
-
+                          const Eigen::MatrixBase<ConfigOut_t>& qout);
 
     /**
      * @brief      Interpolation between two joint's configurations
@@ -134,40 +112,11 @@ namespace se3
      *
      * @return     The interpolated configuration (q0 if u = 0, q1 if u = 1)
      */
-    // ConfigVector_t interpolate(const Eigen::VectorXd & q0,const Eigen::VectorXd & q1, double u) const
-    // { return derived().interpolate_impl(q0, q1, u); }
-    template <class ConfigL_t, class ConfigR_t>
-    static ConfigVector_t interpolate(const Eigen::MatrixBase<ConfigL_t> & q0,
-                                      const Eigen::MatrixBase<ConfigR_t> & q1,
-                                      const Scalar& u)
-    {
-      ConfigVector_t qout;
-      interpolate(q0, q1, u, qout);
-      return qout;
-    }
-
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
     static void interpolate(const Eigen::MatrixBase<ConfigL_t> & q0,
                             const Eigen::MatrixBase<ConfigR_t> & q1,
                             const Scalar& u,
-                            const Eigen::MatrixBase<ConfigOut_t>& qout)
-    {
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigL_t  , ConfigVector_t);
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigR_t  , ConfigVector_t);
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigOut_t, ConfigVector_t);
-      Derived::interpolate_impl(q0, q1, u, qout);
-    }
-
-    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
-    static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
-                                 const Eigen::MatrixBase<ConfigR_t> & q1,
-                                 const Scalar& u,
-                                 const Eigen::MatrixBase<ConfigOut_t>& qout)
-    {
-      if     (u == 0) const_cast<Eigen::MatrixBase<ConfigOut_t>&>(qout) = q0;
-      else if(u == 1) const_cast<Eigen::MatrixBase<ConfigOut_t>&>(qout) = q1;
-      else integrate(q0, u * difference(q0, q1), qout);
-    }
+                            const Eigen::MatrixBase<ConfigOut_t>& qout);
 
     /**
      * @brief      Generate a random joint configuration, normalizing quaternions when necessary.
@@ -177,16 +126,8 @@ namespace se3
      *
      * @return     The joint configuration
      */
-    static ConfigVector_t random()
-    {
-      ConfigVector_t qout;
-      random(qout);
-      return qout;
-    }
-
     template <class Config_t>
-    static void random (const Eigen::MatrixBase<Config_t>& qout)
-    { return Derived::random_impl (qout); }
+    static void random (const Eigen::MatrixBase<Config_t>& qout);
 
     /**
      * @brief      Generate a configuration vector uniformly sampled among
@@ -197,25 +138,10 @@ namespace se3
      *
      * @return     The joint configuration
      */
-    template <class ConfigL_t, class ConfigR_t>
-    static ConfigVector_t randomConfiguration(const Eigen::MatrixBase<ConfigL_t> & lower_pos_limit,
-                                              const Eigen::MatrixBase<ConfigR_t> & upper_pos_limit)
-    {
-      ConfigVector_t qout;
-      randomConfiguration(lower_pos_limit, upper_pos_limit, qout);
-      return qout;
-    }
-
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
     static void randomConfiguration(const Eigen::MatrixBase<ConfigL_t> & lower_pos_limit,
                                     const Eigen::MatrixBase<ConfigR_t> & upper_pos_limit,
-                                    const Eigen::MatrixBase<ConfigOut_t> & qout)
-    {
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigL_t  , ConfigVector_t);
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigR_t  , ConfigVector_t);
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigOut_t, ConfigVector_t);
-      Derived::randomConfiguration_impl(lower_pos_limit, upper_pos_limit, qout);
-    }
+                                    const Eigen::MatrixBase<ConfigOut_t> & qout);
 
     /**
      * @brief      the tangent vector that must be integrated during one unit time to go from q0 to q1
@@ -225,25 +151,10 @@ namespace se3
      *
      * @return     The corresponding velocity
      */
-    template <class ConfigL_t, class ConfigR_t>
-    static TangentVector_t difference(const Eigen::MatrixBase<ConfigL_t> & q0,
-                                      const Eigen::MatrixBase<ConfigR_t> & q1)
-    {
-      TangentVector_t diff;
-      difference(q0, q1, diff);
-      return diff;
-    }
-
     template <class ConfigL_t, class ConfigR_t, class Tangent_t>
     static void difference(const Eigen::MatrixBase<ConfigL_t> & q0,
                            const Eigen::MatrixBase<ConfigR_t> & q1,
-                           const Eigen::MatrixBase<Tangent_t>& d)
-    {
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigL_t, ConfigVector_t);
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigR_t, ConfigVector_t);
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Tangent_t, TangentVector_t);
-      Derived::difference_impl(q0, q1, d);
-    }
+                           const Eigen::MatrixBase<Tangent_t>& d);
 
     /**
      * @brief      Squared distance between two configurations of the joint
@@ -255,21 +166,7 @@ namespace se3
      */
     template <class ConfigL_t, class ConfigR_t>
     static double squaredDistance(const Eigen::MatrixBase<ConfigL_t> & q0,
-                                  const Eigen::MatrixBase<ConfigR_t> & q1)
-    {
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigL_t, ConfigVector_t);
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigR_t, ConfigVector_t);
-      return Derived::squaredDistance_impl(q0, q1);
-    }
-
-    template <class ConfigL_t, class ConfigR_t>
-    static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
-                                       const Eigen::MatrixBase<ConfigR_t> & q1)
-    {
-      TangentVector_t t;
-      difference(q0, q1, t);
-      return t.squaredNorm();
-    }
+                                  const Eigen::MatrixBase<ConfigR_t> & q1);
 
     /**
      * @brief      Distance between two configurations of the joint
@@ -281,29 +178,7 @@ namespace se3
      */
     template <class ConfigL_t, class ConfigR_t>
     static double distance(const Eigen::MatrixBase<ConfigL_t> & q0,
-                           const Eigen::MatrixBase<ConfigR_t> & q1)
-    { return sqrt(squaredDistance(q0, q1)); }
-
-    /**
-     * @brief      Get neutral configuration of joint
-     *
-     * @return     The joint's neutral configuration
-     */
-    // ConfigVector_t neutralConfiguration() const
-    // { return derived().neutralConfiguration_impl(); }
-
-    /**
-     * @brief      Normalize a configuration
-     *
-     * @param[in,out]  q     Configuration to normalize (size full model.nq)
-     */
-    // void normalize(Eigen::VectorXd & q) const
-    // { return derived().normalize_impl(q); }
-
-    /**
-     * @brief      Default implementation of normalize
-     */
-    // void normalize_impl(Eigen::VectorXd &) const { }
+                           const Eigen::MatrixBase<ConfigR_t> & q1);
 
     /**
      * @brief      Check if two configurations are equivalent within the given precision
@@ -314,18 +189,52 @@ namespace se3
     template <class ConfigL_t, class ConfigR_t>
     static bool isSameConfiguration(const Eigen::MatrixBase<ConfigL_t> & q0,
                                     const Eigen::MatrixBase<ConfigR_t> & q1,
-                                    const Scalar & prec = Eigen::NumTraits<Scalar>::dummy_precision())
-    {
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigL_t, ConfigVector_t);
-      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigR_t, ConfigVector_t);
-      return Derived::isSameConfiguration_impl(q0, q1, prec);
-    }
+                                    const Scalar & prec = Eigen::NumTraits<Scalar>::dummy_precision());
+    /// \}
+
+    /// \name API that allocates memory
+    /// \{
+
+    template <class Config_t, class Tangent_t>
+    static ConfigVector_t integrate(const Eigen::MatrixBase<Config_t>  & q,
+                                    const Eigen::MatrixBase<Tangent_t> & v);
+
+    template <class ConfigL_t, class ConfigR_t>
+    static ConfigVector_t interpolate(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                      const Eigen::MatrixBase<ConfigR_t> & q1,
+                                      const Scalar& u);
+
+    static ConfigVector_t random();
+
+    template <class ConfigL_t, class ConfigR_t>
+    static ConfigVector_t randomConfiguration(const Eigen::MatrixBase<ConfigL_t> & lower_pos_limit,
+                                              const Eigen::MatrixBase<ConfigR_t> & upper_pos_limit);
+
+    template <class ConfigL_t, class ConfigR_t>
+    static TangentVector_t difference(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                      const Eigen::MatrixBase<ConfigR_t> & q1);
+    /// \}
+
+
+    /// \name Default implementations
+    /// \{
+
+    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                 const Eigen::MatrixBase<ConfigR_t> & q1,
+                                 const Scalar& u,
+                                 const Eigen::MatrixBase<ConfigOut_t>& qout);
+
+    template <class ConfigL_t, class ConfigR_t>
+    static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                       const Eigen::MatrixBase<ConfigR_t> & q1);
 
     template <class ConfigL_t, class ConfigR_t>
     static bool isSameConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
                                          const Eigen::MatrixBase<ConfigR_t> & q1,
-                                         const Scalar & prec)
-    { return q0.isApprox(q1, prec); }
+                                         const Scalar & prec);
+
+    /// \}
 
   protected:
     /// Default constructor.
@@ -340,5 +249,7 @@ namespace se3
   }; // struct LieGroupOperationBase
 
 } // namespace se3
+
+#include "pinocchio/multibody/liegroup/operation-base.hxx"
 
 #endif // ifndef __se3_lie_group_operation_base_hpp__

--- a/src/multibody/liegroup/operation-base.hxx
+++ b/src/multibody/liegroup/operation-base.hxx
@@ -1,0 +1,229 @@
+//
+// Copyright (c) 2016 CNRS
+//
+// This file is part of Pinocchio
+// Pinocchio is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// Pinocchio is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// Pinocchio If not, see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef __se3_lie_group_operation_base_hxx__
+#define __se3_lie_group_operation_base_hxx__
+
+namespace se3 {
+
+  // --------------- API with return value as argument ---------------------- //
+
+  template <class Derived>
+  template <class ConfigIn_t, class Tangent_t, class ConfigOut_t>
+  void LieGroupOperationBase<Derived>::integrate(
+      const Eigen::MatrixBase<ConfigIn_t> & q,
+      const Eigen::MatrixBase<Tangent_t>  & v,
+      const Eigen::MatrixBase<ConfigOut_t>& qout)
+  {
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigIn_t , ConfigVector_t);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Tangent_t  , TangentVector_t);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigOut_t, ConfigVector_t);
+    Derived::integrate_impl(q, v, qout);
+  }
+
+
+  /**
+   * @brief      Interpolation between two joint's configurations
+   *
+   * @param[in]  q0    Initial configuration to interpolate
+   * @param[in]  q1    Final configuration to interpolate
+   * @param[in]  u     u in [0;1] position along the interpolation.
+   *
+   * @return     The interpolated configuration (q0 if u = 0, q1 if u = 1)
+   */
+  template <class Derived>
+  template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+  void LieGroupOperationBase<Derived>::interpolate(
+      const Eigen::MatrixBase<ConfigL_t> & q0,
+      const Eigen::MatrixBase<ConfigR_t> & q1,
+      const Scalar& u,
+      const Eigen::MatrixBase<ConfigOut_t>& qout)
+  {
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigL_t  , ConfigVector_t);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigR_t  , ConfigVector_t);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigOut_t, ConfigVector_t);
+    Derived::interpolate_impl(q0, q1, u, qout);
+  }
+
+  /**
+   * @brief      Generate a random joint configuration, normalizing quaternions when necessary.
+   *
+   * \warning    Do not take into account the joint limits. To shoot a configuration uniformingly
+   *             depending on joint limits, see uniformySample
+   *
+   * @return     The joint configuration
+   */
+  template <class Derived>
+  template <class Config_t>
+  void LieGroupOperationBase<Derived>::random(
+      const Eigen::MatrixBase<Config_t>& qout)
+  {
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Config_t, ConfigVector_t);
+    return Derived::random_impl (qout);
+  }
+
+  template <class Derived>
+  template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+  void LieGroupOperationBase<Derived>::randomConfiguration(
+      const Eigen::MatrixBase<ConfigL_t> & lower_pos_limit,
+      const Eigen::MatrixBase<ConfigR_t> & upper_pos_limit,
+      const Eigen::MatrixBase<ConfigOut_t> & qout)
+  {
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigL_t  , ConfigVector_t);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigR_t  , ConfigVector_t);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigOut_t, ConfigVector_t);
+    Derived::randomConfiguration_impl(lower_pos_limit, upper_pos_limit, qout);
+  }
+
+  template <class Derived>
+  template <class ConfigL_t, class ConfigR_t, class Tangent_t>
+  void LieGroupOperationBase<Derived>::difference(
+      const Eigen::MatrixBase<ConfigL_t> & q0,
+      const Eigen::MatrixBase<ConfigR_t> & q1,
+      const Eigen::MatrixBase<Tangent_t>& d)
+  {
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigL_t, ConfigVector_t);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigR_t, ConfigVector_t);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Tangent_t, TangentVector_t);
+    Derived::difference_impl(q0, q1, d);
+  }
+
+  template <class Derived>
+  template <class ConfigL_t, class ConfigR_t>
+  double LieGroupOperationBase<Derived>::squaredDistance(
+      const Eigen::MatrixBase<ConfigL_t> & q0,
+      const Eigen::MatrixBase<ConfigR_t> & q1)
+  {
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigL_t, ConfigVector_t);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigR_t, ConfigVector_t);
+    return Derived::squaredDistance_impl(q0, q1);
+  }
+
+  template <class Derived>
+  template <class ConfigL_t, class ConfigR_t>
+  double LieGroupOperationBase<Derived>::distance(
+      const Eigen::MatrixBase<ConfigL_t> & q0,
+      const Eigen::MatrixBase<ConfigR_t> & q1)
+  {
+    return sqrt(squaredDistance(q0, q1));
+  }
+
+  template <class Derived>
+  template <class ConfigL_t, class ConfigR_t>
+  bool LieGroupOperationBase<Derived>::isSameConfiguration(
+      const Eigen::MatrixBase<ConfigL_t> & q0,
+      const Eigen::MatrixBase<ConfigR_t> & q1,
+      const Scalar & prec)
+  {
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigL_t, ConfigVector_t);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigR_t, ConfigVector_t);
+    return Derived::isSameConfiguration_impl(q0, q1, prec);
+  }
+
+  // ----------------- API that allocates memory ---------------------------- //
+
+
+  template <class Derived>
+  template <class Config_t, class Tangent_t>
+  typename LieGroupOperationBase<Derived>::ConfigVector_t LieGroupOperationBase<Derived>::integrate(
+      const Eigen::MatrixBase<Config_t>  & q,
+      const Eigen::MatrixBase<Tangent_t> & v)
+  {
+    ConfigVector_t qout;
+    integrate(q, v, qout);
+    return qout;
+  }
+
+  template <class Derived>
+  template <class ConfigL_t, class ConfigR_t>
+  typename LieGroupOperationBase<Derived>::ConfigVector_t LieGroupOperationBase<Derived>::interpolate(
+      const Eigen::MatrixBase<ConfigL_t> & q0,
+      const Eigen::MatrixBase<ConfigR_t> & q1,
+      const Scalar& u)
+  {
+    ConfigVector_t qout;
+    interpolate(q0, q1, u, qout);
+    return qout;
+  }
+
+  template <class Derived>
+  typename LieGroupOperationBase<Derived>::ConfigVector_t LieGroupOperationBase<Derived>::random()
+  {
+    ConfigVector_t qout;
+    random(qout);
+    return qout;
+  }
+
+  template <class Derived>
+  template <class ConfigL_t, class ConfigR_t>
+  typename LieGroupOperationBase<Derived>::ConfigVector_t LieGroupOperationBase<Derived>::randomConfiguration(
+      const Eigen::MatrixBase<ConfigL_t> & lower_pos_limit,
+      const Eigen::MatrixBase<ConfigR_t> & upper_pos_limit)
+  {
+    ConfigVector_t qout;
+    randomConfiguration(lower_pos_limit, upper_pos_limit, qout);
+    return qout;
+  }
+
+  template <class Derived>
+  template <class ConfigL_t, class ConfigR_t>
+  typename LieGroupOperationBase<Derived>::TangentVector_t LieGroupOperationBase<Derived>::difference(
+      const Eigen::MatrixBase<ConfigL_t> & q0,
+      const Eigen::MatrixBase<ConfigR_t> & q1)
+  {
+    TangentVector_t diff;
+    difference(q0, q1, diff);
+    return diff;
+  }
+
+  // ----------------- Default implementations ------------------------------ //
+  template <class Derived>
+  template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+  void LieGroupOperationBase<Derived>::interpolate_impl(
+      const Eigen::MatrixBase<ConfigL_t> & q0,
+      const Eigen::MatrixBase<ConfigR_t> & q1,
+      const Scalar& u,
+      const Eigen::MatrixBase<ConfigOut_t>& qout)
+  {
+    if     (u == 0) const_cast<Eigen::MatrixBase<ConfigOut_t>&>(qout) = q0;
+    else if(u == 1) const_cast<Eigen::MatrixBase<ConfigOut_t>&>(qout) = q1;
+    else integrate(q0, u * difference(q0, q1), qout);
+  }
+
+  template <class Derived>
+  template <class ConfigL_t, class ConfigR_t>
+  double LieGroupOperationBase<Derived>::squaredDistance_impl(
+      const Eigen::MatrixBase<ConfigL_t> & q0,
+      const Eigen::MatrixBase<ConfigR_t> & q1)
+  {
+    TangentVector_t t;
+    difference(q0, q1, t);
+    return t.squaredNorm();
+  }
+
+  template <class Derived>
+  template <class ConfigL_t, class ConfigR_t>
+  bool LieGroupOperationBase<Derived>::isSameConfiguration_impl(
+      const Eigen::MatrixBase<ConfigL_t> & q0,
+      const Eigen::MatrixBase<ConfigR_t> & q1,
+      const Scalar & prec)
+  {
+    return q0.isApprox(q1, prec);
+  }
+} // namespace se3
+
+#endif // __se3_lie_group_operation_base_hxx__

--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -1,0 +1,266 @@
+//
+// Copyright (c) 2016 CNRS
+//
+// This file is part of Pinocchio
+// Pinocchio is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// Pinocchio is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// Pinocchio If not, see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef __se3_special_euclidean_operation_hpp__
+#define __se3_special_euclidean_operation_hpp__
+
+#include <limits>
+
+#include <pinocchio/spatial/fwd.hpp>
+#include <pinocchio/spatial/se3.hpp>
+#include <pinocchio/multibody/liegroup/operation-base.hpp>
+
+#include <pinocchio/multibody/liegroup/vector-space.hpp>
+#include <pinocchio/multibody/liegroup/cartesian-product.hpp>
+#include <pinocchio/multibody/liegroup/special-orthogonal.hpp>
+
+namespace se3
+{
+  struct SpecialEuclideanOperation;
+  template <> struct traits<SpecialEuclideanOperation> {
+    typedef double Scalar;
+    enum {
+      NQ = 7,
+      NV = 6
+    };
+    typedef Eigen::Matrix<Scalar,NQ,1> ConfigVector_t;
+    typedef Eigen::Matrix<Scalar,NV,1> TangentVector_t;
+  };
+
+  struct SpecialEuclideanOperation : public LieGroupOperationBase <SpecialEuclideanOperation>
+  {
+    typedef CartesianProductOperation <VectorSpaceOperation<3>, SpecialOrthogonalOperation> R3crossSO3_t;
+    typedef SpecialEuclideanOperation LieGroupDerived;
+    SE3_LIE_GROUP_TYPEDEF;
+
+    typedef Eigen::Quaternion<Scalar> Quaternion_t;
+    typedef Eigen::Map<      Quaternion_t> QuaternionMap_t;
+    typedef Eigen::Map<const Quaternion_t> ConstQuaternionMap_t;
+    typedef SE3 Transformation_t;
+
+    template <class ConfigL_t, class ConfigR_t, class Tangent_t>
+    static void difference_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                const Eigen::MatrixBase<ConfigR_t> & q1,
+                                const Eigen::MatrixBase<Tangent_t> & d)
+    {
+      ConstQuaternionMap_t p0 (q0.derived().template tail<4>().data());
+      ConstQuaternionMap_t p1 (q1.derived().template tail<4>().data());
+      const_cast < Eigen::MatrixBase<Tangent_t>& > (d)
+        = log6(  SE3(p0.matrix(), q0.derived().template head<3>()).inverse()
+               * SE3(p1.matrix(), q1.derived().template head<3>())).toVector();
+    }
+
+    template <class ConfigIn_t, class Velocity_t, class ConfigOut_t>
+    static void integrate_impl(const Eigen::MatrixBase<ConfigIn_t> & q,
+                               const Eigen::MatrixBase<Velocity_t> & v,
+                               const Eigen::MatrixBase<ConfigOut_t> & qout)
+    {
+      ConfigOut_t& out = (const_cast< Eigen::MatrixBase<ConfigOut_t>& >(qout)).derived();
+      ConstQuaternionMap_t quat(q.derived().template tail<4>().data());
+      QuaternionMap_t res_quat (out.template tail<4>().data());
+
+      SE3 M0 (quat.matrix(), q.derived().template head<3>());
+      SE3 M1 (M0 * exp6(Motion(v)));
+
+      out.template head<3>() = M1.translation();
+      res_quat = M1.rotation();
+      // Norm of qs might be epsilon-different to 1, so M1.rotation might be epsilon-different to a rotation matrix.
+      // It is then safer to re-normalized after converting M1.rotation to quaternion.
+      firstOrderNormalize(res_quat);
+    }
+
+    // interpolate_impl use default implementation.
+    // template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    // static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                 // const Eigen::MatrixBase<ConfigR_t> & q1,
+                                 // const Scalar& u,
+                                 // const Eigen::MatrixBase<ConfigOut_t>& qout)
+    // {
+    // }
+
+    template <class ConfigL_t, class ConfigR_t>
+    static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                       const Eigen::MatrixBase<ConfigR_t> & q1)
+    {
+      TangentVector_t t;
+      difference_impl(q0, q1, t);
+      return t.squaredNorm();
+    }
+
+    template <class Config_t>
+    static void random_impl (const Eigen::MatrixBase<Config_t>& qout)
+    {
+      R3crossSO3_t::random(qout);
+    }
+
+    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & lower,
+                                         const Eigen::MatrixBase<ConfigR_t> & upper,
+                                         const Eigen::MatrixBase<ConfigOut_t> & qout)
+    { 
+      R3crossSO3_t::randomConfiguration(lower, upper, qout);
+    } 
+
+    template <class ConfigL_t, class ConfigR_t>
+    static bool isSameConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                         const Eigen::MatrixBase<ConfigR_t> & q1,
+                                         const Scalar & prec)
+    {
+      return R3crossSO3_t::isSameConfiguration(q0, q1, prec);
+    }
+  }; // struct SpecialEuclideanOperation
+
+  struct SpecialEuclidean1Operation;
+  template <> struct traits<SpecialEuclidean1Operation> {
+    typedef double Scalar;
+    enum {
+      NQ = 4,
+      NV = 3
+    };
+    typedef Eigen::Matrix<Scalar,NQ,1> ConfigVector_t;
+    typedef Eigen::Matrix<Scalar,NV,1> TangentVector_t;
+  };
+
+  struct SpecialEuclidean1Operation : public LieGroupOperationBase <SpecialEuclidean1Operation>
+  {
+    typedef CartesianProductOperation <VectorSpaceOperation<2>, SpecialOrthogonal1Operation> R2crossSO1_t;
+    typedef SpecialEuclidean1Operation LieGroupDerived;
+    SE3_LIE_GROUP_TYPEDEF;
+
+    template <class ConfigL_t, class ConfigR_t, class Tangent_t>
+    static void difference_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                const Eigen::MatrixBase<ConfigR_t> & q1,
+                                const Eigen::MatrixBase<Tangent_t> & d)
+    {
+      SE3 M0(SE3::Identity()); forwardKinematics(M0, q0);
+      SE3 M1(SE3::Identity()); forwardKinematics(M1, q1);
+
+      Motion nu(log6(M0.inverse()*M1)); // TODO: optimize implementation
+      
+      Tangent_t& out = const_cast< Eigen::MatrixBase<Tangent_t>& >(d).derived();
+      out.template head<2>() = nu.linear().head<2>();
+      out(2) = nu.angular()(2);
+    }
+
+    template <class ConfigIn_t, class Velocity_t, class ConfigOut_t>
+    static void integrate_impl(const Eigen::MatrixBase<ConfigIn_t> & q,
+                               const Eigen::MatrixBase<Velocity_t> & vs,
+                               const Eigen::MatrixBase<ConfigOut_t> & qout)
+    {
+      ConfigOut_t& out = (const_cast< Eigen::MatrixBase<ConfigOut_t>& >(qout)).derived();
+      typedef Eigen::Matrix<Scalar, 2, 2> Matrix22;
+      typedef Eigen::Matrix<Scalar, 2, 1> Vector2;
+
+      const double& c0 = q(2), s0 = q(3);
+      Matrix22 R0;
+      R0 << c0, -s0, s0, c0;
+      
+      const double& t = vs[2];
+      const double theta = std::fabs(t);
+
+      if(theta > 1e-14)
+      {
+        // vs = [ x, y, t ]
+        // w = [ 0, 0, t ]
+        // v = [ x, y, 0 ]
+        // Considering only the 2x2 top left corner:
+        // Sp = [ 0, -1; 1, 0],
+        // if t > 0: S = Sp
+        // else    : S = -Sp
+        // S / t = Sp / |t|
+        // S * S = - I2
+        // R = I2 + ( 1 - ct) / |t| * S + ( 1 - st / |t| ) * S * S
+        //   =      ( 1 - ct) / |t| * S +       st / |t|   * I2
+        //
+        // Ru = exp3 (w)
+        // tu = R * v = (1 - ct) / |t| * S * v + st / t * v
+        //
+        // M0 * Mu = ( R0 * Ru, R0 * tu + t0 )
+
+        // FIXME remove this copy.
+        Vector2 v = vs.template head<2>();
+        Eigen::Matrix<Scalar,2,1> cst;
+        SINCOS (t, &cst[1], &cst[0]);
+        const Scalar inv_theta = 1/theta;
+        const Scalar c_coeff = (1.-cst[0]) * inv_theta;
+        const Scalar s_coeff = std::fabs(cst[1]) * inv_theta;
+        const Vector2 Sp_v (-v[1], v[0]);
+
+        if (t > 0) out.template head<2>() = q.template head<2>() + R0 * (s_coeff * v + c_coeff * Sp_v);
+        else       out.template head<2>() = q.template head<2>() + R0 * (s_coeff * v - c_coeff * Sp_v);
+        out.template tail<2>() = R0 * cst;
+      }
+      else
+      {
+        // cos(t) ~ 1 - t^2 / 2
+        // sin(t) ~ t
+        out.template head<2>() = q.template head<2>() + R0*vs.template head<2>();
+        out(2) = c0 * 1 - s0 * t;
+        out(3) = s0 * 1 + c0 * t;
+      }
+    }
+
+    // interpolate_impl use default implementation.
+    // template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    // static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                 // const Eigen::MatrixBase<ConfigR_t> & q1,
+                                 // const Scalar& u,
+                                 // const Eigen::MatrixBase<ConfigOut_t>& qout)
+
+    // template <class ConfigL_t, class ConfigR_t>
+    // static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                       // const Eigen::MatrixBase<ConfigR_t> & q1)
+
+    template <class Config_t>
+    static void random_impl (const Eigen::MatrixBase<Config_t>& qout)
+    {
+      R2crossSO1_t::random(qout);
+    }
+
+    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & lower,
+                                         const Eigen::MatrixBase<ConfigR_t> & upper,
+                                         const Eigen::MatrixBase<ConfigOut_t> & qout)
+    { 
+      R2crossSO1_t::randomConfiguration(lower, upper, qout);
+    } 
+
+    template <class ConfigL_t, class ConfigR_t>
+    static bool isSameConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                         const Eigen::MatrixBase<ConfigR_t> & q1,
+                                         const Scalar & prec)
+    {
+      return R2crossSO1_t::isSameConfiguration(q0, q1, prec);
+    }
+
+    private:
+    template<typename V>
+    static void forwardKinematics(SE3 & M, const Eigen::MatrixBase<V>& q)
+    {
+      EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(ConfigVector_t,V);
+
+      const double& c_theta = q(2),
+                    s_theta = q(3);
+      
+      M.rotation().topLeftCorner<2,2>() << c_theta, -s_theta, s_theta, c_theta;
+      M.translation().head<2>() = q.template head<2>();
+    }
+  }; // struct SpecialEuclidean1Operation
+
+} // namespace se3
+
+#endif // ifndef __se3_special_euclidean_operation_hpp__

--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -30,102 +30,10 @@
 
 namespace se3
 {
-  struct SpecialEuclideanOperation;
-  template <> struct traits<SpecialEuclideanOperation> {
-    typedef double Scalar;
-    enum {
-      NQ = 7,
-      NV = 6
-    };
-    typedef Eigen::Matrix<Scalar,NQ,1> ConfigVector_t;
-    typedef Eigen::Matrix<Scalar,NV,1> TangentVector_t;
-  };
+  template<int N> struct SpecialEuclideanOperation {};
+  template<int N> struct traits<SpecialEuclideanOperation<N> > {};
 
-  struct SpecialEuclideanOperation : public LieGroupOperationBase <SpecialEuclideanOperation>
-  {
-    typedef CartesianProductOperation <VectorSpaceOperation<3>, SpecialOrthogonalOperation> R3crossSO3_t;
-    typedef SpecialEuclideanOperation LieGroupDerived;
-    SE3_LIE_GROUP_TYPEDEF;
-
-    typedef Eigen::Quaternion<Scalar> Quaternion_t;
-    typedef Eigen::Map<      Quaternion_t> QuaternionMap_t;
-    typedef Eigen::Map<const Quaternion_t> ConstQuaternionMap_t;
-    typedef SE3 Transformation_t;
-
-    template <class ConfigL_t, class ConfigR_t, class Tangent_t>
-    static void difference_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
-                                const Eigen::MatrixBase<ConfigR_t> & q1,
-                                const Eigen::MatrixBase<Tangent_t> & d)
-    {
-      ConstQuaternionMap_t p0 (q0.derived().template tail<4>().data());
-      ConstQuaternionMap_t p1 (q1.derived().template tail<4>().data());
-      const_cast < Eigen::MatrixBase<Tangent_t>& > (d)
-        = log6(  SE3(p0.matrix(), q0.derived().template head<3>()).inverse()
-               * SE3(p1.matrix(), q1.derived().template head<3>())).toVector();
-    }
-
-    template <class ConfigIn_t, class Velocity_t, class ConfigOut_t>
-    static void integrate_impl(const Eigen::MatrixBase<ConfigIn_t> & q,
-                               const Eigen::MatrixBase<Velocity_t> & v,
-                               const Eigen::MatrixBase<ConfigOut_t> & qout)
-    {
-      ConfigOut_t& out = (const_cast< Eigen::MatrixBase<ConfigOut_t>& >(qout)).derived();
-      ConstQuaternionMap_t quat(q.derived().template tail<4>().data());
-      QuaternionMap_t res_quat (out.template tail<4>().data());
-
-      SE3 M0 (quat.matrix(), q.derived().template head<3>());
-      SE3 M1 (M0 * exp6(Motion(v)));
-
-      out.template head<3>() = M1.translation();
-      res_quat = M1.rotation();
-      // Norm of qs might be epsilon-different to 1, so M1.rotation might be epsilon-different to a rotation matrix.
-      // It is then safer to re-normalized after converting M1.rotation to quaternion.
-      firstOrderNormalize(res_quat);
-    }
-
-    // interpolate_impl use default implementation.
-    // template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
-    // static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
-                                 // const Eigen::MatrixBase<ConfigR_t> & q1,
-                                 // const Scalar& u,
-                                 // const Eigen::MatrixBase<ConfigOut_t>& qout)
-    // {
-    // }
-
-    template <class ConfigL_t, class ConfigR_t>
-    static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
-                                       const Eigen::MatrixBase<ConfigR_t> & q1)
-    {
-      TangentVector_t t;
-      difference_impl(q0, q1, t);
-      return t.squaredNorm();
-    }
-
-    template <class Config_t>
-    static void random_impl (const Eigen::MatrixBase<Config_t>& qout)
-    {
-      R3crossSO3_t::random(qout);
-    }
-
-    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
-    static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & lower,
-                                         const Eigen::MatrixBase<ConfigR_t> & upper,
-                                         const Eigen::MatrixBase<ConfigOut_t> & qout)
-    {
-      R3crossSO3_t::randomConfiguration(lower, upper, qout);
-    }
-
-    template <class ConfigL_t, class ConfigR_t>
-    static bool isSameConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
-                                         const Eigen::MatrixBase<ConfigR_t> & q1,
-                                         const Scalar & prec)
-    {
-      return R3crossSO3_t::isSameConfiguration(q0, q1, prec);
-    }
-  }; // struct SpecialEuclideanOperation
-
-  struct SpecialEuclidean1Operation;
-  template <> struct traits<SpecialEuclidean1Operation> {
+  template<> struct traits<SpecialEuclideanOperation<2> > {
     typedef double Scalar;
     enum {
       NQ = 4,
@@ -135,10 +43,21 @@ namespace se3
     typedef Eigen::Matrix<Scalar,NV,1> TangentVector_t;
   };
 
-  struct SpecialEuclidean1Operation : public LieGroupOperationBase <SpecialEuclidean1Operation>
+  template<> struct traits<SpecialEuclideanOperation<3> > {
+    typedef double Scalar;
+    enum {
+      NQ = 7,
+      NV = 6
+    };
+    typedef Eigen::Matrix<Scalar,NQ,1> ConfigVector_t;
+    typedef Eigen::Matrix<Scalar,NV,1> TangentVector_t;
+  };
+
+  template<>
+  struct SpecialEuclideanOperation<2> : public LieGroupOperationBase <SpecialEuclideanOperation<2> >
   {
-    typedef CartesianProductOperation <VectorSpaceOperation<2>, SpecialOrthogonal1Operation> R2crossSO1_t;
-    typedef SpecialEuclidean1Operation LieGroupDerived;
+    typedef CartesianProductOperation <VectorSpaceOperation<2>, SpecialOrthogonalOperation<2> > R2crossSO2_t;
+    typedef SpecialEuclideanOperation LieGroupDerived;
     SE3_LIE_GROUP_TYPEDEF;
 
     template <class ConfigL_t, class ConfigR_t, class Tangent_t>
@@ -228,7 +147,7 @@ namespace se3
     template <class Config_t>
     static void random_impl (const Eigen::MatrixBase<Config_t>& qout)
     {
-      R2crossSO1_t::random(qout);
+      R2crossSO2_t::random(qout);
     }
 
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
@@ -236,7 +155,7 @@ namespace se3
                                          const Eigen::MatrixBase<ConfigR_t> & upper,
                                          const Eigen::MatrixBase<ConfigOut_t> & qout)
     {
-      R2crossSO1_t::randomConfiguration(lower, upper, qout);
+      R2crossSO2_t::randomConfiguration(lower, upper, qout);
     }
 
     template <class ConfigL_t, class ConfigR_t>
@@ -244,7 +163,7 @@ namespace se3
                                          const Eigen::MatrixBase<ConfigR_t> & q1,
                                          const Scalar & prec)
     {
-      return R2crossSO1_t::isSameConfiguration(q0, q1, prec);
+      return R2crossSO2_t::isSameConfiguration(q0, q1, prec);
     }
 
     private:
@@ -259,7 +178,91 @@ namespace se3
       M.rotation().topLeftCorner<2,2>() << c_theta, -s_theta, s_theta, c_theta;
       M.translation().head<2>() = q.template head<2>();
     }
-  }; // struct SpecialEuclidean1Operation
+  }; // struct SpecialEuclideanOperation<2>
+
+  template<>
+  struct SpecialEuclideanOperation<3> : public LieGroupOperationBase <SpecialEuclideanOperation<3> >
+  {
+    typedef CartesianProductOperation <VectorSpaceOperation<3>, SpecialOrthogonalOperation<3> > R3crossSO3_t;
+    typedef SpecialEuclideanOperation LieGroupDerived;
+    SE3_LIE_GROUP_TYPEDEF;
+
+    typedef Eigen::Quaternion<Scalar> Quaternion_t;
+    typedef Eigen::Map<      Quaternion_t> QuaternionMap_t;
+    typedef Eigen::Map<const Quaternion_t> ConstQuaternionMap_t;
+    typedef SE3 Transformation_t;
+
+    template <class ConfigL_t, class ConfigR_t, class Tangent_t>
+    static void difference_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                const Eigen::MatrixBase<ConfigR_t> & q1,
+                                const Eigen::MatrixBase<Tangent_t> & d)
+    {
+      ConstQuaternionMap_t p0 (q0.derived().template tail<4>().data());
+      ConstQuaternionMap_t p1 (q1.derived().template tail<4>().data());
+      const_cast < Eigen::MatrixBase<Tangent_t>& > (d)
+        = log6(  SE3(p0.matrix(), q0.derived().template head<3>()).inverse()
+               * SE3(p1.matrix(), q1.derived().template head<3>())).toVector();
+    }
+
+    template <class ConfigIn_t, class Velocity_t, class ConfigOut_t>
+    static void integrate_impl(const Eigen::MatrixBase<ConfigIn_t> & q,
+                               const Eigen::MatrixBase<Velocity_t> & v,
+                               const Eigen::MatrixBase<ConfigOut_t> & qout)
+    {
+      ConfigOut_t& out = (const_cast< Eigen::MatrixBase<ConfigOut_t>& >(qout)).derived();
+      ConstQuaternionMap_t quat(q.derived().template tail<4>().data());
+      QuaternionMap_t res_quat (out.template tail<4>().data());
+
+      SE3 M0 (quat.matrix(), q.derived().template head<3>());
+      SE3 M1 (M0 * exp6(Motion(v)));
+
+      out.template head<3>() = M1.translation();
+      res_quat = M1.rotation();
+      // Norm of qs might be epsilon-different to 1, so M1.rotation might be epsilon-different to a rotation matrix.
+      // It is then safer to re-normalized after converting M1.rotation to quaternion.
+      firstOrderNormalize(res_quat);
+    }
+
+    // interpolate_impl use default implementation.
+    // template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    // static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                 // const Eigen::MatrixBase<ConfigR_t> & q1,
+                                 // const Scalar& u,
+                                 // const Eigen::MatrixBase<ConfigOut_t>& qout)
+    // {
+    // }
+
+    template <class ConfigL_t, class ConfigR_t>
+    static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                       const Eigen::MatrixBase<ConfigR_t> & q1)
+    {
+      TangentVector_t t;
+      difference_impl(q0, q1, t);
+      return t.squaredNorm();
+    }
+
+    template <class Config_t>
+    static void random_impl (const Eigen::MatrixBase<Config_t>& qout)
+    {
+      R3crossSO3_t::random(qout);
+    }
+
+    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & lower,
+                                         const Eigen::MatrixBase<ConfigR_t> & upper,
+                                         const Eigen::MatrixBase<ConfigOut_t> & qout)
+    {
+      R3crossSO3_t::randomConfiguration(lower, upper, qout);
+    }
+
+    template <class ConfigL_t, class ConfigR_t>
+    static bool isSameConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                         const Eigen::MatrixBase<ConfigR_t> & q1,
+                                         const Scalar & prec)
+    {
+      return R3crossSO3_t::isSameConfiguration(q0, q1, prec);
+    }
+  }; // struct SpecialEuclideanOperation<3>
 
 } // namespace se3
 

--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -111,9 +111,9 @@ namespace se3
     static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & lower,
                                          const Eigen::MatrixBase<ConfigR_t> & upper,
                                          const Eigen::MatrixBase<ConfigOut_t> & qout)
-    { 
+    {
       R3crossSO3_t::randomConfiguration(lower, upper, qout);
-    } 
+    }
 
     template <class ConfigL_t, class ConfigR_t>
     static bool isSameConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
@@ -150,7 +150,7 @@ namespace se3
       SE3 M1(SE3::Identity()); forwardKinematics(M1, q1);
 
       Motion nu(log6(M0.inverse()*M1)); // TODO: optimize implementation
-      
+
       Tangent_t& out = const_cast< Eigen::MatrixBase<Tangent_t>& >(d).derived();
       out.template head<2>() = nu.linear().head<2>();
       out(2) = nu.angular()(2);
@@ -168,7 +168,7 @@ namespace se3
       const double& c0 = q(2), s0 = q(3);
       Matrix22 R0;
       R0 << c0, -s0, s0, c0;
-      
+
       const double& t = vs[2];
       const double theta = std::fabs(t);
 
@@ -235,9 +235,9 @@ namespace se3
     static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & lower,
                                          const Eigen::MatrixBase<ConfigR_t> & upper,
                                          const Eigen::MatrixBase<ConfigOut_t> & qout)
-    { 
+    {
       R2crossSO1_t::randomConfiguration(lower, upper, qout);
-    } 
+    }
 
     template <class ConfigL_t, class ConfigR_t>
     static bool isSameConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
@@ -255,7 +255,7 @@ namespace se3
 
       const double& c_theta = q(2),
                     s_theta = q(3);
-      
+
       M.rotation().topLeftCorner<2,2>() << c_theta, -s_theta, s_theta, c_theta;
       M.translation().head<2>() = q.template head<2>();
     }

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -1,0 +1,232 @@
+//
+// Copyright (c) 2016 CNRS
+//
+// This file is part of Pinocchio
+// Pinocchio is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// Pinocchio is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// Pinocchio If not, see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef __se3_special_orthogonal_operation_hpp__
+#define __se3_special_orthogonal_operation_hpp__
+
+#include <limits>
+
+#include <pinocchio/spatial/explog.hpp>
+#include <pinocchio/math/quaternion.hpp>
+#include <pinocchio/multibody/liegroup/operation-base.hpp>
+
+namespace se3
+{
+  struct SpecialOrthogonalOperation;
+  template <> struct traits<SpecialOrthogonalOperation> {
+    typedef double Scalar;
+    enum {
+      NQ = 4,
+      NV = 3
+    };
+    typedef Eigen::Matrix<Scalar,NQ,1> ConfigVector_t;
+    typedef Eigen::Matrix<Scalar,NV,1> TangentVector_t;
+  };
+
+  struct SpecialOrthogonalOperation : public LieGroupOperationBase <SpecialOrthogonalOperation>
+  {
+    typedef SpecialOrthogonalOperation LieGroupDerived;
+    SE3_LIE_GROUP_TYPEDEF;
+
+    typedef Eigen::Quaternion<Scalar> Quaternion_t;
+    typedef Eigen::Map<      Quaternion_t> QuaternionMap_t;
+    typedef Eigen::Map<const Quaternion_t> ConstQuaternionMap_t;
+
+    template <class ConfigL_t, class ConfigR_t, class Tangent_t>
+    static void difference_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                const Eigen::MatrixBase<ConfigR_t> & q1,
+                                const Eigen::MatrixBase<Tangent_t> & d)
+    {
+      ConstQuaternionMap_t p0 (q0.derived().data());
+      ConstQuaternionMap_t p1 (q1.derived().data());
+      const_cast < Eigen::MatrixBase<Tangent_t>& > (d)
+        = log3((p0.matrix().transpose() * p1.matrix()).eval());
+    }
+
+    template <class ConfigIn_t, class Velocity_t, class ConfigOut_t>
+    static void integrate_impl(const Eigen::MatrixBase<ConfigIn_t> & q,
+                               const Eigen::MatrixBase<Velocity_t> & v,
+                               const Eigen::MatrixBase<ConfigOut_t> & qout)
+    {
+      ConstQuaternionMap_t quat(q.derived().data());
+      QuaternionMap_t quaternion_result (
+          (const_cast< Eigen::MatrixBase<ConfigOut_t>& >(qout)).derived().data()
+          );
+
+      Quaternion_t pOmega(exp3(v));
+      quaternion_result = quat * pOmega;
+      firstOrderNormalize(quaternion_result);
+    }
+
+    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                 const Eigen::MatrixBase<ConfigR_t> & q1,
+                                 const Scalar& u,
+                                 const Eigen::MatrixBase<ConfigOut_t>& qout)
+    {
+      ConstQuaternionMap_t p0 (q0.derived().data());
+      ConstQuaternionMap_t p1 (q1.derived().data());
+      QuaternionMap_t quaternion_result (
+          (const_cast< Eigen::MatrixBase<ConfigOut_t>& >(qout)).derived().data()
+          );
+
+      quaternion_result = p0.slerp(u, p1);
+    }
+
+    template <class ConfigL_t, class ConfigR_t>
+    static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                       const Eigen::MatrixBase<ConfigR_t> & q1)
+    {
+      TangentVector_t t;
+      difference_impl(q0, q1, t);
+      return t.squaredNorm();
+    }
+
+    template <class Config_t>
+    static void random_impl (const Eigen::MatrixBase<Config_t>& qout)
+    {
+      QuaternionMap_t out (
+          (const_cast< Eigen::MatrixBase<Config_t>& >(qout)).derived().data()
+          );
+      uniformRandom(out);
+    }
+
+    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> &,
+                                         const Eigen::MatrixBase<ConfigR_t> &,
+                                         const Eigen::MatrixBase<ConfigOut_t> & qout)
+    { 
+      random_impl(qout);
+    } 
+
+    template <class ConfigL_t, class ConfigR_t>
+    static bool isSameConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                         const Eigen::MatrixBase<ConfigR_t> & q1,
+                                         const Scalar & prec)
+    {
+      ConstQuaternionMap_t quat1(q0.derived().data());
+      ConstQuaternionMap_t quat2(q1.derived().data());
+
+      return defineSameRotation(quat1,quat2);
+    }
+  }; // struct SpecialOrthogonalOperation
+
+  struct SpecialOrthogonal1Operation;
+  template <> struct traits<SpecialOrthogonal1Operation> {
+    typedef double Scalar;
+    enum {
+      NQ = 2,
+      NV = 1
+    };
+    typedef Eigen::Matrix<Scalar,NQ,1> ConfigVector_t;
+    typedef Eigen::Matrix<Scalar,NV,1> TangentVector_t;
+  };
+
+  struct SpecialOrthogonal1Operation : public LieGroupOperationBase <SpecialOrthogonal1Operation>
+  {
+    typedef SpecialOrthogonal1Operation LieGroupDerived;
+    SE3_LIE_GROUP_TYPEDEF;
+
+    template <class ConfigL_t, class ConfigR_t, class Tangent_t>
+    static void difference_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                const Eigen::MatrixBase<ConfigR_t> & q1,
+                                const Eigen::MatrixBase<Tangent_t> & d)
+    {
+      const Scalar & c0 = q0(0), & s0 = q0(1);
+      const Scalar & c1 = q1(0), & s1 = q1(1);
+
+      const_cast < Eigen::MatrixBase<Tangent_t>& > (d) [0]
+        = atan2 (s1*c0 - s0*c1, c0*c1 + s0*s1);
+    }
+
+    template <class ConfigIn_t, class Velocity_t, class ConfigOut_t>
+    static void integrate_impl(const Eigen::MatrixBase<ConfigIn_t> & q,
+                               const Eigen::MatrixBase<Velocity_t> & v,
+                               const Eigen::MatrixBase<ConfigOut_t> & qout)
+    {
+      ConfigOut_t& out = (const_cast< Eigen::MatrixBase<ConfigOut_t>& >(qout)).derived();
+
+      const Scalar & ca = q(0);
+      const Scalar & sa = q(1);
+      const Scalar & omega = v(0);
+
+      Scalar cosOmega,sinOmega; SINCOS(omega, &sinOmega, &cosOmega);
+      // TODO check the cost of atan2 vs SINCOS
+
+      out << cosOmega * ca - sinOmega * sa,
+             sinOmega * ca + cosOmega * sa;
+      const Scalar norm2 = q.squaredNorm();
+      out *= (3 - norm2) / 2;
+    }
+
+    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                 const Eigen::MatrixBase<ConfigR_t> & q1,
+                                 const Scalar& u,
+                                 const Eigen::MatrixBase<ConfigOut_t>& qout)
+    {
+      ConfigOut_t& out = (const_cast< Eigen::MatrixBase<ConfigOut_t>& >(qout)).derived();
+      const Scalar & c0 = q0(0), & s0 = q0(1);
+      const Scalar & c1 = q1(0), & s1 = q1(1);
+
+      assert ( (q0.norm() - 1) < 1e-8 && "initial configuration not normalized");
+      assert ( (q1.norm() - 1) < 1e-8 && "final configuration not normalized");
+      Scalar cosTheta = c0*c1 + s0*s1;
+      Scalar sinTheta = c0*s1 - s0*c1;
+      Scalar theta = atan2(sinTheta, cosTheta);
+      assert (fabs (sin (theta) - sinTheta) < 1e-8);
+
+      if (fabs (theta) > 1e-6 && fabs (theta) < PI - 1e-6)
+      {
+        out = (sin ((1-u)*theta)/sinTheta) * q0 
+                  + (sin (u*theta)/sinTheta) * q1;
+      } 
+      else if (fabs (theta) < 1e-6) // theta = 0
+      {
+        out = (1-u) * q0 + u * q1;
+      }
+      else // theta = +-PI
+      {
+        double theta0 = atan2 (s0, c0);
+        out << cos (theta0 + u * theta),
+               sin (theta0 + u * theta);
+      }
+    }
+
+    // template <class ConfigL_t, class ConfigR_t>
+    // static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                       // const Eigen::MatrixBase<ConfigR_t> & q1)
+
+    template <class Config_t>
+    static void random_impl (const Eigen::MatrixBase<Config_t>& qout)
+    {
+      Config_t& out = (const_cast< Eigen::MatrixBase<Config_t>& >(qout)).derived();
+      const Scalar angle = -PI + 2*PI * ((Scalar)rand())/RAND_MAX;
+      SINCOS (angle, &out(1), &out(0));
+    }
+
+    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> &,
+                                         const Eigen::MatrixBase<ConfigR_t> &,
+                                         const Eigen::MatrixBase<ConfigOut_t> & qout)
+    { 
+      random_impl(qout);
+    } 
+  }; // struct SpecialOrthogonal1Operation
+} // namespace se3
+
+#endif // ifndef __se3_special_orthogonal_operation_hpp__

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -26,8 +26,20 @@
 
 namespace se3
 {
-  struct SpecialOrthogonalOperation;
-  template <> struct traits<SpecialOrthogonalOperation> {
+  template<int N> struct SpecialOrthogonalOperation {};
+  template<int N> struct traits<SpecialOrthogonalOperation<N> > {};
+
+  template <> struct traits<SpecialOrthogonalOperation<2> > {
+    typedef double Scalar;
+    enum {
+      NQ = 2,
+      NV = 1
+    };
+    typedef Eigen::Matrix<Scalar,NQ,1> ConfigVector_t;
+    typedef Eigen::Matrix<Scalar,NV,1> TangentVector_t;
+  };
+
+  template <> struct traits<SpecialOrthogonalOperation<3> > {
     typedef double Scalar;
     enum {
       NQ = 4,
@@ -37,7 +49,96 @@ namespace se3
     typedef Eigen::Matrix<Scalar,NV,1> TangentVector_t;
   };
 
-  struct SpecialOrthogonalOperation : public LieGroupOperationBase <SpecialOrthogonalOperation>
+  template<>
+  struct SpecialOrthogonalOperation<2> : public LieGroupOperationBase <SpecialOrthogonalOperation<2> >
+  {
+    typedef SpecialOrthogonalOperation LieGroupDerived;
+    SE3_LIE_GROUP_TYPEDEF;
+
+    template <class ConfigL_t, class ConfigR_t, class Tangent_t>
+    static void difference_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                const Eigen::MatrixBase<ConfigR_t> & q1,
+                                const Eigen::MatrixBase<Tangent_t> & d)
+    {
+      const_cast < Eigen::MatrixBase<Tangent_t>& > (d) [0]
+        = atan2 (q0(0)*q1(1) - q0(1)*q1(0), q0.dot(q1));
+    }
+
+    template <class ConfigIn_t, class Velocity_t, class ConfigOut_t>
+    static void integrate_impl(const Eigen::MatrixBase<ConfigIn_t> & q,
+                               const Eigen::MatrixBase<Velocity_t> & v,
+                               const Eigen::MatrixBase<ConfigOut_t> & qout)
+    {
+      ConfigOut_t& out = (const_cast< Eigen::MatrixBase<ConfigOut_t>& >(qout)).derived();
+
+      const Scalar & ca = q(0);
+      const Scalar & sa = q(1);
+      const Scalar & omega = v(0);
+
+      Scalar cosOmega,sinOmega; SINCOS(omega, &sinOmega, &cosOmega);
+      // TODO check the cost of atan2 vs SINCOS
+
+      out << cosOmega * ca - sinOmega * sa,
+             sinOmega * ca + cosOmega * sa;
+      const Scalar norm2 = q.squaredNorm();
+      out *= (3 - norm2) / 2;
+    }
+
+    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                 const Eigen::MatrixBase<ConfigR_t> & q1,
+                                 const Scalar& u,
+                                 const Eigen::MatrixBase<ConfigOut_t>& qout)
+    {
+      ConfigOut_t& out = (const_cast< Eigen::MatrixBase<ConfigOut_t>& >(qout)).derived();
+
+      assert ( (q0.norm() - 1) < 1e-8 && "initial configuration not normalized");
+      assert ( (q1.norm() - 1) < 1e-8 && "final configuration not normalized");
+      Scalar cosTheta = q0.dot(q1);
+      Scalar sinTheta = q0(0)*q1(1) - q0(1)*q1(0);
+      Scalar theta = atan2(sinTheta, cosTheta);
+      assert (fabs (sin (theta) - sinTheta) < 1e-8);
+
+      if (fabs (theta) > 1e-6 && fabs (theta) < PI - 1e-6)
+      {
+        out = (sin ((1-u)*theta)/sinTheta) * q0
+            + (sin (   u *theta)/sinTheta) * q1;
+      }
+      else if (fabs (theta) < 1e-6) // theta = 0
+      {
+        out = (1-u) * q0 + u * q1;
+      }
+      else // theta = +-PI
+      {
+        double theta0 = atan2 (q0(1), q0(0));
+        out << cos (theta0 + u * theta),
+               sin (theta0 + u * theta);
+      }
+    }
+
+    // template <class ConfigL_t, class ConfigR_t>
+    // static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                       // const Eigen::MatrixBase<ConfigR_t> & q1)
+
+    template <class Config_t>
+    static void random_impl (const Eigen::MatrixBase<Config_t>& qout)
+    {
+      Config_t& out = (const_cast< Eigen::MatrixBase<Config_t>& >(qout)).derived();
+      const Scalar angle = -PI + 2*PI * ((Scalar)rand())/RAND_MAX;
+      SINCOS (angle, &out(1), &out(0));
+    }
+
+    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> &,
+                                         const Eigen::MatrixBase<ConfigR_t> &,
+                                         const Eigen::MatrixBase<ConfigOut_t> & qout)
+    {
+      random_impl(qout);
+    }
+  }; // struct SpecialOrthogonalOperation<2>
+
+  template<>
+  struct SpecialOrthogonalOperation<3> : public LieGroupOperationBase <SpecialOrthogonalOperation<3> >
   {
     typedef SpecialOrthogonalOperation LieGroupDerived;
     SE3_LIE_GROUP_TYPEDEF;
@@ -123,105 +224,7 @@ namespace se3
 
       return defineSameRotation(quat1,quat2,prec);
     }
-  }; // struct SpecialOrthogonalOperation
-
-  struct SpecialOrthogonal1Operation;
-  template <> struct traits<SpecialOrthogonal1Operation> {
-    typedef double Scalar;
-    enum {
-      NQ = 2,
-      NV = 1
-    };
-    typedef Eigen::Matrix<Scalar,NQ,1> ConfigVector_t;
-    typedef Eigen::Matrix<Scalar,NV,1> TangentVector_t;
-  };
-
-  struct SpecialOrthogonal1Operation : public LieGroupOperationBase <SpecialOrthogonal1Operation>
-  {
-    typedef SpecialOrthogonal1Operation LieGroupDerived;
-    SE3_LIE_GROUP_TYPEDEF;
-
-    template <class ConfigL_t, class ConfigR_t, class Tangent_t>
-    static void difference_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
-                                const Eigen::MatrixBase<ConfigR_t> & q1,
-                                const Eigen::MatrixBase<Tangent_t> & d)
-    {
-      const_cast < Eigen::MatrixBase<Tangent_t>& > (d) [0]
-        = atan2 (q0(0)*q1(1) - q0(1)*q1(0), q0.dot(q1));
-    }
-
-    template <class ConfigIn_t, class Velocity_t, class ConfigOut_t>
-    static void integrate_impl(const Eigen::MatrixBase<ConfigIn_t> & q,
-                               const Eigen::MatrixBase<Velocity_t> & v,
-                               const Eigen::MatrixBase<ConfigOut_t> & qout)
-    {
-      ConfigOut_t& out = (const_cast< Eigen::MatrixBase<ConfigOut_t>& >(qout)).derived();
-
-      const Scalar & ca = q(0);
-      const Scalar & sa = q(1);
-      const Scalar & omega = v(0);
-
-      Scalar cosOmega,sinOmega; SINCOS(omega, &sinOmega, &cosOmega);
-      // TODO check the cost of atan2 vs SINCOS
-
-      out << cosOmega * ca - sinOmega * sa,
-             sinOmega * ca + cosOmega * sa;
-      const Scalar norm2 = q.squaredNorm();
-      out *= (3 - norm2) / 2;
-    }
-
-    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
-    static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
-                                 const Eigen::MatrixBase<ConfigR_t> & q1,
-                                 const Scalar& u,
-                                 const Eigen::MatrixBase<ConfigOut_t>& qout)
-    {
-      ConfigOut_t& out = (const_cast< Eigen::MatrixBase<ConfigOut_t>& >(qout)).derived();
-
-      assert ( (q0.norm() - 1) < 1e-8 && "initial configuration not normalized");
-      assert ( (q1.norm() - 1) < 1e-8 && "final configuration not normalized");
-      Scalar cosTheta = q0.dot(q1);
-      Scalar sinTheta = q0(0)*q1(1) - q0(1)*q1(0);
-      Scalar theta = atan2(sinTheta, cosTheta);
-      assert (fabs (sin (theta) - sinTheta) < 1e-8);
-
-      if (fabs (theta) > 1e-6 && fabs (theta) < PI - 1e-6)
-      {
-        out = (sin ((1-u)*theta)/sinTheta) * q0
-            + (sin (   u *theta)/sinTheta) * q1;
-      }
-      else if (fabs (theta) < 1e-6) // theta = 0
-      {
-        out = (1-u) * q0 + u * q1;
-      }
-      else // theta = +-PI
-      {
-        double theta0 = atan2 (q0(1), q0(0));
-        out << cos (theta0 + u * theta),
-               sin (theta0 + u * theta);
-      }
-    }
-
-    // template <class ConfigL_t, class ConfigR_t>
-    // static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
-                                       // const Eigen::MatrixBase<ConfigR_t> & q1)
-
-    template <class Config_t>
-    static void random_impl (const Eigen::MatrixBase<Config_t>& qout)
-    {
-      Config_t& out = (const_cast< Eigen::MatrixBase<Config_t>& >(qout)).derived();
-      const Scalar angle = -PI + 2*PI * ((Scalar)rand())/RAND_MAX;
-      SINCOS (angle, &out(1), &out(0));
-    }
-
-    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
-    static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> &,
-                                         const Eigen::MatrixBase<ConfigR_t> &,
-                                         const Eigen::MatrixBase<ConfigOut_t> & qout)
-    {
-      random_impl(qout);
-    }
-  }; // struct SpecialOrthogonal1Operation
+  }; // struct SpecialOrthogonalOperation<3>
 } // namespace se3
 
 #endif // ifndef __se3_special_orthogonal_operation_hpp__

--- a/src/multibody/liegroup/vector-space.hpp
+++ b/src/multibody/liegroup/vector-space.hpp
@@ -71,11 +71,11 @@ namespace se3
     static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & lower_pos_limit,
                                          const Eigen::MatrixBase<ConfigR_t> & upper_pos_limit,
                                          const Eigen::MatrixBase<ConfigOut_t> & qout)
-    { 
+    {
       ConfigOut_t& res = const_cast< Eigen::MatrixBase<ConfigOut_t>& > (qout).derived();
       for (int i = 0; i < NQ; ++i)
       {
-        if(lower_pos_limit[i] == -std::numeric_limits<Scalar>::infinity() || 
+        if(lower_pos_limit[i] == -std::numeric_limits<Scalar>::infinity() ||
            upper_pos_limit[i] ==  std::numeric_limits<Scalar>::infinity() )
         {
           std::ostringstream error;
@@ -85,7 +85,7 @@ namespace se3
         }
         res[i] = lower_pos_limit[i] + (( upper_pos_limit[i] - lower_pos_limit[i]) * rand())/RAND_MAX;
       }
-    } 
+    }
   }; // struct VectorSpaceOperation
 
 } // namespace se3

--- a/src/multibody/liegroup/vector-space.hpp
+++ b/src/multibody/liegroup/vector-space.hpp
@@ -1,0 +1,93 @@
+//
+// Copyright (c) 2016 CNRS
+//
+// This file is part of Pinocchio
+// Pinocchio is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// Pinocchio is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// Pinocchio If not, see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef __se3_vector_space_operation_hpp__
+#define __se3_vector_space_operation_hpp__
+
+#include <stdexcept>
+
+#include <pinocchio/multibody/liegroup/operation-base.hpp>
+
+namespace se3
+{
+  template<int Size> struct VectorSpaceOperation;
+  template<int Size> struct traits<VectorSpaceOperation<Size> > {
+    typedef double Scalar;
+    enum {
+      NQ = Size,
+      NV = Size
+    };
+    typedef Eigen::Matrix<Scalar,NQ,1> ConfigVector_t;
+    typedef Eigen::Matrix<Scalar,NV,1> TangentVector_t;
+  };
+
+  template<int Size = Eigen::Dynamic>
+  struct VectorSpaceOperation : public LieGroupOperationBase <VectorSpaceOperation<Size> >
+  {
+    typedef VectorSpaceOperation<Size>  LieGroupDerived;
+    SE3_LIE_GROUP_TYPEDEF;
+
+    template <class ConfigL_t, class ConfigR_t, class Tangent_t>
+    static void difference_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                const Eigen::MatrixBase<ConfigR_t> & q1,
+                                const Eigen::MatrixBase<Tangent_t> & d)
+    {
+      const_cast< Eigen::MatrixBase<Tangent_t>& > (d) = q1 - q0;
+    }
+
+    template <class ConfigIn_t, class Velocity_t, class ConfigOut_t>
+    static void integrate_impl(const Eigen::MatrixBase<ConfigIn_t> & q,
+                               const Eigen::MatrixBase<Velocity_t> & v,
+                               const Eigen::MatrixBase<ConfigOut_t> & qout)
+    {
+      const_cast< Eigen::MatrixBase<ConfigOut_t>& > (qout) = q + v;
+    }
+
+    // template <class ConfigL_t, class ConfigR_t>
+    // static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                                       // const Eigen::MatrixBase<ConfigR_t> & q1)
+
+    template <class Config_t>
+    static void random_impl (const Eigen::MatrixBase<Config_t>& qout)
+    {
+      qout.setRandom();
+    }
+
+    template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
+    static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & lower_pos_limit,
+                                         const Eigen::MatrixBase<ConfigR_t> & upper_pos_limit,
+                                         const Eigen::MatrixBase<ConfigOut_t> & qout)
+    { 
+      ConfigOut_t& res = const_cast< Eigen::MatrixBase<ConfigOut_t>& > (qout).derived();
+      for (int i = 0; i < NQ; ++i)
+      {
+        if(lower_pos_limit[i] == -std::numeric_limits<Scalar>::infinity() || 
+           upper_pos_limit[i] ==  std::numeric_limits<Scalar>::infinity() )
+        {
+          std::ostringstream error;
+          error << "non bounded limit. Cannot uniformly sample joint at rank " << i;
+          assert(false && "non bounded limit. Cannot uniformly sample joint revolute");
+          throw std::runtime_error(error.str());
+        }
+        res[i] = lower_pos_limit[i] + (( upper_pos_limit[i] - lower_pos_limit[i]) * rand())/RAND_MAX;
+      }
+    } 
+  }; // struct VectorSpaceOperation
+
+} // namespace se3
+
+#endif // ifndef __se3_vector_space_operation_hpp__

--- a/src/multibody/liegroup/vector-space.hpp
+++ b/src/multibody/liegroup/vector-space.hpp
@@ -80,7 +80,7 @@ namespace se3
         {
           std::ostringstream error;
           error << "non bounded limit. Cannot uniformly sample joint at rank " << i;
-          assert(false && "non bounded limit. Cannot uniformly sample joint revolute");
+          // assert(false && "non bounded limit. Cannot uniformly sample joint revolute");
           throw std::runtime_error(error.str());
         }
         res[i] = lower_pos_limit[i] + (( upper_pos_limit[i] - lower_pos_limit[i]) * rand())/RAND_MAX;

--- a/src/spatial/explog.hpp
+++ b/src/spatial/explog.hpp
@@ -58,7 +58,7 @@ namespace se3
   template <typename D> Eigen::Matrix<typename D::Scalar,3,1,Eigen::internal::traits<D>::Options>
   log3(const Eigen::MatrixBase<D> & R)
   {
-    EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(D, 3, 3);
+    EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(D, Eigen::Matrix3d);
     Eigen::AngleAxis<typename D::Scalar> angleAxis(R);
     assert(0 <= angleAxis.angle() && angleAxis.angle() <= 2 * M_PI);
     if (angleAxis.angle() > M_PI)

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -134,3 +134,4 @@ ADD_UNIT_TEST(visitor eigen3)
 ADD_UNIT_TEST(algo-check eigen3)
 ADD_UNIT_TEST(joint-composite eigen3)
 
+ADD_UNIT_TEST(liegroups eigen3)

--- a/unittest/joint-composite.cpp
+++ b/unittest/joint-composite.cpp
@@ -91,6 +91,12 @@ void test_joint_methods(const JointModelBase<JointModel> & jmodel, JointModelCom
   BOOST_CHECK(jdata.Dinv.isApprox(jdata_composite.Dinv));
   BOOST_CHECK(jdata.UDinv.isApprox(jdata_composite.UDinv));
   
+  /// TODO: Remove me. This is for testing purposes.
+  Eigen::VectorXd qq = q;
+  Eigen::VectorXd vv = v;
+  Eigen::VectorXd res(jmodel_composite.nq());
+  typename se3::IntegrateStep<se3::LieGroupTpl>::ArgsType args(qq, vv, res);
+  se3::IntegrateStep<se3::LieGroupTpl>::run(jmodel_composite, args);
 }
 
 struct TestJointComposite{

--- a/unittest/liegroups.cpp
+++ b/unittest/liegroups.cpp
@@ -14,9 +14,10 @@
 // received a copy of the GNU Lesser General Public License along with
 // pinocchio. If not, see <http://www.gnu.org/licenses/>.
 
+#include "pinocchio/multibody/liegroup/liegroup.hpp"
+
 #include "pinocchio/multibody/joint/joint-composite.hpp"
 #include "pinocchio/multibody/joint/joint.hpp"
-#include "pinocchio/multibody/liegroup/liegroup.hpp"
 
 #include <boost/test/unit_test.hpp>
 #include <boost/utility/binary.hpp>

--- a/unittest/liegroups.cpp
+++ b/unittest/liegroups.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) 2017, Joseph Mirabel
+// Authors: Joseph Mirabel (joseph.mirabel@laas.fr)
+//
+// This file is part of pinocchio.
+// pinocchio is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// pinocchio is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+// General Lesser Public License for more details.  You should have
+// received a copy of the GNU Lesser General Public License along with
+// pinocchio. If not, see <http://www.gnu.org/licenses/>.
+
+#include "pinocchio/multibody/joint/joint-composite.hpp"
+#include "pinocchio/multibody/joint/joint.hpp"
+#include "pinocchio/multibody/liegroup/liegroup.hpp"
+
+#include <boost/test/unit_test.hpp>
+#include <boost/utility/binary.hpp>
+
+using namespace se3;
+
+template <typename T>
+void test_lie_group_methods (T & jmodel, typename T::JointDataDerived &)
+{
+    std::cout << "Testing Joint over " << jmodel.shortname() << std::endl;
+    typedef typename T::ConfigVector_t  ConfigVector_t;
+    typedef typename T::TangentVector_t TangentVector_t;
+
+    ConfigVector_t  q1(ConfigVector_t::Random (jmodel.nq()));
+    TangentVector_t q1_dot(TangentVector_t::Random (jmodel.nv()));
+    ConfigVector_t  q2(ConfigVector_t::Random (jmodel.nq()));
+    double u = 0.3;
+    // se3::Inertia::Matrix6 Ia(se3::Inertia::Random().matrix());
+    // bool update_I = false;
+
+    q1 = jmodel.random();
+    q2 = jmodel.random();
+
+    // jmodel.calc(jdata, q1, q1_dot);
+    // jmodel.calc_aba(jdata, Ia, update_I);
+
+    typedef typename LieGroup<T>::type LieGroupType;
+    // LieGroupType lg;
+
+    static Eigen::VectorXd Ones (Eigen::VectorXd::Ones(jmodel.nq()));
+
+    std::string error_prefix("LieGroup ");
+    BOOST_CHECK_MESSAGE(jmodel.nq() == LieGroupType::NQ, std::string(error_prefix + " - nq "));
+    BOOST_CHECK_MESSAGE(jmodel.nv() == LieGroupType::NV, std::string(error_prefix + " - nv "));
+
+    BOOST_CHECK_MESSAGE(jmodel.integrate(q1,q1_dot).isApprox(LieGroupType::integrate(q1,q1_dot)) ,std::string(error_prefix + " - integrate "));
+    BOOST_CHECK_MESSAGE(jmodel.interpolate(q1,q2,u).isApprox(LieGroupType::interpolate(q1,q2,u)) ,std::string(error_prefix + " - interpolate "));
+    BOOST_CHECK_MESSAGE(jmodel.randomConfiguration( -1 * Ones, Ones).size()
+                        == LieGroupType::randomConfiguration(-1 * Ones, Ones).size(),
+                        std::string(error_prefix + " - RandomConfiguration dimensions "));
+    BOOST_CHECK_MESSAGE(jmodel.difference(q1,q2).isApprox(LieGroupType::difference(q1,q2)) ,std::string(error_prefix + " - difference "));
+    BOOST_CHECK_MESSAGE(fabs(jmodel.distance(q1,q2) - LieGroupType::distance(q1,q2)) < 1e-12 ,std::string(error_prefix + " - distance "));
+}
+
+struct TestJoint{
+
+  template <typename T>
+  void operator()(const T ) const
+  {
+    T jmodel;
+    jmodel.setIndexes(0,0,0);
+    typename T::JointDataDerived jdata = jmodel.createData();
+
+    test_lie_group_methods(jmodel, jdata);    
+  }
+
+  void operator()(const se3::JointModelComposite & ) const
+  {
+    // se3::JointModelComposite jmodel(2);
+    // jmodel.addJointModel(se3::JointModelRX());
+    // jmodel.addJointModel(se3::JointModelRY());
+
+    se3::JointModelComposite jmodel((se3::JointModelRX()));
+    jmodel.addJoint(se3::JointModelRY());
+    jmodel.setIndexes(0,0,0);
+
+    se3::JointModelComposite::JointDataDerived jdata = jmodel.createData();
+
+    test_lie_group_methods(jmodel, jdata);
+  }
+
+  void operator()(const se3::JointModelRevoluteUnaligned & ) const
+  {
+    se3::JointModelRevoluteUnaligned jmodel(1.5, 1., 0.);
+    jmodel.setIndexes(0,0,0);
+    se3::JointModelRevoluteUnaligned::JointDataDerived jdata = jmodel.createData();
+
+    test_lie_group_methods(jmodel, jdata);
+  }
+
+  void operator()(const se3::JointModelPrismaticUnaligned & ) const
+  {
+    se3::JointModelPrismaticUnaligned jmodel(1.5, 1., 0.);
+    jmodel.setIndexes(0,0,0);
+    se3::JointModelPrismaticUnaligned::JointDataDerived jdata = jmodel.createData();
+
+    test_lie_group_methods(jmodel, jdata);
+  }
+
+};
+
+BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
+
+BOOST_AUTO_TEST_CASE ( test_all_joints )
+{
+  typedef boost::variant< JointModelRX, JointModelRY, JointModelRZ, JointModelRevoluteUnaligned
+                          , JointModelSpherical, JointModelSphericalZYX
+                          , JointModelPX, JointModelPY, JointModelPZ
+                          , JointModelPrismaticUnaligned
+                          , JointModelFreeFlyer
+                          , JointModelPlanar
+                          , JointModelTranslation
+                          , JointModelRUBX, JointModelRUBY, JointModelRUBZ
+                          > Variant;
+  boost::mpl::for_each<Variant::types>(TestJoint());
+  // FIXME JointModelComposite does not work.
+  // boost::mpl::for_each<JointModelVariant::types>(TestJoint());
+}
+
+BOOST_AUTO_TEST_SUITE_END ()

--- a/unittest/liegroups.cpp
+++ b/unittest/liegroups.cpp
@@ -16,7 +16,6 @@
 
 #include "pinocchio/multibody/liegroup/liegroup.hpp"
 
-#include "pinocchio/multibody/joint/joint-composite.hpp"
 #include "pinocchio/multibody/joint/joint.hpp"
 
 #include <boost/test/unit_test.hpp>
@@ -72,21 +71,6 @@ struct TestJoint{
     typename T::JointDataDerived jdata = jmodel.createData();
 
     test_lie_group_methods(jmodel, jdata);    
-  }
-
-  void operator()(const se3::JointModelComposite & ) const
-  {
-    // se3::JointModelComposite jmodel(2);
-    // jmodel.addJointModel(se3::JointModelRX());
-    // jmodel.addJointModel(se3::JointModelRY());
-
-    se3::JointModelComposite jmodel((se3::JointModelRX()));
-    jmodel.addJoint(se3::JointModelRY());
-    jmodel.setIndexes(0,0,0);
-
-    se3::JointModelComposite::JointDataDerived jdata = jmodel.createData();
-
-    test_lie_group_methods(jmodel, jdata);
   }
 
   void operator()(const se3::JointModelRevoluteUnaligned & ) const

--- a/unittest/liegroups.cpp
+++ b/unittest/liegroups.cpp
@@ -95,7 +95,7 @@ struct TestJoint{
 
 BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 
-BOOST_AUTO_TEST_CASE ( test_all_joints )
+BOOST_AUTO_TEST_CASE ( test_all_liegroups )
 {
   typedef boost::variant< JointModelRX, JointModelRY, JointModelRZ, JointModelRevoluteUnaligned
                           , JointModelSpherical, JointModelSphericalZYX
@@ -109,6 +109,24 @@ BOOST_AUTO_TEST_CASE ( test_all_joints )
   boost::mpl::for_each<Variant::types>(TestJoint());
   // FIXME JointModelComposite does not work.
   // boost::mpl::for_each<JointModelVariant::types>(TestJoint());
+}
+
+BOOST_AUTO_TEST_CASE ( test_vector_space )
+{
+  typedef VectorSpaceOperation<3> VSO_t;
+  VSO_t::ConfigVector_t q,
+    lo(VSO_t::ConfigVector_t::Constant(-std::numeric_limits<double>::infinity())),
+    // lo(VSO_t::ConfigVector_t::Constant(                                       0)),
+    // up(VSO_t::ConfigVector_t::Constant( std::numeric_limits<double>::infinity()));
+    up(VSO_t::ConfigVector_t::Constant(                                       0));
+
+  bool error = false;
+  try {
+    VSO_t::randomConfiguration(lo, up, q);
+  } catch (const std::runtime_error&) {
+    error = true;
+  }
+  BOOST_CHECK_MESSAGE(error, "Random configuration between infinite bounds should return an error");
 }
 
 BOOST_AUTO_TEST_SUITE_END ()


### PR DESCRIPTION
The spaces taken into account are SO1, SO3, SE1, SE3, vector spaces and the Cartesian product of two of them.
The association `JointModel` <-> `LieGroupOperationBase` derived classes is made by the class `LieGroup` in file `src/multubody/liegroup/liegroup.hpp`.

Comments are welcome. Please focus first on important matters, such as names and architectures.
I emphasize the following points:
- name `SpecialOrthogonal1` and  `SpecialEuclidean1` are both very ugly and should be 2 instead of 1.
- `SpecialEuclidean1::forwardKinematics` seems weird to me (naming or architecture problem?).

Solves #344 