### PR TITLE
[Doc] Revision of outline after discussion with Nicolas.

### DIFF
--- a/doc/outline.txt
+++ b/doc/outline.txt
@@ -2,44 +2,32 @@
 - ABSTRACT (taken from SII paper)
 - Installation link
 - Simplest example with compilation command (load urdf and run rnea)
-- More complete example with C++ and Python (load model and run a loop for an IK with 3D task)
-- How to cite Pinocchios
+- More complete example with C++ and Python (load model and run a loop for an IK with 3D task) # I don't think it's needed. It can go in the tutorials (Gabriele)
+- How to cite Pinocchio
 - Presentation of the content of the documentation.
 
 *** List of features
 # Take the list from SII, shorten the description and add url links to the doc.
-# This should act as an index of the remaining of the doc.
-- Spatial algebra
-- Model and data
-- Supported kinematic models
+# This should act as an index for the "Features" part
+# Normally, it should be contained in a single page
+# It should contain url links for each page contained in "Features", possibly with short descriptions taken from SII
+# As an alternative, it may be directly moved to the next section as an introductory page
+
+*** Features
+# This section will be modeled on Eigen's "long tutorial".
+# It contains a description of all most important features of Pinocchio, from the user's point of view
+# Each section consists of a page and it teaches the user how to use a certain feature, using code snippets.
+- Spatial Algebra module
+- Model and data   # just explain the concept of model and data and what they contain. The explanation on how to build and/or load a model is delayed to the two following pages (explicitely say so from the start). Just use buildModels::humanoidSimple(model) in the snippets
+- Joints # Or: Building the model: joints and bodies. Maybe merge this section with previous one?
+- Loading the model  # how to load from an external file
 - Dealing with Lie group geometry
-- Geometric models
-- Main algorithms
+- Kinematic algorithms
+- Dynamic algorithms
+- Operational frames # as frames are not necessary to understand the previous sections, it could be a good idea to treat them separately. Introduce them here together with the related algorithms
+- Geometric models   # with related algos
 - Analytical derivatives
 - Automatic differentiation and source code generation
-
-*** Mathematics
-# For each subpart, add the list of "main related topics" toward algo description, specification, etc
-# and add the direct url toward corresponding pages of the doc.
-- Overview: rigid dynamics, joint dynamics, articulated dynamics, algorithms
-- Rigid bodies: geomtry, kinematics and dynamics
-- Joint dynamics: geometry, configuration space, kinematics, tangent space, list of joints
-- Articulated dynamics: kinematic tree, configuration and velocity, geometry, kinematics and jacobian, inverse and direct dynamics
-- Collision volums
-- Main algorithm: list taken from SII
-- Templatization, autodiff, code gen
-
-*** Implementation
-# Should we put implementation before mathematics. If not, we should make clear in the math
-# section that the reader may want to jump to the implementation section and skip the math.
-- Overview: what is making Pinocchio efficient
-- CRTP concept
-- Spatial Algebra module
-- Model / Data separation
-- Joint module
-- Loading the model
-- Algorithm module
-- Templatization (concept, code gen, auto diff)
 - Python bindings
 - Unit test
 
@@ -64,6 +52,23 @@
 - QP (normal forces) unilateral contact dynamics (if we can write it concise enough)
 - Posture generation using derivatives (if we can write it concise enough)
 - A RRT planner for a robot arm (if we can write it concise enough)
+
+*** Mathematics
+# For each subpart, add the list of "main related topics" toward algo description, specification, etc
+# and add the direct url toward corresponding pages of the doc.
+- Overview: rigid dynamics, joint dynamics, articulated dynamics, algorithms
+- Rigid bodies: geomtry, kinematics and dynamics
+- Joint dynamics: geometry, configuration space, kinematics, tangent space, list of joints
+- Articulated dynamics: kinematic tree, configuration and velocity, geometry, kinematics and jacobian, inverse and direct dynamics
+- Collision volums
+- Main algorithm: list taken from SII
+- Templatization, autodiff, code gen
+
+*** Implementation / Technical details
+- Overview: what is making Pinocchio efficient
+- Handling the sparsity
+- CRTP concept
+- Templatization, autodiff, code gen
 
 *** Benchmarks
 - Overview of algo with plots


### PR DESCRIPTION
After discussing with Nicolas, I changed the outline of the doc.
I think the doc should be modeled on Eigen's "long tutorial": a series of pages, each covering a topic from the user point of view, with worked examples in the form of short snippets intertwined with the code.
Then the proper tutorials will contain larger in-depth examples.
The technical part, containing implementation details, should be separate.
So, the main user doc in a part I called  "Features". As "List of features" should closely reflect the content of "Features", I removed all content from the former part and put in into the latter.
Also, I moved the math to later in the doc, as discussed