### PR TITLE
[frames] Helper functions for frames

### DIFF
--- a/bindings/python/algorithm/expose-frames.cpp
+++ b/bindings/python/algorithm/expose-frames.cpp
@@ -45,7 +45,7 @@ namespace se3
                                                )
     {
       computeJointJacobians(model,data,q);
-      framesForwardKinematics(model,data);
+      updateFramePlacements(model,data);
   
       return get_frame_jacobian_proxy(model, data, frame_id, rf);
     }
@@ -74,21 +74,59 @@ namespace se3
                                                               )
     {
       computeJointJacobiansTimeVariation(model,data,q,v);
-      framesForwardKinematics(model,data);
+      updateFramePlacements(model,data);
   
       return get_frame_jacobian_time_variation_proxy(model, data, frame_id, rf);
     }        
 
+    static Motion get_frame_velocity_proxy(const Model & model,
+                                           Data & data,
+                                           const Model::FrameIndex frame_id
+                                           )
+    {
+      Motion v;
+      getFrameVelocity(model,data,frame_id,v);
+      return v;
+    }
+
+    static Motion get_frame_acceleration_proxy(const Model & model,
+                                               Data & data,
+                                               const Model::FrameIndex frame_id
+                                               )
+    {
+      Motion a;
+      getFrameAcceleration(model,data,frame_id,a);
+      return a;
+    }
     
     void exposeFramesAlgo()
     {
-      bp::def("framesKinematics",
-              (void (*)(const Model &, Data &))&framesForwardKinematics,
+      bp::def("updateFramePlacements",
+              (void (*)(const Model &, Data &))&updateFramePlacements,
               bp::args("Model","Data"),
               "Computes the placements of all the operational frames according to the current joint placement stored in data"
-              "and put the results in data.");
+              "and puts the results in data.");
+
+      bp::def("updateFramePlacement",
+              (const SE3 & (*)(const Model &, Data &, const Model::FrameIndex))&updateFramePlacement,
+              bp::args("Model","Data","Operational frame ID (int)"),
+              "Computes the placement of the given operational frames according to the current joint placement stored in data,"
+              "puts the results in data and returns it.",
+              bp::return_value_policy<bp::return_by_value>());
+
+      bp::def("getFrameVelocity",
+              (Motion (*)(const Model &, Data &, const Model::FrameIndex))&get_frame_velocity_proxy,
+              bp::args("Model","Data","Operational frame ID (int)"),
+              "Returns the spatial velocity of the frame expressed in the LOCAL frame coordinate system."
+              "Fist or second order forwardKinematics should be called first.");
+
+      bp::def("getFrameAcceleration",
+              (Motion (*)(const Model &, Data &, const Model::FrameIndex))&get_frame_acceleration_proxy,
+              bp::args("Model","Data","Operational frame ID (int)"),
+              "Returns the spatial velocity of the frame expressed in the LOCAL frame coordinate system."
+              "Second order forwardKinematics should be called first.");
       
-      bp::def("framesKinematics",
+      bp::def("framesForwardKinematics",
               (void (*)(const Model &, Data &, const Eigen::VectorXd &))&framesForwardKinematics,
               bp::args("Model","Data",
                        "Configuration q (size Model::nq)"),

--- a/bindings/python/scripts/deprecated.py
+++ b/bindings/python/scripts/deprecated.py
@@ -21,6 +21,13 @@ from __future__ import print_function
 from . import libpinocchio_pywrap as se3 
 from .deprecation import deprecated
 
+@deprecated("This function has been renamed updateFramePlacements when taking two arguments, and framesForwardKinematics when taking three. Please change to the appropriate method.")
+def framesKinematics(model,data,q=None):
+  if q is None:
+    se3.updateFramePlacements(model,data)
+  else:
+    se3.framesForwardKinematics(model,data,q)
+
 @deprecated("This function has been renamed computeJointJacobians and will be removed in release 1.4.0 of Pinocchio. Please change for new computeJacobians.")
 def computeJacobians(model,data,q=None):
   if q is None:

--- a/bindings/python/scripts/deprecation.py
+++ b/bindings/python/scripts/deprecation.py
@@ -30,6 +30,8 @@ def deprecated(instructions):
 
             return func(*args, **kwargs)
 
+        if wrapper.__doc__ is None:
+            wrapper.__doc__ = instructions
         return wrapper
 
     return decorator

--- a/src/algorithm/frames.hpp
+++ b/src/algorithm/frames.hpp
@@ -25,7 +25,7 @@ namespace se3
 {
 
   /**
-   * @brief      Updates the position of each frame contained in the model
+   * @brief      Updates the placement of each frame contained in the model
    *
    * @param[in]  model  The kinematic model.
    * @param      data   Data associated to model.
@@ -48,14 +48,62 @@ namespace se3
                                       const Eigen::VectorXd & q);
 
   /**
-   * @brief      Returns the jacobian of the frame expresssed either expressed in the LOCAL frame coordinate system or in the WORLD coordinate system,
+   * @brief      Updates the placement of the given frame.
+   *
+   * @param[in]  model        The kinematic model.
+   * @param      data         Data associated to model.
+   * @param[in]  frame_id     Id of the operational Frame.
+   *
+   * @return     A reference to the frame placement stored in data.oMf[frame_id]
+   *
+   * @warning    One of the algorithms forwardKinematics should have been called first
+   */
+  inline const SE3 & frameForwardKinematics(const Model & model,
+                                            Data & data,
+                                            const Model::FrameIndex frame_id);
+
+  /**
+   * @brief      Returns the spatial velocity of the frame expressed in the LOCAL frame coordinate system.
+   *             You must first call se3::forwardKinematics to update placement and velocity values in data structure.
+   *
+   * @param[in]  model       The kinematic model
+   * @param[in]  data        Data associated to model
+   * @param[in]  frame_id    Id of the operational Frame
+   * @param[out] frame_v     The spatial velocity of the Frame expressed in the coordinates Frame.
+   *
+   * @warning    Fist or second order forwardKinematics should have been called first
+   */
+  void getFrameVelocity(const Model & model,
+                        const Data & data,
+                        const Model::FrameIndex frame_id,
+                        Motion & frame_v);
+
+  /**
+   * @brief      Returns the spatial acceleration of the frame expressed in the LOCAL frame coordinate system.
+   *             You must first call se3::forwardKinematics to update placement values in data structure.
+   *
+   * @param[in]  model       The kinematic model
+   * @param[in]  data        Data associated to model
+   * @param[in]  frame_id    Id of the operational Frame
+   * @param[out] frame_a     The spatial acceleration of the Frame expressed in the coordinates Frame.
+   *
+   * @warning    Second order forwardKinematics should have been called first
+   */
+  void getFrameAcceleration(const Model & model,
+                            const Data & data,
+                            const Model::FrameIndex frame_id,
+                            Motion & frame_a);
+
+
+  /**
+   * @brief      Returns the jacobian of the frame expressed either in the LOCAL frame coordinate system or in the WORLD coordinate system,
    *             depending on the value of the template parameter rf.
    *             You must first call se3::computeJointJacobians followed by se3::framesForwardKinematics to update placement values in data structure.
    *
    * @tparam     rf Reference frame in which the columns of the Jacobian are expressed.
-   
+   *
    * @remark     Similarly to se3::getJointJacobian with LOCAL or WORLD templated parameters, if rf == LOCAL, this function returns the Jacobian of the frame expressed
-   *             in the local coordinates of the frame, or if rl == WORDL, it returns the Jacobian expressed of the point coincident with the origin
+   *             in the local coordinates of the frame, or if rl == WORLD, it returns the Jacobian expressed of the point coincident with the origin
    *             and expressed in a coordinate system aligned with the WORLD.
    *
    * @param[in]  model       The kinematic model
@@ -63,7 +111,7 @@ namespace se3
    * @param[in]  frame_id    Id of the operational Frame
    * @param[out] J           The Jacobian of the Frame expressed in the coordinates Frame.
    *
-   * @warning    The function se3::computeJointJacobians and se3::framesForwardKinematics should have been called first.
+   * @warning    The functions se3::computeJointJacobians and se3::framesForwardKinematics should have been called first.
    */
   template<ReferenceFrame rf>
   void getFrameJacobian(const Model & model,

--- a/src/algorithm/frames.hpp
+++ b/src/algorithm/frames.hpp
@@ -32,6 +32,35 @@ namespace se3
    *
    * @warning    One of the algorithms forwardKinematics should have been called first
    */
+  inline void updateFramePlacements(const Model & model,
+                                    Data & data);
+
+  /**
+   * @brief      Updates the placement of the given frame.
+   *
+   * @param[in]  model        The kinematic model.
+   * @param      data         Data associated to model.
+   * @param[in]  frame_id     Id of the operational Frame.
+   *
+   * @return     A reference to the frame placement stored in data.oMf[frame_id]
+   *
+   * @warning    One of the algorithms forwardKinematics should have been called first
+   */
+  inline const SE3 & updateFramePlacement(const Model & model,
+                                          Data & data,
+                                          const Model::FrameIndex frame_id);
+
+  /**
+   * @brief      Updates the placement of each frame contained in the model
+   *
+   * @deprecated This function is now deprecated. Please call se3::updateFramePlacements for same functionality
+   *
+   * @param[in]  model  The kinematic model.
+   * @param      data   Data associated to model.
+   *
+   * @warning    One of the algorithms forwardKinematics should have been called first
+   */
+  PINOCCHIO_DEPRECATED
   inline void framesForwardKinematics(const Model & model,
                                       Data & data);
 
@@ -46,21 +75,6 @@ namespace se3
   inline void framesForwardKinematics(const Model & model,
                                       Data & data,
                                       const Eigen::VectorXd & q);
-
-  /**
-   * @brief      Updates the placement of the given frame.
-   *
-   * @param[in]  model        The kinematic model.
-   * @param      data         Data associated to model.
-   * @param[in]  frame_id     Id of the operational Frame.
-   *
-   * @return     A reference to the frame placement stored in data.oMf[frame_id]
-   *
-   * @warning    One of the algorithms forwardKinematics should have been called first
-   */
-  inline const SE3 & frameForwardKinematics(const Model & model,
-                                            Data & data,
-                                            const Model::FrameIndex frame_id);
 
   /**
    * @brief      Returns the spatial velocity of the frame expressed in the LOCAL frame coordinate system.

--- a/src/algorithm/frames.hxx
+++ b/src/algorithm/frames.hxx
@@ -26,13 +26,13 @@ namespace se3
 {
   
   
-  inline void framesForwardKinematics(const Model & model,
-                                      Data & data)
+  inline void updateFramePlacements(const Model & model,
+                                    Data & data)
   {
     assert(model.check(data) && "data is not consistent with model.");
     
     // The following for loop starts by index 1 because the first frame is fixed
-    // and corresponds to the universe.s
+    // and corresponds to the universe
     for (Model::FrameIndex i=1; i < (Model::FrameIndex) model.nframes; ++i)
     {
       const Frame & frame = model.frames[i];
@@ -43,20 +43,10 @@ namespace se3
         data.oMf[i] = data.oMi[parent]*frame.placement;
     }
   }
-  
-  inline void framesForwardKinematics(const Model & model,
-                                      Data & data,
-                                      const Eigen::VectorXd & q)
-  {
-    assert(model.check(data) && "data is not consistent with model.");
-    
-    forwardKinematics(model, data, q);
-    framesForwardKinematics(model, data);
-  }
 
-  inline const SE3 & frameForwardKinematics(const Model & model,
-                                            Data & data,
-                                            const Model::FrameIndex frame_id)
+  inline const SE3 & updateFramePlacement(const Model & model,
+                                          Data & data,
+                                          const Model::FrameIndex frame_id)
   {
     const Frame & frame = model.frames[frame_id];
     const Model::JointIndex & parent = frame.parent;
@@ -65,6 +55,22 @@ namespace se3
     else
       data.oMf[frame_id] = data.oMi[parent]*frame.placement;
     return data.oMf[frame_id];
+  }
+
+  inline void framesForwardKinematics(const Model & model,
+                                      Data & data)
+  {
+    updateFramePlacements(model,data);
+  }
+
+  inline void framesForwardKinematics(const Model & model,
+                                      Data & data,
+                                      const Eigen::VectorXd & q)
+  {
+    assert(model.check(data) && "data is not consistent with model.");
+    
+    forwardKinematics(model, data, q);
+    updateFramePlacements(model, data);
   }
 
   void getFrameVelocity(const Model & model,

--- a/src/algorithm/frames.hxx
+++ b/src/algorithm/frames.hxx
@@ -53,6 +53,43 @@ namespace se3
     forwardKinematics(model, data, q);
     framesForwardKinematics(model, data);
   }
+
+  inline const SE3 & frameForwardKinematics(const Model & model,
+                                            Data & data,
+                                            const Model::FrameIndex frame_id)
+  {
+    const Frame & frame = model.frames[frame_id];
+    const Model::JointIndex & parent = frame.parent;
+    if (frame.placement.isIdentity())
+      data.oMf[frame_id] = data.oMi[parent];
+    else
+      data.oMf[frame_id] = data.oMi[parent]*frame.placement;
+    return data.oMf[frame_id];
+  }
+
+  void getFrameVelocity(const Model & model,
+                        const Data & data,
+                        const Model::FrameIndex frame_id,
+                        Motion & frame_v)
+  {
+    assert(model.check(data) && "data is not consistent with model.");
+
+    const Frame & frame = model.frames[frame_id];
+    const Model::JointIndex & parent = frame.parent;
+    frame_v = frame.placement.actInv(data.v[parent]);
+  }
+
+  void getFrameAcceleration(const Model & model,
+                            const Data & data,
+                            const Model::FrameIndex frame_id,
+                            Motion & frame_a)
+  {
+    assert(model.check(data) && "data is not consistent with model.");
+
+    const Frame & frame = model.frames[frame_id];
+    const Model::JointIndex & parent = frame.parent;
+    frame_a = frame.placement.actInv(data.a[parent]);
+  }
   
   template<ReferenceFrame rf>
   inline void getFrameJacobian(const Model & model,

--- a/src/algorithm/jacobian.hpp
+++ b/src/algorithm/jacobian.hpp
@@ -200,7 +200,7 @@ namespace se3
                 const Model::JointIndex jointId)
   {
     data.J.setZero();
-    jacobian(model,data,q,jointId,data.J);
+    jointJacobian(model,data,q,jointId,data.J);
     
     return data.J;
   }

--- a/unittest/frames.cpp
+++ b/unittest/frames.cpp
@@ -60,6 +60,82 @@ BOOST_AUTO_TEST_CASE ( test_kinematics )
 
 }
 
+BOOST_AUTO_TEST_CASE ( test_single_kinematics )
+{
+  using namespace Eigen;
+  using namespace se3;
+
+  se3::Model model;
+  se3::buildModels::humanoidSimple(model);
+  Model::Index parent_idx = model.existJointName("rarm2_joint")?model.getJointId("rarm2_joint"):(Model::Index)(model.njoints-1);
+  const std::string & frame_name = std::string( model.names[parent_idx]+ "_frame");
+  const SE3 & framePlacement = SE3::Random();
+  model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
+  Model::FrameIndex frame_idx = model.getFrameId(frame_name);
+  se3::Data data(model);
+  se3::Data data_ref(model);
+
+  VectorXd q = VectorXd::Ones(model.nq);
+  q.middleRows<4> (3).normalize();
+
+  forwardKinematics(model, data, q);
+  frameForwardKinematics(model, data, frame_idx);
+
+  framesForwardKinematics(model, data_ref, q);
+
+  BOOST_CHECK(data.oMf[frame_idx].isApprox(data_ref.oMf[frame_idx]));
+}
+
+BOOST_AUTO_TEST_CASE ( test_velocity )
+{
+  using namespace Eigen;
+  using namespace se3;
+
+  se3::Model model;
+  se3::buildModels::humanoidSimple(model);
+  Model::Index parent_idx = model.existJointName("rarm2_joint")?model.getJointId("rarm2_joint"):(Model::Index)(model.njoints-1);
+  const std::string & frame_name = std::string( model.names[parent_idx]+ "_frame");
+  const SE3 & framePlacement = SE3::Random();
+  model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
+  Model::FrameIndex frame_idx = model.getFrameId(frame_name);
+  se3::Data data(model);
+
+  VectorXd q = VectorXd::Ones(model.nq);
+  q.middleRows<4> (3).normalize();
+  VectorXd v = VectorXd::Ones(model.nv);
+  forwardKinematics(model, data, q, v);
+
+  Motion vf;
+  getFrameVelocity(model, data, frame_idx, vf);
+
+  BOOST_CHECK(vf.isApprox(framePlacement.actInv(data.v[parent_idx])));
+}
+
+BOOST_AUTO_TEST_CASE ( test_acceleration )
+{
+  using namespace Eigen;
+  using namespace se3;
+
+  se3::Model model;
+  se3::buildModels::humanoidSimple(model);
+  Model::Index parent_idx = model.existJointName("rarm2_joint")?model.getJointId("rarm2_joint"):(Model::Index)(model.njoints-1);
+  const std::string & frame_name = std::string( model.names[parent_idx]+ "_frame");
+  const SE3 & framePlacement = SE3::Random();
+  model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
+  Model::FrameIndex frame_idx = model.getFrameId(frame_name);
+  se3::Data data(model);
+
+  VectorXd q = VectorXd::Ones(model.nq);
+  q.middleRows<4> (3).normalize();
+  VectorXd v = VectorXd::Ones(model.nv);
+  VectorXd a = VectorXd::Ones(model.nv);
+  forwardKinematics(model, data, q, v, a);
+
+  Motion af;
+  getFrameAcceleration(model, data, frame_idx, af);
+
+  BOOST_CHECK(af.isApprox(framePlacement.actInv(data.a[parent_idx])));
+}
 
 BOOST_AUTO_TEST_CASE ( test_jacobian )
 {
@@ -86,7 +162,7 @@ BOOST_AUTO_TEST_CASE ( test_jacobian )
   BOOST_CHECK(frame.placement.isApprox_impl(framePlacement));
   Data::Matrix6x Jjj(6,model.nv); Jjj.fill(0);
   Data::Matrix6x Jff(6,model.nv); Jff.fill(0);
-  getFrameJacobian(model,data,idx,Jff);
+  getFrameJacobian<LOCAL>(model,data,idx,Jff);
   getJointJacobian<LOCAL>(model, data_ref, parent_idx, Jjj);
 
   Motion nu_frame = Motion(Jff*q_dot);

--- a/unittest/frames.cpp
+++ b/unittest/frames.cpp
@@ -60,7 +60,7 @@ BOOST_AUTO_TEST_CASE ( test_kinematics )
 
 }
 
-BOOST_AUTO_TEST_CASE ( test_single_kinematics )
+BOOST_AUTO_TEST_CASE ( test_update_placements )
 {
   using namespace Eigen;
   using namespace se3;
@@ -79,7 +79,33 @@ BOOST_AUTO_TEST_CASE ( test_single_kinematics )
   q.middleRows<4> (3).normalize();
 
   forwardKinematics(model, data, q);
-  frameForwardKinematics(model, data, frame_idx);
+  updateFramePlacements(model, data);
+
+  framesForwardKinematics(model, data_ref, q);
+
+  BOOST_CHECK(data.oMf[frame_idx].isApprox(data_ref.oMf[frame_idx]));
+}
+
+BOOST_AUTO_TEST_CASE ( test_update_single_placement )
+{
+  using namespace Eigen;
+  using namespace se3;
+
+  se3::Model model;
+  se3::buildModels::humanoidSimple(model);
+  Model::Index parent_idx = model.existJointName("rarm2_joint")?model.getJointId("rarm2_joint"):(Model::Index)(model.njoints-1);
+  const std::string & frame_name = std::string( model.names[parent_idx]+ "_frame");
+  const SE3 & framePlacement = SE3::Random();
+  model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
+  Model::FrameIndex frame_idx = model.getFrameId(frame_name);
+  se3::Data data(model);
+  se3::Data data_ref(model);
+
+  VectorXd q = VectorXd::Ones(model.nq);
+  q.middleRows<4> (3).normalize();
+
+  forwardKinematics(model, data, q);
+  updateFramePlacement(model, data, frame_idx);
 
   framesForwardKinematics(model, data_ref, q);
 
@@ -199,9 +225,10 @@ BOOST_AUTO_TEST_CASE ( test_frame_jacobian_time_variation )
   VectorXd a = VectorXd::Random(model.nv);
   
   computeJointJacobiansTimeVariation(model,data,q,v);
+  updateFramePlacements(model,data);
+
   forwardKinematics(model,data_ref,q,v,a);
-  framesForwardKinematics(model,data_ref);
-  framesForwardKinematics(model,data);
+  updateFramePlacements(model,data_ref);  
 
   BOOST_CHECK(isFinite(data.dJ));
 
@@ -250,7 +277,7 @@ BOOST_AUTO_TEST_CASE ( test_frame_jacobian_time_variation )
     Data::Matrix6x J_ref_world(6,model.nv), J_ref_local(6,model.nv);
     J_ref_world.fill(0.);     J_ref_local.fill(0.);
     computeJointJacobians(model,data_ref,q);
-    framesForwardKinematics(model,data_ref);
+    updateFramePlacements(model,data_ref);
     const SE3 & oMf_q = data_ref.oMf[idx];
     getFrameJacobian<WORLD>(model,data_ref,idx,J_ref_world);
     getFrameJacobian<LOCAL>(model,data_ref,idx,J_ref_local);
@@ -259,7 +286,7 @@ BOOST_AUTO_TEST_CASE ( test_frame_jacobian_time_variation )
     Data::Matrix6x J_ref_plus_world(6,model.nv), J_ref_plus_local(6,model.nv);
     J_ref_plus_world.fill(0.);    J_ref_plus_local.fill(0.);
     computeJointJacobians(model,data_ref_plus,q_plus);
-    framesForwardKinematics(model,data_ref_plus);
+    updateFramePlacements(model,data_ref_plus);
     const SE3 & oMf_qplus = data_ref_plus.oMf[idx];
     getFrameJacobian<WORLD>(model,data_ref_plus,idx,J_ref_plus_world);
     getFrameJacobian<LOCAL>(model,data_ref_plus,idx,J_ref_plus_local);
@@ -275,7 +302,7 @@ BOOST_AUTO_TEST_CASE ( test_frame_jacobian_time_variation )
     //data
     computeJointJacobiansTimeVariation(model,data,q,v);
     forwardKinematics(model,data,q,v);
-    framesForwardKinematics(model,data);
+    updateFramePlacements(model,data);
     Data::Matrix6x dJ_world(6,model.nv), dJ_local(6,model.nv);
     dJ_world.fill(0.);    dJ_local.fill(0.);
     getFrameJacobianTimeVariation<WORLD>(model,data,idx,dJ_world);


### PR DESCRIPTION
framesForwardKinematics(model, data, frame_id) computes oMf[frame_id], stores it and returns it. Assumes forwardKinematics has already been run. Thought it might be useful if the model contains many frames but we are only interested in one or two of them.

getFrameVelocity(model, data, frame_id, v_frame) computes the velocity of frame frame_id and puts it in v_frame. Assumes first-order forwardKinematics has already been run.

getFrameAcceleration(model, data, frame_id, a_frame) computes the acceleration of frame frame_id and puts it in a_frame. Assumes second-order forwardKinematics has already been run.