### PR TITLE
Handle recent version of boost >= 1.67.0

### DIFF
--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -53,7 +53,11 @@ ENDMACRO(ADD_UNIT_TEST)
 # --- RULES -------------------------------------------------------------------
 # --- RULES -------------------------------------------------------------------
 # --- RULES -------------------------------------------------------------------
-ADD_CUSTOM_TARGET(check COMMAND ${CMAKE_CTEST_COMMAND})
+IF(APPLE)
+  ADD_CUSTOM_TARGET(check COMMAND export DYLD_LIBRARY_PATH=$ENV{DYLD_LIBRARY_PATH} && ${CMAKE_CTEST_COMMAND})
+ELSE(APPLE)
+  ADD_CUSTOM_TARGET(check COMMAND ${CMAKE_CTEST_COMMAND})
+ENDIF(APPLE)
 
 ADD_UNIT_TEST(tspatial eigen3)
 IF(METAPOD_FOUND)


### PR DESCRIPTION
It also corrects a bad behaviour of ctest command under OSX