### PR TITLE
Update function name when considering joint Jacobian

### DIFF
--- a/benchmark/timings.cpp
+++ b/benchmark/timings.cpp
@@ -151,14 +151,14 @@ int main(int argc, const char ** argv)
   timer.tic();
   SMOOTH(NBT)
     {
-      computeJacobians(model,data,qs[_smooth]);
+      computeJointJacobians(model,data,qs[_smooth]);
     }
   std::cout << "Jacobian = \t"; timer.toc(std::cout,NBT);
   
   timer.tic();
   SMOOTH(NBT)
   {
-    computeJacobiansTimeVariation(model,data,qs[_smooth],qdots[_smooth]);
+    computeJointJacobiansTimeVariation(model,data,qs[_smooth],qdots[_smooth]);
   }
   std::cout << "Jacobian Time Variation = \t"; timer.toc(std::cout,NBT);
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -184,6 +184,7 @@ INSTALL(TARGETS ${PYWRAP} DESTINATION ${${PYWRAP}_INSTALL_DIR})
 # --- INSTALL SCRIPTS 
 SET(PYTHON_FILES
   __init__.py
+  deprecated.py
   deprecation.py
   utils.py
   robot_wrapper.py

--- a/bindings/python/algorithm/expose-frames.cpp
+++ b/bindings/python/algorithm/expose-frames.cpp
@@ -43,7 +43,7 @@ namespace se3
                                                const bool local,
                                                const Eigen::VectorXd & q)
     {
-      computeJacobians(model,data,q);
+      computeJointJacobians(model,data,q);
       framesForwardKinematics(model,data);
   
       return frame_jacobian_proxy(model, data, frame_id, local);
@@ -85,7 +85,7 @@ namespace se3
               "The columns of the Jacobian are expressed in the frame coordinates.\n"
               "In other words, the velocity of the frame vF expressed in the local coordinate is given by J*v,"
               "where v is the time derivative of the configuration q.\n"
-              "Be aware that computeJacobians and framesKinematics must have been called first.");
+              "Be aware that computeJointJacobians and framesKinematics must have been called first.");
       
     }
   } // namespace python

--- a/bindings/python/algorithm/expose-jacobian.cpp
+++ b/bindings/python/algorithm/expose-jacobian.cpp
@@ -34,10 +34,10 @@ namespace se3
       Data::Matrix6x J(6,model.nv); J.setZero();
       
       if (update_kinematics)
-        computeJacobians(model,data,q);
+        computeJointJacobians(model,data,q);
       
-      if(local) getJacobian<LOCAL> (model,data,jointId,J);
-      else getJacobian<WORLD> (model,data,jointId,J);
+      if(local) getJointJacobian<LOCAL>(model,data,jointId,J);
+      else getJointJacobian<WORLD>(model,data,jointId,J);
       
       return J;
     }
@@ -50,8 +50,8 @@ namespace se3
     {
       Data::Matrix6x J(6,model.nv); J.setZero();
       
-      if(local) getJacobian<LOCAL> (model,data,jointId,J);
-      else getJacobian<WORLD> (model,data,jointId,J);
+      if(local) getJointJacobian<LOCAL>(model,data,jointId,J);
+      else getJointJacobian<WORLD>(model,data,jointId,J);
       
       return J;
     }
@@ -64,23 +64,22 @@ namespace se3
     {
       Data::Matrix6x dJ(6,model.nv); dJ.setZero();
       
-      
-      if(local) getJacobianTimeVariation<LOCAL> (model,data,jointId,dJ);
-      else getJacobianTimeVariation<WORLD> (model,data,jointId,dJ);
+      if(local) getJointJacobianTimeVariation<LOCAL>(model,data,jointId,dJ);
+      else getJointJacobianTimeVariation<WORLD>(model,data,jointId,dJ);
       
       return dJ;
     }
   
     void exposeJacobian()
     {
-      bp::def("computeJacobians",(const Data::Matrix6x &(*)(const Model &, Data &, const Eigen::VectorXd &))&computeJacobians,
+      bp::def("computeJacobians",(const Data::Matrix6x &(*)(const Model &, Data &, const Eigen::VectorXd &))&computeJointJacobians,
               bp::args("Model","Data",
                        "Joint configuration q (size Model::nq)"),
               "Computes the full model Jacobian, i.e. the stack of all motion subspace expressed in the world frame.\n"
               "The result is accessible through data.J. This function computes also the forwardKinematics of the model.",
               bp::return_value_policy<bp::return_by_value>());
       
-      bp::def("computeJacobians",(const Data::Matrix6x &(*)(const Model &, Data &))&computeJacobians,
+      bp::def("computeJacobians",(const Data::Matrix6x &(*)(const Model &, Data &))&computeJointJacobians,
               bp::args("Model","Data"),
               "Computes the full model Jacobian, i.e. the stack of all motion subspace expressed in the world frame.\n"
               "The result is accessible through data.J. This function assumes that forwardKinematics has been called before",
@@ -96,7 +95,7 @@ namespace se3
               "Computes the jacobian of a given given joint according to the given input configuration."
               "If local is set to true, it returns the jacobian associated to the joint frame. Otherwise, it returns the jacobian of the frame coinciding with the world frame.");
       
-      bp::def("getJacobian",get_jacobian_proxy,
+      bp::def("getJointJacobian",get_jacobian_proxy,
               bp::args("Model, the model of the kinematic tree",
                        "Data, the data associated to the model where the results are stored",
                        "Joint ID, the index of the joint.",
@@ -104,20 +103,21 @@ namespace se3
               "Computes the jacobian of a given given joint according to the given entries in data."
               "If local is set to true, it returns the jacobian associated to the joint frame. Otherwise, it returns the jacobian of the frame coinciding with the world frame.");
       
-      bp::def("computeJacobiansTimeVariation",computeJacobiansTimeVariation,
+      bp::def("computeJacobiansTimeVariation",computeJointJacobiansTimeVariation,
               bp::args("Model","Data",
                        "Joint configuration q (size Model::nq)",
                        "Joint velocity v (size Model::nv)"),
-              "Calling computeJacobiansTimeVariation",
+              "Computes the full model Jacobian variations with respect to time. It corresponds to dJ/dt which depends both on q and v."
+              "The result is accessible through data.dJ.",
               bp::return_value_policy<bp::return_by_value>());
       
-      bp::def("getJacobianTimeVariation",get_jacobian_time_variation_proxy,
+      bp::def("getJointJacobianTimeVariation",get_jacobian_time_variation_proxy,
               bp::args("Model, the model of the kinematic tree",
                        "Data, the data associated to the model where the results are stored",
                        "Joint ID, the index of the joint.",
                        "frame (true = local, false = world)"),
               "Computes the Jacobian time variation of a specific joint frame expressed either in the world frame or in the local frame of the joint."
-              "You have to run computeJacobiansTimeVariation first."
+              "You have to call computeJointJacobiansTimeVariation first."
               "If local is set to true, it returns the jacobian time variation associated to the joint frame. Otherwise, it returns the jacobian time variation of the frame coinciding with the world frame.");
     }
     

--- a/bindings/python/algorithm/expose-jacobian.cpp
+++ b/bindings/python/algorithm/expose-jacobian.cpp
@@ -72,14 +72,14 @@ namespace se3
   
     void exposeJacobian()
     {
-      bp::def("computeJacobians",(const Data::Matrix6x &(*)(const Model &, Data &, const Eigen::VectorXd &))&computeJointJacobians,
+      bp::def("computeJointJacobians",(const Data::Matrix6x &(*)(const Model &, Data &, const Eigen::VectorXd &))&computeJointJacobians,
               bp::args("Model","Data",
                        "Joint configuration q (size Model::nq)"),
               "Computes the full model Jacobian, i.e. the stack of all motion subspace expressed in the world frame.\n"
               "The result is accessible through data.J. This function computes also the forwardKinematics of the model.",
               bp::return_value_policy<bp::return_by_value>());
       
-      bp::def("computeJacobians",(const Data::Matrix6x &(*)(const Model &, Data &))&computeJointJacobians,
+      bp::def("computeJointJacobians",(const Data::Matrix6x &(*)(const Model &, Data &))&computeJointJacobians,
               bp::args("Model","Data"),
               "Computes the full model Jacobian, i.e. the stack of all motion subspace expressed in the world frame.\n"
               "The result is accessible through data.J. This function assumes that forwardKinematics has been called before",
@@ -103,7 +103,7 @@ namespace se3
               "Computes the jacobian of a given given joint according to the given entries in data."
               "If local is set to true, it returns the jacobian associated to the joint frame. Otherwise, it returns the jacobian of the frame coinciding with the world frame.");
       
-      bp::def("computeJacobiansTimeVariation",computeJointJacobiansTimeVariation,
+      bp::def("computeJointJacobiansTimeVariation",computeJointJacobiansTimeVariation,
               bp::args("Model","Data",
                        "Joint configuration q (size Model::nq)",
                        "Joint velocity v (size Model::nv)"),

--- a/bindings/python/algorithm/expose-jacobian.cpp
+++ b/bindings/python/algorithm/expose-jacobian.cpp
@@ -28,7 +28,7 @@ namespace se3
                    Data & data,
                    const Eigen::VectorXd & q,
                    Model::JointIndex jointId,
-                   bool local,
+                   ReferenceFrame rf,
                    bool update_kinematics)
     {
       Data::Matrix6x J(6,model.nv); J.setZero();
@@ -36,7 +36,7 @@ namespace se3
       if (update_kinematics)
         computeJointJacobians(model,data,q);
       
-      if(local) getJointJacobian<LOCAL>(model,data,jointId,J);
+      if(rf == LOCAL) getJointJacobian<LOCAL>(model,data,jointId,J);
       else getJointJacobian<WORLD>(model,data,jointId,J);
       
       return J;
@@ -46,11 +46,11 @@ namespace se3
     get_jacobian_proxy(const Model & model,
                        Data & data,
                        Model::JointIndex jointId,
-                       bool local)
+                       ReferenceFrame rf)
     {
       Data::Matrix6x J(6,model.nv); J.setZero();
       
-      if(local) getJointJacobian<LOCAL>(model,data,jointId,J);
+      if(rf == LOCAL) getJointJacobian<LOCAL>(model,data,jointId,J);
       else getJointJacobian<WORLD>(model,data,jointId,J);
       
       return J;
@@ -60,11 +60,11 @@ namespace se3
     get_jacobian_time_variation_proxy(const Model & model,
                                   Data & data,
                                   Model::JointIndex jointId,
-                                  bool local)
+                                  ReferenceFrame rf)
     {
       Data::Matrix6x dJ(6,model.nv); dJ.setZero();
       
-      if(local) getJointJacobianTimeVariation<LOCAL>(model,data,jointId,dJ);
+      if(rf == LOCAL) getJointJacobianTimeVariation<LOCAL>(model,data,jointId,dJ);
       else getJointJacobianTimeVariation<WORLD>(model,data,jointId,dJ);
       
       return dJ;
@@ -85,40 +85,40 @@ namespace se3
               "The result is accessible through data.J. This function assumes that forwardKinematics has been called before",
               bp::return_value_policy<bp::return_by_value>());
       
-      bp::def("jacobian",jacobian_proxy,
+      bp::def("jointJacobian",jacobian_proxy,
               bp::args("Model, the model of the kinematic tree",
                        "Data, the data associated to the model where the results are stored",
                        "Joint configuration q (size Model::nq)",
                        "Joint ID, the index of the joint.",
-                       "frame (true = local, false = world)",
+                       "Reference frame rf (either ReferenceFrame.LOCAL or ReferenceFrame.WORLD)",
                        "update_kinematics (true = update the value of the total jacobian)"),
               "Computes the jacobian of a given given joint according to the given input configuration."
-              "If local is set to true, it returns the jacobian associated to the joint frame. Otherwise, it returns the jacobian of the frame coinciding with the world frame.");
+              "If rf is set to LOCAL, it returns the jacobian associated to the joint frame. Otherwise, it returns the jacobian of the frame coinciding with the world frame.");
       
       bp::def("getJointJacobian",get_jacobian_proxy,
               bp::args("Model, the model of the kinematic tree",
                        "Data, the data associated to the model where the results are stored",
                        "Joint ID, the index of the joint.",
-                       "frame (true = local, false = world)"),
+                       "Reference frame rf (either ReferenceFrame.LOCAL or ReferenceFrame.WORLD)"),
               "Computes the jacobian of a given given joint according to the given entries in data."
-              "If local is set to true, it returns the jacobian associated to the joint frame. Otherwise, it returns the jacobian of the frame coinciding with the world frame.");
+              "If rf is set to LOCAL, it returns the jacobian associated to the joint frame. Otherwise, it returns the jacobian of the frame coinciding with the world frame.");
       
       bp::def("computeJointJacobiansTimeVariation",computeJointJacobiansTimeVariation,
               bp::args("Model","Data",
                        "Joint configuration q (size Model::nq)",
                        "Joint velocity v (size Model::nv)"),
-              "Computes the full model Jacobian variations with respect to time. It corresponds to dJ/dt which depends both on q and v."
-              "The result is accessible through data.dJ.",
+              "Computes the full model Jacobian variations with respect to time. It corresponds to dJ/dt which depends both on q and v. It also computes the joint Jacobian of the model (similar to computeJointJacobians)."
+              "The result is accessible through data.dJ and data.J.",
               bp::return_value_policy<bp::return_by_value>());
       
       bp::def("getJointJacobianTimeVariation",get_jacobian_time_variation_proxy,
               bp::args("Model, the model of the kinematic tree",
                        "Data, the data associated to the model where the results are stored",
                        "Joint ID, the index of the joint.",
-                       "frame (true = local, false = world)"),
+                       "Reference frame rf (either ReferenceFrame.LOCAL or ReferenceFrame.WORLD)"),
               "Computes the Jacobian time variation of a specific joint frame expressed either in the world frame or in the local frame of the joint."
               "You have to call computeJointJacobiansTimeVariation first."
-              "If local is set to true, it returns the jacobian time variation associated to the joint frame. Otherwise, it returns the jacobian time variation of the frame coinciding with the world frame.");
+              "If rf is set to LOCAL, it returns the jacobian time variation associated to the joint frame. Otherwise, it returns the jacobian time variation of the frame coinciding with the world frame.");
     }
     
   } // namespace python

--- a/bindings/python/scripts/__init__.py
+++ b/bindings/python/scripts/__init__.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015-2016 CNRS
+# Copyright (c) 2015-2016,2018 CNRS
 #
 # This file is part of Pinocchio
 # Pinocchio is free software: you can redistribute it
@@ -21,6 +21,7 @@ from . import libpinocchio_pywrap as se3
 from . import utils
 from .explog import exp, log
 from .libpinocchio_pywrap import *
+from .deprecated import *
 
 se3.AngleAxis.__repr__ = lambda s: 'AngleAxis(%s)' % s.vector()
 

--- a/bindings/python/scripts/deprecated.py
+++ b/bindings/python/scripts/deprecated.py
@@ -1,0 +1,56 @@
+#
+# Copyright (c) 2018 CNRS
+#
+# This file is part of Pinocchio
+# Pinocchio is free software: you can redistribute it
+# and/or modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation, either version
+# 3 of the License, or (at your option) any later version.
+# Pinocchio is distributed in the hope that it will be
+# useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+# of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Lesser Public License for more details. You should have
+# received a copy of the GNU Lesser General Public License along with
+# Pinocchio If not, see
+# <http://www.gnu.org/licenses/>.
+
+## In this file, are reported some depracated functions that are still maintain until the next important release 1.4.0 ##
+
+from __future__ import print_function
+
+from . import libpinocchio_pywrap as se3 
+from .deprecation import deprecated
+
+@deprecated("This function has been renamed computeJointJacobians and will be removed in release 1.4.0 of Pinocchio. Please change for new computeJacobians.")
+def computeJacobians(model,data,q=None):
+  if q is None:
+    return computeJointJacobians(model,data)
+  else:
+    return computeJointJacobians(model,data,q)
+
+@deprecated("This function has been renamed jointJacobian and will be removed in release 1.4.0 of Pinocchio. Please change for new jointJacobian.")
+def jacobian(model,data,q,jointId,local,update_kinematics):
+  if local:
+    return jointJacobian(model,data,q,jointId,se3.ReferenceFrame.LOCAL,update_kinematics)
+  else:
+    return jointJacobian(model,data,q,jointId,se3.ReferenceFrame.WORLD,update_kinematics)
+
+@deprecated("This function has been renamed getJointJacobian and will be removed in release 1.4.0 of Pinocchio. Please change for new getJointJacobian.")
+def getJointJacobian(model,data,jointId,local):
+  if local:
+    return getJointJacobian(model,data,jointId,se3.ReferenceFrame.LOCAL)
+  else:
+    return getJointJacobian(model,data,jointId,se3.ReferenceFrame.WORLD)
+
+@deprecated("This function has been renamed computeJacobiansTimeVariation and will be removed in release 1.4.0 of Pinocchio. Please change for new computeJacobiansTimeVariation.")
+def computeJacobiansTimeVariation(model,data,q,v):
+  return computeJointJacobiansTimeVariation(model,data,q,v)
+
+@deprecated("This function has been renamed getJointJacobianTimeVariation and will be removed in release 1.4.0 of Pinocchio. Please change for new getJointJacobianTimeVariation.")
+def getJacobianTimeVariation(model,data,jointId,local):
+  if local:
+    return getJointJacobianTimeVariation(model,data,jointId,se3.ReferenceFrame.LOCAL)
+  else:
+    return getJointJacobianTimeVariation(model,data,jointId,se3.ReferenceFrame.WORLD)
+
+

--- a/bindings/python/scripts/derivative/dcrba.py
+++ b/bindings/python/scripts/derivative/dcrba.py
@@ -31,7 +31,7 @@ def hessian(robot,q,crossterms=False):
     '''
     lambdas.setRobotArgs(robot)
     H=np.zeros([6,robot.model.nv,robot.model.nv])
-    se3.computeJacobians(robot.model,robot.data,q)
+    se3.computeJointJacobians(robot.model,robot.data,q)
     J = robot.data.J
     skiplast = -1 if not crossterms else None
     for joint_i in range(1,robot.model.njoints):

--- a/bindings/python/scripts/robot_wrapper.py
+++ b/bindings/python/scripts/robot_wrapper.py
@@ -16,6 +16,8 @@
 
 from . import libpinocchio_pywrap as se3
 from . import utils
+from .deprecation import deprecated
+
 import time
 import os
 
@@ -171,8 +173,12 @@ class RobotWrapper(object):
     def jacobian(self, q, index, update_kinematics=True, local_frame=True):
         return se3.jacobian(self.model, self.data, q, index, local_frame, update_kinematics)
 
+    @deprecated("This method is now deprecated. Please use computeJointJacobians instead.")
     def computeJacobians(self, q):
-        return se3.computeJacobians(self.model, self.data, q)
+        return se3.computeJointJacobians(self.model, self.data, q)
+
+    def computeJointJacobians(self, q):
+        return se3.computeJointJacobians(self.model, self.data, q)
 
     def updateGeometryPlacements(self, q=None, visual=False):
         if visual:
@@ -191,7 +197,7 @@ class RobotWrapper(object):
     def framesKinematics(self, q): 
         se3.framesKinematics(self.model, self.data, q)
     
-    ''' Call computeJacobians if update_geometry is true. If not, user should call computeJacobians first.
+    ''' Call computeJointJacobians if update_geometry is true. If not, user should call computeJointJacobians first.
     Then call getJacobian and return the resulted jacobian matrix. Attention: if update_geometry is true, 
     the function computes all the jacobians of the model. It is therefore outrageously costly wrt a 
     dedicated call. Use only with update_geometry for prototyping.

--- a/src/algorithm/center-of-mass.hpp
+++ b/src/algorithm/center-of-mass.hpp
@@ -114,7 +114,7 @@ namespace se3
   
   ///
   /// \brief Computes both the jacobian and the the center of mass position of a given model according to a particular joint configuration.
-  ///        The results are accessible through data.Jcom and data.com[0] and are both expressed in the world frame. In addition, the algorithm also computes the Jacobian of all the joints (\sa se3::computeJacobians).
+  ///        The results are accessible through data.Jcom and data.com[0] and are both expressed in the world frame. In addition, the algorithm also computes the Jacobian of all the joints (\sa se3::computeJointJacobians).
   ///        And data.com[i] gives the center of mass of the subtree supported by joint i (expressed in the world frame).
   ///
   /// \param[in] model The model structure of the rigid body system.

--- a/src/algorithm/compute-all-terms.hpp
+++ b/src/algorithm/compute-all-terms.hpp
@@ -33,7 +33,7 @@ namespace se3
   ///         - se3::forwardKinematics
   ///         - se3::crba
   ///         - se3::nonLinearEffects
-  ///         - se3::computeJacobians
+  ///         - se3::computeJointJacobians
   ///         - se3::centerOfMass
   ///         - se3::jacobianCenterOfMass
   ///         - se3::kineticEnergy

--- a/src/algorithm/frames.hpp
+++ b/src/algorithm/frames.hpp
@@ -50,11 +50,11 @@ namespace se3
   /**
    * @brief      Returns the jacobian of the frame expresssed either expressed in the LOCAL frame coordinate system or in the WORLD coordinate system,
    *             depending on the value of the template parameter rf.
-   *             You must first call se3::computeJacobians followed by se3::framesForwardKinematics to update placement values in data structure.
+   *             You must first call se3::computeJointJacobians followed by se3::framesForwardKinematics to update placement values in data structure.
    *
    * @tparam     rf Reference frame in which the columns of the Jacobian are expressed.
    
-   * @remark     Similarly to se3::getJacobian with LOCAL or WORLD templated parameters, if rf == LOCAL, this function returns the Jacobian of the frame expressed
+   * @remark     Similarly to se3::getJointJacobian with LOCAL or WORLD templated parameters, if rf == LOCAL, this function returns the Jacobian of the frame expressed
    *             in the local coordinates of the frame, or if rl == WORDL, it returns the Jacobian expressed of the point coincident with the origin
    *             and expressed in a coordinate system aligned with the WORLD.
    *
@@ -63,7 +63,7 @@ namespace se3
    * @param[in]  frame_id    Id of the operational Frame
    * @param[out] J           The Jacobian of the Frame expressed in the coordinates Frame.
    *
-   * @warning    The function se3::computeJacobians and se3::framesForwardKinematics should have been called first.
+   * @warning    The function se3::computeJointJacobians and se3::framesForwardKinematics should have been called first.
    */
   template<ReferenceFrame rf>
   void getFrameJacobian(const Model & model,
@@ -73,14 +73,14 @@ namespace se3
   
   /**
    * @brief      Returns the jacobian of the frame expresssed the LOCAL frame coordinate system.
-   *             You must first call se3::computeJacobians followed by se3::framesForwardKinematics to update placement values in data structure.
+   *             You must first call se3::computeJointJacobians followed by se3::framesForwardKinematics to update placement values in data structure.
    *
    * @param[in]  model       The kinematic model
    * @param[in]  data        Data associated to model
    * @param[in]  frame_id    Id of the operational Frame
    * @param[out] J           The Jacobian of the Frame expressed in the coordinates Frame.
    *
-   * @warning    The function se3::computeJacobians and se3::framesForwardKinematics should have been called first.
+   * @warning    The function se3::computeJointJacobians and se3::framesForwardKinematics should have been called first.
    */
    
   inline void getFrameJacobian(const Model & model,

--- a/src/algorithm/frames.hxx
+++ b/src/algorithm/frames.hxx
@@ -68,7 +68,7 @@ namespace se3
     const Model::JointIndex & joint_id = frame.parent;
     if (rf == WORLD)
     {
-      getJacobian<WORLD>(model,data,joint_id,J);
+      getJointJacobian<WORLD>(model,data,joint_id,J);
       return;
     }
     

--- a/src/algorithm/jacobian.hpp
+++ b/src/algorithm/jacobian.hpp
@@ -28,7 +28,7 @@ namespace se3
   /// \brief Computes the full model Jacobian, i.e. the stack of all motion subspace expressed in the world frame.
   ///        The result is accessible through data.J. This function computes also the forwardKinematics of the model.
   ///
-  /// \note This Jacobian does not correspond to any specific joint frame Jacobian. From this Jacobian, it is then possible to easily extract the Jacobian of a specific joint frame. \sa se3::getJacobian for doing this specific extraction.
+  /// \note This Jacobian does not correspond to any specific joint frame Jacobian. From this Jacobian, it is then possible to easily extract the Jacobian of a specific joint frame. \sa se3::getJointJacobian for doing this specific extraction.
   ///
   /// \param[in] model The model structure of the rigid body system.
   /// \param[in] data The data structure of the rigid body system.
@@ -37,15 +37,36 @@ namespace se3
   /// \return The full model Jacobian (matrix 6 x model.nv).
   ///
   inline const Data::Matrix6x &
+  computeJointJacobians(const Model & model,
+                        Data & data,
+                        const Eigen::VectorXd & q);
+  
+  ///
+  /// \brief Computes the full model Jacobian, i.e. the stack of all motion subspace expressed in the world frame.
+  ///        The result is accessible through data.J. This function computes also the forwardKinematics of the model.
+  ///
+  /// \deprecated This function is now deprecated. Please refer now to se3::computeJointJacobians for similar function with updated name.
+  ///
+  /// \note This Jacobian does not correspond to any specific joint frame Jacobian. From this Jacobian, it is then possible to easily extract the Jacobian of a specific joint frame. \sa se3::getJointJacobian for doing this specific extraction.
+  ///
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  /// \param[in] q The joint configuration vector (dim model.nq).
+  ///
+  /// \return The full model Jacobian (matrix 6 x model.nv).
+  ///
+  PINOCCHIO_DEPRECATED
+  inline const Data::Matrix6x &
   computeJacobians(const Model & model,
                    Data & data,
-                   const Eigen::VectorXd & q);
+                   const Eigen::VectorXd & q)
+  { return computeJointJacobians(model,data,q); }
   
   ///
   /// \brief Computes the full model Jacobian, i.e. the stack of all motion subspace expressed in the world frame.
   ///        The result is accessible through data.J. This function assumes that se3::forwardKinematics has been called before.
   ///
-  /// \note This Jacobian does not correspond to any specific joint frame Jacobian. From this Jacobian, it is then possible to easily extract the Jacobian of a specific joint frame. \sa se3::getJacobian for doing this specific extraction.
+  /// \note This Jacobian does not correspond to any specific joint frame Jacobian. From this Jacobian, it is then possible to easily extract the Jacobian of a specific joint frame. \sa se3::getJointJacobian for doing this specific extraction.
   ///
   /// \param[in] model The model structure of the rigid body system.
   /// \param[in] data The data structure of the rigid body system.
@@ -53,12 +74,31 @@ namespace se3
   /// \return The full model Jacobian (matrix 6 x model.nv).
   ///
   inline const Data::Matrix6x &
+  computeJointJacobians(const Model & model,
+                        Data & data);
+  
+  ///
+  /// \brief Computes the full model Jacobian, i.e. the stack of all motion subspace expressed in the world frame.
+  ///        The result is accessible through data.J. This function assumes that se3::forwardKinematics has been called before.
+  ///
+  /// \deprecated This function is now deprecated. Please refer now to se3::computeJointJacobians for similar function with updated name.
+  ///
+  /// \note This Jacobian does not correspond to any specific joint frame Jacobian. From this Jacobian, it is then possible to easily extract the Jacobian of a specific joint frame. \sa se3::getJointJacobian for doing this specific extraction.
+  ///
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  ///
+  /// \return The full model Jacobian (matrix 6 x model.nv).
+  ///
+  PINOCCHIO_DEPRECATED
+  inline const Data::Matrix6x &
   computeJacobians(const Model & model,
-                   Data & data);
+                   Data & data)
+  { return computeJointJacobians(model,data); }
   
   ///
   /// \brief Computes the Jacobian of a specific joint frame expressed either in the world (rf = WORLD) frame or in the local frame (rf = LOCAL) of the joint.
-  /// \note This jacobian is extracted from data.J. You have to run se3::computeJacobians before calling it.
+  /// \note This jacobian is extracted from data.J. You have to run se3::computeJointJacobians before calling it.
   ///
   /// \tparam rf Reference frame in which the Jacobian is expressed.
   ///
@@ -69,10 +109,32 @@ namespace se3
   /// \param[out] J A reference on the Jacobian matrix where the results will be stored in (dim 6 x model.nv). You must fill J with zero elements, e.g. J.fill(0.).
   ///
   template<ReferenceFrame rf>
+  void getJointJacobian(const Model & model,
+                        const Data & data,
+                        const Model::JointIndex jointId,
+                        Data::Matrix6x & J);
+  
+  ///
+  /// \brief Computes the Jacobian of a specific joint frame expressed either in the world (rf = WORLD) frame or in the local frame (rf = LOCAL) of the joint.
+  /// \note This jacobian is extracted from data.J. You have to run se3::computeJacobians before calling it.
+  ///
+  /// \deprecated This function is now deprecated. Please refer now to se3::getJointJacobian for similar function with updated name.
+  ///
+  /// \tparam rf Reference frame in which the Jacobian is expressed.
+  ///
+  /// \param[in] localFrame Expressed the Jacobian in the local frame or world frame coordinates system.
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  /// \param[in] jointId The id of the joint.
+  /// \param[out] J A reference on the Jacobian matrix where the results will be stored in (dim 6 x model.nv). You must fill J with zero elements, e.g. J.fill(0.).
+  ///
+  template<ReferenceFrame rf>
+  PINOCCHIO_DEPRECATED
   void getJacobian(const Model & model,
                    const Data & data,
                    const Model::JointIndex jointId,
-                   Data::Matrix6x & J);
+                   Data::Matrix6x & J)
+  { getJointJacobian<rf>(model,data,jointId,J); }
   
   ///
   /// \brief Computes the Jacobian of a specific joint frame expressed in the local frame of the joint and store the result in the input argument J.
@@ -85,15 +147,40 @@ namespace se3
   ///
   /// \return The Jacobian of the specific joint frame expressed in the local frame of the joint (matrix 6 x model.nv).
   ///
-  /// \remark This function is equivalent to call first computeJacobians(model,data,q) and then call getJacobian<true>(model,data,jointId,J).
+  /// \remark This function is equivalent to call first computeJacobians(model,data,q) and then call getJointJacobian<LOCAL>(model,data,jointId,J).
   ///         It is worth to call jacobian if you only need a single Jacobian for a specific joint. Otherwise, for several Jacobians, it is better
-  ///         to call computeJacobians(model,data,q) followed by getJacobian<true>(model,data,jointId,J) for each Jacobian.
+  ///         to call computeJacobians(model,data,q) followed by getJointJacobian<LOCAL>(model,data,jointId,J) for each Jacobian.
   ///
+  inline void jointJacobian(const Model & model,
+                            Data & data,
+                            const Eigen::VectorXd & q,
+                            const Model::JointIndex jointId,
+                            Data::Matrix6x & J);
+  
+  ///
+  /// \brief Computes the Jacobian of a specific joint frame expressed in the local frame of the joint and store the result in the input argument J.
+  ///
+  /// \deprecated This function is now deprecated. Please refer now to se3::jointJacobian for similar function with updated name.
+  ///
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  /// \param[in] q The joint configuration vector (dim model.nq).
+  /// \param[in] jointId The id of the joint refering to model.joints[jointId].
+  /// \param[out] J A reference on the Jacobian matrix where the results will be stored in (dim 6 x model.nv). You must fill J with zero elements, e.g. J.setZero().
+  ///
+  /// \return The Jacobian of the specific joint frame expressed in the local frame of the joint (matrix 6 x model.nv).
+  ///
+  /// \remark This function is equivalent to call first computeJacobians(model,data,q) and then call getJointJacobian<LOCAL>(model,data,jointId,J).
+  ///         It is worth to call jacobian if you only need a single Jacobian for a specific joint. Otherwise, for several Jacobians, it is better
+  ///         to call computeJacobians(model,data,q) followed by getJointJacobian<LOCAL>(model,data,jointId,J) for each Jacobian.
+  ///
+  PINOCCHIO_DEPRECATED
   inline void jacobian(const Model & model,
                        Data & data,
                        const Eigen::VectorXd & q,
                        const Model::JointIndex jointId,
-                       Data::Matrix6x & J);
+                       Data::Matrix6x & J)
+  { jointJacobian(model,data,q,jointId,J); }
   
   ///
   /// \brief Computes the Jacobian of a specific joint frame expressed in the local frame of the joint. The result is stored in data.J.
@@ -107,19 +194,19 @@ namespace se3
   ///
   PINOCCHIO_DEPRECATED
   inline const Data::Matrix6x &
-  jacobian(const Model & model,
-           Data & data,
-           const Eigen::VectorXd & q,
-           const Model::JointIndex jointId)
+  jointJacobian(const Model & model,
+                Data & data,
+                const Eigen::VectorXd & q,
+                const Model::JointIndex jointId)
   {
     data.J.setZero();
     jacobian(model,data,q,jointId,data.J);
     
     return data.J;
   }
-
+  
   ///
-  /// \brief Computes the full model Jacobian variations with respect to time. It corresponds to dJ/dt which depends both on q and v
+  /// \brief Computes the full model Jacobian variations with respect to time. It corresponds to dJ/dt which depends both on q and v.
   ///        The result is accessible through data.dJ.
   ///
   ///
@@ -131,14 +218,37 @@ namespace se3
   /// \return The full model Jacobian (matrix 6 x model.nv).
   ///
   inline const Data::Matrix6x &
+  computeJointJacobiansTimeVariation(const Model & model,
+                                     Data & data,
+                                     const Eigen::VectorXd & q,
+                                     const Eigen::VectorXd & v);
+  
+  ///
+  /// \brief Computes the full model Jacobian variations with respect to time. It corresponds to dJ/dt which depends both on q and v.
+  ///        The result is accessible through data.dJ.
+  ///
+  /// \deprecated This function is now deprecated. Please refer now to se3::computeJointJacobiansTimeVariation for similar function with updated name.
+  ///
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  /// \param[in] q The joint configuration vector (dim model.nq).
+  /// \param[in] v The joint velocity vector (dim model.nv).
+  ///
+  /// \return The full model Jacobian (matrix 6 x model.nv).
+  ///
+  PINOCCHIO_DEPRECATED
+  inline const Data::Matrix6x &
   computeJacobiansTimeVariation(const Model & model,
                                 Data & data,
                                 const Eigen::VectorXd & q,
-                                const Eigen::VectorXd & v);
+                                const Eigen::VectorXd & v)
+  { return computeJointJacobiansTimeVariation(model,data,q,v); }
   
   ///
   /// \brief Computes the Jacobian time variation of a specific joint frame expressed either in the world frame (rf = WORLD) or in the local frame (rf = LOCAL) of the joint.
   /// \note This jacobian is extracted from data.dJ. You have to run se3::computeJacobiansTimeVariation before calling it.
+  ///
+  /// \deprecated This function is now deprecated. Please refer now to se3::getJointJacobianTimeVariation for similar function with updated name.
   ///
   /// \tparam rf Reference frame in which the Jacobian is expressed.
   ///
@@ -149,10 +259,30 @@ namespace se3
   /// \param[out] dJ A reference on the Jacobian matrix where the results will be stored in (dim 6 x model.nv). You must fill dJ with zero elements, e.g. dJ.fill(0.).
   ///
   template<ReferenceFrame rf>
+  void getJointJacobianTimeVariation(const Model & model,
+                                     const Data & data,
+                                     const Model::JointIndex jointId,
+                                     Data::Matrix6x & dJ);
+  
+  ///
+  /// \brief Computes the Jacobian time variation of a specific joint frame expressed either in the world frame (rf = WORLD) or in the local frame (rf = LOCAL) of the joint.
+  /// \note This jacobian is extracted from data.dJ. You have to run se3::computeJointJacobiansTimeVariation before calling it.
+  ///
+  /// \tparam rf Reference frame in which the Jacobian is expressed.
+  ///
+  /// \param[in] localFrame Expressed the Jacobian in the local frame or world frame coordinates system.
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  /// \param[in] jointId The id of the joint.
+  /// \param[out] dJ A reference on the Jacobian matrix where the results will be stored in (dim 6 x model.nv). You must fill dJ with zero elements, e.g. dJ.fill(0.).
+  ///
+  template<ReferenceFrame rf>
+  PINOCCHIO_DEPRECATED
   void getJacobianTimeVariation(const Model & model,
                                 const Data & data,
                                 const Model::JointIndex jointId,
-                                Data::Matrix6x & dJ);
+                                Data::Matrix6x & dJ)
+  { getJointJacobianTimeVariation<rf>(model,data,jointId,dJ); }
   
 } // namespace se3 
 

--- a/src/algorithm/jacobian.hxx
+++ b/src/algorithm/jacobian.hxx
@@ -25,14 +25,14 @@
 
 namespace se3
 {
-  struct JacobiansForwardStep : public fusion::JointVisitor<JacobiansForwardStep>
+  struct JointJacobiansForwardStep : public fusion::JointVisitor<JointJacobiansForwardStep>
   {
     typedef boost::fusion::vector <const se3::Model &,
                                    se3::Data &,
                                    const Eigen::VectorXd &
                                    > ArgsType;
     
-    JOINT_VISITOR_INIT(JacobiansForwardStep);
+    JOINT_VISITOR_INIT(JointJacobiansForwardStep);
     
     template<typename JointModel>
     static void algo(const se3::JointModelBase<JointModel> & jmodel,
@@ -56,25 +56,25 @@ namespace se3
   };
   
   inline const Data::Matrix6x &
-  computeJacobians(const Model & model, Data & data,
-                   const Eigen::VectorXd & q)
+  computeJointJacobians(const Model & model, Data & data,
+                        const Eigen::VectorXd & q)
   {
     assert(model.check(data) && "data is not consistent with model.");
     
     for( Model::JointIndex i=1; i< (Model::JointIndex) model.njoints;++i )
     {
-      JacobiansForwardStep::run(model.joints[i],data.joints[i],
-                                JacobiansForwardStep::ArgsType(model,data,q));
+      JointJacobiansForwardStep::run(model.joints[i],data.joints[i],
+                                JointJacobiansForwardStep::ArgsType(model,data,q));
     }
   
     return data.J;
   }
   
-  struct JacobiansForwardStep2 : public fusion::JointVisitor<JacobiansForwardStep2>
+  struct JointJacobiansForwardStep2 : public fusion::JointVisitor<JointJacobiansForwardStep2>
   {
     typedef boost::fusion::vector<se3::Data &> ArgsType;
     
-    JOINT_VISITOR_INIT(JacobiansForwardStep2);
+    JOINT_VISITOR_INIT(JointJacobiansForwardStep2);
     
     template<typename JointModel>
     static void algo(const se3::JointModelBase<JointModel> & jmodel,
@@ -89,14 +89,14 @@ namespace se3
   };
   
   inline const Data::Matrix6x &
-  computeJacobians(const Model & model, Data & data)
+  computeJointJacobians(const Model & model, Data & data)
   {
     assert(model.check(data) && "data is not consistent with model.");
     
     for( Model::JointIndex i=1; i< (Model::JointIndex) model.njoints;++i )
     {
-      JacobiansForwardStep2::run(model.joints[i],data.joints[i],
-                                 JacobiansForwardStep2::ArgsType(data));
+      JointJacobiansForwardStep2::run(model.joints[i],data.joints[i],
+                                 JointJacobiansForwardStep2::ArgsType(data));
     }
     
     return data.J;
@@ -106,7 +106,7 @@ namespace se3
    world frame or in the local frame depending on the template argument. The
    function computeJacobians should have been called first. */
   template<ReferenceFrame rf>
-  void getJacobian(const Model & model,
+  void getJointJacobian(const Model & model,
                    const Data & data,
                    const Model::JointIndex jointId,
                    Data::Matrix6x & J)
@@ -125,7 +125,7 @@ namespace se3
   }
   
   
-  struct JacobianForwardStep : public fusion::JointVisitor<JacobianForwardStep>
+  struct JointJacobianForwardStep : public fusion::JointVisitor<JointJacobianForwardStep>
   {
     typedef boost::fusion::vector<const se3::Model &,
                                   se3::Data &,
@@ -133,7 +133,7 @@ namespace se3
                                   se3::Data::Matrix6x &
                                   > ArgsType;
     
-    JOINT_VISITOR_INIT(JacobianForwardStep);
+    JOINT_VISITOR_INIT(JointJacobianForwardStep);
     
     template<typename JointModel>
     static void algo(const se3::JointModelBase<JointModel> & jmodel,
@@ -156,22 +156,22 @@ namespace se3
   
   };
   
-  inline void jacobian(const Model & model, Data & data,
-                       const Eigen::VectorXd & q,
-                       const Model::JointIndex jointId,
-                       Data::Matrix6x & J)
+  inline void jointJacobian(const Model & model, Data & data,
+                            const Eigen::VectorXd & q,
+                            const Model::JointIndex jointId,
+                            Data::Matrix6x & J)
   {
     assert(model.check(data) && "data is not consistent with model.");
     
     data.iMf[jointId].setIdentity();
     for( Model::JointIndex i=jointId;i>0;i=model.parents[i] )
     {
-      JacobianForwardStep::run(model.joints[i],data.joints[i],
-                               JacobianForwardStep::ArgsType(model,data,q,J));
+      JointJacobianForwardStep::run(model.joints[i],data.joints[i],
+                               JointJacobianForwardStep::ArgsType(model,data,q,J));
     }
   }
   
-  struct JacobiansTimeVariationForwardStep : public fusion::JointVisitor<JacobiansTimeVariationForwardStep>
+  struct JointJacobiansTimeVariationForwardStep : public fusion::JointVisitor<JointJacobiansTimeVariationForwardStep>
   {
     typedef boost::fusion::vector <const se3::Model &,
     se3::Data &,
@@ -179,7 +179,7 @@ namespace se3
     const Eigen::VectorXd &
     > ArgsType;
     
-    JOINT_VISITOR_INIT(JacobiansTimeVariationForwardStep);
+    JOINT_VISITOR_INIT(JointJacobiansTimeVariationForwardStep);
     
     template<typename JointModel>
     static void algo(const se3::JointModelBase<JointModel> & jmodel,
@@ -225,27 +225,27 @@ namespace se3
   };
   
   inline const Data::Matrix6x &
-  computeJacobiansTimeVariation(const Model & model,
-                                Data & data,
-                                const Eigen::VectorXd & q,
-                                const Eigen::VectorXd & v)
+  computeJointJacobiansTimeVariation(const Model & model,
+                                     Data & data,
+                                     const Eigen::VectorXd & q,
+                                     const Eigen::VectorXd & v)
   {
     assert(model.check(data) && "data is not consistent with model.");
     
     for(Model::JointIndex i=1; i< (Model::JointIndex) model.njoints;++i)
     {
-      JacobiansTimeVariationForwardStep::run(model.joints[i],data.joints[i],
-                                             JacobiansTimeVariationForwardStep::ArgsType(model,data,q,v));
+      JointJacobiansTimeVariationForwardStep::run(model.joints[i],data.joints[i],
+                                             JointJacobiansTimeVariationForwardStep::ArgsType(model,data,q,v));
     }
     
     return data.dJ;
   }
   
   template<ReferenceFrame rf>
-  void getJacobianTimeVariation(const Model & model,
-                                const Data & data,
-                                const Model::JointIndex jointId,
-                                Data::Matrix6x & dJ)
+  void getJointJacobianTimeVariation(const Model & model,
+                                     const Data & data,
+                                     const Model::JointIndex jointId,
+                                     Data::Matrix6x & dJ)
   {
     assert( dJ.rows() == data.dJ.rows() );
     assert( dJ.cols() == data.dJ.cols() );

--- a/src/algorithm/kinematics-derivatives.hpp
+++ b/src/algorithm/kinematics-derivatives.hpp
@@ -33,7 +33,7 @@ namespace se3
   /// \param[in] q The joint configuration (vector dim model.nq).
   /// \param[in] v The joint velocity (vector dim model.nv).
   ///
-  /// \remarks This function is similar to do a forwardKinematics(model,data,q,v) followed by a computeJacobians(model,data,q).
+  /// \remarks This function is similar to do a forwardKinematics(model,data,q,v) followed by a computeJointJacobians(model,data,q).
   ///          In addition, it computes the spatial velocity of the joint expressed in the world frame (see data.ov).
   ///
   inline void computeForwardKinematicsDerivatives(const Model & model,

--- a/src/multibody/data.hpp
+++ b/src/multibody/data.hpp
@@ -213,7 +213,7 @@ namespace se3
     std::vector<int> nvSubtree_fromRow;
     
     /// \brief Jacobian of joint placements.
-    /// \note The columns of J corresponds to the basis of the spatial velocities of each joint and expressed at the origin of the inertial frame. In other words, if \f$ v_{J_{i}} = S_{i} \dot{q}_{i}\f$ is the relative velocity of the joint i regarding to its parent, then \f$J = \begin{bmatrix} ^{0}X_{1} S_{1} & \cdots & ^{0}X_{i} S_{i} & \cdots & ^{0}X_{\text{nj}} S_{\text{nj}} \end{bmatrix} \f$. This Jacobian has no special meaning. To get the jacobian of a precise joint, you need to call se3::getJacobian
+    /// \note The columns of J corresponds to the basis of the spatial velocities of each joint and expressed at the origin of the inertial frame. In other words, if \f$ v_{J_{i}} = S_{i} \dot{q}_{i}\f$ is the relative velocity of the joint i regarding to its parent, then \f$J = \begin{bmatrix} ^{0}X_{1} S_{1} & \cdots & ^{0}X_{i} S_{i} & \cdots & ^{0}X_{\text{nj}} S_{\text{nj}} \end{bmatrix} \f$. This Jacobian has no special meaning. To get the jacobian of a precise joint, you need to call se3::getJointJacobian
     Matrix6x J;
     
     /// \brief Derivative of the Jacobian with respect to the time.

--- a/unittest/aba-derivatives.cpp
+++ b/unittest/aba-derivatives.cpp
@@ -69,7 +69,7 @@ BOOST_AUTO_TEST_CASE(test_aba)
     BOOST_CHECK(data.doYcrb[k].isApprox(data_ref.doYcrb[k]));
   }
   
-  computeJacobians(model,data_ref,q);
+  computeJointJacobians(model,data_ref,q);
   BOOST_CHECK(data.J.isApprox(data_ref.J));
   
   aba(model,data_ref,q,v,tau);

--- a/unittest/aba.cpp
+++ b/unittest/aba.cpp
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE ( test_aba_with_fext )
   container::aligned_vector<Force> fext(model.joints.size(), Force::Random());
   
   crba(model, data, q);
-  computeJacobians(model, data, q);
+  computeJointJacobians(model, data, q);
   nonLinearEffects(model, data, q, v);
   data.M.triangularView<Eigen::StrictlyLower>()
   = data.M.transpose().triangularView<Eigen::StrictlyLower>();
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE ( test_aba_with_fext )
   VectorXd tau = data.M * a + data.nle;
   Data::Matrix6x J = Data::Matrix6x::Zero(6, model.nv);
   for(Model::Index i=1;i<(Model::Index)model.njoints;++i) {
-    getJacobian<LOCAL>(model, data, i, J);
+    getJointJacobian<LOCAL>(model, data, i, J);
     tau -= J.transpose()*fext[i].toVector();
     J.setZero();
   }

--- a/unittest/compute-all-terms.cpp
+++ b/unittest/compute-all-terms.cpp
@@ -60,8 +60,8 @@ BOOST_AUTO_TEST_CASE ( test_against_algo )
 
   nonLinearEffects(model,data_other,q,v);
   crba(model,data_other,q);
-  computeJacobians(model,data_other,q);
   getJacobianComFromCrba(model, data_other);
+  computeJointJacobians(model,data_other,q);
   centerOfMass(model, data_other, q, v, true);
   kineticEnergy(model, data_other, q, v, true);
   potentialEnergy(model, data_other, q, true);
@@ -90,8 +90,8 @@ BOOST_AUTO_TEST_CASE ( test_against_algo )
 
   nonLinearEffects(model,data_other,q,v);
   crba(model,data_other,q);
-  computeJacobians(model,data_other,q);
   getJacobianComFromCrba(model, data_other);
+  computeJointJacobians(model,data_other,q);
   centerOfMass(model, data_other, q, v, true);
   kineticEnergy(model, data_other, q, v, true);
   potentialEnergy(model, data_other, q, true);
@@ -121,8 +121,8 @@ BOOST_AUTO_TEST_CASE ( test_against_algo )
 
   nonLinearEffects(model,data_other,q,v);
   crba(model,data_other,q);
-  computeJacobians(model,data_other,q);
   getJacobianComFromCrba(model, data_other);
+  computeJointJacobians(model,data_other,q);
   centerOfMass(model, data_other, q, v, true);
   kineticEnergy(model, data_other, q, v, true);
   potentialEnergy(model, data_other, q, true);
@@ -152,8 +152,8 @@ BOOST_AUTO_TEST_CASE ( test_against_algo )
 
   nonLinearEffects(model,data_other,q,v);
   crba(model,data_other,q);
-  computeJacobians(model,data_other,q);
   getJacobianComFromCrba(model, data_other);
+  computeJointJacobians(model,data_other,q);
   centerOfMass(model, data_other, q, v, true);
   kineticEnergy(model, data_other, q, v, true);
   potentialEnergy(model, data_other, q, true);

--- a/unittest/crba.cpp
+++ b/unittest/crba.cpp
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(test_minimal_crba)
   BOOST_CHECK(data.M.isApprox(data_ref.M));
   
   ccrba(model,data_ref,q,v);
-  computeJacobians(model,data_ref,q);
+  computeJointJacobians(model,data_ref,q);
   BOOST_CHECK(data.Ag.isApprox(data_ref.Ag));
   BOOST_CHECK(data.J.isApprox(data_ref.J));
   

--- a/unittest/dynamics.cpp
+++ b/unittest/dynamics.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016 CNRS
+// Copyright (c) 2016,2018 CNRS
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE ( test_FD )
   VectorXd q = VectorXd::Ones(model.nq);
   q.segment <4> (3).normalize();
   
-  se3::computeJacobians(model, data, q);
+  se3::computeJointJacobians(model, data, q);
   
   VectorXd v = VectorXd::Ones(model.nv);
   VectorXd tau = VectorXd::Zero(model.nv);
@@ -52,10 +52,10 @@ BOOST_AUTO_TEST_CASE ( test_FD )
   
   Data::Matrix6x J_RF (6, model.nv);
   J_RF.setZero();
-  getJacobian<LOCAL> (model, data, model.getJointId(RF), J_RF);
+  getJointJacobian<LOCAL> (model, data, model.getJointId(RF), J_RF);
   Data::Matrix6x J_LF (6, model.nv);
   J_LF.setZero();
-  getJacobian<LOCAL> (model, data, model.getJointId(LF), J_LF);
+  getJointJacobian<LOCAL> (model, data, model.getJointId(LF), J_LF);
   
   Eigen::MatrixXd J (12, model.nv);
   J.setZero();
@@ -105,7 +105,7 @@ BOOST_AUTO_TEST_CASE ( test_ID )
   VectorXd q = VectorXd::Ones(model.nq);
   q.segment <4> (3).normalize();
   
-  se3::computeJacobians(model, data, q);
+  se3::computeJointJacobians(model, data, q);
   
   VectorXd v_before = VectorXd::Ones(model.nv);
   
@@ -114,10 +114,10 @@ BOOST_AUTO_TEST_CASE ( test_ID )
   
   Data::Matrix6x J_RF (6, model.nv);
   J_RF.setZero();
-  getJacobian<LOCAL> (model, data, model.getJointId(RF), J_RF);
+  getJointJacobian<LOCAL> (model, data, model.getJointId(RF), J_RF);
   Data::Matrix6x J_LF (6, model.nv);
   J_LF.setZero();
-  getJacobian<LOCAL> (model, data, model.getJointId(LF), J_LF);
+  getJointJacobian<LOCAL> (model, data, model.getJointId(LF), J_LF);
   
   Eigen::MatrixXd J (12, model.nv);
   J.setZero();
@@ -176,7 +176,7 @@ BOOST_AUTO_TEST_CASE (timings_fd_llt)
   VectorXd q = VectorXd::Ones(model.nq);
   q.segment <4> (3).normalize();
   
-  se3::computeJacobians(model, data, q);
+  se3::computeJointJacobians(model, data, q);
   
   VectorXd v = VectorXd::Ones(model.nv);
   VectorXd tau = VectorXd::Zero(model.nv);
@@ -185,9 +185,9 @@ BOOST_AUTO_TEST_CASE (timings_fd_llt)
   const std::string LF = "lleg6_joint";
   
   Data::Matrix6x J_RF (6, model.nv);
-  getJacobian<LOCAL> (model, data, model.getJointId(RF), J_RF);
+  getJointJacobian<LOCAL> (model, data, model.getJointId(RF), J_RF);
   Data::Matrix6x J_LF (6, model.nv);
-  getJacobian<LOCAL> (model, data, model.getJointId(LF), J_LF);
+  getJointJacobian<LOCAL> (model, data, model.getJointId(LF), J_LF);
   
   Eigen::MatrixXd J (12, model.nv);
   J.topRows<6> () = J_RF;

--- a/unittest/finite-differences.cpp
+++ b/unittest/finite-differences.cpp
@@ -213,16 +213,16 @@ BOOST_AUTO_TEST_CASE (test_jacobian_vs_finit_diff)
 
   VectorXd q = VectorXd::Ones(model.nq);
   q.segment<4>(3).normalize();
-  computeJacobians(model,data,q);
+  computeJointJacobians(model,data,q);
 
   Model::Index idx = model.existJointName("rarm2")?model.getJointId("rarm2"):(Model::Index)(model.njoints-1);
   Data::Matrix6x Jrh(6,model.nv); Jrh.fill(0);
   
-  getJacobian<WORLD>(model,data,idx,Jrh);
+  getJointJacobian<WORLD>(model,data,idx,Jrh);
   Data::Matrix6x Jrh_finite_diff = finiteDiffJacobian<false>(model,data,q,idx);
   BOOST_CHECK(Jrh_finite_diff.isApprox(Jrh,fd_increment.maxCoeff()*1e1));
   
-  getJacobian<LOCAL>(model,data,idx,Jrh);
+  getJointJacobian<LOCAL>(model,data,idx,Jrh);
   Jrh_finite_diff = finiteDiffJacobian<true>(model,data,q,idx);
   BOOST_CHECK(Jrh_finite_diff.isApprox(Jrh,fd_increment.maxCoeff()*1e1));
 }

--- a/unittest/frames.cpp
+++ b/unittest/frames.cpp
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_CASE ( test_jacobian )
   Data::Matrix6x Jjj(6,model.nv); Jjj.fill(0);
   Data::Matrix6x Jff(6,model.nv); Jff.fill(0);
   getFrameJacobian(model,data,idx,Jff);
-  getJacobian<LOCAL>(model, data_ref, parent_idx, Jjj);
+  getJointJacobian<LOCAL>(model, data_ref, parent_idx, Jjj);
 
   Motion nu_frame = Motion(Jff*q_dot);
   Motion nu_joint = Motion(Jjj*q_dot);
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE ( test_jacobian )
   
   // In world frame
   getFrameJacobian<WORLD>(model,data,idx,Jff);
-  getJacobian<WORLD>(model, data_ref, parent_idx, Jjj);
+  getJointJacobian<WORLD>(model, data_ref, parent_idx, Jjj);
   BOOST_CHECK(Jff.isApprox(Jjj));
 }
 

--- a/unittest/joints.cpp
+++ b/unittest/joints.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2015-2016 CNRS
+// Copyright (c) 2015-2016,2018 CNRS
 // Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 // This file is part of Pinocchio
@@ -144,10 +144,10 @@ BOOST_AUTO_TEST_CASE (vsRX)
   // Jacobian
   Eigen::Matrix<double, 6, Eigen::Dynamic> jacobianRX;jacobianRX.resize(6,1); jacobianRX.setZero();
   Eigen::Matrix<double, 6, Eigen::Dynamic> jacobianRevoluteUnaligned;jacobianRevoluteUnaligned.resize(6,1);jacobianRevoluteUnaligned.setZero();
-  computeJacobians(modelRX, dataRX, q);
-  computeJacobians(modelRevoluteUnaligned, dataRevoluteUnaligned, q);
-  getJacobian<LOCAL>(modelRX, dataRX, 1, jacobianRX);
-  getJacobian<LOCAL>(modelRevoluteUnaligned, dataRevoluteUnaligned, 1, jacobianRevoluteUnaligned);
+  computeJointJacobians(modelRX, dataRX, q);
+  computeJointJacobians(modelRevoluteUnaligned, dataRevoluteUnaligned, q);
+  getJointJacobian<LOCAL>(modelRX, dataRX, 1, jacobianRX);
+  getJointJacobian<LOCAL>(modelRevoluteUnaligned, dataRevoluteUnaligned, 1, jacobianRevoluteUnaligned);
 
 
   BOOST_CHECK(jacobianRX.isApprox(jacobianRevoluteUnaligned));
@@ -220,10 +220,10 @@ BOOST_AUTO_TEST_CASE (vsPX)
   // Jacobian
   Eigen::Matrix<double, 6, Eigen::Dynamic> jacobianPX;jacobianPX.resize(6,1); jacobianPX.setZero();
   Eigen::Matrix<double, 6, Eigen::Dynamic> jacobianPrismaticUnaligned;jacobianPrismaticUnaligned.resize(6,1);jacobianPrismaticUnaligned.setZero();
-  computeJacobians(modelPX, dataPX, q);
-  computeJacobians(modelPrismaticUnaligned, dataPrismaticUnaligned, q);
-  getJacobian<LOCAL>(modelPX, dataPX, 1, jacobianPX);
-  getJacobian<LOCAL>(modelPrismaticUnaligned, dataPrismaticUnaligned, 1, jacobianPrismaticUnaligned);
+  computeJointJacobians(modelPX, dataPX, q);
+  computeJointJacobians(modelPrismaticUnaligned, dataPrismaticUnaligned, q);
+  getJointJacobian<LOCAL>(modelPX, dataPX, 1, jacobianPX);
+  getJointJacobian<LOCAL>(modelPrismaticUnaligned, dataPrismaticUnaligned, 1, jacobianPrismaticUnaligned);
 
   BOOST_CHECK(jacobianPX.isApprox(jacobianPrismaticUnaligned));
 }
@@ -304,10 +304,10 @@ BOOST_AUTO_TEST_CASE (vsFreeFlyer)
   // Jacobian
   Eigen::Matrix<double, 6, Eigen::Dynamic> jacobian_planar;jacobian_planar.resize(6,3); jacobian_planar.setZero();
   Eigen::Matrix<double, 6, Eigen::Dynamic> jacobian_ff;jacobian_ff.resize(6,6);jacobian_ff.setZero();
-  computeJacobians(modelSpherical, dataSpherical, q);
-  computeJacobians(modelFreeflyer, dataFreeFlyer, qff);
-  getJacobian<LOCAL>(modelSpherical, dataSpherical, 1, jacobian_planar);
-  getJacobian<LOCAL>(modelFreeflyer, dataFreeFlyer, 1, jacobian_ff);
+  computeJointJacobians(modelSpherical, dataSpherical, q);
+  computeJointJacobians(modelFreeflyer, dataFreeFlyer, qff);
+  getJointJacobian<LOCAL>(modelSpherical, dataSpherical, 1, jacobian_planar);
+  getJointJacobian<LOCAL>(modelFreeflyer, dataFreeFlyer, 1, jacobian_ff);
 
 
   Eigen::Matrix<double, 6, 3> jacobian_expected; jacobian_expected << jacobian_ff.col(3),
@@ -673,10 +673,10 @@ BOOST_AUTO_TEST_CASE (vsFreeFlyer)
   // Jacobian
   Eigen::Matrix<double, 6, Eigen::Dynamic> jacobian_planar;jacobian_planar.resize(6,3); jacobian_planar.setZero();
   Eigen::Matrix<double, 6, Eigen::Dynamic> jacobian_ff;jacobian_ff.resize(6,6);jacobian_ff.setZero();
-  computeJacobians(modelPlanar, dataPlanar, q);
-  computeJacobians(modelFreeflyer, dataFreeFlyer, qff);
-  getJacobian<LOCAL>(modelPlanar, dataPlanar, 1, jacobian_planar);
-  getJacobian<LOCAL>(modelFreeflyer, dataFreeFlyer, 1, jacobian_ff);
+  computeJointJacobians(modelPlanar, dataPlanar, q);
+  computeJointJacobians(modelFreeflyer, dataFreeFlyer, qff);
+  getJointJacobian<LOCAL>(modelPlanar, dataPlanar, 1, jacobian_planar);
+  getJointJacobian<LOCAL>(modelFreeflyer, dataFreeFlyer, 1, jacobian_ff);
 
   Eigen::Matrix<double, 6, 3> jacobian_expected; jacobian_expected << jacobian_ff.col(0),
                                                                       jacobian_ff.col(1),
@@ -758,10 +758,10 @@ BOOST_AUTO_TEST_CASE (vsFreeFlyer)
   // Jacobian
   Eigen::Matrix<double, 6, Eigen::Dynamic> jacobian_planar;jacobian_planar.resize(6,3); jacobian_planar.setZero();
   Eigen::Matrix<double, 6, Eigen::Dynamic> jacobian_ff;jacobian_ff.resize(6,6);jacobian_ff.setZero();
-  computeJacobians(modelTranslation, dataTranslation, q);
-  computeJacobians(modelFreeflyer, dataFreeFlyer, qff);
-  getJacobian<LOCAL>(modelTranslation, dataTranslation, 1, jacobian_planar);
-  getJacobian<LOCAL>(modelFreeflyer, dataFreeFlyer, 1, jacobian_ff);
+  computeJointJacobians(modelTranslation, dataTranslation, q);
+  computeJointJacobians(modelFreeflyer, dataFreeFlyer, qff);
+  getJointJacobian<LOCAL>(modelTranslation, dataTranslation, 1, jacobian_planar);
+  getJointJacobian<LOCAL>(modelFreeflyer, dataFreeFlyer, 1, jacobian_ff);
 
 
   Eigen::Matrix<double, 6, 3> jacobian_expected; jacobian_expected << jacobian_ff.col(0),
@@ -844,10 +844,10 @@ BOOST_AUTO_TEST_CASE (vsRX)
   // Jacobian
   Eigen::Matrix<double, 6, Eigen::Dynamic> jacobianPX;jacobianPX.resize(6,1); jacobianPX.setZero();
   Eigen::Matrix<double, 6, Eigen::Dynamic> jacobianPrismaticUnaligned;jacobianPrismaticUnaligned.resize(6,1);jacobianPrismaticUnaligned.setZero();
-  computeJacobians(modelRX, dataRX, q_rx);
-  computeJacobians(modelRevoluteUnbounded, dataRevoluteUnbounded, q_rubx);
-  getJacobian<LOCAL>(modelRX, dataRX, 1, jacobianPX);
-  getJacobian<LOCAL>(modelRevoluteUnbounded, dataRevoluteUnbounded, 1, jacobianPrismaticUnaligned);
+  computeJointJacobians(modelRX, dataRX, q_rx);
+  computeJointJacobians(modelRevoluteUnbounded, dataRevoluteUnbounded, q_rubx);
+  getJointJacobian<LOCAL>(modelRX, dataRX, 1, jacobianPX);
+  getJointJacobian<LOCAL>(modelRevoluteUnbounded, dataRevoluteUnbounded, 1, jacobianPrismaticUnaligned);
 
 
   BOOST_CHECK(jacobianPX.isApprox(jacobianPrismaticUnaligned));

--- a/unittest/kinematics-derivatives.cpp
+++ b/unittest/kinematics-derivatives.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2017 CNRS
+// Copyright (c) 2017-2018 CNRS
 //
 // This file is part of Pinocchio
 // Pinocchio is free software: you can redistribute it
@@ -58,10 +58,10 @@ BOOST_AUTO_TEST_CASE(test_kinematics_derivatives_all)
     BOOST_CHECK(data.oa[i].isApprox(data_ref.oMi[i].act(data_ref.a[i])));
   }
   
-  computeJacobians(model,data_ref,q);
+  computeJointJacobians(model,data_ref,q);
   BOOST_CHECK(data.J.isApprox(data_ref.J));
   
-  computeJacobiansTimeVariation(model, data_ref, q, v);
+  computeJointJacobiansTimeVariation(model, data_ref, q, v);
   BOOST_CHECK(data.dJ.isApprox(data_ref.dJ));
 }
 
@@ -97,9 +97,9 @@ BOOST_AUTO_TEST_CASE(test_kinematics_derivatives_velocity)
   
   Data::Matrix6x J_ref(6,model.nv); J_ref.setZero();
   Data::Matrix6x J_ref_local(6,model.nv); J_ref_local.setZero();
-  computeJacobians(model,data_ref,q);
-  getJacobian<WORLD>(model,data_ref,jointId,J_ref);
-  getJacobian<LOCAL>(model,data_ref,jointId,J_ref_local);
+  computeJointJacobians(model,data_ref,q);
+  getJointJacobian<WORLD>(model,data_ref,jointId,J_ref);
+  getJointJacobian<LOCAL>(model,data_ref,jointId,J_ref_local);
   
   BOOST_CHECK(partial_dv.isApprox(J_ref));
   BOOST_CHECK(partial_dv_local.isApprox(J_ref_local));
@@ -151,9 +151,9 @@ BOOST_AUTO_TEST_CASE(test_kinematics_derivatives_velocity)
   
   BOOST_CHECK(partial_dq_local.isApprox(partial_dq_fd_local,sqrt(alpha)));
   
-//  computeJacobiansTimeVariation(model,data_ref,q,v);
+//  computeJointJacobiansTimeVariation(model,data_ref,q,v);
 //  Data::Matrix6x dJ_ref(6,model.nv); dJ_ref.setZero();
-//  getJacobianTimeVariation<WORLD>(model,data_ref,jointId,dJ_ref);
+//  getJointJacobianTimeVariation<WORLD>(model,data_ref,jointId,dJ_ref);
 //  BOOST_CHECK(partial_dq.isApprox(dJ_ref));
 //  
 //  std::cout << "partial_dq\n" << partial_dq << std::endl;
@@ -220,9 +220,9 @@ BOOST_AUTO_TEST_CASE(test_kinematics_derivatives_acceleration)
   
   Data::Matrix6x J_ref(6,model.nv); J_ref.setZero();
   Data::Matrix6x J_ref_local(6,model.nv); J_ref_local.setZero();
-  computeJacobians(model,data_ref,q);
-  getJacobian<WORLD>(model,data_ref,jointId,J_ref);
-  getJacobian<LOCAL>(model,data_ref,jointId,J_ref_local);
+  computeJointJacobians(model,data_ref,q);
+  getJointJacobian<WORLD>(model,data_ref,jointId,J_ref);
+  getJointJacobian<LOCAL>(model,data_ref,jointId,J_ref_local);
   
   BOOST_CHECK(a_partial_da.isApprox(J_ref));
   BOOST_CHECK(a_partial_da_local.isApprox(J_ref_local));

--- a/unittest/rnea-derivatives.cpp
+++ b/unittest/rnea-derivatives.cpp
@@ -236,7 +236,7 @@ BOOST_AUTO_TEST_CASE(test_rnea_derivatives)
     BOOST_CHECK(data.oMi[k].isApprox(data_ref.oMi[k]));
   }
   
-  computeJacobiansTimeVariation(model,data_ref,q,v);
+  computeJointJacobiansTimeVariation(model,data_ref,q,v);
   BOOST_CHECK(data.dJ.isApprox(data_ref.dJ));
   crba(model,data_ref,q);
   

--- a/unittest/rnea.cpp
+++ b/unittest/rnea.cpp
@@ -221,7 +221,7 @@ BOOST_AUTO_TEST_CASE(test_compute_gravity)
     
     model.gravity.setZero();
     rnea(model,data_ref,q,v,VectorXd::Zero(model.nv));
-    computeJacobiansTimeVariation(model,data_ref,q,v);
+    computeJointJacobiansTimeVariation(model,data_ref,q,v);
     computeCoriolisMatrix(model,data,q,v);
 
     BOOST_CHECK(data.dJ.isApprox(data_ref.dJ));


### PR DESCRIPTION
Some functions working on Jacobian have been renamed:

- getJacobian is now getJointJacobian
- computeJacobians is now computeJointJacobians
- getJacobianTimeVariation is now getJointJacobianTimeVariation
- computeJacobiansTimeVariation is now getJointJacobianTimeVariation

It follows some discussions occurred in #432