### PR TITLE
[bug] Fix sample geometry model and python geometry unit test

### DIFF
--- a/src/parsers/sample-models.cpp
+++ b/src/parsers/sample-models.cpp
@@ -193,38 +193,46 @@ namespace se3
                                          GeometryModel & geom,
                                          const std::string & pre = "")
     {
+      FrameIndex parentFrame;
+
+      parentFrame = model.getBodyId(pre+"shoulder1_body");
       GeometryObject shoulderBall(pre+"shoulder_object",
-                                  model.getBodyId(pre+"shoulder1_body"),/*NR*/0,
+                                  parentFrame, model.frames[parentFrame].parent,
                                   boost::shared_ptr<fcl::Sphere>(new fcl::Sphere(0.05)),
                                   SE3::Identity());
       geom.addGeometryObject(shoulderBall);
       
+      parentFrame = model.getBodyId(pre+"elbow_body");
       GeometryObject elbowBall(pre+"elbow_object",
-                               model.getBodyId(pre+"elbow_body"),/*NR*/0,
+                               parentFrame, model.frames[parentFrame].parent,
                                boost::shared_ptr<fcl::Sphere>(new fcl::Sphere(0.05)),
                                SE3::Identity());
       geom.addGeometryObject(elbowBall);
       
+      parentFrame = model.getBodyId(pre+"wrist1_body");
       GeometryObject wristBall(pre+"wrist_object",
-                               model.getBodyId(pre+"wrist1_body"),/*NR*/0,
+                              parentFrame, model.frames[parentFrame].parent,
                                boost::shared_ptr<fcl::Sphere>(new fcl::Sphere(0.05)),
                                SE3::Identity());
       geom.addGeometryObject(wristBall);
 
+      parentFrame = model.getBodyId(pre+"upperarm_body");
       GeometryObject upperArm(pre+"upperarm_object",
-                              model.getBodyId(pre+"upperarm_body"),/*NR*/0,
+                              parentFrame, model.frames[parentFrame].parent,
                               boost::shared_ptr<fcl::Capsule>(new fcl::Capsule(0.05, .8)),
                               SE3(Eigen::Matrix3d::Identity(), Eigen::Vector3d(0,0,0.5)) );
       geom.addGeometryObject(upperArm);
 
+      parentFrame = model.getBodyId(pre+"lowerarm_body");
       GeometryObject lowerArm(pre+"lowerarm_object",
-                              model.getBodyId(pre+"lowerarm_body"),/*NR*/0,
+                              parentFrame, model.frames[parentFrame].parent,
                               boost::shared_ptr<fcl::Capsule>(new fcl::Capsule(0.05, .8)),
                               SE3(Eigen::Matrix3d::Identity(), Eigen::Vector3d(0,0,0.5)) );
       geom.addGeometryObject(lowerArm);
 
+      parentFrame = model.getBodyId(pre+"effector_body");
       GeometryObject effectorArm(pre+"effector_object",
-                                 model.getBodyId(pre+"effector_body"),/*NR*/0,
+                                 parentFrame, model.frames[parentFrame].parent,
                                  boost::shared_ptr<fcl::Capsule>(new fcl::Capsule(0.05, .2)),
                                  SE3(Eigen::Matrix3d::Identity(), Eigen::Vector3d(0,0,0.1)) );
       geom.addGeometryObject(effectorArm);
@@ -316,20 +324,25 @@ namespace se3
       addManipulatorGeometries(model,geom,"rarm");
       addManipulatorGeometries(model,geom,"larm");
 
+      FrameIndex parentFrame;
+
+      parentFrame = model.getBodyId("chest1_body");
       GeometryObject chestBall("chest_object",
-                               model.getBodyId("chest1_body"),/*NR*/0,
+                               parentFrame, model.frames[parentFrame].parent,
                                boost::shared_ptr<fcl::Sphere>(new fcl::Sphere(0.05)),
                                SE3::Identity());
       geom.addGeometryObject(chestBall);
 
+      parentFrame = model.getBodyId("head2_body");
       GeometryObject headBall("head_object",
-                               model.getBodyId("head2_body"),/*NR*/0,
+                               parentFrame, model.frames[parentFrame].parent,
                                boost::shared_ptr<fcl::Sphere>(new fcl::Sphere(0.25)),
                                SE3(Eigen::Matrix3d::Identity(), Eigen::Vector3d(0,0,0.5)) );
       geom.addGeometryObject(headBall);
 
+      parentFrame = model.getBodyId("chest2_body");
       GeometryObject chestArm("chest2_object",
-                              model.getBodyId("chest2_body"),/*NR*/0,
+                              parentFrame, model.frames[parentFrame].parent,
                               boost::shared_ptr<fcl::Capsule>(new fcl::Capsule(0.05, .8)),
                               SE3(Eigen::Matrix3d::Identity(), Eigen::Vector3d(0,0,0.5)) );
       geom.addGeometryObject(chestArm);

--- a/unittest/python/bindings_geometry_object.py
+++ b/unittest/python/bindings_geometry_object.py
@@ -1,63 +1,36 @@
 import unittest
 import pinocchio as se3
 import numpy as np
-from pinocchio.utils import eye,zero,rand
-import os
-
-ones = lambda n: np.matrix(np.ones([n, 1] if isinstance(n, int) else n), np.double)
-
-# TODO: remove these lines. Do not use RobotWrapper. Do not use URDF
-from pinocchio.robot_wrapper import RobotWrapper
-current_file =  os.path.dirname(os.path.abspath(__file__))
-romeo_model_dir = os.path.abspath(os.path.join(current_file, '../../models/romeo'))
-romeo_model_path = os.path.abspath(os.path.join(romeo_model_dir, 'romeo_description/urdf/romeo.urdf'))
-hint_list = [romeo_model_dir, "wrong/hint"] # hint list
-robot = RobotWrapper(romeo_model_path, hint_list, se3.JointModelFreeFlyer())
-expected_mesh_path = os.path.join(romeo_model_dir,'romeo_description/meshes/V1/collision/LHipPitch.dae')
 
 class TestGeometryObjectBindings(unittest.TestCase):
 
-    v3zero = zero(3)
-    v6zero = zero(6)
-    v3ones = ones(3)
-    m3zero = zero([3,3])
-    m6zero = zero([6,6])
-    m3ones = eye(3)
-    m4ones = eye(4)
-
-    # WARNING: the collision model is the same object is the same for all the tests.
-    # This can cause problems if a test expects the collision model to be in a certain way but a previous test has changed it
-    # Still, at the moment this is not the case.
-    # Loading the URDF and related meshes before each test would make the whole unit test run too slowly
-    # 
-    # TODO: do not use URDF. Then, build self.collision_model from scratch for each test
     def setUp(self):
-        self.collision_model = robot.collision_model
-        self.expected_mesh_path = expected_mesh_path
+        model = se3.buildSampleModelHumanoid()
+        self.collision_model = se3.buildSampleGeometryModelHumanoid(model)
 
     def test_name_get_set(self):
-        col = self.collision_model.geometryObjects[1]
-        self.assertTrue(col.name == 'LHipPitchLink_0')
+        col = self.collision_model.geometryObjects[0]
+        self.assertTrue(col.name == 'rlegshoulder_object')
         col.name = 'new_collision_name'
         self.assertTrue(col.name == 'new_collision_name')
 
     def test_parent_get_set(self):
-        col = self.collision_model.geometryObjects[1]
-        self.assertTrue(col.parentJoint == 4)
-        col.parentJoint = 5
-        self.assertTrue(col.parentJoint == 5)
+        col = self.collision_model.geometryObjects[0]
+        self.assertTrue(col.parentJoint == 2)
+        col.parentJoint = 3
+        self.assertTrue(col.parentJoint == 3)
 
     def test_placement_get_set(self):
-        m = se3.SE3(self.m3ones, self.v3zero)
-        new_m = se3.SE3(rand([3,3]), rand(3))
-        col = self.collision_model.geometryObjects[1]
+        m = se3.SE3.Identity()
+        new_m = se3.SE3.Random()
+        col = self.collision_model.geometryObjects[0]
         self.assertTrue(np.allclose(col.placement.homogeneous,m.homogeneous))
         col.placement = new_m
         self.assertTrue(np.allclose(col.placement.homogeneous , new_m.homogeneous))
 
     def test_meshpath_get(self):
-        col = self.collision_model.geometryObjects[1]
-        self.assertTrue(col.meshPath == self.expected_mesh_path)
+        col = self.collision_model.geometryObjects[0]
+        self.assertTrue(col.meshPath == "")
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
For some reason, the corrections I had made to  unittest/python/bindings_geometry_object.py seem to have been eaten up by last merge, so I restored them.
While correcting, I discovered a bug which was introduced with Pinocchio 2.0 in the sample geometry models, so I fixed it. Basically the parent joint of the geometry objects was not set correctly.

This is due to the fact that, before, `geommodel.addGeometryObject(object, model, bool)` was employed and this method was taking care of setting the parent. But in Pinocchio 2.0, this method was deprecated and replaced by `geommodel.addGeometryObject(object)`, leaving the parent joint unset.