### PR TITLE
Fix TYPEDEF for GNUC 442

### DIFF
--- a/src/multibody/joint/joint-base.hpp
+++ b/src/multibody/joint/joint-base.hpp
@@ -76,7 +76,7 @@ namespace se3
 
 #define SE3_JOINT_TYPEDEF_ARG(prefix)         \
   typedef int Index;              \
-  typedef prefix traits<JointDerived>::Scalar Scalar;
+  typedef prefix traits<JointDerived>::Scalar Scalar;     \
   typedef prefix traits<JointDerived>::JointDataDerived JointDataDerived;      \
   typedef prefix traits<JointDerived>::JointModelDerived JointModelDerived;      \
   typedef prefix traits<JointDerived>::Constraint_t Constraint_t;    \


### PR DESCRIPTION
I am pretty sure this is a bug. There was a \ missing, thereby breaking the definition of the macro.
This should only happen when compiling with GCC 4.4.2 . Haven't tested it, but the problem seems obvious.

Speaking about it, it seems very weird to me that the compiler version is apparently checked for equality, instead of using >= or <= . Is there a reason for it?