### PR TITLE
[Coverage] fix regex to find bindings/python in some subdirs, ref #534

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -89,8 +89,8 @@ doc-coverage:
     - make doc
     - mv doc/doxygen-html ${CI_PROJECT_DIR}
     - mkdir -p ${CI_PROJECT_DIR}/coverage/
-    - gcovr -r . --exclude bindings/python
-    - gcovr -r . --exclude bindings/python --html --html-details -o ${CI_PROJECT_DIR}/coverage/index.html
+    - gcovr -r . --exclude .*bindings/python
+    - gcovr -r . --exclude .*bindings/python --html --html-details -o ${CI_PROJECT_DIR}/coverage/index.html
   artifacts:
     expire_in: 1 day
     paths:


### PR DESCRIPTION
Hi,

This PR follows #538 which has already been merged.
The coverage now goes from 92.0 to 93.3:
http://projects.laas.fr/gepetto/doc/gsaurel/pinocchio/devel/coverage/