### PR TITLE
[CI][Gitlab] Use a dedicated target for generating doc and coverage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,92 +11,79 @@ cache:
 .robotpkg-pinocchio: &robotpkg-pinocchio
   except:
     - gh-pages
-  before_script:
-    - mkdir -p ccache
   script:
+    - mkdir -p ccache
     - cd /root/robotpkg/math/pinocchio
     - git pull
     - make checkout MASTER_REPOSITORY="dir ${CI_PROJECT_DIR}"
     - make install
     - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
     - make check
-    - make doc
-    - mv doc/doxygen-html ${CI_PROJECT_DIR}
 
-
-robotpkg-pinocchio-14.04:
+robotpkg-pinocchio-14.04-release:
   <<: *robotpkg-pinocchio
   image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/pinocchio:14.04
 
-robotpkg-pinocchio-dubnium:
-  <<: *robotpkg-pinocchio
-  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/pinocchio:dubnium
-
-robotpkg-pinocchio-16.04:
+robotpkg-pinocchio-16.04-release:
   <<: *robotpkg-pinocchio
   image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/pinocchio:16.04
-  artifacts:
-    expire_in: 1 day
-    paths:
-      - doxygen-html/
 
-robotpkg-pinocchio-18.04:
+robotpkg-pinocchio-18.04-release:
   <<: *robotpkg-pinocchio
   image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/pinocchio:18.04
-
 
 .robotpkg-py-pinocchio: &robotpkg-py-pinocchio
   except:
     - gh-pages
-  before_script:
-    - mkdir -p ccache
   script:
+    - mkdir -p ccache
     - cd /root/robotpkg/math/py-pinocchio
     - git pull
     - make checkout MASTER_REPOSITORY="dir ${CI_PROJECT_DIR}"
     - make install
     - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
     - make check
-    - make doc
-    - mv doc/doxygen-html ${CI_PROJECT_DIR}
 
+robotpkg-py-pinocchio-py3-18.04-release:
+  <<: *robotpkg-py-pinocchio
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:18.04
 
-robotpkg-py-pinocchio-14.04:
+robotpkg-py-pinocchio-16.04-release:
+  <<: *robotpkg-py-pinocchio
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio:16.04
+
+robotpkg-py-pinocchio-18.04-release:
+  <<: *robotpkg-py-pinocchio
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio:18.04
+
+robotpkg-py-pinocchio-py3-14.04-release:
+  <<: *robotpkg-py-pinocchio
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:14.04
+
+robotpkg-py-pinocchio-14.04-release:
   <<: *robotpkg-py-pinocchio
   image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio:14.04
 
-robotpkg-py-pinocchio-dubnium:
+robotpkg-py-pinocchio-py3-16.04-release:
   <<: *robotpkg-py-pinocchio
-  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio:dubnium
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:16.04
 
-robotpkg-py-pinocchio-16.04:
+doc-coverage:
   <<: *robotpkg-py-pinocchio
   image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio:16.04
+  before_script:
+    - echo -e 'CXXFLAGS+= --coverage\nLDFLAGS+= --coverage\nPKG_DEFAULT_OPTIONS= debug' >> /opt/openrobots/etc/robotpkg.conf
+  after_script:
+    - cd /root/robotpkg/math/py-pinocchio
+    - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
+    - make doc
+    - mv doc/doxygen-html ${CI_PROJECT_DIR}
+    - mkdir -p ${CI_PROJECT_DIR}/coverage/
+    - gcovr -r .
+    - gcovr -r . --html --html-details -o ${CI_PROJECT_DIR}/coverage/index.html
   artifacts:
     expire_in: 1 day
     paths:
       - doxygen-html/
-
-robotpkg-py-pinocchio-18.04:
-  <<: *robotpkg-py-pinocchio
-  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio:18.04
-
-robotpkg-py-pinocchio-py3-14.04:
-  <<: *robotpkg-py-pinocchio
-  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:14.04
-
-robotpkg-py-pinocchio-py3-dubnium:
-  <<: *robotpkg-py-pinocchio
-  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:dubnium
-
-robotpkg-py-pinocchio-py3-16.04:
-  <<: *robotpkg-py-pinocchio
-  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:16.04
-
-robotpkg-py-pinocchio-py3-18.04:
-  <<: *robotpkg-py-pinocchio
-  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:18.04
-
-
-
+      - coverage/
 


### PR DESCRIPTION
Hi,

This PR updates the gitlab CI configuration file to use a dedicated build target for generating the documentation and the coverage reports of this project.

It is also ready to add build targets in DEBUG mode if needed.