### PR TITLE
[LieGroup] Fix bug related to the Scalar product return type

### DIFF
--- a/src/multibody/liegroup/operation-base.hxx
+++ b/src/multibody/liegroup/operation-base.hxx
@@ -239,7 +239,11 @@ namespace se3 {
   {
     if     (u == 0) const_cast<Eigen::MatrixBase<ConfigOut_t>&>(qout) = q0;
     else if(u == 1) const_cast<Eigen::MatrixBase<ConfigOut_t>&>(qout) = q1;
-    else integrate(q0, u * difference(q0, q1), qout);
+    else 
+    {
+      TangentVector_t vdiff(u * difference(q0, q1));
+      integrate(q0, vdiff, qout);
+    }
   }
 
   template <class Derived>


### PR DESCRIPTION
This bug is appearing with Eigen3 >= 3.3.4.
The scalar product return type does not have an Options which is required by exp3.