### PR TITLE
[Minor][C++] Homogenize behaviour of URDF regarding root joint.

### DIFF
--- a/src/parsers/urdf/model.cpp
+++ b/src/parsers/urdf/model.cpp
@@ -493,7 +493,8 @@ namespace se3
       ///
       void parseRootTree (::urdf::LinkConstPtr root_link, Model & model, const bool verbose) throw (std::invalid_argument)
       {
-        appendBodyToJoint(model, 0, root_link->inertial, SE3::Identity(), root_link->name);
+        addFixedJointAndBody(model, 0, SE3::Identity(), "root_joint",
+            root_link->inertial, root_link->name);
 
         BOOST_FOREACH(::urdf::LinkPtr child, root_link->child_links)
         {


### PR DESCRIPTION
In both cases, the frame tree starts with frame "root_joint"