### PR TITLE
 [Coverage] Temporarly exclude bindings/python directory from coverage reports, fix #534

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,8 +89,8 @@ doc-coverage:
     - make doc
     - mv doc/doxygen-html ${CI_PROJECT_DIR}
     - mkdir -p ${CI_PROJECT_DIR}/coverage/
-    - gcovr -r .
-    - gcovr -r . --html --html-details -o ${CI_PROJECT_DIR}/coverage/index.html
+    - gcovr -r --exclude-directories bindings/python .
+    - gcovr -r --exclude-directories bindings/python . --html --html-details -o ${CI_PROJECT_DIR}/coverage/index.html
   artifacts:
     expire_in: 1 day
     paths:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,8 +89,8 @@ doc-coverage:
     - make doc
     - mv doc/doxygen-html ${CI_PROJECT_DIR}
     - mkdir -p ${CI_PROJECT_DIR}/coverage/
-    - gcovr -r --exclude-directories bindings/python .
-    - gcovr -r --exclude-directories bindings/python . --html --html-details -o ${CI_PROJECT_DIR}/coverage/index.html
+    - gcovr -r . --exclude bindings/python
+    - gcovr -r . --exclude bindings/python --html --html-details -o ${CI_PROJECT_DIR}/coverage/index.html
   artifacts:
     expire_in: 1 day
     paths:


### PR DESCRIPTION
Hi,

with `--exclude bindings/python`, the coverage went from:
```
TOTAL                                      10764    9832    91%
```
to
```
TOTAL                                      10331    9503    91%
```