### PR TITLE
[c++11] Making pinocchio compiles with c++11

### DIFF
--- a/bindings/python/multibody/model.hpp
+++ b/bindings/python/multibody/model.hpp
@@ -160,7 +160,7 @@ namespace se3
                                  const SE3 & joint_placement,
                                  const std::string & joint_name)
       {
-        JointModelVariant jmodel_variant = bp::extract<JointModelVariant> (jmodel);
+        JointModelVariant jmodel_variant = bp::extract<JointModelVariant> (jmodel)();
         return boost::apply_visitor(addJointVisitor(model,parent_id,joint_placement,joint_name), jmodel_variant);
       }
       

--- a/bindings/python/parsers/parsers.hpp
+++ b/bindings/python/parsers/parsers.hpp
@@ -57,7 +57,7 @@ namespace se3
                                       bp::object & root_joint_object
                                       )
       {
-        JointModelVariant root_joint = bp::extract<JointModelVariant> (root_joint_object);
+        JointModelVariant root_joint = bp::extract<JointModelVariant> (root_joint_object)();
         Model model;
         se3::urdf::buildModel(filename, root_joint, model);
         return model;


### PR DESCRIPTION
Fix access to boost::variant::extract in model.hpp and parsers.hpp.