### PR TITLE
[bindings] [sample models] Manage deprecation and overloads in python

### DIFF
--- a/bindings/python/multibody/model.hpp
+++ b/bindings/python/multibody/model.hpp
@@ -154,10 +154,6 @@ namespace se3
         .def("addFrame",(bool (Model::*)(const Frame &)) &Model::addFrame,bp::args("frame"),"Add a frame to the vector of frames.")
         
         .def("createData",&ModelPythonVisitor::createData)
-        .def("BuildEmptyModel",&ModelPythonVisitor::maker_empty)
-        .staticmethod("BuildEmptyModel")
-        .def("BuildHumanoidSimple",&ModelPythonVisitor::maker_humanoidSimple)
-        .staticmethod("BuildHumanoidSimple")
         
         .def("check",(bool (Model::*)(const Data &) const) &Model::check,bp::arg("data"),"Check consistency of data wrt model.")
         ;
@@ -175,14 +171,6 @@ namespace se3
       }
       
       static Data createData(const Model & model) { return Data(model); }
-      static Model maker_empty() { return Model(); }
-      
-      static Model maker_humanoidSimple()
-      {
-        Model model;
-        buildModels::humanoidSimple(model);
-        return model;
-      }
 
       ///
       /// \brief Provide equivalent to python list index function for

--- a/bindings/python/parsers/sample-models.hpp
+++ b/bindings/python/parsers/sample-models.hpp
@@ -30,10 +30,17 @@ namespace se3
     struct SampleModelsPythonVisitor
     {
 
-      static Model buildSampleModelHumanoidSimple(bool usingFF)
+      static Model buildSampleModelHumanoidRandom()
       {
         Model model;
-        buildModels::humanoidSimple(model,usingFF);
+        buildModels::humanoidRandom(model);
+        return model;
+      }
+
+      static Model buildSampleModelHumanoidRandom(bool usingFF)
+      {
+        Model model;
+        buildModels::humanoidRandom(model,usingFF);
         return model;
       }
 
@@ -57,6 +64,13 @@ namespace se3
         buildModels::humanoid(model);
         return model;
       }
+
+      static Model buildSampleModelHumanoid(bool usingFF)
+      {
+        Model model;
+        buildModels::humanoid(model,usingFF);
+        return model;
+      }
       
       static GeometryModel buildSampleGeometryModelHumanoid(const Model& model)
       {
@@ -71,10 +85,15 @@ namespace se3
 
     inline void SampleModelsPythonVisitor::expose()
     {
-      bp::def("buildSampleModelHumanoidSimple",
-              static_cast <Model (*) (bool)> (&SampleModelsPythonVisitor::buildSampleModelHumanoidSimple),
+      bp::def("buildSampleModelHumanoidRandom",
+              static_cast <Model (*) ()> (&SampleModelsPythonVisitor::buildSampleModelHumanoidRandom),
+              "Generate a (hard-coded) model of a humanoid robot with 6-DOF limbs and random joint placements.\nOnly meant for unit tests."
+              );
+
+      bp::def("buildSampleModelHumanoidRandom",
+              static_cast <Model (*) (bool)> (&SampleModelsPythonVisitor::buildSampleModelHumanoidRandom),
               bp::args("bool (usingFreeFlyer)"),
-              "Generate a (hard-coded) model of a simple humanoid robot."
+              "Generate a (hard-coded) model of a humanoid robot with 6-DOF limbs and random joint placements.\nOnly meant for unit tests."
               );
 
       bp::def("buildSampleModelManipulator",
@@ -90,6 +109,12 @@ namespace se3
       
       bp::def("buildSampleModelHumanoid",
               static_cast <Model (*) ()> (&SampleModelsPythonVisitor::buildSampleModelHumanoid),
+              "Generate a (hard-coded) model of a simple humanoid."
+              );
+
+      bp::def("buildSampleModelHumanoid",
+              static_cast <Model (*) (bool)> (&SampleModelsPythonVisitor::buildSampleModelHumanoid),
+              bp::args("bool (usingFreeFlyer)"),
               "Generate a (hard-coded) model of a simple humanoid."
               );
 

--- a/bindings/python/scripts/deprecated.py
+++ b/bindings/python/scripts/deprecated.py
@@ -21,6 +21,21 @@ from __future__ import print_function
 from . import libpinocchio_pywrap as se3 
 from .deprecation import deprecated
 
+@deprecated("This function has been deprecated. Please use buildSampleModelHumanoid or buildSampleModelHumanoidRandom instead.")
+def buildSampleModelHumanoidSimple(usingFF=True):
+    return se3.buildSampleModelHumanoidRandom(usingFF)
+
+@deprecated("Static method Model.BuildHumanoidSimple has been deprecated. Please use function buildSampleModelHumanoid or buildSampleModelHumanoidRandom instead.")
+def _Model__BuildHumanoidSimple(usingFF=True):
+    return se3.buildSampleModelHumanoidRandom(usingFF)
+
+se3.Model.BuildHumanoidSimple = staticmethod(_Model__BuildHumanoidSimple)
+
+@deprecated("Static method Model.BuildEmptyModel has been deprecated. Please use the empty Model constructor instead.")
+def _Model__BuildEmptyModel():
+    return se3.Model()
+
+se3.Model.BuildEmptyModel = staticmethod(_Model__BuildEmptyModel)
 
 @deprecated("This function has been renamed updateFramePlacements when taking two arguments, and framesForwardKinematics when taking three. Please change your code to the appropriate method.")
 def framesKinematics(model,data,q=None):

--- a/src/parsers/sample-models.hpp
+++ b/src/parsers/sample-models.hpp
@@ -41,9 +41,10 @@ namespace se3
 
     /** \brief Create a 28-DOF kinematic chain of a floating humanoid robot.
      * 
-     * The kinematic chain has 4 limbs shoulder-elbow-wrist, one 2-dof torso, one
-     * 2-dof neck. The float joint is either a free-float joint JointModelFreeFloating
-     * (with nq=7 and nv=6), or a composite joint with 3 prismatic and 1 roll-pitch-yaw.
+     * The kinematic chain has four 6-DOF limbs shoulder-elbow-wrist, one 2-DOF torso, one
+     * 2-DOF neck. The float joint is either a JointModelFreeFloating (with nq=7 and nv=6),
+     * or a composite joint with a JointModelTranslation
+     * and a roll-pitch-yaw joint JointModelSphericalZYX (with total nq=nv=6).
      * Using a free-floating or a composite joint is decided by the boolean usingFF.
      *
      * \param model: model, typically given empty, where the kinematic chain is added.
@@ -59,7 +60,7 @@ namespace se3
      */
     void humanoidGeometries(const Model& model, GeometryModel & geom);
     
-    /** \brief Create a humanoid kinematic tree with 6D limbs and random joint placement.
+    /** \brief Create a humanoid kinematic tree with 6-DOF limbs and random joint placements.
      *
      * This method is only meant to be used in unittest. Due to random placement and masses,
      * the resulting model is likely to not correspond to any physically-plausible model. 
@@ -67,7 +68,7 @@ namespace se3
      * rather define a plain and non-random model. 
      * \param model: model, typically given empty, where the kinematic chain is added.
      * \param usingFF: if True, implement the chain with a plain JointModelFreeFloating; if False,
-     * uses a composite joint. This changes the size of the configuration space (35 vs 34).
+     * uses 3 prismatic + 3 revolute joints. This changes the size of the configuration space (33 vs 32).
      */
     void humanoidRandom(Model& model, bool usingFF = true);
 


### PR DESCRIPTION
Correct the bindings for the newly-introduced models.
- expose `buildSampleModelHumanoidRandom` in python
- deprecate `buildSampleModelHumanoidSimple` in python
- deprecate static method `Model.BuildHumanoidSimple` in python
- add overloads for `buildSampleModelHumanoid` and `buildSampleModelHumanoidRandom` in python (for `usingFF`)

Two observations:
- `buildSampleModelHumanoidSimple` was introduced by @nmansard in his last commits. Since it calls a function which is deprecated in C++, I thought it should be deprecated in python too. Until now, the way to create a simple humanoid in python was to call static method `Model.BuildHumanoidSimple`, which was calling the deprecated C++ function. It needs to be deprecated too if the warning has to appear in existing python code. Also, I think the pattern `se3.buildSampleModelXXX` is much better than `se3.Model.BuildXXX`. @nmansard's latest commit was going in this direction
- If you agree, I would also deprecate `Model.BuildEmptyModel`, replacing it with `se3.buildEmptyModel`. Or, better, providing no replacement, since the empty constructor `Model()` is enough