### PR TITLE
[bindings] Implement bindings, solve name inconsistencies, fix #529

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -195,6 +195,7 @@ SET(PYTHON_FILES
   romeo_wrapper.py
   rpy.py
   explog.py
+  shortcuts.py
   )
 
 FOREACH(python ${PYTHON_FILES})

--- a/bindings/python/algorithm/expose-com.cpp
+++ b/bindings/python/algorithm/expose-com.cpp
@@ -80,7 +80,9 @@ namespace se3
       
       bp::def("jacobianCenterOfMass",&jacobianCenterOfMass<double,0,JointCollectionDefaultTpl,VectorXd>,
               jacobianCenterOfMass_overload(bp::args("Model","Data",
-                       "Joint configuration q (size Model::nq)"),
+                       "Joint configuration q (size Model::nq)",
+                       "computeSubtreeComs If true, the algorithm computes also the center of mass of the subtrees",
+                       "updateKinematics If true, the algorithm updates first the geometry of the tree. Otherwise, it uses the current kinematics stored in data."),
               "Computes the jacobian of the center of mass, puts the result in Data and return it.")[
               bp::return_value_policy<bp::return_by_value>()]);
       

--- a/bindings/python/algorithm/expose-rnea-derivatives.cpp
+++ b/bindings/python/algorithm/expose-rnea-derivatives.cpp
@@ -29,6 +29,7 @@ namespace se3
                                                         const Eigen::VectorXd & q)
     {
       Data::MatrixXs res(model.nv,model.nv);
+      res.setZero();
       se3::computeGeneralizedGravityDerivatives(model,data,q,res);
       return res;
     }

--- a/bindings/python/algorithm/expose-rnea.cpp
+++ b/bindings/python/algorithm/expose-rnea.cpp
@@ -45,31 +45,28 @@ namespace se3
                        "Vector of external forces expressed in the local frame of each joint (size Model::njoints)"),
               "Compute the RNEA with external forces, put the result in Data and return it.",
               bp::return_value_policy<bp::return_by_value>());
-      
 
-      bp::def("nle",
+      bp::def("nonLinearEffects",
               &nonLinearEffects<double,0,JointCollectionDefaultTpl,VectorXd,VectorXd>,
               bp::args("Model","Data",
                        "Configuration q (size Model::nq)",
                        "Velocity v (size Model::nv)"),
               "Compute the Non Linear Effects (coriolis, centrifugal and gravitational effects), put the result in Data and return it.",
               bp::return_value_policy<bp::return_by_value>());
-      
-      
+
       bp::def("computeGeneralizedGravity",
               &computeGeneralizedGravity<double,0,JointCollectionDefaultTpl,VectorXd>,
               bp::args("Model","Data",
                        "Configuration q (size Model::nq)"),
-              "Computes the generalized gravity contribution g(q) of the Lagrangian dynamics.",
+              "Compute the generalized gravity contribution g(q) of the Lagrangian dynamics, put the result in data.g and return it.",
               bp::return_value_policy<bp::return_by_value>());
-      
-      
+
       bp::def("computeCoriolisMatrix",
               &computeCoriolisMatrix<double,0,JointCollectionDefaultTpl,VectorXd,VectorXd>,
               bp::args("Model","Data",
                        "Configuration q (size Model::nq)",
                        "Velocity v (size Model::nv)"),
-              "Computes the Coriolis Matrix C(q,v) of the Lagrangian dynamics.",
+              "Compute the Coriolis Matrix C(q,v) of the Lagrangian dynamics, put the result in data.C and return it.",
               bp::return_value_policy<bp::return_by_value>());
       
     }

--- a/bindings/python/scripts/deprecated.py
+++ b/bindings/python/scripts/deprecated.py
@@ -14,12 +14,16 @@
 # Pinocchio If not, see
 # <http://www.gnu.org/licenses/>.
 
-## In this file, are reported some depracated functions that are still maintain until the next important release 1.4.0 ##
+## In this file, are reported some deprecated functions that are still maintained until the next important future releases ##
 
 from __future__ import print_function
 
 from . import libpinocchio_pywrap as se3 
 from .deprecation import deprecated
+
+@deprecated("This function has been renamed to impulseDynamics for consistency with the C++ interface. Please change for impulseDynamics.")
+def impactDynamics(model, data, q, v_before, J, r_coeff=0.0, update_kinematics=True):
+  return se3.impulseDynamics(model, data, q, v_before, J, r_coeff, update_kinematics)
 
 @deprecated("This function has been deprecated. Please use buildSampleModelHumanoid or buildSampleModelHumanoidRandom instead.")
 def buildSampleModelHumanoidSimple(usingFF=True):
@@ -44,51 +48,51 @@ def framesKinematics(model,data,q=None):
   else:
     se3.framesForwardKinematics(model,data,q)
 
-@deprecated("This function has been renamed computeJointJacobians and will be removed in release 1.4.0 of Pinocchio. Please change for new computeJointJacobians.")
+@deprecated("This function has been renamed computeJointJacobians and will be removed in future releases of Pinocchio. Please change for new computeJointJacobians.")
 def computeJacobians(model,data,q=None):
   if q is None:
     return se3.computeJointJacobians(model,data)
   else:
     return se3.computeJointJacobians(model,data,q)
 
-@deprecated("This function has been renamed jointJacobian and will be removed in release 1.4.0 of Pinocchio. Please change for new jointJacobian function.")
+@deprecated("This function has been renamed jointJacobian and will be removed in future releases of Pinocchio. Please change for new jointJacobian function.")
 def jacobian(model,data,q,jointId,local,update_kinematics):
   if local:
     return se3.jointJacobian(model,data,q,jointId,se3.ReferenceFrame.LOCAL,update_kinematics)
   else:
     return se3.jointJacobian(model,data,q,jointId,se3.ReferenceFrame.WORLD,update_kinematics)
 
-@deprecated("This function has been renamed getJointJacobian and will be removed in release 1.4.0 of Pinocchio. Please change for new getJointJacobian function.")
+@deprecated("This function has been renamed getJointJacobian and will be removed in future releases of Pinocchio. Please change for new getJointJacobian function.")
 def getJacobian(model,data,jointId,local):
   if local:
     return se3.getJointJacobian(model,data,jointId,se3.ReferenceFrame.LOCAL)
   else:
     return se3.getJointJacobian(model,data,jointId,se3.ReferenceFrame.WORLD)
 
-@deprecated("This function has been renamed computeJacobiansTimeVariation and will be removed in release 1.4.0 of Pinocchio. Please change for new computeJointJacobiansTimeVariation.")
+@deprecated("This function has been renamed computeJacobiansTimeVariation and will be removed in future releases of Pinocchio. Please change for new computeJointJacobiansTimeVariation.")
 def computeJacobiansTimeVariation(model,data,q,v):
   return se3.computeJointJacobiansTimeVariation(model,data,q,v)
 
-@deprecated("This function has been renamed getJointJacobianTimeVariation and will be removed in release 1.4.0 of Pinocchio. Please change for new getJointJacobianTimeVariation function.")
+@deprecated("This function has been renamed getJointJacobianTimeVariation and will be removed in future releases of Pinocchio. Please change for new getJointJacobianTimeVariation function.")
 def getJacobianTimeVariation(model,data,jointId,local):
   if local:
     return se3.getJointJacobianTimeVariation(model,data,jointId,se3.ReferenceFrame.LOCAL)
   else:
     return se3.getJointJacobianTimeVariation(model,data,jointId,se3.ReferenceFrame.WORLD)
 
-@deprecated("This function has been renamed difference and will be removed in release 1.4.0 of Pinocchio. Please change for new difference function.")
+@deprecated("This function has been renamed difference and will be removed in future releases of Pinocchio. Please change for new difference function.")
 def differentiate(model,q0,q1):
   return se3.difference(model,q0,q1)
 
-@deprecated("This function has been renamed difference and will be removed in release 1.4.0 of Pinocchio. Please change for new getNeutralConfiguration function.")
+@deprecated("This function has been renamed difference and will be removed in future releases of Pinocchio. Please change for new getNeutralConfiguration function.")
 def getNeutralConfigurationFromSrdf(model, filename, verbose):
   return se3.getNeutralConfiguration(model,filename,verbose)
 
-@deprecated("This function has been renamed difference and will be removed in release 1.4.0 of Pinocchio. Please change for new loadRotorParameters function.")
+@deprecated("This function has been renamed difference and will be removed in future releases of Pinocchio. Please change for new loadRotorParameters function.")
 def loadRotorParamsFromSrdf(model, filename, verbose):
   return se3.loadRotorParams(model,filename,verbose)
 
-@deprecated("This function has been renamed difference and will be removed in release 1.4.0 of Pinocchio. Please change for new removeCollisionPairs function.")
+@deprecated("This function has been renamed difference and will be removed in future releases of Pinocchio. Please change for new removeCollisionPairs function.")
 def removeCollisionPairsFromSrdf(model, geomModel, filename, verbose):
   return se3.removeCollisionPairs(model,geomModel,filename,verbose)
 

--- a/bindings/python/scripts/robot_wrapper.py
+++ b/bindings/python/scripts/robot_wrapper.py
@@ -121,11 +121,15 @@ class RobotWrapper(object):
     def mass(self, q):
         return se3.crba(self.model, self.data, q)
 
+    def nle(self, q, v):
+        return se3.nonLinearEffects(self.model, self.data, q, v)
+
+    @deprecated("This method is now renamed nle. Please use nle instead.")
     def bias(self, q, v):
-        return se3.nle(self.model, self.data, q, v)
+        return se3.nonLinearEffects(self.model, self.data, q, v)
 
     def gravity(self, q):
-        return se3.rnea(self.model, self.data, q, self.v0, self.v0)
+        return se3.computeGeneralizedGravity(self.model, self.data, q)
 
     def forwardKinematics(self, q, v=None, a=None):
         if v is not None:

--- a/bindings/python/scripts/shortcuts.py
+++ b/bindings/python/scripts/shortcuts.py
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2015-2016,2018 CNRS
+# Copyright (c) 2018 CNRS
 #
 # This file is part of Pinocchio
 # Pinocchio is free software: you can redistribute it
@@ -14,15 +14,8 @@
 # Pinocchio If not, see
 # <http://www.gnu.org/licenses/>.
 
-import numpy as np
-from pinocchio.robot_wrapper import RobotWrapper
+## In this file, some shortcuts are provided ##
 
 from . import libpinocchio_pywrap as se3
-from . import utils
-from .explog import exp, log
-from .libpinocchio_pywrap import *
-from .deprecated import *
-from .shortcuts import *
 
-se3.AngleAxis.__repr__ = lambda s: 'AngleAxis(%s)' % s.vector()
-
+nle = se3.nonLinearEffects

--- a/unittest/python/bindings_dynamics.py
+++ b/unittest/python/bindings_dynamics.py
@@ -1,0 +1,76 @@
+import unittest
+from test_case import TestCase
+import pinocchio as se3
+from pinocchio.utils import rand, zero
+import numpy as np
+
+# common quantities for all tests.
+# They correspond to the default values of the arguments, and they need to stay this way
+r_coeff = 0.0
+inv_damping = 0.0
+update_kinematics = True
+
+
+class TestDynamicsBindings(TestCase):
+
+    def setUp(self):
+        self.model = se3.buildSampleModelHumanoidRandom()
+        self.data = self.model.createData()
+
+        qmax = np.matrix(np.full((self.model.nv,1),np.pi))
+        self.q = se3.randomConfiguration(self.model,-qmax,qmax)
+        self.v = rand(self.model.nv)
+        self.tau = rand(self.model.nv)
+
+        # we compute J on a different self.data
+        self.J = se3.jointJacobian(self.model,self.model.createData(),self.q,self.model.getJointId('lleg6_joint'),se3.ReferenceFrame.LOCAL,True)
+        self.gamma = zero(6)
+
+    def test_forwardDynamics7(self):
+        ddq = se3.forwardDynamics(self.model,self.data,self.q,self.v,self.tau,self.J,self.gamma)
+        self.assertFalse(np.isnan(ddq).any())
+
+    def test_forwardDynamics8(self):
+        ddq = se3.forwardDynamics(self.model,self.data,self.q,self.v,self.tau,self.J,self.gamma,r_coeff)
+        self.assertFalse(np.isnan(ddq).any())
+
+    def test_forwardDynamics9(self):
+        ddq = se3.forwardDynamics(self.model,self.data,self.q,self.v,self.tau,self.J,self.gamma,r_coeff,update_kinematics)
+        self.assertFalse(np.isnan(ddq).any())
+
+    def test_forwardDynamics789(self):
+        data7 = self.data
+        data8 = self.model.createData()
+        data9 = self.model.createData()
+        ddq7 = se3.forwardDynamics(self.model,data7,self.q,self.v,self.tau,self.J,self.gamma)
+        ddq8 = se3.forwardDynamics(self.model,data8,self.q,self.v,self.tau,self.J,self.gamma,r_coeff)
+        ddq9 = se3.forwardDynamics(self.model,data9,self.q,self.v,self.tau,self.J,self.gamma,r_coeff,update_kinematics)
+        self.assertTrue((ddq7==ddq8).all())
+        self.assertTrue((ddq7==ddq9).all())
+        self.assertTrue((ddq8==ddq9).all())
+
+    def test_impulseDynamics5(self):
+        ddq = se3.impulseDynamics(self.model,self.data,self.q,self.v,self.J)
+        self.assertFalse(np.isnan(ddq).any())
+
+    def test_impulseDynamics6(self):
+        ddq = se3.impulseDynamics(self.model,self.data,self.q,self.v,self.J,inv_damping)
+        self.assertFalse(np.isnan(ddq).any())
+
+    def test_impulseDynamics7(self):
+        ddq = se3.impulseDynamics(self.model,self.data,self.q,self.v,self.J,inv_damping,update_kinematics)
+        self.assertFalse(np.isnan(ddq).any())
+
+    def test_impulseDynamics567(self):
+        data5 = self.data
+        data6 = self.model.createData()
+        data7 = self.model.createData()
+        vnext5 = se3.impulseDynamics(self.model,data5,self.q,self.v,self.J)
+        vnext6 = se3.impulseDynamics(self.model,data6,self.q,self.v,self.J,inv_damping)
+        vnext7 = se3.impulseDynamics(self.model,data7,self.q,self.v,self.J,inv_damping,update_kinematics)
+        self.assertTrue((vnext5==vnext6).all())
+        self.assertTrue((vnext5==vnext7).all())
+        self.assertTrue((vnext6==vnext7).all())
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unittest/python/tests.py
+++ b/unittest/python/tests.py
@@ -12,6 +12,7 @@ from bindings_inertia import TestInertiaBindings
 from bindings_frame import TestFrameBindings
 from bindings_geometry_object import TestGeometryObjectBindings
 from bindings_geometry_object_urdf import TestGeometryObjectUrdfBindings
+from bindings_dynamics import TestDynamicsBindings
 from explog import TestExpLog
 from model import TestModel
 from rpy import TestRPY


### PR DESCRIPTION
- turned impactDynamics to impulseDynamics in python, deprecated impactDynamics
- exposed nonLinearEffects, but left nle available as a shorthand
- exposed computeGeneralizedGravity
- exposed computeCoriolisMatrix
- exposed computeGeneralizedGravityDerivatives
- exposed all available overloads of impulseDynamics
- exposed all available overloads of forwardDynamics
- turned RobotWrapper.bias to RobotWrapper.nle, deprecated RobotWrapper.bias
- used newly exposed computeGeneralizedGravity instead of rnea in RobotWrapper.gravity