### PR TITLE
In SE(n) and SO(n), difference is exactly zero if operands are equal.

### DIFF
--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -170,6 +170,10 @@ namespace se3
                                 const Eigen::MatrixBase<ConfigR_t> & q1,
                                 const Eigen::MatrixBase<Tangent_t> & d)
     {
+      if (q0 == q1) {
+        (const_cast <Eigen::MatrixBase<Tangent_t> &> (d)).setZero ();
+        return;
+      }
       Matrix2 R0, R1; Vector2 t0, t1;
       forwardKinematics(R0, t0, q0);
       forwardKinematics(R1, t1, q1);
@@ -338,6 +342,10 @@ namespace se3
                                 const Eigen::MatrixBase<ConfigR_t> & q1,
                                 const Eigen::MatrixBase<Tangent_t> & d)
     {
+      if (q0 == q1) {
+        (const_cast < Eigen::MatrixBase<Tangent_t>& > (d)).setZero ();
+        return;
+      }
       ConstQuaternionMap_t p0 (q0.derived().template tail<4>().data());
       ConstQuaternionMap_t p1 (q1.derived().template tail<4>().data());
       const_cast < Eigen::MatrixBase<Tangent_t>& > (d)

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -103,6 +103,10 @@ namespace se3
                                 const Eigen::MatrixBase<ConfigR_t> & q1,
                                 const Eigen::MatrixBase<Tangent_t> & d)
     {
+      if (q0 == q1) {
+        (const_cast < Tangent_t& > (d.derived())).setZero ();
+        return;
+      }
       Matrix2 R; // R0.transpose() * R1;
       R(0,0) = R(1,1) = q0.dot(q1);
       R(1,0) = q0(0) * q1(1) - q0(1) * q1(0);
@@ -257,6 +261,10 @@ namespace se3
                                 const Eigen::MatrixBase<ConfigR_t> & q1,
                                 const Eigen::MatrixBase<Tangent_t> & d)
     {
+      if (q0 == q1) {
+        (const_cast < Eigen::MatrixBase<Tangent_t>& > (d)).setZero ();
+        return;
+      }
       ConstQuaternionMap_t p0 (q0.derived().data());
       ConstQuaternionMap_t p1 (q1.derived().data());
       const_cast < Eigen::MatrixBase<Tangent_t>& > (d)

--- a/unittest/liegroups.cpp
+++ b/unittest/liegroups.cpp
@@ -99,6 +99,12 @@ void test_lie_group_methods (T & jmodel, typename T::JointDataDerived &)
     BOOST_CHECK_MESSAGE(M_interpolate_expected.isApprox(M_interpolate,1e2*prec), std::string("Error when interpolating " + jmodel.shortname()));
   }
 
+  // Check that difference between two equal configuration is exactly 0
+  TangentVector_t zero = LieGroupType().difference(q1,q1);
+  BOOST_CHECK_MESSAGE (zero.isZero (0), std::string ("Error: difference between two equal configurations is not 0."));
+  zero = LieGroupType().difference(q2,q2);
+  BOOST_CHECK_MESSAGE (zero.isZero (0), std::string ("Error: difference between two equal configurations is not 0."));
+
   // Check differentiate
   TangentVector_t vdiff = LieGroupType().difference(q1,q2);
   BOOST_CHECK_MESSAGE(vdiff.isApprox(q1_dot,1e2*prec), std::string("Error when differentiating " + jmodel.shortname()));


### PR DESCRIPTION
Otherwise, distance between equal configurations may not be equal to 0.