### PR TITLE
[doxygen] [minor] replaced \cross with \times in doxygen formulas

### DIFF
--- a/src/spatial/inertia.hpp
+++ b/src/spatial/inertia.hpp
@@ -68,7 +68,7 @@ namespace se3
     Matrix6 variation(const Motion & v) const { return derived().variation_impl(v); }
     
     /// \brief Time variation operator.
-    ///        It computes the time derivative of an inertia I corresponding to the formula \f$ \dot{I} = v \cross^{*} I \f$.
+    ///        It computes the time derivative of an inertia I corresponding to the formula \f$ \dot{I} = v \times^{*} I \f$.
     ///
     /// \param[in] v The spatial velocity of the frame supporting the inertia.
     /// \param[in] I The spatial inertia in motion.
@@ -89,7 +89,7 @@ namespace se3
     }
     
     /// \brief Time variation operator.
-    ///        It computes the time derivative of an inertia I corresponding to the formula \f$ \dot{I} = v \cross^{*} I \f$.
+    ///        It computes the time derivative of an inertia I corresponding to the formula \f$ \dot{I} = v \times^{*} I \f$.
     ///
     /// \param[in] v The spatial velocity of the frame supporting the inertia.
     /// \param[in] I The spatial inertia in motion.

--- a/src/spatial/skew.hpp
+++ b/src/spatial/skew.hpp
@@ -25,7 +25,7 @@ namespace se3
   
   ///
   /// \brief Computes the skew representation of a given 3d vector,
-  ///        i.e. the antisymmetric matrix representation of the cross product operator (\f$ [v]_{\cross} x = v \cross x \f$)
+  ///        i.e. the antisymmetric matrix representation of the cross product operator (\f$ [v]_{\times} x = v \times x \f$)
   ///
   /// \param[in]  v a vector of dimension 3.
   /// \param[out] M the skew matrix representation of dimension 3x3.
@@ -65,7 +65,7 @@ namespace se3
   ///
   /// \brief Inverse of skew operator. From a given skew-symmetric matrix M
   ///        of dimension 3x3, it extracts the supporting vector, i.e. the entries of M.
-  ///        Mathematically speacking, it computes \f$ v \f$ such that \f$ M x = v \cross x \f$.
+  ///        Mathematically speacking, it computes \f$ v \f$ such that \f$ M x = v \times x \f$.
   ///
   /// \param[in]  M a 3x3 skew symmetric matrix.
   /// \param[out] v the 3d vector representation of M.
@@ -89,7 +89,7 @@ namespace se3
   ///
   /// \brief Inverse of skew operator. From a given skew-symmetric matrix M
   ///        of dimension 3x3, it extracts the supporting vector, i.e. the entries of M.
-  ///        Mathematically speacking, it computes \f$ v \f$ such that \f$ M x = v \cross x \f$.
+  ///        Mathematically speacking, it computes \f$ v \f$ such that \f$ M x = v \times x \f$.
   ///
   /// \param[in] M a 3x3 matrix.
   ///
@@ -106,7 +106,7 @@ namespace se3
 
   ///
   /// \brief Computes the skew representation of a given 3d vector multiplied by a given scalar.
-  ///        i.e. the antisymmetric matrix representation of the cross product operator (\f$ [\alpha v]_{\cross} x = \alpha v \cross x \f$)
+  ///        i.e. the antisymmetric matrix representation of the cross product operator (\f$ [\alpha v]_{\times} x = \alpha v \times x \f$)
   ///
   /// \param[in]  alpha a real scalar.
   /// \param[in]  v a vector of dimension 3.
@@ -130,7 +130,7 @@ namespace se3
   
   ///
   /// \brief Computes the skew representation of a given 3d vector multiplied by a given scalar.
-  ///        i.e. the antisymmetric matrix representation of the cross product operator (\f$ [\alpha v]_{\cross} x = \alpha v \cross x \f$)
+  ///        i.e. the antisymmetric matrix representation of the cross product operator (\f$ [\alpha v]_{\times} x = \alpha v \times x \f$)
   ///
   /// \param[in]  alpha a real scalar.
   /// \param[in]  v a vector of dimension 3.
@@ -197,7 +197,7 @@ namespace se3
   /// \param[in] Min    a 3 rows matrix.
   /// \param[out] Mout  a 3 rows matrix.
   ///
-  /// \return the results of \f$ Mout = [v]_{\cross} Min \f$.
+  /// \return the results of \f$ Mout = [v]_{\times} Min \f$.
   ///
   template <typename Vector3, typename Matrix3xIn, typename Matrix3xOut>
   inline void cross(const Eigen::MatrixBase<Vector3> & v,
@@ -221,7 +221,7 @@ namespace se3
   /// \param[in] v a vector of dimension 3.
   /// \param[in] M a 3 rows matrix.
   ///
-  /// \return the results of \f$ [v]_{\cross} M \f$.
+  /// \return the results of \f$ [v]_{\times} M \f$.
   ///
   template <typename Vector3, typename Matrix3x>
   inline typename EIGEN_PLAIN_TYPE(Matrix3x)

--- a/src/spatial/symmetric3.hpp
+++ b/src/spatial/symmetric3.hpp
@@ -234,7 +234,7 @@ namespace se3
     }
     
     ///
-    /// \brief Performs the operation \f$ M = [v]_{\cross} S_{3} \f$.
+    /// \brief Performs the operation \f$ M = [v]_{\times} S_{3} \f$.
     ///        This operation is equivalent to applying the cross product of v on each column of S.
     ///
     /// \tparam Vector3, Matrix3
@@ -278,14 +278,14 @@ namespace se3
     }
     
     ///
-    /// \brief Performs the operation \f$ [v]_{\cross} S \f$.
+    /// \brief Performs the operation \f$ [v]_{\times} S \f$.
     ///        This operation is equivalent to applying the cross product of v on each column of S.
     ///
     /// \tparam Vector3
     ///
     /// \param[in]  v  a vector of dimension 3.
     ///
-    /// \returns the result \f$ [v]_{\cross} S \f$.
+    /// \returns the result \f$ [v]_{\times} S \f$.
     ///
     template<typename Vector3>
     Matrix3 vxs(const Eigen::MatrixBase<Vector3> & v) const
@@ -296,7 +296,7 @@ namespace se3
     }
     
     ///
-    /// \brief Performs the operation \f$ M = S_{3} [v]_{\cross \f$.
+    /// \brief Performs the operation \f$ M = S_{3} [v]_{\times \f$.
     ///
     /// \tparam Vector3, Matrix3
     ///
@@ -337,13 +337,13 @@ namespace se3
       M_(2,2) = d * v1 - e * v0;
     }
     
-    /// \brief Performs the operation \f$ M = S_{3} [v]_{\cross \f$.
+    /// \brief Performs the operation \f$ M = S_{3} [v]_{\times \f$.
     ///
     /// \tparam Vector3
     ///
     /// \param[in]  v  a vector of dimension 3.
     ///
-    /// \returns the result \f$ S [v]_{\cross} \f$.
+    /// \returns the result \f$ S [v]_{\times} \f$.
     ///
     template<typename Vector3>
     Matrix3 svx(const Eigen::MatrixBase<Vector3> & v) const


### PR DESCRIPTION
The \cross command employed in many doxygen comment formulas is not recognized by latex, causing an error message to be shown in place of the whole formula when the html is displayed on a browser. This is what happens on my system at least. The problem is \cross is not part of amsmath nor amssymb, \times should be used instead.

I replaced all occurrences of \cross with \times.
I didn't know which branch would be more appropriate, I put it in topic/doc-v2 for now.

The other option is to get doxygen to accept \cross. This needs to be done in the cmake submodule, I think. For that, ALIASES does not seem to work, I think one would need to create a custom latex package that does nothing more than defining \cross (maybe to be identical to \times) and then add this package to the Doxyfile through EXTRA_PACKAGES. It would allow us to happily use \cross forever after, but seems kind of an overkill.
If you prefer the second solution, feel free to discard this pull request and wait for a new one.