### PR TITLE
Fix Boost 1.58 usage, and update gitlab-ci

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,6 +1,8 @@
+# Please don't edit this file, and use the version generated at
+# http://rainboard.laas.fr/project/pinocchio/.gitlab-ci.yml
+
 variables:
   GIT_SUBMODULE_STRATEGY: "recursive"
-  GIT_DEPTH: "3"
   CCACHE_BASEDIR: "${CI_PROJECT_DIR}"
   CCACHE_DIR: "${CI_PROJECT_DIR}/ccache"
 
@@ -13,8 +15,9 @@ cache:
     - gh-pages
   script:
     - mkdir -p ccache
-    - cd /root/robotpkg/math/pinocchio
+    - cd /root/robotpkg/math
     - git pull
+    - cd pinocchio
     - make checkout MASTER_REPOSITORY="dir ${CI_PROJECT_DIR}"
     - make install
     - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
@@ -37,8 +40,12 @@ robotpkg-pinocchio-18.04-release:
     - gh-pages
   script:
     - mkdir -p ccache
-    - cd /root/robotpkg/math/py-pinocchio
+    - cd /root/robotpkg/math
     - git pull
+    - cd pinocchio
+    - make checkout MASTER_REPOSITORY="dir ${CI_PROJECT_DIR}"
+    - cd ..
+    - cd py-pinocchio
     - make checkout MASTER_REPOSITORY="dir ${CI_PROJECT_DIR}"
     - make install
     - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,6 @@ cache:
     - make checkout MASTER_REPOSITORY="dir ${CI_PROJECT_DIR}"
     - make install
     - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
-    - make build_tests
     - make test
 
 robotpkg-pinocchio-14.04-release:
@@ -43,30 +42,31 @@ robotpkg-pinocchio-18.04-release:
     - make checkout MASTER_REPOSITORY="dir ${CI_PROJECT_DIR}"
     - make install
     - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
-
-robotpkg-py-pinocchio-py3-18.04-release:
-  <<: *robotpkg-py-pinocchio
-  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:18.04
-
-robotpkg-py-pinocchio-16.04-release:
-  <<: *robotpkg-py-pinocchio
-  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio:16.04
-
-robotpkg-py-pinocchio-18.04-release:
-  <<: *robotpkg-py-pinocchio
-  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio:18.04
-
-robotpkg-py-pinocchio-py3-14.04-release:
-  <<: *robotpkg-py-pinocchio
-  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:14.04
+    - make test
 
 robotpkg-py-pinocchio-14.04-release:
   <<: *robotpkg-py-pinocchio
   image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio:14.04
 
+robotpkg-py-pinocchio-py3-14.04-release:
+  <<: *robotpkg-py-pinocchio
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:14.04
+
+robotpkg-py-pinocchio-16.04-release:
+  <<: *robotpkg-py-pinocchio
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio:16.04
+
 robotpkg-py-pinocchio-py3-16.04-release:
   <<: *robotpkg-py-pinocchio
   image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:16.04
+
+robotpkg-py-pinocchio-18.04-release:
+  <<: *robotpkg-py-pinocchio
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio:18.04
+
+robotpkg-py-pinocchio-py3-18.04-release:
+  <<: *robotpkg-py-pinocchio
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:18.04
 
 doc-coverage:
   <<: *robotpkg-py-pinocchio

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -58,6 +58,7 @@ robotpkg-py-pinocchio-14.04-release:
 robotpkg-py-pinocchio-py3-14.04-release:
   <<: *robotpkg-py-pinocchio
   image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:14.04
+  allow_failure: true
 
 robotpkg-py-pinocchio-16.04-release:
   <<: *robotpkg-py-pinocchio
@@ -66,6 +67,7 @@ robotpkg-py-pinocchio-16.04-release:
 robotpkg-py-pinocchio-py3-16.04-release:
   <<: *robotpkg-py-pinocchio
   image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:16.04
+  allow_failure: true
 
 robotpkg-py-pinocchio-18.04-release:
   <<: *robotpkg-py-pinocchio
@@ -74,6 +76,7 @@ robotpkg-py-pinocchio-18.04-release:
 robotpkg-py-pinocchio-py3-18.04-release:
   <<: *robotpkg-py-pinocchio
   image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:18.04
+  allow_failure: true
 
 doc-coverage:
   <<: *robotpkg-py-pinocchio
@@ -93,4 +96,3 @@ doc-coverage:
     paths:
       - doxygen-html/
       - coverage/
-

--- a/bindings/python/parsers/python/model.cpp
+++ b/bindings/python/parsers/python/model.cpp
@@ -20,17 +20,23 @@
 #include <iostream>
 #include <Python.h>
 #include <boost/shared_ptr.hpp>
+#include <boost/version.hpp>
+
+// Boost 1.58
+#if BOOST_VERSION / 100 % 1000 == 58
+#include <fstream>
+#endif
 
 namespace se3
 {
   namespace python
   {
     namespace bp = boost::python;
-    
+
     Model buildModel(const std::string & filename, const std::string & model_name, bool verbose) throw (bp::error_already_set)
     {
       Py_Initialize();
-      
+
       bp::object main_module = bp::import("__main__");
       // Get a dict for the global namespace to exec further python code with
       bp::dict globals = bp::extract<bp::dict>(main_module.attr("__dict__"));
@@ -42,13 +48,23 @@ namespace se3
       // can update as you want.
       try
       {
+// Boost 1.58
+#if BOOST_VERSION / 100 % 1000 == 58
+        // Avoid a segv with exec_file
+        // See: https://github.com/boostorg/python/pull/15
+        std::ifstream t(filename.c_str());
+        std::stringstream buffer;
+        buffer << t.rdbuf();
+        bp::exec(buffer.str().c_str(), globals);
+#else // default implementation
         bp::exec_file((bp::str)filename, globals);
+#endif
       }
       catch (bp::error_already_set & e)
       {
         PyErr_PrintEx(0);
       }
-      
+
       Model model;
       try
       {
@@ -64,10 +80,10 @@ namespace se3
         std::cout << "Your model has been built. It has " << model.nv;
         std::cout << " degrees of freedom." << std::endl;
       }
-      
+
       // close interpreter
       Py_Finalize();
-        
+
       return model;
     }
   } // namespace python


### PR DESCRIPTION
Hi,

This PR updates the gitlab CI configuration by:
- compiling both robotpkg-pinocchio & robotpkg-py-pinocchio on the current commit
- using docker images with `CMAKE_ARGS += -DBUILD_UNIT_TESTS=ON`
- ignore failing tests on python3 for now

and fixes the tests on python2 / ubuntu xenial, which uses boost python v1.58, which has a bug in `exec_file`.