### PR TITLE
Change from namespace se3 to pinocchio

### DIFF
--- a/benchmark/timings-cg.cpp
+++ b/benchmark/timings-cg.cpp
@@ -37,7 +37,7 @@
 int main(int argc, const char ** argv)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
   PinocchioTicToc timer(PinocchioTicToc::US);
   #ifdef NDEBUG
@@ -47,7 +47,7 @@ int main(int argc, const char ** argv)
     std::cout << "(the time score in debug mode is not relevant) " << std::endl;
   #endif
     
-  se3::Model model;
+  pinocchio::Model model;
 
   std::string filename = PINOCCHIO_SOURCE_DIR"/models/simple_humanoid.urdf";
   if(argc>1) filename = argv[1];
@@ -61,18 +61,18 @@ int main(int argc, const char ** argv)
   }
   
   if( filename == "H")
-    se3::buildModels::humanoidRandom(model,true);
+    pinocchio::buildModels::humanoidRandom(model,true);
   else
     if(with_ff)
-      se3::urdf::buildModel(filename,JointModelFreeFlyer(),model);
+      pinocchio::urdf::buildModel(filename,JointModelFreeFlyer(),model);
     else
-      se3::urdf::buildModel(filename,model);
+      pinocchio::urdf::buildModel(filename,model);
   
   std::cout << "nq = " << model.nq << std::endl;
   std::cout << "nv = " << model.nv << std::endl;
   std::cout << "--" << std::endl;
 
-  se3::Data data(model);
+  pinocchio::Data data(model);
   
   CodeGenRNEA<double> rnea_code_gen(model);
   rnea_code_gen.initLib();
@@ -98,10 +98,10 @@ int main(int argc, const char ** argv)
   aba_derivatives_code_gen.initLib();
   aba_derivatives_code_gen.loadLib();
 
-  se3::container::aligned_vector<VectorXd> qs     (NBT);
-  se3::container::aligned_vector<VectorXd> qdots  (NBT);
-  se3::container::aligned_vector<VectorXd> qddots (NBT);
-  se3::container::aligned_vector<VectorXd> taus (NBT);
+  pinocchio::container::aligned_vector<VectorXd> qs     (NBT);
+  pinocchio::container::aligned_vector<VectorXd> qdots  (NBT);
+  pinocchio::container::aligned_vector<VectorXd> qddots (NBT);
+  pinocchio::container::aligned_vector<VectorXd> taus (NBT);
   
   for(size_t i=0;i<NBT;++i)
   {

--- a/benchmark/timings-cholesky.cpp
+++ b/benchmark/timings-cholesky.cpp
@@ -36,7 +36,7 @@ EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(Eigen::VectorXd)
 int main(int argc, const char ** argv)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
   PinocchioTicToc timer(PinocchioTicToc::US);
   #ifdef NDEBUG
@@ -46,19 +46,19 @@ int main(int argc, const char ** argv)
     std::cout << "(the time score in debug mode is not relevant) " << std::endl;
   #endif
     
-  se3::Model model;
+  pinocchio::Model model;
 
   std::string filename = PINOCCHIO_SOURCE_DIR"/models/simple_humanoid.urdf";
   if(argc>1) filename = argv[1];
   if( filename == "HS") 
-    se3::buildModels::humanoidRandom(model,true);
+    pinocchio::buildModels::humanoidRandom(model,true);
   else if( filename == "H2" )
-    se3::buildModels::humanoid2d(model);
+    pinocchio::buildModels::humanoid2d(model);
   else
-    se3::urdf::buildModel(filename,JointModelFreeFlyer(),model);
+    pinocchio::urdf::buildModel(filename,JointModelFreeFlyer(),model);
   std::cout << "nq = " << model.nq << std::endl;
 
-  se3::Data data(model);
+  pinocchio::Data data(model);
   VectorXd q = VectorXd::Random(model.nq);
   VectorXd qdot = VectorXd::Random(model.nv);
   VectorXd qddot = VectorXd::Random(model.nv);

--- a/benchmark/timings-derivatives.cpp
+++ b/benchmark/timings-derivatives.cpp
@@ -33,7 +33,7 @@
 #include "pinocchio/utils/timer.hpp"
 
 template<typename Matrix1, typename Matrix2, typename Matrix3>
-void rnea_fd(const se3::Model & model, se3::Data & data_fd,
+void rnea_fd(const pinocchio::Model & model, pinocchio::Data & data_fd,
              const Eigen::VectorXd & q,
              const Eigen::VectorXd & v,
              const Eigen::VectorXd & a,
@@ -82,13 +82,13 @@ void rnea_fd(const se3::Model & model, se3::Data & data_fd,
   
 }
 
-void aba_fd(const se3::Model & model, se3::Data & data_fd,
+void aba_fd(const pinocchio::Model & model, pinocchio::Data & data_fd,
             const Eigen::VectorXd & q,
             const Eigen::VectorXd & v,
             const Eigen::VectorXd & tau,
             Eigen::MatrixXd & daba_dq,
             Eigen::MatrixXd & daba_dv,
-            se3::Data::RowMatrixXs & daba_dtau)
+            pinocchio::Data::RowMatrixXs & daba_dtau)
 {
   using namespace Eigen;
   VectorXd v_eps(VectorXd::Zero(model.nv));
@@ -127,7 +127,7 @@ void aba_fd(const se3::Model & model, se3::Data & data_fd,
 int main(int argc, const char ** argv)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
   PinocchioTicToc timer(PinocchioTicToc::US);
   #ifdef NDEBUG
@@ -154,10 +154,10 @@ int main(int argc, const char ** argv)
     buildModels::humanoidRandom(model,true);
   else
     if(with_ff)
-      se3::urdf::buildModel(filename,JointModelFreeFlyer(),model);
-//      se3::urdf::buildModel(filename,JointModelRX(),model);
+      pinocchio::urdf::buildModel(filename,JointModelFreeFlyer(),model);
+//      pinocchio::urdf::buildModel(filename,JointModelRX(),model);
     else
-      se3::urdf::buildModel(filename,model);
+      pinocchio::urdf::buildModel(filename,model);
   std::cout << "nq = " << model.nq << std::endl;
   std::cout << "nv = " << model.nv << std::endl;
 

--- a/benchmark/timings-geometry.cpp
+++ b/benchmark/timings-geometry.cpp
@@ -41,7 +41,7 @@ EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(Eigen::VectorXd)
 int main()
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
   PinocchioTicToc timer(PinocchioTicToc::US);
   #ifdef NDEBUG
@@ -58,9 +58,9 @@ int main()
   std::string romeo_meshDir  = PINOCCHIO_SOURCE_DIR"/models/";
   package_dirs.push_back(romeo_meshDir);
 
-  se3::Model model;
-  se3::urdf::buildModel(romeo_filename, se3::JointModelFreeFlyer(),model);
-  se3::GeometryModel geom_model; se3::urdf::buildGeom(model, romeo_filename, COLLISION, geom_model, package_dirs);
+  pinocchio::Model model;
+  pinocchio::urdf::buildModel(romeo_filename, pinocchio::JointModelFreeFlyer(),model);
+  pinocchio::GeometryModel geom_model; pinocchio::urdf::buildGeom(model, romeo_filename, COLLISION, geom_model, package_dirs);
 #ifdef PINOCCHIO_WITH_HPP_FCL  
   geom_model.addAllCollisionPairs();
 #endif // PINOCCHIO_WITH_HPP_FCL
@@ -100,7 +100,7 @@ int main()
   SMOOTH(NBT)
   {
     updateGeometryPlacements(model,data,geom_model,geom_data,qs_romeo[_smooth]);
-    for (std::vector<se3::CollisionPair>::iterator it = geom_model.collisionPairs.begin(); it != geom_model.collisionPairs.end(); ++it)
+    for (std::vector<pinocchio::CollisionPair>::iterator it = geom_model.collisionPairs.begin(); it != geom_model.collisionPairs.end(); ++it)
     {
       computeCollision(geom_model,geom_data,std::size_t(it-geom_model.collisionPairs.begin()));
     }

--- a/benchmark/timings.cpp
+++ b/benchmark/timings.cpp
@@ -42,7 +42,7 @@ EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(Eigen::VectorXd)
 int main(int argc, const char ** argv)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
   PinocchioTicToc timer(PinocchioTicToc::US);
   #ifdef NDEBUG
@@ -52,7 +52,7 @@ int main(int argc, const char ** argv)
     std::cout << "(the time score in debug mode is not relevant) " << std::endl;
   #endif
     
-  se3::Model model;
+  pinocchio::Model model;
 
   std::string filename = PINOCCHIO_SOURCE_DIR"/models/simple_humanoid.urdf";
   if(argc>1) filename = argv[1];
@@ -66,17 +66,17 @@ int main(int argc, const char ** argv)
   }
   
   if( filename == "HS") 
-    se3::buildModels::humanoidRandom(model,true);
+    pinocchio::buildModels::humanoidRandom(model,true);
   else
     if(with_ff)
-      se3::urdf::buildModel(filename,JointModelFreeFlyer(),model);
+      pinocchio::urdf::buildModel(filename,JointModelFreeFlyer(),model);
     else
-      se3::urdf::buildModel(filename,model);
+      pinocchio::urdf::buildModel(filename,model);
   std::cout << "nq = " << model.nq << std::endl;
   
   
 
-  se3::Data data(model);
+  pinocchio::Data data(model);
   VectorXd q = VectorXd::Random(model.nq);
   VectorXd qdot = VectorXd::Random(model.nv);
   VectorXd qddot = VectorXd::Random(model.nv);

--- a/bindings/python/algorithm/algorithms.hpp
+++ b/bindings/python/algorithm/algorithms.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_algorithm_hpp__
-#define __se3_python_algorithm_hpp__
+#ifndef __pinocchio_python_algorithm_hpp__
+#define __pinocchio_python_algorithm_hpp__
 
 #include <boost/python.hpp>
 #include "pinocchio/bindings/python/fwd.hpp"
@@ -51,5 +51,5 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // ifndef __se3_python_algorithm_hpp__
+#endif // ifndef __pinocchio_python_algorithm_hpp__
 

--- a/bindings/python/algorithm/algorithms.hpp
+++ b/bindings/python/algorithm/algorithms.hpp
@@ -21,7 +21,7 @@
 #include <boost/python.hpp>
 #include "pinocchio/bindings/python/fwd.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -49,7 +49,7 @@ namespace se3
     void exposeAlgorithms();
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_python_algorithm_hpp__
 

--- a/bindings/python/algorithm/expose-aba-derivatives.cpp
+++ b/bindings/python/algorithm/expose-aba-derivatives.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
 #include "pinocchio/algorithm/aba-derivatives.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -48,4 +48,4 @@ namespace se3
     
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/algorithm/expose-aba.cpp
+++ b/bindings/python/algorithm/expose-aba.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
 #include "pinocchio/algorithm/aba.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -66,4 +66,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/algorithm/expose-algorithms.cpp
+++ b/bindings/python/algorithm/expose-algorithms.cpp
@@ -17,7 +17,7 @@
 
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -46,4 +46,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/algorithm/expose-cat.cpp
+++ b/bindings/python/algorithm/expose-cat.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
 #include "pinocchio/algorithm/compute-all-terms.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -43,4 +43,4 @@ namespace se3
               "in the same loop and put the results in data.");
     }
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/algorithm/expose-centroidal.cpp
+++ b/bindings/python/algorithm/expose-centroidal.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
 #include "pinocchio/algorithm/centroidal.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -46,4 +46,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/algorithm/expose-com.cpp
+++ b/bindings/python/algorithm/expose-com.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/python/overloads.hpp>
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -89,4 +89,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/algorithm/expose-crba.cpp
+++ b/bindings/python/algorithm/expose-crba.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
 #include "pinocchio/algorithm/crba.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -42,4 +42,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/algorithm/expose-dynamics.cpp
+++ b/bindings/python/algorithm/expose-dynamics.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
 #include "pinocchio/algorithm/dynamics.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -72,4 +72,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/algorithm/expose-energy.cpp
+++ b/bindings/python/algorithm/expose-energy.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
 #include "pinocchio/algorithm/energy.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -48,4 +48,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/algorithm/expose-frames.cpp
+++ b/bindings/python/algorithm/expose-frames.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
 #include "pinocchio/algorithm/frames.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -175,4 +175,4 @@ namespace se3
 
     }
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/algorithm/expose-geometry.cpp
+++ b/bindings/python/algorithm/expose-geometry.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
 #include "pinocchio/algorithm/geometry.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -82,4 +82,4 @@ namespace se3
 #endif // PINOCCHIO_WITH_HPP_FCL      
     }
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/algorithm/expose-jacobian.cpp
+++ b/bindings/python/algorithm/expose-jacobian.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
 #include "pinocchio/algorithm/jacobian.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -121,4 +121,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/algorithm/expose-joints.cpp
+++ b/bindings/python/algorithm/expose-joints.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
 #include "pinocchio/algorithm/joint-configuration.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -104,4 +104,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/algorithm/expose-kinematics-derivatives.cpp
+++ b/bindings/python/algorithm/expose-kinematics-derivatives.cpp
@@ -20,7 +20,7 @@
 
 #include <boost/python/tuple.hpp>
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -101,4 +101,4 @@ namespace se3
     
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/algorithm/expose-kinematics.cpp
+++ b/bindings/python/algorithm/expose-kinematics.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
 #include "pinocchio/algorithm/kinematics.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -58,4 +58,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/algorithm/expose-regressor.cpp
+++ b/bindings/python/algorithm/expose-regressor.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
 #include "pinocchio/algorithm/regressor.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -38,4 +38,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/algorithm/expose-rnea-derivatives.cpp
+++ b/bindings/python/algorithm/expose-rnea-derivatives.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
 #include "pinocchio/algorithm/rnea-derivatives.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -30,7 +30,7 @@ namespace se3
     {
       Data::MatrixXs res(model.nv,model.nv);
       res.setZero();
-      se3::computeGeneralizedGravityDerivatives(model,data,q,res);
+      pinocchio::computeGeneralizedGravityDerivatives(model,data,q,res);
       return res;
     }
     
@@ -39,7 +39,7 @@ namespace se3
                                       const Eigen::VectorXd & v,
                                       const Eigen::VectorXd & a)
     {
-      se3::computeRNEADerivatives(model,data,q,v,a);
+      pinocchio::computeRNEADerivatives(model,data,q,v,a);
       // Symmetrize M
       data.M.triangularView<Eigen::StrictlyLower>()
       = data.M.transpose().triangularView<Eigen::StrictlyLower>();
@@ -51,7 +51,7 @@ namespace se3
                                      const Eigen::VectorXd & a,
                                      const ForceAlignedVector & fext)
     {
-      se3::computeRNEADerivatives(model,data,q,v,a,fext);
+      pinocchio::computeRNEADerivatives(model,data,q,v,a,fext);
       // Symmetrize M
       data.M.triangularView<Eigen::StrictlyLower>()
       = data.M.transpose().triangularView<Eigen::StrictlyLower>();
@@ -94,4 +94,4 @@ namespace se3
     
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/algorithm/expose-rnea.cpp
+++ b/bindings/python/algorithm/expose-rnea.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
 #include "pinocchio/algorithm/rnea.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -72,4 +72,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/fwd.hpp
+++ b/bindings/python/fwd.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_python_hpp__
-#define __se3_python_python_hpp__
+#ifndef __pinocchio_python_python_hpp__
+#define __pinocchio_python_python_hpp__
 
 #include "pinocchio/fwd.hpp"
 
@@ -54,5 +54,5 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // ifndef __se3_python_python_hpp__
+#endif // ifndef __pinocchio_python_python_hpp__
 

--- a/bindings/python/fwd.hpp
+++ b/bindings/python/fwd.hpp
@@ -21,7 +21,7 @@
 
 #include "pinocchio/fwd.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -52,7 +52,7 @@ namespace se3
 #endif // PINOCCHIO_WITH_HPP_FCL
 
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_python_python_hpp__
 

--- a/bindings/python/module.cpp
+++ b/bindings/python/module.cpp
@@ -24,7 +24,7 @@
 #include "pinocchio/bindings/python/utils/version.hpp"
 
 namespace bp = boost::python;
-using namespace se3::python;
+using namespace pinocchio::python;
 
 BOOST_PYTHON_MODULE(libpinocchio_pywrap)
 {
@@ -49,9 +49,9 @@ BOOST_PYTHON_MODULE(libpinocchio_pywrap)
   exposeJoints();
   exposeExplog();
   
-  bp::enum_< ::se3::ReferenceFrame >("ReferenceFrame")
-  .value("WORLD",::se3::WORLD)
-  .value("LOCAL",::se3::LOCAL)
+  bp::enum_< ::pinocchio::ReferenceFrame >("ReferenceFrame")
+  .value("WORLD",::pinocchio::WORLD)
+  .value("LOCAL",::pinocchio::LOCAL)
   ;
 
   exposeModel();

--- a/bindings/python/multibody/data.hpp
+++ b/bindings/python/multibody/data.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_data_hpp__
-#define __se3_python_data_hpp__
+#ifndef __pinocchio_python_data_hpp__
+#define __pinocchio_python_data_hpp__
 
 #include "pinocchio/multibody/data.hpp"
 
@@ -141,5 +141,5 @@ namespace se3
     
   }} // namespace se3::python
 
-#endif // ifndef __se3_python_data_hpp__
+#endif // ifndef __pinocchio_python_data_hpp__
 

--- a/bindings/python/multibody/data.hpp
+++ b/bindings/python/multibody/data.hpp
@@ -24,9 +24,9 @@
 #include <eigenpy/eigenpy.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(se3::Data)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(pinocchio::Data)
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -139,7 +139,7 @@ namespace se3
 
     };
     
-  }} // namespace se3::python
+  }} // namespace pinocchio::python
 
 #endif // ifndef __pinocchio_python_data_hpp__
 

--- a/bindings/python/multibody/expose-data.cpp
+++ b/bindings/python/multibody/expose-data.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/fwd.hpp"
 #include "pinocchio/bindings/python/multibody/data.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -29,4 +29,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/multibody/expose-frame.cpp
+++ b/bindings/python/multibody/expose-frame.cpp
@@ -19,7 +19,7 @@
 #include "pinocchio/bindings/python/multibody/frame.hpp"
 #include "pinocchio/bindings/python/utils/std-aligned-vector.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -31,4 +31,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/multibody/expose-geometry.cpp
+++ b/bindings/python/multibody/expose-geometry.cpp
@@ -21,7 +21,7 @@
 #include "pinocchio/bindings/python/multibody/geometry-data.hpp"
 #include "pinocchio/bindings/python/utils/std-aligned-vector.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -37,4 +37,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/multibody/expose-model.cpp
+++ b/bindings/python/multibody/expose-model.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/fwd.hpp"
 #include "pinocchio/bindings/python/multibody/model.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -29,4 +29,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/multibody/fcl/collision-geometry.hpp
+++ b/bindings/python/multibody/fcl/collision-geometry.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_fcl_collision_geometry_hpp__
-#define __se3_python_fcl_collision_geometry_hpp__
+#ifndef __pinocchio_python_fcl_collision_geometry_hpp__
+#define __pinocchio_python_fcl_collision_geometry_hpp__
 
 #include "pinocchio/spatial/fcl-pinocchio-conversions.hpp"
 #include <hpp/fcl/collision_object.h>
@@ -105,4 +105,4 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // namespace __se3_python_fcl_collision_geometry_hpp__
+#endif // namespace __pinocchio_python_fcl_collision_geometry_hpp__

--- a/bindings/python/multibody/fcl/collision-geometry.hpp
+++ b/bindings/python/multibody/fcl/collision-geometry.hpp
@@ -25,7 +25,7 @@
 #include <boost/python/return_internal_reference.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -103,6 +103,6 @@ namespace se3
     } // namespace fcl
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // namespace __pinocchio_python_fcl_collision_geometry_hpp__

--- a/bindings/python/multibody/fcl/collision-result.hpp
+++ b/bindings/python/multibody/fcl/collision-result.hpp
@@ -25,7 +25,7 @@
 #include <boost/python/return_internal_reference.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -76,6 +76,6 @@ namespace se3
     } // namespace fcl
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // namespace __pinocchio_python_fcl_collision_result_hpp__

--- a/bindings/python/multibody/fcl/collision-result.hpp
+++ b/bindings/python/multibody/fcl/collision-result.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_fcl_collision_result_hpp__
-#define __se3_python_fcl_collision_result_hpp__
+#ifndef __pinocchio_python_fcl_collision_result_hpp__
+#define __pinocchio_python_fcl_collision_result_hpp__
 
 #include "pinocchio/spatial/fcl-pinocchio-conversions.hpp"
 #include <hpp/fcl/collision_data.h>
@@ -78,4 +78,4 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // namespace __se3_python_fcl_collision_result_hpp__
+#endif // namespace __pinocchio_python_fcl_collision_result_hpp__

--- a/bindings/python/multibody/fcl/contact.hpp
+++ b/bindings/python/multibody/fcl/contact.hpp
@@ -25,7 +25,7 @@
 #include <boost/python/copy_const_reference.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -104,6 +104,6 @@ namespace se3
     } // namespace fcl
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // namespace __pinocchio_python_fcl_contact_hpp__

--- a/bindings/python/multibody/fcl/contact.hpp
+++ b/bindings/python/multibody/fcl/contact.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_fcl_contact_hpp__
-#define __se3_python_fcl_contact_hpp__
+#ifndef __pinocchio_python_fcl_contact_hpp__
+#define __pinocchio_python_fcl_contact_hpp__
 
 #include "pinocchio/spatial/fcl-pinocchio-conversions.hpp"
 #include <hpp/fcl/collision_data.h>
@@ -106,4 +106,4 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // namespace __se3_python_fcl_contact_hpp__
+#endif // namespace __pinocchio_python_fcl_contact_hpp__

--- a/bindings/python/multibody/fcl/distance-result.hpp
+++ b/bindings/python/multibody/fcl/distance-result.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_fcl_distance_result_hpp__
-#define __se3_python_fcl_distance_result_hpp__
+#ifndef __pinocchio_python_fcl_distance_result_hpp__
+#define __pinocchio_python_fcl_distance_result_hpp__
 
 #include "pinocchio/spatial/fcl-pinocchio-conversions.hpp"
 #include <hpp/fcl/collision_data.h>
@@ -77,4 +77,4 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // namespace __se3_python_fcl_distance_result_hpp__
+#endif // namespace __pinocchio_python_fcl_distance_result_hpp__

--- a/bindings/python/multibody/fcl/distance-result.hpp
+++ b/bindings/python/multibody/fcl/distance-result.hpp
@@ -25,7 +25,7 @@
 #include <boost/python/return_internal_reference.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -75,6 +75,6 @@ namespace se3
     } // namespace fcl
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // namespace __pinocchio_python_fcl_distance_result_hpp__

--- a/bindings/python/multibody/fcl/expose-fcl.cpp
+++ b/bindings/python/multibody/fcl/expose-fcl.cpp
@@ -23,13 +23,13 @@
 
 #include "pinocchio/bindings/python/utils/std-vector.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
     void exposeFCL()
     {
-      using namespace se3::python::fcl;
+      using namespace pinocchio::python::fcl;
       ContactPythonVisitor::expose();
       StdVectorPythonVisitor<ContactPythonVisitor::Contact>::expose("StdVect_Contact");
       
@@ -43,4 +43,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/multibody/frame.hpp
+++ b/bindings/python/multibody/frame.hpp
@@ -23,7 +23,7 @@
 #include "pinocchio/bindings/python/utils/copyable.hpp"
 #include "pinocchio/bindings/python/utils/printable.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -73,6 +73,6 @@ namespace se3
     
 
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_python_frame_hpp__

--- a/bindings/python/multibody/frame.hpp
+++ b/bindings/python/multibody/frame.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_frame_hpp__
-#define __se3_python_frame_hpp__
+#ifndef __pinocchio_python_frame_hpp__
+#define __pinocchio_python_frame_hpp__
 
 #include "pinocchio/multibody/fwd.hpp"
 #include "pinocchio/multibody/frame.hpp"
@@ -75,4 +75,4 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // ifndef __se3_python_frame_hpp__
+#endif // ifndef __pinocchio_python_frame_hpp__

--- a/bindings/python/multibody/geometry-data.hpp
+++ b/bindings/python/multibody/geometry-data.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_geometry_data_hpp__
-#define __se3_python_geometry_data_hpp__
+#ifndef __pinocchio_python_geometry_data_hpp__
+#define __pinocchio_python_geometry_data_hpp__
 
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <eigenpy/memory.hpp>
@@ -125,5 +125,5 @@ namespace se3
     
   }} // namespace se3::python
 
-#endif // ifndef __se3_python_geometry_data_hpp__
+#endif // ifndef __pinocchio_python_geometry_data_hpp__
 

--- a/bindings/python/multibody/geometry-data.hpp
+++ b/bindings/python/multibody/geometry-data.hpp
@@ -24,9 +24,9 @@
 #include "pinocchio/bindings/python/utils/eigen_container.hpp"
 #include "pinocchio/bindings/python/utils/printable.hpp"
 
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(se3::GeometryData)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(pinocchio::GeometryData)
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -123,7 +123,7 @@ namespace se3
 
     };
     
-  }} // namespace se3::python
+  }} // namespace pinocchio::python
 
 #endif // ifndef __pinocchio_python_geometry_data_hpp__
 

--- a/bindings/python/multibody/geometry-model.hpp
+++ b/bindings/python/multibody/geometry-model.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_geometry_model_hpp__
-#define __se3_python_geometry_model_hpp__
+#ifndef __pinocchio_python_geometry_model_hpp__
+#define __pinocchio_python_geometry_model_hpp__
 
 #include <eigenpy/memory.hpp>
 
@@ -102,4 +102,4 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // ifndef __se3_python_geometry_model_hpp__
+#endif // ifndef __pinocchio_python_geometry_model_hpp__

--- a/bindings/python/multibody/geometry-model.hpp
+++ b/bindings/python/multibody/geometry-model.hpp
@@ -24,9 +24,9 @@
 #include "pinocchio/bindings/python/utils/printable.hpp"
 #include "pinocchio/multibody/geometry.hpp"
 
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(se3::GeometryModel)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(pinocchio::GeometryModel)
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -100,6 +100,6 @@ namespace se3
     };
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_python_geometry_model_hpp__

--- a/bindings/python/multibody/geometry-object.hpp
+++ b/bindings/python/multibody/geometry-object.hpp
@@ -23,9 +23,9 @@
 
 #include "pinocchio/multibody/geometry.hpp"
 
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(se3::GeometryObject)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(pinocchio::GeometryObject)
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -92,6 +92,6 @@ namespace se3
     
 
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_python_geometry_object_hpp__

--- a/bindings/python/multibody/geometry-object.hpp
+++ b/bindings/python/multibody/geometry-object.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_geometry_object_hpp__
-#define __se3_python_geometry_object_hpp__
+#ifndef __pinocchio_python_geometry_object_hpp__
+#define __pinocchio_python_geometry_object_hpp__
 
 #include <boost/python.hpp>
 #include <eigenpy/memory.hpp>
@@ -94,4 +94,4 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // ifndef __se3_python_geometry_object_hpp__
+#endif // ifndef __pinocchio_python_geometry_object_hpp__

--- a/bindings/python/multibody/joint/expose-joints.cpp
+++ b/bindings/python/multibody/joint/expose-joints.cpp
@@ -22,7 +22,7 @@
 
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -30,7 +30,7 @@ namespace se3
     static void exposeVariants()
     {
       boost::mpl::for_each<JointModelVariant::types>(exposer());
-      bp::to_python_converter<se3::JointModelVariant, jointModelVariantVisitor>();
+      bp::to_python_converter<pinocchio::JointModelVariant, jointModelVariantVisitor>();
     }
     
     void exposeJoints()
@@ -42,4 +42,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/multibody/joint/joint-derived.hpp
+++ b/bindings/python/multibody/joint/joint-derived.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_joint_dense_hpp__
-#define __se3_python_joint_dense_hpp__
+#ifndef __pinocchio_python_joint_dense_hpp__
+#define __pinocchio_python_joint_dense_hpp__
 
 #include <eigenpy/exception.hpp>
 #include <eigenpy/eigenpy.hpp>
@@ -68,5 +68,5 @@ namespace se3
 
   }} // namespace se3::python
 
-#endif // ifndef __se3_python_joint_dense_hpp__
+#endif // ifndef __pinocchio_python_joint_dense_hpp__
 

--- a/bindings/python/multibody/joint/joint-derived.hpp
+++ b/bindings/python/multibody/joint/joint-derived.hpp
@@ -23,7 +23,7 @@
 
 #include "pinocchio/multibody/joint/joint-collection.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -66,7 +66,7 @@ namespace se3
     
 
 
-  }} // namespace se3::python
+  }} // namespace pinocchio::python
 
 #endif // ifndef __pinocchio_python_joint_dense_hpp__
 

--- a/bindings/python/multibody/joint/joint.hpp
+++ b/bindings/python/multibody/joint/joint.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_joint_hpp__
-#define __se3_python_joint_hpp__
+#ifndef __pinocchio_python_joint_hpp__
+#define __pinocchio_python_joint_hpp__
 
 #include <eigenpy/exception.hpp>
 #include <eigenpy/eigenpy.hpp>
@@ -74,4 +74,4 @@ namespace se3
     
 }} // namespace se3::python
 
-#endif // ifndef __se3_python_joint_hpp__
+#endif // ifndef __pinocchio_python_joint_hpp__

--- a/bindings/python/multibody/joint/joint.hpp
+++ b/bindings/python/multibody/joint/joint.hpp
@@ -24,7 +24,7 @@
 #include "pinocchio/multibody/joint/joint-generic.hpp"
 #include "pinocchio/bindings/python/utils/printable.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -64,7 +64,7 @@ namespace se3
         bp::class_<JointModel>("JointModel",
                                "Generic Joint Model",
                                bp::no_init)
-        .def(bp::init<se3::JointModelVariant>())
+        .def(bp::init<pinocchio::JointModelVariant>())
         .def(JointModelPythonVisitor())
         .def(PrintableVisitor<JointModel>())
         ;
@@ -72,6 +72,6 @@ namespace se3
 
     }; 
     
-}} // namespace se3::python
+}} // namespace pinocchio::python
 
 #endif // ifndef __pinocchio_python_joint_hpp__

--- a/bindings/python/multibody/joint/joints-models.hpp
+++ b/bindings/python/multibody/joint/joints-models.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_joints_models_hpp__
-#define __se3_python_joints_models_hpp__
+#ifndef __pinocchio_python_joints_models_hpp__
+#define __pinocchio_python_joints_models_hpp__
 
 #include <eigenpy/exception.hpp>
 #include <eigenpy/eigenpy.hpp>
@@ -44,4 +44,4 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // ifndef __se3_python_joint_models_hpp__
+#endif // ifndef __pinocchio_python_joint_models_hpp__

--- a/bindings/python/multibody/joint/joints-models.hpp
+++ b/bindings/python/multibody/joint/joints-models.hpp
@@ -22,7 +22,7 @@
 #include <eigenpy/eigenpy.hpp>
 #include "pinocchio/multibody/joint/joint-collection.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -42,6 +42,6 @@ namespace se3
       return cl.def(bp::init<double, double, double> ((bp::args("x"), bp::args("y"), bp::args("z")), "Init JointRevoluteUnaligned from the components x, y, z of the axis"));
     }
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_python_joint_models_hpp__

--- a/bindings/python/multibody/joint/joints-variant.hpp
+++ b/bindings/python/multibody/joint/joints-variant.hpp
@@ -23,7 +23,7 @@
 #include "pinocchio/multibody/joint/joint-collection.hpp"
 #include "pinocchio/bindings/python/multibody/joint/joints-models.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -49,11 +49,11 @@ namespace se3
       void operator()(T)
       {
         expose_constructors<T>(bp::class_<T>(T::classname().c_str(),bp::init<>()).def(JointPythonVisitor<T>()));
-        bp::implicitly_convertible<T,se3::JointModelVariant>();
+        bp::implicitly_convertible<T,pinocchio::JointModelVariant>();
       }
     };
 
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_python_joints_variant_hpp__

--- a/bindings/python/multibody/joint/joints-variant.hpp
+++ b/bindings/python/multibody/joint/joints-variant.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_joints_variant_hpp__
-#define __se3_python_joints_variant_hpp__
+#ifndef __pinocchio_python_joints_variant_hpp__
+#define __pinocchio_python_joints_variant_hpp__
 
 #include <eigenpy/exception.hpp>
 #include <eigenpy/eigenpy.hpp>
@@ -56,4 +56,4 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // ifndef __se3_python_joints_variant_hpp__
+#endif // ifndef __pinocchio_python_joints_variant_hpp__

--- a/bindings/python/multibody/model.hpp
+++ b/bindings/python/multibody/model.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_model_hpp__
-#define __se3_python_model_hpp__
+#ifndef __pinocchio_python_model_hpp__
+#define __pinocchio_python_model_hpp__
 
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <boost/python/overloads.hpp>
@@ -229,5 +229,5 @@ namespace se3
 
   }} // namespace se3::python
 
-#endif // ifndef __se3_python_model_hpp__
+#endif // ifndef __pinocchio_python_model_hpp__
 

--- a/bindings/python/multibody/model.hpp
+++ b/bindings/python/multibody/model.hpp
@@ -31,9 +31,9 @@
 #include "pinocchio/bindings/python/utils/printable.hpp"
 #include "pinocchio/bindings/python/utils/copyable.hpp"
 
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(se3::Model)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(pinocchio::Model)
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -227,7 +227,7 @@ namespace se3
     
 
 
-  }} // namespace se3::python
+  }} // namespace pinocchio::python
 
 #endif // ifndef __pinocchio_python_model_hpp__
 

--- a/bindings/python/parsers/expose-parsers.cpp
+++ b/bindings/python/parsers/expose-parsers.cpp
@@ -18,7 +18,7 @@
 #include "pinocchio/bindings/python/parsers/parsers.hpp"
 #include "pinocchio/bindings/python/parsers/sample-models.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -30,4 +30,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/parsers/parsers.hpp
+++ b/bindings/python/parsers/parsers.hpp
@@ -36,7 +36,7 @@
 
 #include "pinocchio/parsers/srdf.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -56,14 +56,14 @@ namespace se3
       static Model buildModelFromUrdf(const std::string & filename)
       {
         Model model;
-        se3::urdf::buildModel(filename, model);
+        pinocchio::urdf::buildModel(filename, model);
         return model;
       }
       
       static void buildModelFromUrdf(const std::string & filename,
                                      Model & model)
       {
-        se3::urdf::buildModel(filename, model);
+        pinocchio::urdf::buildModel(filename, model);
       }
 
       static Model buildModelFromUrdf(const std::string & filename,
@@ -72,7 +72,7 @@ namespace se3
       {
         JointModelVariant root_joint = bp::extract<JointModelVariant> (root_joint_object)();
         Model model;
-        se3::urdf::buildModel(filename, root_joint, model);
+        pinocchio::urdf::buildModel(filename, root_joint, model);
         return model;
       }
       
@@ -82,7 +82,7 @@ namespace se3
                                      )
       {
         JointModelVariant root_joint = bp::extract<JointModelVariant> (root_joint_object)();
-        se3::urdf::buildModel(filename, root_joint, model);
+        pinocchio::urdf::buildModel(filename, root_joint, model);
       }
       
       static Model buildModelFromXML(const std::string & XMLstream,
@@ -91,14 +91,14 @@ namespace se3
       {
         JointModelVariant root_joint = bp::extract<JointModelVariant> (root_joint_object)();
         Model model;
-        se3::urdf::buildModelFromXML(XMLstream, root_joint, model);
+        pinocchio::urdf::buildModelFromXML(XMLstream, root_joint, model);
         return model;
       }
       
       static Model buildModelFromXML(const std::string & XMLstream)
       {
         Model model;
-        se3::urdf::buildModelFromXML(XMLstream, model);
+        pinocchio::urdf::buildModelFromXML(XMLstream, model);
         return model;
       }
 
@@ -110,7 +110,7 @@ namespace se3
       {
         std::vector<std::string> hints;
         GeometryModel geometry_model;
-        se3::urdf::buildGeom(model,filename,type,geometry_model,hints);
+        pinocchio::urdf::buildGeom(model,filename,type,geometry_model,hints);
         
         return geometry_model;
       }
@@ -123,7 +123,7 @@ namespace se3
                         )
       {
         GeometryModel geometry_model;
-        se3::urdf::buildGeom(model,filename,type,geometry_model,package_dirs);
+        pinocchio::urdf::buildGeom(model,filename,type,geometry_model,package_dirs);
         
         return geometry_model;
       }
@@ -137,7 +137,7 @@ namespace se3
                                             )
       {
         Model model;
-        model = se3::lua::buildModel (filename, ff, verbose);
+        model = pinocchio::lua::buildModel (filename, ff, verbose);
         return model;
       }
 #endif // #ifdef PINOCCHIO_WITH_LUA5
@@ -236,6 +236,6 @@ namespace se3
     }
     
   }
-} // namespace se3::python
+} // namespace pinocchio::python
 
 #endif // ifndef __pinocchio_python_parsers_hpp__

--- a/bindings/python/parsers/parsers.hpp
+++ b/bindings/python/parsers/parsers.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_parsers_hpp__
-#define __se3_python_parsers_hpp__
+#ifndef __pinocchio_python_parsers_hpp__
+#define __pinocchio_python_parsers_hpp__
 
 #include <eigenpy/exception.hpp>
 #include <eigenpy/eigenpy.hpp>
@@ -238,4 +238,4 @@ namespace se3
   }
 } // namespace se3::python
 
-#endif // ifndef __se3_python_parsers_hpp__
+#endif // ifndef __pinocchio_python_parsers_hpp__

--- a/bindings/python/parsers/python.hpp
+++ b/bindings/python/parsers/python.hpp
@@ -22,7 +22,7 @@
 
 #include "pinocchio/multibody/model.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -41,6 +41,6 @@ namespace se3
     
   } // namespace python
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_pythonparser_hpp__

--- a/bindings/python/parsers/python.hpp
+++ b/bindings/python/parsers/python.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_pythonparser_hpp__
-#define __se3_pythonparser_hpp__
+#ifndef __pinocchio_pythonparser_hpp__
+#define __pinocchio_pythonparser_hpp__
 
 #include <boost/python.hpp>
 
@@ -43,4 +43,4 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_pythonparser_hpp__
+#endif // ifndef __pinocchio_pythonparser_hpp__

--- a/bindings/python/parsers/python/model.cpp
+++ b/bindings/python/parsers/python/model.cpp
@@ -27,7 +27,7 @@
 #include <fstream>
 #endif
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -87,5 +87,5 @@ namespace se3
       return model;
     }
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 

--- a/bindings/python/parsers/sample-models.hpp
+++ b/bindings/python/parsers/sample-models.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_sample_models_hpp__
-#define __se3_python_sample_models_hpp__
+#ifndef __pinocchio_python_sample_models_hpp__
+#define __pinocchio_python_sample_models_hpp__
 
 #include "pinocchio/parsers/sample-models.hpp"
 #include "pinocchio/bindings/python/multibody/data.hpp"
@@ -136,4 +136,4 @@ namespace se3
   }
 } // namespace se3::python
 
-#endif // ifndef __se3_python_sample_models_hpp__
+#endif // ifndef __pinocchio_python_sample_models_hpp__

--- a/bindings/python/parsers/sample-models.hpp
+++ b/bindings/python/parsers/sample-models.hpp
@@ -22,7 +22,7 @@
 #include "pinocchio/bindings/python/multibody/data.hpp"
 #include "pinocchio/bindings/python/multibody/geometry-model.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -134,6 +134,6 @@ namespace se3
     }
     
   }
-} // namespace se3::python
+} // namespace pinocchio::python
 
 #endif // ifndef __pinocchio_python_sample_models_hpp__

--- a/bindings/python/spatial/explog.hpp
+++ b/bindings/python/spatial/explog.hpp
@@ -23,7 +23,7 @@
 
 # include "pinocchio/spatial/explog.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -95,6 +95,6 @@ namespace se3
       }
     };
   } // namespace python
-} //namespace se3
+} //namespace pinocchio
 
 #endif // ifndef __pinocchio_python_explog_hpp__

--- a/bindings/python/spatial/explog.hpp
+++ b/bindings/python/spatial/explog.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_explog_hpp__
-# define __se3_python_explog_hpp__
+#ifndef __pinocchio_python_explog_hpp__
+# define __pinocchio_python_explog_hpp__
 
 # include <eigenpy/eigenpy.hpp>
 
@@ -97,4 +97,4 @@ namespace se3
   } // namespace python
 } //namespace se3
 
-#endif // ifndef __se3_python_explog_hpp__
+#endif // ifndef __pinocchio_python_explog_hpp__

--- a/bindings/python/spatial/expose-SE3.cpp
+++ b/bindings/python/spatial/expose-SE3.cpp
@@ -19,7 +19,7 @@
 #include "pinocchio/bindings/python/spatial/se3.hpp"
 #include "pinocchio/bindings/python/utils/std-aligned-vector.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -31,4 +31,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/spatial/expose-explog.cpp
+++ b/bindings/python/spatial/expose-explog.cpp
@@ -19,7 +19,7 @@
 #include "pinocchio/bindings/python/fwd.hpp"
 #include "pinocchio/bindings/python/spatial/explog.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -30,4 +30,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/spatial/expose-force.cpp
+++ b/bindings/python/spatial/expose-force.cpp
@@ -19,7 +19,7 @@
 #include "pinocchio/bindings/python/spatial/force.hpp"
 #include "pinocchio/bindings/python/utils/std-aligned-vector.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -31,4 +31,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/spatial/expose-inertia.cpp
+++ b/bindings/python/spatial/expose-inertia.cpp
@@ -19,7 +19,7 @@
 #include "pinocchio/bindings/python/spatial/inertia.hpp"
 #include "pinocchio/bindings/python/utils/std-aligned-vector.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -31,4 +31,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/spatial/expose-motion.cpp
+++ b/bindings/python/spatial/expose-motion.cpp
@@ -19,7 +19,7 @@
 #include "pinocchio/bindings/python/spatial/motion.hpp"
 #include "pinocchio/bindings/python/utils/std-aligned-vector.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -31,4 +31,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/spatial/force.hpp
+++ b/bindings/python/spatial/force.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_force_hpp__
-#define __se3_python_force_hpp__
+#ifndef __pinocchio_python_force_hpp__
+#define __pinocchio_python_force_hpp__
 
 #include <eigenpy/memory.hpp>
 #include <boost/python/tuple.hpp>
@@ -147,5 +147,5 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // ifndef __se3_python_se3_hpp__
+#endif // ifndef __pinocchio_python_se3_hpp__
 

--- a/bindings/python/spatial/force.hpp
+++ b/bindings/python/spatial/force.hpp
@@ -27,9 +27,9 @@
 #include "pinocchio/bindings/python/utils/copyable.hpp"
 #include "pinocchio/bindings/python/utils/printable.hpp"
 
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(se3::Force)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(pinocchio::Force)
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -145,7 +145,7 @@ namespace se3
     };
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_python_se3_hpp__
 

--- a/bindings/python/spatial/inertia.hpp
+++ b/bindings/python/spatial/inertia.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_inertia_hpp__
-#define __se3_python_inertia_hpp__
+#ifndef __pinocchio_python_inertia_hpp__
+#define __pinocchio_python_inertia_hpp__
 
 #include <eigenpy/exception.hpp>
 #include <eigenpy/memory.hpp>
@@ -183,4 +183,4 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // ifndef __se3_python_se3_hpp__
+#endif // ifndef __pinocchio_python_se3_hpp__

--- a/bindings/python/spatial/inertia.hpp
+++ b/bindings/python/spatial/inertia.hpp
@@ -27,9 +27,9 @@
 #include "pinocchio/bindings/python/utils/copyable.hpp"
 #include "pinocchio/bindings/python/utils/printable.hpp"
 
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(se3::Inertia)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(pinocchio::Inertia)
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -181,6 +181,6 @@ namespace se3
     }; // struct InertiaPythonVisitor
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_python_se3_hpp__

--- a/bindings/python/spatial/motion.hpp
+++ b/bindings/python/spatial/motion.hpp
@@ -28,9 +28,9 @@
 #include "pinocchio/bindings/python/utils/copyable.hpp"
 #include "pinocchio/bindings/python/utils/printable.hpp"
 
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(se3::Motion)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(pinocchio::Motion)
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -159,7 +159,7 @@ namespace se3
     
 
 
-  }} // namespace se3::python
+  }} // namespace pinocchio::python
 
 #endif // ifndef __pinocchio_python_se3_hpp__
 

--- a/bindings/python/spatial/motion.hpp
+++ b/bindings/python/spatial/motion.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_motion_hpp__
-#define __se3_python_motion_hpp__
+#ifndef __pinocchio_python_motion_hpp__
+#define __pinocchio_python_motion_hpp__
 
 #include <eigenpy/memory.hpp>
 #include <boost/python/tuple.hpp>
@@ -161,5 +161,5 @@ namespace se3
 
   }} // namespace se3::python
 
-#endif // ifndef __se3_python_se3_hpp__
+#endif // ifndef __pinocchio_python_se3_hpp__
 

--- a/bindings/python/spatial/se3.hpp
+++ b/bindings/python/spatial/se3.hpp
@@ -30,9 +30,9 @@
 #include "pinocchio/bindings/python/utils/copyable.hpp"
 #include "pinocchio/bindings/python/utils/printable.hpp"
 
-EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(se3::SE3)
+EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(pinocchio::SE3)
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -167,7 +167,7 @@ namespace se3
 
 
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_python_se3_hpp__
 

--- a/bindings/python/spatial/se3.hpp
+++ b/bindings/python/spatial/se3.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_se3_hpp__
-#define __se3_python_se3_hpp__
+#ifndef __pinocchio_python_se3_hpp__
+#define __pinocchio_python_se3_hpp__
 
 #include <eigenpy/memory.hpp>
 #include <boost/python/tuple.hpp>
@@ -169,5 +169,5 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // ifndef __se3_python_se3_hpp__
+#endif // ifndef __pinocchio_python_se3_hpp__
 

--- a/bindings/python/utils/constant.hpp
+++ b/bindings/python/utils/constant.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_utils_constant_hpp__
-#define __se3_python_utils_constant_hpp__
+#ifndef __pinocchio_python_utils_constant_hpp__
+#define __pinocchio_python_utils_constant_hpp__
 
 #include <boost/python/scope.hpp>
 
@@ -43,4 +43,4 @@ namespace boost
   } // namespace python
 } // namespace boost
 
-#endif // ifndef __se3_python_utils_constant_hpp__
+#endif // ifndef __pinocchio_python_utils_constant_hpp__

--- a/bindings/python/utils/copyable.hpp
+++ b/bindings/python/utils/copyable.hpp
@@ -20,7 +20,7 @@
 
 #include <boost/python.hpp>
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -41,6 +41,6 @@ namespace se3
       static C copy(const C & self) { return C(self); }
     };
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_python_utils_copyable_hpp__

--- a/bindings/python/utils/copyable.hpp
+++ b/bindings/python/utils/copyable.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_utils_copyable_hpp__
-#define __se3_python_utils_copyable_hpp__
+#ifndef __pinocchio_python_utils_copyable_hpp__
+#define __pinocchio_python_utils_copyable_hpp__
 
 #include <boost/python.hpp>
 
@@ -43,4 +43,4 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // ifndef __se3_python_utils_copyable_hpp__
+#endif // ifndef __pinocchio_python_utils_copyable_hpp__

--- a/bindings/python/utils/eigen_container.hpp
+++ b/bindings/python/utils/eigen_container.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_eigen_container_hpp__
-#define __se3_python_eigen_container_hpp__
+#ifndef __pinocchio_python_eigen_container_hpp__
+#define __pinocchio_python_eigen_container_hpp__
 
 #include <eigenpy/exception.hpp>
 #include <eigenpy/eigenpy.hpp>
@@ -79,5 +79,5 @@ namespace se3
 
   }} // namespace se3::python
 
-#endif // ifndef __se3_python_eigen_container_hpp__
+#endif // ifndef __pinocchio_python_eigen_container_hpp__
 

--- a/bindings/python/utils/eigen_container.hpp
+++ b/bindings/python/utils/eigen_container.hpp
@@ -25,7 +25,7 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/python/return_internal_reference.hpp>
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -77,7 +77,7 @@ namespace se3
       }
     };
 
-  }} // namespace se3::python
+  }} // namespace pinocchio::python
 
 #endif // ifndef __pinocchio_python_eigen_container_hpp__
 

--- a/bindings/python/utils/handler.hpp
+++ b/bindings/python/utils/handler.hpp
@@ -20,7 +20,7 @@
 
 #include <boost/shared_ptr.hpp>
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -87,7 +87,7 @@ namespace se3
     };
 
 
-  }} // namespace se3::python
+  }} // namespace pinocchio::python
 
 #endif // ifndef __pinocchio_python_handler_hpp__
 

--- a/bindings/python/utils/handler.hpp
+++ b/bindings/python/utils/handler.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_handler_hpp__
-#define __se3_python_handler_hpp__
+#ifndef __pinocchio_python_handler_hpp__
+#define __pinocchio_python_handler_hpp__
 
 #include <boost/shared_ptr.hpp>
 
@@ -89,5 +89,5 @@ namespace se3
 
   }} // namespace se3::python
 
-#endif // ifndef __se3_python_handler_hpp__
+#endif // ifndef __pinocchio_python_handler_hpp__
 

--- a/bindings/python/utils/printable.hpp
+++ b/bindings/python/utils/printable.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_utils_printable_hpp__
-#define __se3_python_utils_printable_hpp__
+#ifndef __pinocchio_python_utils_printable_hpp__
+#define __pinocchio_python_utils_printable_hpp__
 
 #include <boost/python.hpp>
 
@@ -45,4 +45,4 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // ifndef __se3_python_utils_printable_hpp__
+#endif // ifndef __pinocchio_python_utils_printable_hpp__

--- a/bindings/python/utils/printable.hpp
+++ b/bindings/python/utils/printable.hpp
@@ -20,7 +20,7 @@
 
 #include <boost/python.hpp>
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -43,6 +43,6 @@ namespace se3
       }
     };
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_python_utils_printable_hpp__

--- a/bindings/python/utils/std-aligned-vector.hpp
+++ b/bindings/python/utils/std-aligned-vector.hpp
@@ -23,7 +23,7 @@
 #include <string>
 #include "pinocchio/container/aligned-vector.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -50,6 +50,6 @@ namespace se3
       }
     };
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_python_utils_std_aligned_vector_hpp__

--- a/bindings/python/utils/std-aligned-vector.hpp
+++ b/bindings/python/utils/std-aligned-vector.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_utils_std_aligned_vector_hpp__
-#define __se3_python_utils_std_aligned_vector_hpp__
+#ifndef __pinocchio_python_utils_std_aligned_vector_hpp__
+#define __pinocchio_python_utils_std_aligned_vector_hpp__
 
 #include <boost/python.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
@@ -52,4 +52,4 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // ifndef __se3_python_utils_std_aligned_vector_hpp__
+#endif // ifndef __pinocchio_python_utils_std_aligned_vector_hpp__

--- a/bindings/python/utils/std-vector.hpp
+++ b/bindings/python/utils/std-vector.hpp
@@ -23,7 +23,7 @@
 #include <string>
 #include <vector>
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -50,6 +50,6 @@ namespace se3
       }
     };
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_python_utils_std_vector_hpp__

--- a/bindings/python/utils/std-vector.hpp
+++ b/bindings/python/utils/std-vector.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_utils_std_vector_hpp__
-#define __se3_python_utils_std_vector_hpp__
+#ifndef __pinocchio_python_utils_std_vector_hpp__
+#define __pinocchio_python_utils_std_vector_hpp__
 
 #include <boost/python.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
@@ -52,4 +52,4 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // ifndef __se3_python_utils_std_vector_hpp__
+#endif // ifndef __pinocchio_python_utils_std_vector_hpp__

--- a/bindings/python/utils/version.cpp
+++ b/bindings/python/utils/version.cpp
@@ -21,7 +21,7 @@
 
 #include <boost/python.hpp>
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -50,4 +50,4 @@ namespace se3
     }
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio

--- a/bindings/python/utils/version.hpp
+++ b/bindings/python/utils/version.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_python_utils_version_hpp__
-#define __se3_python_utils_version_hpp__
+#ifndef __pinocchio_python_utils_version_hpp__
+#define __pinocchio_python_utils_version_hpp__
 
 #include "pinocchio/bindings/python/fwd.hpp"
 
@@ -30,4 +30,4 @@ namespace se3
   } // namespace python
 } // namespace se3
 
-#endif // ifndef __se3_python_utils_version_hpp__
+#endif // ifndef __pinocchio_python_utils_version_hpp__

--- a/bindings/python/utils/version.hpp
+++ b/bindings/python/utils/version.hpp
@@ -20,7 +20,7 @@
 
 #include "pinocchio/bindings/python/fwd.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace python
   {
@@ -28,6 +28,6 @@ namespace se3
     void exposeVersion();
     
   } // namespace python
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_python_utils_version_hpp__

--- a/src/algorithm/aba-derivatives.hpp
+++ b/src/algorithm/aba-derivatives.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_aba_derivatives_hpp__
-#define __se3_aba_derivatives_hpp__
+#ifndef __pinocchio_aba_derivatives_hpp__
+#define __pinocchio_aba_derivatives_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -163,4 +163,4 @@ namespace se3
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/aba-derivatives.hxx"
 
-#endif // ifndef __se3_aba_derivatives_hpp__
+#endif // ifndef __pinocchio_aba_derivatives_hpp__

--- a/src/algorithm/aba-derivatives.hpp
+++ b/src/algorithm/aba-derivatives.hpp
@@ -21,7 +21,7 @@
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
 
-namespace se3
+namespace pinocchio
 {
   ///
   /// \brief The derivatives of the Articulated-Body algorithm.
@@ -45,7 +45,7 @@ namespace se3
   ///
   /// \note aba_partial_dtau is in fact nothing more than the inverse of the joint space inertia matrix.
   ///
-  /// \sa se3::aba
+  /// \sa pinocchio::aba
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2,
            typename MatrixType1, typename MatrixType2, typename MatrixType3>
@@ -80,7 +80,7 @@ namespace se3
   ///
   /// \note aba_partial_dtau is in fact nothing more than the inverse of the joint space inertia matrix.
   ///
-  /// \sa se3::aba
+  /// \sa pinocchio::aba
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2,
   typename MatrixType1, typename MatrixType2, typename MatrixType3>
@@ -110,9 +110,9 @@ namespace se3
   ///
   /// \returns The results are stored in data.ddq_dq, data.ddq_dv and data.Minv which respectively correspond
   ///          to the partial derivatives of the joint acceleration vector with respect to the joint configuration, velocity and torque.
-  ///          And as for se3::computeMinverse, only the upper triangular part of data.Minv is filled.
+  ///          And as for pinocchio::computeMinverse, only the upper triangular part of data.Minv is filled.
   ///
-  /// \sa se3::aba and \sa se3::computeABADerivatives.
+  /// \sa pinocchio::aba and \sa pinocchio::computeABADerivatives.
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2>
   inline void computeABADerivatives(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
@@ -142,9 +142,9 @@ namespace se3
   ///
   /// \returns The results are stored in data.ddq_dq, data.ddq_dv and data.Minv which respectively correspond
   ///          to the partial derivatives of the joint acceleration vector with respect to the joint configuration, velocity and torque.
-  ///          And as for se3::computeMinverse, only the upper triangular part of data.Minv is filled.
+  ///          And as for pinocchio::computeMinverse, only the upper triangular part of data.Minv is filled.
   ///
-  /// \sa se3::aba and \sa se3::computeABADerivatives.
+  /// \sa pinocchio::aba and \sa pinocchio::computeABADerivatives.
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2>
   inline void computeABADerivatives(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
@@ -158,7 +158,7 @@ namespace se3
                           data.ddq_dq,data.ddq_dv,data.Minv);
   }
 
-} // namespace se3
+} // namespace pinocchio
 
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/aba-derivatives.hxx"

--- a/src/algorithm/aba-derivatives.hxx
+++ b/src/algorithm/aba-derivatives.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_aba_derivatives_hxx__
-#define __se3_aba_derivatives_hxx__
+#ifndef __pinocchio_aba_derivatives_hxx__
+#define __pinocchio_aba_derivatives_hxx__
 
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/algorithm/check.hpp"
@@ -481,5 +481,5 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_aba_derivatives_hxx__
+#endif // ifndef __pinocchio_aba_derivatives_hxx__
 

--- a/src/algorithm/aba-derivatives.hxx
+++ b/src/algorithm/aba-derivatives.hxx
@@ -22,7 +22,7 @@
 #include "pinocchio/algorithm/check.hpp"
 #include "pinocchio/algorithm/aba.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType>
@@ -479,7 +479,7 @@ namespace se3
   }
   
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_aba_derivatives_hxx__
 

--- a/src/algorithm/aba.hpp
+++ b/src/algorithm/aba.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_aba_hpp__
-#define __se3_aba_hpp__
+#ifndef __pinocchio_aba_hpp__
+#define __pinocchio_aba_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -101,4 +101,4 @@ namespace se3
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/aba.hxx"
 
-#endif // ifndef __se3_aba_hpp__
+#endif // ifndef __pinocchio_aba_hpp__

--- a/src/algorithm/aba.hpp
+++ b/src/algorithm/aba.hpp
@@ -22,7 +22,7 @@
 #include "pinocchio/multibody/data.hpp"
 #include "pinocchio/algorithm/check.hpp"
 
-namespace se3
+namespace pinocchio
 {
   ///
   /// \brief The Articulated-Body algorithm. It computes the forward dynamics, aka the joint accelerations given the current state and actuation of the model.
@@ -96,7 +96,7 @@ namespace se3
 
   DEFINE_ALGO_CHECKER(ABA);
 
-} // namespace se3
+} // namespace pinocchio
 
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/aba.hxx"

--- a/src/algorithm/aba.hxx
+++ b/src/algorithm/aba.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_aba_hxx__
-#define __se3_aba_hxx__
+#ifndef __pinocchio_aba_hxx__
+#define __pinocchio_aba_hxx__
 
 #include "pinocchio/spatial/act-on-set.hpp"
 #include "pinocchio/multibody/visitor.hpp"
@@ -522,4 +522,4 @@ namespace se3
 
 /// @endcond
 
-#endif // ifndef __se3_aba_hxx__
+#endif // ifndef __pinocchio_aba_hxx__

--- a/src/algorithm/aba.hxx
+++ b/src/algorithm/aba.hxx
@@ -24,7 +24,7 @@
 
 /// @cond DEV
 
-namespace se3
+namespace pinocchio
 {
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType>
   struct AbaForwardStep1
@@ -40,8 +40,8 @@ namespace se3
                                   > ArgsType;
     
     template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     se3::JointDataBase<typename JointModel::JointDataDerived> & jdata,
+    static void algo(const pinocchio::JointModelBase<JointModel> & jmodel,
+                     pinocchio::JointDataBase<typename JointModel::JointDataDerived> & jdata,
                      const Model & model,
                      Data & data,
                      const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -206,8 +206,8 @@ namespace se3
                                   Data &> ArgsType;
     
     template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     se3::JointDataBase<typename JointModel::JointDataDerived> & jdata,
+    static void algo(const pinocchio::JointModelBase<JointModel> & jmodel,
+                     pinocchio::JointDataBase<typename JointModel::JointDataDerived> & jdata,
                      const Model & model,
                      Data & data)
     {
@@ -326,8 +326,8 @@ namespace se3
                                   > ArgsType;
     
     template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     se3::JointDataBase<typename JointModel::JointDataDerived> & jdata,
+    static void algo(const pinocchio::JointModelBase<JointModel> & jmodel,
+                     pinocchio::JointDataBase<typename JointModel::JointDataDerived> & jdata,
                      const Model & model,
                      Data & data,
                      const Eigen::MatrixBase<ConfigVectorType> & q)
@@ -428,8 +428,8 @@ namespace se3
                                   Data &> ArgsType;
     
     template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     se3::JointDataBase<typename JointModel::JointDataDerived> & jdata,
+    static void algo(const pinocchio::JointModelBase<JointModel> & jmodel,
+                     pinocchio::JointDataBase<typename JointModel::JointDataDerived> & jdata,
                      const Model & model,
                      Data & data)
     {
@@ -518,7 +518,7 @@ namespace se3
     return true;
   }
 
-} // namespace se3
+} // namespace pinocchio
 
 /// @endcond
 

--- a/src/algorithm/center-of-mass.hpp
+++ b/src/algorithm/center-of-mass.hpp
@@ -21,7 +21,7 @@
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   ///
@@ -135,7 +135,7 @@ namespace se3
   
   ///
   /// \brief Computes both the jacobian and the the center of mass position of a given model according to a particular joint configuration.
-  ///        The results are accessible through data.Jcom and data.com[0] and are both expressed in the world frame. In addition, the algorithm also computes the Jacobian of all the joints (\sa se3::computeJointJacobians).
+  ///        The results are accessible through data.Jcom and data.com[0] and are both expressed in the world frame. In addition, the algorithm also computes the Jacobian of all the joints (\sa pinocchio::computeJointJacobians).
   ///        And data.com[i] gives the center of mass of the subtree supported by joint i (expressed in the world frame).
   ///
   /// \tparam JointCollection Collection of Joint types.
@@ -194,7 +194,7 @@ namespace se3
   getJacobianComFromCrba(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                          DataTpl<Scalar,Options,JointCollectionTpl> & data);
   
-} // namespace se3 
+} // namespace pinocchio 
 
 /* --- Details -------------------------------------------------------------------- */
 /* --- Details -------------------------------------------------------------------- */

--- a/src/algorithm/center-of-mass.hpp
+++ b/src/algorithm/center-of-mass.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_center_of_mass_hpp__
-#define __se3_center_of_mass_hpp__
+#ifndef __pinocchio_center_of_mass_hpp__
+#define __pinocchio_center_of_mass_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -201,4 +201,4 @@ namespace se3
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/center-of-mass.hxx"
 
-#endif // ifndef __se3_center_of_mass_hpp__
+#endif // ifndef __pinocchio_center_of_mass_hpp__

--- a/src/algorithm/center-of-mass.hxx
+++ b/src/algorithm/center-of-mass.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_center_of_mass_hxx__
-#define __se3_center_of_mass_hxx__
+#ifndef __pinocchio_center_of_mass_hxx__
+#define __pinocchio_center_of_mass_hxx__
 
 #include "pinocchio/algorithm/check.hpp"
 #include "pinocchio/multibody/visitor.hpp"
@@ -323,4 +323,4 @@ namespace se3
 
 /// @endcond
 
-#endif // ifndef __se3_center_of_mass_hxx__
+#endif // ifndef __pinocchio_center_of_mass_hxx__

--- a/src/algorithm/center-of-mass.hxx
+++ b/src/algorithm/center-of-mass.hxx
@@ -24,7 +24,7 @@
 
 /// @cond DEV
 
-namespace se3
+namespace pinocchio
 {
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
   inline const typename DataTpl<Scalar,Options,JointCollectionTpl>::Vector3 &
@@ -319,7 +319,7 @@ namespace se3
     return data.Jcom;
   }
 
-} // namespace se3
+} // namespace pinocchio
 
 /// @endcond
 

--- a/src/algorithm/centroidal-derivatives.hpp
+++ b/src/algorithm/centroidal-derivatives.hpp
@@ -22,7 +22,7 @@
 #include "pinocchio/multibody/data.hpp"
 #include "pinocchio/algorithm/check.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   ///
@@ -68,7 +68,7 @@ namespace se3
                                        const Eigen::MatrixBase<Matrix6xLike3> & dhdot_da);
   ///
   /// \brief Retrive the analytical derivatives of the centroidal dynamics from the RNEA derivatives.
-  ///        se3::computeRNEADerivatives should have been called first.
+  ///        pinocchio::computeRNEADerivatives should have been called first.
   ///
   /// \details Computes the first order approximation of the centroidal dynamics time derivative
   ///          and corresponds to the following equation
@@ -97,7 +97,7 @@ namespace se3
                                    const Eigen::MatrixBase<Matrix6xLike3> & dhdot_da);
   
   
-} // namespace se3
+} // namespace pinocchio
 
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/centroidal-derivatives.hxx"

--- a/src/algorithm/centroidal-derivatives.hpp
+++ b/src/algorithm/centroidal-derivatives.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_algorithm_centroidal_derivatives_hpp__
-#define __se3_algorithm_centroidal_derivatives_hpp__
+#ifndef __pinocchio_algorithm_centroidal_derivatives_hpp__
+#define __pinocchio_algorithm_centroidal_derivatives_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -102,4 +102,4 @@ namespace se3
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/centroidal-derivatives.hxx"
 
-#endif // ifndef __se3_algorithm_centroidal_derivatives_hpp__
+#endif // ifndef __pinocchio_algorithm_centroidal_derivatives_hpp__

--- a/src/algorithm/centroidal-derivatives.hxx
+++ b/src/algorithm/centroidal-derivatives.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_algorithm_centroidal_derivatives_hxx__
-#define __se3_algorithm_centroidal_derivatives_hxx__
+#ifndef __pinocchio_algorithm_centroidal_derivatives_hxx__
+#define __pinocchio_algorithm_centroidal_derivatives_hxx__
 
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/spatial/act-on-set.hpp"
@@ -411,5 +411,5 @@ namespace se3
 
 /// @endcond
 
-#endif // ifndef __se3_algorithm_centroidal_derivatives_hxx__
+#endif // ifndef __pinocchio_algorithm_centroidal_derivatives_hxx__
 

--- a/src/algorithm/centroidal-derivatives.hxx
+++ b/src/algorithm/centroidal-derivatives.hxx
@@ -25,7 +25,7 @@
 
 /// @cond DEV
 
-namespace se3
+namespace pinocchio
 {
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl,
            typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2>
@@ -407,7 +407,7 @@ namespace se3
     translateForceSet(data.dFda,com,EIGEN_CONST_CAST(Matrix6xLike3,dhdot_da));
   }
   
-} // namespace se3
+} // namespace pinocchio
 
 /// @endcond
 

--- a/src/algorithm/centroidal.hpp
+++ b/src/algorithm/centroidal.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_centroidal_hpp__
-#define __se3_centroidal_hpp__
+#ifndef __pinocchio_centroidal_hpp__
+#define __pinocchio_centroidal_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -127,4 +127,4 @@ namespace se3
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/centroidal.hxx"
 
-#endif // ifndef __se3_centroidal_hpp__
+#endif // ifndef __pinocchio_centroidal_hpp__

--- a/src/algorithm/centroidal.hpp
+++ b/src/algorithm/centroidal.hpp
@@ -22,7 +22,7 @@
 #include "pinocchio/multibody/data.hpp"
 #include "pinocchio/algorithm/check.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   ///
@@ -122,7 +122,7 @@ namespace se3
          const Eigen::MatrixBase<ConfigVectorType> & q,
          const Eigen::MatrixBase<TangentVectorType> & v);
   
-} // namespace se3
+} // namespace pinocchio
 
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/centroidal.hxx"

--- a/src/algorithm/centroidal.hxx
+++ b/src/algorithm/centroidal.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_centroidal_hxx__
-#define __se3_centroidal_hxx__
+#ifndef __pinocchio_centroidal_hxx__
+#define __pinocchio_centroidal_hxx__
 
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/spatial/act-on-set.hpp"
@@ -411,5 +411,5 @@ namespace se3
 
 /// @endcond
 
-#endif // ifndef __se3_centroidal_hxx__
+#endif // ifndef __pinocchio_centroidal_hxx__
 

--- a/src/algorithm/centroidal.hxx
+++ b/src/algorithm/centroidal.hxx
@@ -25,7 +25,7 @@
 
 /// @cond DEV
 
-namespace se3
+namespace pinocchio
 {
   
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl,
@@ -407,7 +407,7 @@ namespace se3
     return data.dAg;
   }
   
-} // namespace se3
+} // namespace pinocchio
 
 /// @endcond
 

--- a/src/algorithm/check.hpp
+++ b/src/algorithm/check.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_check_hpp__
-#define __se3_check_hpp__
+#ifndef __pinocchio_check_hpp__
+#define __pinocchio_check_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -121,4 +121,4 @@ namespace se3
   /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/check.hxx"
 
-#endif // ifndef __se3_check_hpp__
+#endif // ifndef __pinocchio_check_hpp__

--- a/src/algorithm/check.hpp
+++ b/src/algorithm/check.hpp
@@ -27,7 +27,7 @@
 #define PINOCCHIO_ALGO_CHECKER_LIST_MAX_LIST_SIZE 5
 #endif
 
-namespace se3
+namespace pinocchio
 {
 
   /// CRTP class describing the API of the checkers 
@@ -115,7 +115,7 @@ namespace se3
   inline bool checkData(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                         const DataTpl<Scalar,Options,JointCollectionTpl> & data);
 
-} // namespace se3 
+} // namespace pinocchio 
 
 
   /* --- Details -------------------------------------------------------------------- */

--- a/src/algorithm/check.hxx
+++ b/src/algorithm/check.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_check_hxx__
-#define __se3_check_hxx__
+#ifndef __pinocchio_check_hxx__
+#define __pinocchio_check_hxx__
 
 #include <boost/fusion/algorithm.hpp>
 #include <boost/foreach.hpp>
@@ -175,4 +175,4 @@ namespace se3
 
 } // namespace se3 
 
-#endif // ifndef __se3_check_hxx__
+#endif // ifndef __pinocchio_check_hxx__

--- a/src/algorithm/check.hxx
+++ b/src/algorithm/check.hxx
@@ -21,7 +21,7 @@
 #include <boost/fusion/algorithm.hpp>
 #include <boost/foreach.hpp>
 
-namespace se3
+namespace pinocchio
 {
   namespace internal
   {
@@ -173,6 +173,6 @@ namespace se3
   { return checkData(*this,data); }
 
 
-} // namespace se3 
+} // namespace pinocchio 
 
 #endif // ifndef __pinocchio_check_hxx__

--- a/src/algorithm/cholesky.hpp
+++ b/src/algorithm/cholesky.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_cholesky_hpp__
-#define __se3_cholesky_hpp__
+#ifndef __pinocchio_cholesky_hpp__
+#define __pinocchio_cholesky_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -228,4 +228,4 @@ namespace se3
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/cholesky.hxx"
 
-#endif // ifndef __se3_cholesky_hpp__
+#endif // ifndef __pinocchio_cholesky_hpp__

--- a/src/algorithm/cholesky.hpp
+++ b/src/algorithm/cholesky.hpp
@@ -21,7 +21,7 @@
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
   
-namespace se3
+namespace pinocchio
 {
   namespace cholesky
   {
@@ -221,7 +221,7 @@ namespace se3
                       const Eigen::MatrixBase<Mat> & Minv);
     
   } // namespace cholesky  
-} // namespace se3 
+} // namespace pinocchio 
 
 /* --- Details -------------------------------------------------------------------- */
 /* --- Details -------------------------------------------------------------------- */

--- a/src/algorithm/cholesky.hxx
+++ b/src/algorithm/cholesky.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_cholesky_hxx__
-#define __se3_cholesky_hxx__
+#ifndef __pinocchio_cholesky_hxx__
+#define __pinocchio_cholesky_hxx__
 
 #include "pinocchio/algorithm/check.hpp"
 
@@ -550,4 +550,4 @@ namespace se3
 
 /// @endcond
 
-#endif // ifndef __se3_cholesky_hxx__
+#endif // ifndef __pinocchio_cholesky_hxx__

--- a/src/algorithm/cholesky.hxx
+++ b/src/algorithm/cholesky.hxx
@@ -22,7 +22,7 @@
 
 /// @cond DEV
 
-namespace se3 
+namespace pinocchio 
 {
   namespace cholesky
   {
@@ -546,7 +546,7 @@ namespace se3
     }
 
   } //   namespace cholesky
-} // namespace se3
+} // namespace pinocchio
 
 /// @endcond
 

--- a/src/algorithm/compute-all-terms.hpp
+++ b/src/algorithm/compute-all-terms.hpp
@@ -26,18 +26,18 @@
 #include "pinocchio/algorithm/energy.hpp"
 #include "pinocchio/algorithm/check.hpp"
 
-namespace se3
+namespace pinocchio
 {
   ///
   /// \brief Computes efficiently all the terms needed for dynamic simulation. It is equivalent to the call at the same time to:
-  ///         - se3::forwardKinematics
-  ///         - se3::crba
-  ///         - se3::nonLinearEffects
-  ///         - se3::computeJointJacobians
-  ///         - se3::centerOfMass
-  ///         - se3::jacobianCenterOfMass
-  ///         - se3::kineticEnergy
-  ///         - se3::potentialEnergy
+  ///         - pinocchio::forwardKinematics
+  ///         - pinocchio::crba
+  ///         - pinocchio::nonLinearEffects
+  ///         - pinocchio::computeJointJacobians
+  ///         - pinocchio::centerOfMass
+  ///         - pinocchio::jacobianCenterOfMass
+  ///         - pinocchio::kineticEnergy
+  ///         - pinocchio::potentialEnergy
   ///
   /// \tparam JointCollection Collection of Joint types.
   /// \tparam ConfigVectorType Type of the joint configuration vector.
@@ -55,11 +55,11 @@ namespace se3
                               const Eigen::MatrixBase<ConfigVectorType> & q,
                               const Eigen::MatrixBase<TangentVectorType> & v);
 
-} // namespace se3
+} // namespace pinocchio
 
 
 /* --- Details -------------------------------------------------------------------- */
-namespace se3
+namespace pinocchio
 {
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType>
   struct CATForwardStep
@@ -259,7 +259,7 @@ namespace se3
     potentialEnergy(model, data, q, false);
 
   }
-} // namespace se3
+} // namespace pinocchio
 
 
 #endif // ifndef __pinocchio_compute_all_terms_hpp__

--- a/src/algorithm/compute-all-terms.hpp
+++ b/src/algorithm/compute-all-terms.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_compute_all_terms_hpp__
-#define __se3_compute_all_terms_hpp__
+#ifndef __pinocchio_compute_all_terms_hpp__
+#define __pinocchio_compute_all_terms_hpp__
 
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/multibody/model.hpp"
@@ -262,5 +262,5 @@ namespace se3
 } // namespace se3
 
 
-#endif // ifndef __se3_compute_all_terms_hpp__
+#endif // ifndef __pinocchio_compute_all_terms_hpp__
 

--- a/src/algorithm/copy.hpp
+++ b/src/algorithm/copy.hpp
@@ -22,7 +22,7 @@
 #include "pinocchio/multibody/data.hpp"
 #include "pinocchio/algorithm/check.hpp"
   
-namespace se3
+namespace pinocchio
 {
   ///
   /// \brief Copy part of the data from <orig> to <dest>. Template parameter can be 
@@ -42,13 +42,13 @@ namespace se3
        DataTpl<Scalar,Options,JointCollectionTpl> & dest,
        int LEVEL);
 
-} // namespace se3 
+} // namespace pinocchio 
 
 /* --- Details -------------------------------------------------------------------- */
 //#include "pinocchio/algorithm/copy.hxx"
 
 
-namespace se3
+namespace pinocchio
 {
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
   inline void
@@ -79,6 +79,6 @@ namespace se3
   }
 
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_copy_hpp__

--- a/src/algorithm/copy.hpp
+++ b/src/algorithm/copy.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_copy_hpp__
-#define __se3_copy_hpp__
+#ifndef __pinocchio_copy_hpp__
+#define __pinocchio_copy_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -81,4 +81,4 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_copy_hpp__
+#endif // ifndef __pinocchio_copy_hpp__

--- a/src/algorithm/crba.hpp
+++ b/src/algorithm/crba.hpp
@@ -22,7 +22,7 @@
 #include "pinocchio/multibody/data.hpp"
 #include "pinocchio/algorithm/check.hpp"
   
-namespace se3
+namespace pinocchio
 {
   ///
   /// \brief Computes the upper triangular part of the joint space inertia matrix M by
@@ -77,7 +77,7 @@ namespace se3
 
   DEFINE_ALGO_CHECKER(CRBA);
 
-} // namespace se3 
+} // namespace pinocchio 
 
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/crba.hxx"

--- a/src/algorithm/crba.hpp
+++ b/src/algorithm/crba.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_crba_hpp__
-#define __se3_crba_hpp__
+#ifndef __pinocchio_crba_hpp__
+#define __pinocchio_crba_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -82,4 +82,4 @@ namespace se3
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/crba.hxx"
 
-#endif // ifndef __se3_crba_hpp__
+#endif // ifndef __pinocchio_crba_hpp__

--- a/src/algorithm/crba.hxx
+++ b/src/algorithm/crba.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_crba_hxx__
-#define __se3_crba_hxx__
+#ifndef __pinocchio_crba_hxx__
+#define __pinocchio_crba_hxx__
 
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/spatial/act-on-set.hpp"
@@ -297,4 +297,4 @@ namespace se3
 
 /// @endcond
 
-#endif // ifndef __se3_crba_hxx__
+#endif // ifndef __pinocchio_crba_hxx__

--- a/src/algorithm/crba.hxx
+++ b/src/algorithm/crba.hxx
@@ -25,7 +25,7 @@
 
 /// @cond DEV
 
-namespace se3 
+namespace pinocchio 
 {
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
   struct CrbaForwardStep
@@ -293,7 +293,7 @@ namespace se3
   }
 
 
-} // namespace se3
+} // namespace pinocchio
 
 /// @endcond
 

--- a/src/algorithm/default-check.hpp
+++ b/src/algorithm/default-check.hpp
@@ -22,7 +22,7 @@
 #include <pinocchio/algorithm/aba.hpp>
 #include <pinocchio/algorithm/crba.hpp>
 
-namespace se3
+namespace pinocchio
 {
   /// Default checker-list, used as the default argument in Model::check().
   inline AlgorithmCheckerList<ParentChecker,CRBAChecker,ABAChecker> makeDefaultCheckerList()
@@ -34,6 +34,6 @@ namespace se3
   inline bool ModelTpl<Scalar,Options,JointCollectionTpl>::check() const
   { return this->check(DEFAULT_CHECKERS); }
 
-} // namespace se3 
+} // namespace pinocchio 
 
 #endif // ifndef __pinocchio_default_check_hpp__

--- a/src/algorithm/default-check.hpp
+++ b/src/algorithm/default-check.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_default_check_hpp__
-#define __se3_default_check_hpp__
+#ifndef __pinocchio_default_check_hpp__
+#define __pinocchio_default_check_hpp__
 
 #include <pinocchio/algorithm/check.hpp>
 #include <pinocchio/algorithm/aba.hpp>
@@ -36,4 +36,4 @@ namespace se3
 
 } // namespace se3 
 
-#endif // ifndef __se3_default_check_hpp__
+#endif // ifndef __pinocchio_default_check_hpp__

--- a/src/algorithm/dynamics.hpp
+++ b/src/algorithm/dynamics.hpp
@@ -27,7 +27,7 @@
 
 #include <Eigen/Cholesky>
 
-namespace se3
+namespace pinocchio
 {
   
   ///
@@ -55,7 +55,7 @@ namespace se3
   /// \param[in] J The Jacobian of the constraints (dim nb_constraints*model.nv).
   /// \param[in] gamma The drift of the constraints (dim nb_constraints).
   /// \param[in] inv_damping Damping factor for cholesky decomposition of JMinvJt. Set to zero if constraints are full rank.    
-  /// \param[in] updateKinematics If true, the algorithm calls first se3::computeAllTerms. Otherwise, it uses the current dynamic values stored in data. \\
+  /// \param[in] updateKinematics If true, the algorithm calls first pinocchio::computeAllTerms. Otherwise, it uses the current dynamic values stored in data. \\
   ///            \note A hint: 1e-12 as the damping factor gave good result in the particular case of redundancy in contact constraints on the two feet.
   ///
   /// \return A reference to the joint acceleration stored in data.ddq. The Lagrange Multipliers linked to the contact forces are available throw data.lambda_c vector.
@@ -139,7 +139,7 @@ namespace se3
   /// \param[in] v_before The joint velocity before impact (vector dim model.nv).
   /// \param[in] J The Jacobian of the constraints (dim nb_constraints*model.nv).
   /// \param[in] r_coeff The coefficient of restitution. Must be in [0;1].
-  /// \param[in] updateKinematics If true, the algorithm calls first se3::crba. Otherwise, it uses the current mass matrix value stored in data.
+  /// \param[in] updateKinematics If true, the algorithm calls first pinocchio::crba. Otherwise, it uses the current mass matrix value stored in data.
   ///
   /// \return A reference to the generalized velocity after impact stored in data.dq_after. The Lagrange Multipliers linked to the contact impulsed are available throw data.impulse_c vector.
   ///
@@ -190,7 +190,7 @@ namespace se3
     
     return dq_after;
   }
-} // namespace se3
+} // namespace pinocchio
 
 
 #endif // ifndef __pinocchio_dynamics_hpp__

--- a/src/algorithm/dynamics.hpp
+++ b/src/algorithm/dynamics.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_dynamics_hpp__
-#define __se3_dynamics_hpp__
+#ifndef __pinocchio_dynamics_hpp__
+#define __pinocchio_dynamics_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -193,4 +193,4 @@ namespace se3
 } // namespace se3
 
 
-#endif // ifndef __se3_dynamics_hpp__
+#endif // ifndef __pinocchio_dynamics_hpp__

--- a/src/algorithm/energy.hpp
+++ b/src/algorithm/energy.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_energy_hpp__
-#define __se3_energy_hpp__
+#ifndef __pinocchio_energy_hpp__
+#define __pinocchio_energy_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -133,4 +133,4 @@ namespace se3
     return data.potential_energy;
   }
 }
-#endif // __se3_energy_hpp__
+#endif // __pinocchio_energy_hpp__

--- a/src/algorithm/energy.hpp
+++ b/src/algorithm/energy.hpp
@@ -23,7 +23,7 @@
 #include "pinocchio/algorithm/kinematics.hpp"
 #include "pinocchio/algorithm/check.hpp"
 
-namespace se3 {
+namespace pinocchio {
   
   ///
   /// \brief Computes the kinetic energy of the system.
@@ -72,7 +72,7 @@ namespace se3 {
 /* --- Details -------------------------------------------------------------------- */
 /* --- Details -------------------------------------------------------------------- */
 /* --- Details -------------------------------------------------------------------- */
-namespace se3
+namespace pinocchio
 {
    
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType>

--- a/src/algorithm/finite-differences.hpp
+++ b/src/algorithm/finite-differences.hpp
@@ -20,7 +20,7 @@
 
 #include "pinocchio/multibody/model.hpp"
 
-namespace se3 {
+namespace pinocchio {
   
   ///
   /// \brief Computes the finite difference increments for each degree of freedom according to the current joint configuration.

--- a/src/algorithm/finite-differences.hpp
+++ b/src/algorithm/finite-differences.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_finite_differences_hpp__
-#define __se3_finite_differences_hpp__
+#ifndef __pinocchio_finite_differences_hpp__
+#define __pinocchio_finite_differences_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 
@@ -39,4 +39,4 @@ namespace se3 {
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/finite-differences.hxx"
 
-#endif // ifndef __se3_finite_differences_hpp__
+#endif // ifndef __pinocchio_finite_differences_hpp__

--- a/src/algorithm/finite-differences.hxx
+++ b/src/algorithm/finite-differences.hxx
@@ -22,7 +22,7 @@
 
 /// @cond DEV
 
-namespace se3
+namespace pinocchio
 {
   namespace details
   {
@@ -48,7 +48,7 @@ namespace se3
   inline typename ModelTpl<Scalar,Options,JointCollectionTpl>::TangentVectorType
   finiteDifferenceIncrement(const ModelTpl<Scalar,Options,JointCollectionTpl> & model)
   {
-    using namespace se3::details;
+    using namespace pinocchio::details;
     
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
@@ -64,7 +64,7 @@ namespace se3
     
     return fd_increment;
   }
-} // namespace se3
+} // namespace pinocchio
 
 /// @endcond
 

--- a/src/algorithm/finite-differences.hxx
+++ b/src/algorithm/finite-differences.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_finite_differences_hxx__
-#define __se3_finite_differences_hxx__
+#ifndef __pinocchio_finite_differences_hxx__
+#define __pinocchio_finite_differences_hxx__
 
 #include "pinocchio/multibody/visitor.hpp"
 
@@ -68,4 +68,4 @@ namespace se3
 
 /// @endcond
 
-#endif // ifndef __se3_finite_differences_hxx__
+#endif // ifndef __pinocchio_finite_differences_hxx__

--- a/src/algorithm/frames.hpp
+++ b/src/algorithm/frames.hpp
@@ -21,7 +21,7 @@
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
 
-namespace se3
+namespace pinocchio
 {
 
   /**
@@ -58,7 +58,7 @@ namespace se3
 
   /**
    * @brief      First calls the forwardKinematics on the model, then computes the placement of each frame.
-   *             /sa se3::forwardKinematics.
+   *             /sa pinocchio::forwardKinematics.
    *
    * @tparam JointCollection Collection of Joint types.
    * @tparam ConfigVectorType Type of the joint configuration vector.
@@ -75,7 +75,7 @@ namespace se3
 
   /**
    * @brief      Returns the spatial velocity of the frame expressed in the LOCAL frame coordinate system.
-   *             You must first call se3::forwardKinematics to update placement and velocity values in data structure.
+   *             You must first call pinocchio::forwardKinematics to update placement and velocity values in data structure.
    *
    * @param[in]  model       The kinematic model
    * @param[in]  data        Data associated to model
@@ -93,9 +93,9 @@ namespace se3
   /**
    * @brief      Returns the jacobian of the frame expresssed either expressed in the LOCAL frame coordinate system or in the WORLD coordinate system,
    *             depending on the value of rf.
-   *             You must first call se3::computeJointJacobians followed by se3::framesForwardKinematics to update placement values in data structure.
+   *             You must first call pinocchio::computeJointJacobians followed by pinocchio::framesForwardKinematics to update placement values in data structure.
    *
-   * @remark     Similarly to se3::getJointJacobian with LOCAL or WORLD parameters, if rf == LOCAL, this function returns the Jacobian of the frame expressed
+   * @remark     Similarly to pinocchio::getJointJacobian with LOCAL or WORLD parameters, if rf == LOCAL, this function returns the Jacobian of the frame expressed
    *             in the local coordinates of the frame, or if rl == WORDL, it returns the Jacobian expressed of the point coincident with the origin
    *             and expressed in a coordinate system aligned with the WORLD.
    *
@@ -108,7 +108,7 @@ namespace se3
    * @param[in]  rf          Reference frame in which the Jacobian is expressed.
    * @param[out] J           The Jacobian of the Frame expressed in the coordinates Frame.
    *
-   * @warning    The function se3::computeJointJacobians and se3::framesForwardKinematics should have been called first.
+   * @warning    The function pinocchio::computeJointJacobians and pinocchio::framesForwardKinematics should have been called first.
    */
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename Matrix6xLike>
   inline void getFrameJacobian(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
@@ -120,7 +120,7 @@ namespace se3
 
    /**
    * @brief      Returns the spatial acceleration of the frame expressed in the LOCAL frame coordinate system.
-   *             You must first call se3::forwardKinematics to update placement values in data structure.
+   *             You must first call pinocchio::forwardKinematics to update placement values in data structure.
    *
    * @param[in]  model       The kinematic model
    * @param[in]  data        Data associated to model
@@ -138,12 +138,12 @@ namespace se3
   /**
    * @brief      Returns the jacobian of the frame expresssed either expressed in the LOCAL frame coordinate system or in the WORLD coordinate system,
    *             depending on the value of rf.
-   *             You must first call se3::computeJointJacobians followed by se3::updateFramePlacements to update placement values in data structure.
+   *             You must first call pinocchio::computeJointJacobians followed by pinocchio::updateFramePlacements to update placement values in data structure.
    *
    * @tparam     rf Reference frame in which the columns of the Jacobian are expressed.
-   * @deprecated This function is now deprecated. Please call se3::getFrameJacobian for same functionality.
+   * @deprecated This function is now deprecated. Please call pinocchio::getFrameJacobian for same functionality.
    
-   * @remark     Similarly to se3::getJointJacobian with LOCAL or WORLD parameters, if rf == LOCAL, this function returns the Jacobian of the frame expressed
+   * @remark     Similarly to pinocchio::getJointJacobian with LOCAL or WORLD parameters, if rf == LOCAL, this function returns the Jacobian of the frame expressed
    *             in the local coordinates of the frame, or if rl == WORDL, it returns the Jacobian expressed of the point coincident with the origin
    *             and expressed in a coordinate system aligned with the WORLD.
    *
@@ -153,7 +153,7 @@ namespace se3
    * @param[in] rf Reference frame in which the Jacobian is expressed.
    * @param[out] J           The Jacobian of the Frame expressed in the coordinates Frame.
    *
-   * @warning    The functions se3::computeJointJacobians and se3::updateFramePlacements should have been called first.
+   * @warning    The functions pinocchio::computeJointJacobians and pinocchio::updateFramePlacements should have been called first.
    */
   template<ReferenceFrame rf>
   PINOCCHIO_DEPRECATED
@@ -165,8 +165,8 @@ namespace se3
   
   /**
    * @brief      Returns the jacobian of the frame expresssed in the LOCAL coordinate system of the frame.
-   *             You must first call se3::computeJointJacobians followed by se3::updateFramePlacements to update placement values in data structure.
-   * @deprecated This function is now deprecated. Please call se3::getFrameJacobian for same functionality
+   *             You must first call pinocchio::computeJointJacobians followed by pinocchio::updateFramePlacements to update placement values in data structure.
+   * @deprecated This function is now deprecated. Please call pinocchio::getFrameJacobian for same functionality
    *
    * @tparam JointCollection Collection of Joint types.
    * @tparam Matrix6xLike Type of the matrix containing the joint Jacobian.
@@ -176,7 +176,7 @@ namespace se3
    * @param[in]  frame_id    Id of the operational Frame
    * @param[out] J           The Jacobian of the Frame expressed in the coordinates Frame.
    *
-   * @warning    The function se3::computeJointJacobians and se3::updateFramePlacements should have been called first.
+   * @warning    The function pinocchio::computeJointJacobians and pinocchio::updateFramePlacements should have been called first.
    */
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename Matrix6xLike>
   PINOCCHIO_DEPRECATED
@@ -187,7 +187,7 @@ namespace se3
   
   ///
   /// \brief Computes the Jacobian time variation of a specific frame (given by frame_id) expressed either in the world frame (rf = WORLD) or in the local frame (rf = LOCAL).
-  /// \note This jacobian is extracted from data.dJ. You have to run se3::computeJacobiansTimeVariation before calling it.
+  /// \note This jacobian is extracted from data.dJ. You have to run pinocchio::computeJacobiansTimeVariation before calling it.
   ///
   /// \tparam JointCollection Collection of Joint types.
   /// \tparam Matrix6xLike Type of the matrix containing the joint Jacobian.
@@ -207,8 +207,8 @@ namespace se3
 
   ///
   /// \brief Computes the Jacobian time variation of a specific frame (given by frame_id) expressed either in the world frame (rf = WORLD) or in the local frame (rf = LOCAL).
-  /// \note This jacobian is extracted from data.dJ. You have to run se3::computeJacobiansTimeVariation before calling it.
-  /// \deprecated This function is now deprecated. Please call se3::getFrameJacobianTimeVariation for same functionality
+  /// \note This jacobian is extracted from data.dJ. You have to run pinocchio::computeJacobiansTimeVariation before calling it.
+  /// \deprecated This function is now deprecated. Please call pinocchio::getFrameJacobianTimeVariation for same functionality
   ///
   /// \tparam rf Reference frame in which the Jacobian is expressed.
   ///
@@ -228,7 +228,7 @@ namespace se3
     getFrameJacobianTimeVariation(model,data,frameId,rf,dJ);
   }
 
-} // namespace se3
+} // namespace pinocchio
 
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/frames.hxx"

--- a/src/algorithm/frames.hpp
+++ b/src/algorithm/frames.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_frames_hpp__
-#define __se3_frames_hpp__
+#ifndef __pinocchio_frames_hpp__
+#define __pinocchio_frames_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -233,4 +233,4 @@ namespace se3
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/frames.hxx"
 
-#endif // ifndef __se3_frames_hpp__
+#endif // ifndef __pinocchio_frames_hpp__

--- a/src/algorithm/frames.hxx
+++ b/src/algorithm/frames.hxx
@@ -22,7 +22,7 @@
 #include "pinocchio/algorithm/jacobian.hpp"
 #include "pinocchio/algorithm/check.hpp"
 
-namespace se3 
+namespace pinocchio 
 {
   
   
@@ -202,6 +202,6 @@ namespace se3
   }
   
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_frames_hxx__

--- a/src/algorithm/frames.hxx
+++ b/src/algorithm/frames.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_frames_hxx__
-#define __se3_frames_hxx__
+#ifndef __pinocchio_frames_hxx__
+#define __pinocchio_frames_hxx__
 
 #include "pinocchio/algorithm/kinematics.hpp"
 #include "pinocchio/algorithm/jacobian.hpp"
@@ -204,4 +204,4 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_frames_hxx__
+#endif // ifndef __pinocchio_frames_hxx__

--- a/src/algorithm/geometry.hpp
+++ b/src/algorithm/geometry.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_algo_geometry_hpp__
-#define __se3_algo_geometry_hpp__
+#ifndef __pinocchio_algo_geometry_hpp__
+#define __pinocchio_algo_geometry_hpp__
 
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/multibody/model.hpp"
@@ -223,4 +223,4 @@ namespace se3
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/geometry.hxx"
 
-#endif // ifndef __se3_algo_geometry_hpp__
+#endif // ifndef __pinocchio_algo_geometry_hpp__

--- a/src/algorithm/geometry.hpp
+++ b/src/algorithm/geometry.hpp
@@ -25,7 +25,7 @@
 #include "pinocchio/algorithm/kinematics.hpp"
 #include "pinocchio/multibody/geometry.hpp"
 
-namespace se3
+namespace pinocchio
 {
 
   ///
@@ -218,7 +218,7 @@ namespace se3
   inline void appendGeometryModel(GeometryModel & geomModel1,
                                   const GeometryModel & geomModel2);
 
-} // namespace se3 
+} // namespace pinocchio 
 
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/geometry.hxx"

--- a/src/algorithm/geometry.hxx
+++ b/src/algorithm/geometry.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_algo_geometry_hxx__
-#define __se3_algo_geometry_hxx__
+#ifndef __pinocchio_algo_geometry_hxx__
+#define __pinocchio_algo_geometry_hxx__
 
 #include <boost/foreach.hpp>
 
@@ -322,4 +322,4 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifnded __se3_algo_geometry_hxx__
+#endif // ifnded __pinocchio_algo_geometry_hxx__

--- a/src/algorithm/geometry.hxx
+++ b/src/algorithm/geometry.hxx
@@ -20,7 +20,7 @@
 
 #include <boost/foreach.hpp>
 
-namespace se3 
+namespace pinocchio 
 {
   /* --- GEOMETRY PLACEMENTS -------------------------------------------------------- */
   /* --- GEOMETRY PLACEMENTS -------------------------------------------------------- */
@@ -320,6 +320,6 @@ namespace se3
     }
   }
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifnded __pinocchio_algo_geometry_hxx__

--- a/src/algorithm/jacobian.hpp
+++ b/src/algorithm/jacobian.hpp
@@ -22,13 +22,13 @@
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
 
-namespace se3
+namespace pinocchio
 {
   ///
   /// \brief Computes the full model Jacobian, i.e. the stack of all motion subspace expressed in the world frame.
   ///        The result is accessible through data.J. This function computes also the forwardKinematics of the model.
   ///
-  /// \note This Jacobian does not correspond to any specific joint frame Jacobian. From this Jacobian, it is then possible to easily extract the Jacobian of a specific joint frame. \sa se3::getJointJacobian for doing this specific extraction.
+  /// \note This Jacobian does not correspond to any specific joint frame Jacobian. From this Jacobian, it is then possible to easily extract the Jacobian of a specific joint frame. \sa pinocchio::getJointJacobian for doing this specific extraction.
   ///
   /// \tparam JointCollection Collection of Joint types.
   /// \tparam ConfigVectorType Type of the joint configuration vector.
@@ -49,9 +49,9 @@ namespace se3
   /// \brief Computes the full model Jacobian, i.e. the stack of all motion subspace expressed in the world frame.
   ///        The result is accessible through data.J. This function computes also the forwardKinematics of the model.
   ///
-  /// \deprecated This function is now deprecated. Please refer now to se3::computeJointJacobians for similar function with updated name.
+  /// \deprecated This function is now deprecated. Please refer now to pinocchio::computeJointJacobians for similar function with updated name.
   ///
-  /// \note This Jacobian does not correspond to any specific joint frame Jacobian. From this Jacobian, it is then possible to easily extract the Jacobian of a specific joint frame. \sa se3::getJointJacobian for doing this specific extraction.
+  /// \note This Jacobian does not correspond to any specific joint frame Jacobian. From this Jacobian, it is then possible to easily extract the Jacobian of a specific joint frame. \sa pinocchio::getJointJacobian for doing this specific extraction.
   ///
   /// \param[in] model The model structure of the rigid body system.
   /// \param[in] data The data structure of the rigid body system.
@@ -68,9 +68,9 @@ namespace se3
   
   ///
   /// \brief Computes the full model Jacobian, i.e. the stack of all motion subspace expressed in the world frame.
-  ///        The result is accessible through data.J. This function assumes that se3::forwardKinematics has been called before.
+  ///        The result is accessible through data.J. This function assumes that pinocchio::forwardKinematics has been called before.
   ///
-  /// \note This Jacobian does not correspond to any specific joint frame Jacobian. From this Jacobian, it is then possible to easily extract the Jacobian of a specific joint frame. \sa se3::getJointJacobian for doing this specific extraction.
+  /// \note This Jacobian does not correspond to any specific joint frame Jacobian. From this Jacobian, it is then possible to easily extract the Jacobian of a specific joint frame. \sa pinocchio::getJointJacobian for doing this specific extraction.
   ///
   /// \tparam JointCollection Collection of Joint types.
   ///
@@ -86,11 +86,11 @@ namespace se3
   
   ///
   /// \brief Computes the full model Jacobian, i.e. the stack of all motion subspace expressed in the world frame.
-  ///        The result is accessible through data.J. This function assumes that se3::forwardKinematics has been called before.
+  ///        The result is accessible through data.J. This function assumes that pinocchio::forwardKinematics has been called before.
   ///
-  /// \deprecated This function is now deprecated. Please refer now to se3::computeJointJacobians for similar function with updated name.
+  /// \deprecated This function is now deprecated. Please refer now to pinocchio::computeJointJacobians for similar function with updated name.
   ///
-  /// \note This Jacobian does not correspond to any specific joint frame Jacobian. From this Jacobian, it is then possible to easily extract the Jacobian of a specific joint frame. \sa se3::getJointJacobian for doing this specific extraction.
+  /// \note This Jacobian does not correspond to any specific joint frame Jacobian. From this Jacobian, it is then possible to easily extract the Jacobian of a specific joint frame. \sa pinocchio::getJointJacobian for doing this specific extraction.
   ///
   /// \param[in] model The model structure of the rigid body system.
   /// \param[in] data The data structure of the rigid body system.
@@ -105,7 +105,7 @@ namespace se3
   
   ///
   /// \brief Computes the Jacobian of a specific joint frame expressed either in the world (rf = WORLD) frame or in the local frame (rf = LOCAL) of the joint.
-  /// \note This jacobian is extracted from data.J. You have to run se3::computeJointJacobians before calling it.
+  /// \note This jacobian is extracted from data.J. You have to run pinocchio::computeJointJacobians before calling it.
   ///
   /// \tparam JointCollection Collection of Joint types.
   /// \tparam Matrix6xLike Type of the matrix containing the joint Jacobian.
@@ -125,7 +125,7 @@ namespace se3
   
   ///
   /// \brief Computes the Jacobian of a specific joint frame expressed either in the world (rf = WORLD) frame or in the local frame (rf = LOCAL) of the joint.
-  /// \note This jacobian is extracted from data.J. You have to run se3::computeJointJacobians before calling it.
+  /// \note This jacobian is extracted from data.J. You have to run pinocchio::computeJointJacobians before calling it.
   ///
   /// \tparam rf Reference frame in which the Jacobian is expressed.
   ///
@@ -145,9 +145,9 @@ namespace se3
   
   ///
   /// \brief Computes the Jacobian of a specific joint frame expressed either in the world (rf = WORLD) frame or in the local frame (rf = LOCAL) of the joint.
-  /// \note This jacobian is extracted from data.J. You have to run se3::computeJacobians before calling it.
+  /// \note This jacobian is extracted from data.J. You have to run pinocchio::computeJacobians before calling it.
   ///
-  /// \deprecated This function is now deprecated. Please refer now to se3::getJointJacobian for similar function with updated name.
+  /// \deprecated This function is now deprecated. Please refer now to pinocchio::getJointJacobian for similar function with updated name.
   ///
   /// \tparam rf Reference frame in which the Jacobian is expressed.
   ///
@@ -194,7 +194,7 @@ namespace se3
   ///
   /// \brief Computes the Jacobian of a specific joint frame expressed in the local frame of the joint and store the result in the input argument J.
   ///
-  /// \deprecated This function is now deprecated. Please refer now to se3::jointJacobian for similar function with updated name.
+  /// \deprecated This function is now deprecated. Please refer now to pinocchio::jointJacobian for similar function with updated name.
   ///
   /// \param[in] model The model structure of the rigid body system.
   /// \param[in] data The data structure of the rigid body system.
@@ -265,7 +265,7 @@ namespace se3
   /// \brief Computes the full model Jacobian variations with respect to time. It corresponds to dJ/dt which depends both on q and v.
   ///        The result is accessible through data.dJ.
   ///
-  /// \deprecated This function is now deprecated. Please refer now to se3::computeJointJacobiansTimeVariation for similar function with updated name.
+  /// \deprecated This function is now deprecated. Please refer now to pinocchio::computeJointJacobiansTimeVariation for similar function with updated name.
   ///
   /// \param[in] model The model structure of the rigid body system.
   /// \param[in] data The data structure of the rigid body system.
@@ -284,7 +284,7 @@ namespace se3
   
   ///
   /// \brief Computes the Jacobian time variation of a specific joint frame expressed either in the world frame (rf = WORLD) or in the local frame (rf = LOCAL) of the joint.
-  /// \note This jacobian is extracted from data.dJ. You have to run se3::computeJacobiansTimeVariation before calling it.
+  /// \note This jacobian is extracted from data.dJ. You have to run pinocchio::computeJacobiansTimeVariation before calling it.
   ///
   /// \tparam JointCollection Collection of Joint types.
   /// \tparam Matrix6xLike Type of the matrix containing the joint Jacobian.
@@ -304,9 +304,9 @@ namespace se3
   
   ///
   /// \brief Computes the Jacobian time variation of a specific joint frame expressed either in the world frame (rf = WORLD) or in the local frame (rf = LOCAL) of the joint.
-  /// \note This jacobian is extracted from data.dJ. You have to run se3::computeJacobiansTimeVariation before calling it.
+  /// \note This jacobian is extracted from data.dJ. You have to run pinocchio::computeJacobiansTimeVariation before calling it.
   ///
-  /// \deprecated This function is now deprecated. Please refer now to se3::getJointJacobianTimeVariation for similar function with updated name.
+  /// \deprecated This function is now deprecated. Please refer now to pinocchio::getJointJacobianTimeVariation for similar function with updated name.
   ///
   /// \tparam rf Reference frame in which the Jacobian is expressed.
   ///
@@ -326,10 +326,10 @@ namespace se3
   
   ///
   /// \brief Computes the Jacobian time variation of a specific joint frame expressed either in the world frame (rf = WORLD) or in the local frame (rf = LOCAL) of the joint.
-  /// \note This jacobian is extracted from data.dJ. You have to run se3::computeJointJacobiansTimeVariation before calling it.
-  /// \deprecated This function is now deprecated. Please refer now to se3::getJointJacobianTimeVariation for similar function with updated name.  
+  /// \note This jacobian is extracted from data.dJ. You have to run pinocchio::computeJointJacobiansTimeVariation before calling it.
+  /// \deprecated This function is now deprecated. Please refer now to pinocchio::getJointJacobianTimeVariation for similar function with updated name.  
   ///
-  /// \deprecated This function is now deprecated. Please refer now to se3::getJacobianTimeVariation for similar function without ReferenceFrame template parameters.
+  /// \deprecated This function is now deprecated. Please refer now to pinocchio::getJacobianTimeVariation for similar function without ReferenceFrame template parameters.
   ///
   /// \tparam rf Reference frame in which the Jacobian is expressed.
   ///
@@ -347,7 +347,7 @@ namespace se3
                                        Data::Matrix6x & dJ)
   { getJointJacobianTimeVariation<rf>(model,data,jointId,dJ); }
   
-} // namespace se3 
+} // namespace pinocchio 
 
 /* --- Details -------------------------------------------------------------------- */
 /* --- Details -------------------------------------------------------------------- */

--- a/src/algorithm/jacobian.hpp
+++ b/src/algorithm/jacobian.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_jacobian_hpp__
-#define __se3_jacobian_hpp__
+#ifndef __pinocchio_jacobian_hpp__
+#define __pinocchio_jacobian_hpp__
 
 #include "pinocchio/multibody/fwd.hpp"
 #include "pinocchio/multibody/model.hpp"
@@ -355,4 +355,4 @@ namespace se3
 
 #include "pinocchio/algorithm/jacobian.hxx"
 
-#endif // ifndef __se3_jacobian_hpp__
+#endif // ifndef __pinocchio_jacobian_hpp__

--- a/src/algorithm/jacobian.hxx
+++ b/src/algorithm/jacobian.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_jacobian_hxx__
-#define __se3_jacobian_hxx__
+#ifndef __pinocchio_jacobian_hxx__
+#define __pinocchio_jacobian_hxx__
 
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/algorithm/check.hpp"
@@ -326,4 +326,4 @@ namespace se3
 
 /// @endcond
 
-#endif // ifndef __se3_jacobian_hxx__
+#endif // ifndef __pinocchio_jacobian_hxx__

--- a/src/algorithm/jacobian.hxx
+++ b/src/algorithm/jacobian.hxx
@@ -23,7 +23,7 @@
 
 /// @cond DEV
 
-namespace se3
+namespace pinocchio
 {
   
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
@@ -322,7 +322,7 @@ namespace se3
   }
   
   
-} // namespace se3
+} // namespace pinocchio
 
 /// @endcond
 

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -20,7 +20,7 @@
 
 #include "pinocchio/multibody/fwd.hpp"
 
-namespace se3
+namespace pinocchio
 {
 
   /**
@@ -189,7 +189,7 @@ namespace se3
                              const Eigen::MatrixBase<ConfigVector> & q,
                              const Eigen::MatrixBase<JacobianMatrix> & jacobian);
 
-} // namespace se3
+} // namespace pinocchio
 
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/joint-configuration.hxx"

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_configuration_hpp__
-#define __se3_joint_configuration_hpp__
+#ifndef __pinocchio_joint_configuration_hpp__
+#define __pinocchio_joint_configuration_hpp__
 
 #include "pinocchio/multibody/fwd.hpp"
 
@@ -194,5 +194,5 @@ namespace se3
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/joint-configuration.hxx"
 
-#endif // ifndef __se3_joint_configuration_hpp__
+#endif // ifndef __pinocchio_joint_configuration_hpp__
 

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_configuration_hxx__
-#define __se3_joint_configuration_hxx__
+#ifndef __pinocchio_joint_configuration_hxx__
+#define __pinocchio_joint_configuration_hxx__
 
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/multibody/model.hpp"
@@ -326,5 +326,5 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_joint_configuration_hxx__
+#endif // ifndef __pinocchio_joint_configuration_hxx__
 

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -28,7 +28,7 @@
 #include <cmath>
 
 /* --- Details -------------------------------------------------------------------- */
-namespace se3
+namespace pinocchio
 {
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType>
   inline typename EIGEN_PLAIN_TYPE(ConfigVectorType)
@@ -324,7 +324,7 @@ namespace se3
   }
 
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_joint_configuration_hxx__
 

--- a/src/algorithm/kinematics-derivatives.hpp
+++ b/src/algorithm/kinematics-derivatives.hpp
@@ -21,7 +21,7 @@
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   ///
@@ -104,7 +104,7 @@ namespace se3
 
  
 
-} // namespace se3 
+} // namespace pinocchio 
 
 #include "pinocchio/algorithm/kinematics-derivatives.hxx"
 

--- a/src/algorithm/kinematics-derivatives.hpp
+++ b/src/algorithm/kinematics-derivatives.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_kinematics_derivatives_hpp__
-#define __se3_kinematics_derivatives_hpp__
+#ifndef __pinocchio_kinematics_derivatives_hpp__
+#define __pinocchio_kinematics_derivatives_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -108,4 +108,4 @@ namespace se3
 
 #include "pinocchio/algorithm/kinematics-derivatives.hxx"
 
-#endif // ifndef __se3_kinematics_derivatives_hpp__
+#endif // ifndef __pinocchio_kinematics_derivatives_hpp__

--- a/src/algorithm/kinematics-derivatives.hxx
+++ b/src/algorithm/kinematics-derivatives.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_kinematics_derivatives_hxx__
-#define __se3_kinematics_derivatives_hxx__
+#ifndef __pinocchio_kinematics_derivatives_hxx__
+#define __pinocchio_kinematics_derivatives_hxx__
 
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/algorithm/check.hpp"
@@ -389,5 +389,5 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_kinematics_derivatives_hxx__
+#endif // ifndef __pinocchio_kinematics_derivatives_hxx__
 

--- a/src/algorithm/kinematics-derivatives.hxx
+++ b/src/algorithm/kinematics-derivatives.hxx
@@ -21,7 +21,7 @@
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/algorithm/check.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2>
@@ -387,7 +387,7 @@ namespace se3
     data.oa[0].setZero();
   }
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_kinematics_derivatives_hxx__
 

--- a/src/algorithm/kinematics.hpp
+++ b/src/algorithm/kinematics.hpp
@@ -21,7 +21,7 @@
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
 
-namespace se3
+namespace pinocchio
 {
   ///
   /// \brief Browse through the kinematic structure with a void step.
@@ -47,7 +47,7 @@ namespace se3
   /// \param[in] data The data structure of the rigid body system.
   ///
   /// \remark This algorithm may be useful to call to update global joint placement
-  ///         after calling se3::rnea, se3::aba, etc for example.
+  ///         after calling pinocchio::rnea, pinocchio::aba, etc for example.
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
   inline void updateGlobalPlacements(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
@@ -106,7 +106,7 @@ namespace se3
                                 const Eigen::MatrixBase<TangentVectorType1> & v,
                                 const Eigen::MatrixBase<TangentVectorType2> & a);
 
-} // namespace se3 
+} // namespace pinocchio 
 
 /* --- Details -------------------------------------------------------------------- */
 /* --- Details -------------------------------------------------------------------- */

--- a/src/algorithm/kinematics.hpp
+++ b/src/algorithm/kinematics.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_kinematics_hpp__
-#define __se3_kinematics_hpp__
+#ifndef __pinocchio_kinematics_hpp__
+#define __pinocchio_kinematics_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -114,4 +114,4 @@ namespace se3
 #include "pinocchio/algorithm/kinematics.hxx"
 
 
-#endif // ifndef __se3_kinematics_hpp__
+#endif // ifndef __pinocchio_kinematics_hpp__

--- a/src/algorithm/kinematics.hxx
+++ b/src/algorithm/kinematics.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_kinematics_hxx__
-#define __se3_kinematics_hxx__
+#ifndef __pinocchio_kinematics_hxx__
+#define __pinocchio_kinematics_hxx__
 
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/algorithm/check.hpp"
@@ -268,4 +268,4 @@ namespace se3
   }
 } // namespace se3
 
-#endif // ifndef __se3_kinematics_hxx__
+#endif // ifndef __pinocchio_kinematics_hxx__

--- a/src/algorithm/kinematics.hxx
+++ b/src/algorithm/kinematics.hxx
@@ -21,7 +21,7 @@
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/algorithm/check.hpp"
 
-namespace se3 
+namespace pinocchio 
 {
   
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
@@ -266,6 +266,6 @@ namespace se3
                 typename Algo::ArgsType(model,data,q.derived(),v.derived(),a.derived()));
     }
   }
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_kinematics_hxx__

--- a/src/algorithm/regressor.hpp
+++ b/src/algorithm/regressor.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_regressor_hpp__
-#define __se3_regressor_hpp__
+#ifndef __pinocchio_regressor_hpp__
+#define __pinocchio_regressor_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -53,4 +53,4 @@ namespace se3
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/regressor.hxx"
 
-#endif // ifndef __se3_regressor_hpp__
+#endif // ifndef __pinocchio_regressor_hpp__

--- a/src/algorithm/regressor.hpp
+++ b/src/algorithm/regressor.hpp
@@ -21,7 +21,7 @@
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   namespace regressor
@@ -48,7 +48,7 @@ namespace se3
                            const Eigen::MatrixBase<ConfigVectorType> & q);
   }
   
-} // namespace se3
+} // namespace pinocchio
 
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/regressor.hxx"

--- a/src/algorithm/regressor.hxx
+++ b/src/algorithm/regressor.hxx
@@ -21,7 +21,7 @@
 #include "pinocchio/algorithm/check.hpp"
 #include "pinocchio/algorithm/kinematics.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   namespace regressor
@@ -65,6 +65,6 @@ namespace se3
     }
   }
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_regressor_hxx__

--- a/src/algorithm/regressor.hxx
+++ b/src/algorithm/regressor.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_regressor_hxx__
-#define __se3_regressor_hxx__
+#ifndef __pinocchio_regressor_hxx__
+#define __pinocchio_regressor_hxx__
 
 #include "pinocchio/algorithm/check.hpp"
 #include "pinocchio/algorithm/kinematics.hpp"
@@ -67,4 +67,4 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_regressor_hxx__
+#endif // ifndef __pinocchio_regressor_hxx__

--- a/src/algorithm/rnea-derivatives.hpp
+++ b/src/algorithm/rnea-derivatives.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_rnea_derivatives_hpp__
-#define __se3_rnea_derivatives_hpp__
+#ifndef __pinocchio_rnea_derivatives_hpp__
+#define __pinocchio_rnea_derivatives_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -201,4 +201,4 @@ namespace se3
 
 #include "pinocchio/algorithm/rnea-derivatives.hxx"
 
-#endif // ifndef __se3_rnea_derivatives_hpp__
+#endif // ifndef __pinocchio_rnea_derivatives_hpp__

--- a/src/algorithm/rnea-derivatives.hpp
+++ b/src/algorithm/rnea-derivatives.hpp
@@ -23,7 +23,7 @@
 
 #include "pinocchio/container/aligned-vector.hpp"
 
-namespace se3
+namespace pinocchio
 {
 
   ///
@@ -41,7 +41,7 @@ namespace se3
   ///
   /// \remark gravity_partial_dq must be first initialized with zeros (gravity_partial_dq.setZero).
   ///
-  /// \sa se3::computeGeneralizedGravity
+  /// \sa pinocchio::computeGeneralizedGravity
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename ReturnMatrixType>
   inline void
@@ -72,9 +72,9 @@ namespace se3
   /// \param[out] rnea_partial_da Partial derivative of the generalized torque vector with respect to the joint acceleration.
   ///
   /// \remark rnea_partial_dq, rnea_partial_dv and rnea_partial_da must be first initialized with zeros (rnea_partial_dq.setZero(),etc).
-  ///         As for se3::crba, only the upper triangular part of rnea_partial_da is filled.
+  ///         As for pinocchio::crba, only the upper triangular part of rnea_partial_da is filled.
   ///
-  /// \sa se3::rnea
+  /// \sa pinocchio::rnea
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2,
   typename MatrixType1, typename MatrixType2, typename MatrixType3>
@@ -111,9 +111,9 @@ namespace se3
   /// \param[out] rnea_partial_da Partial derivative of the generalized torque vector with respect to the joint acceleration.
   ///
   /// \remark rnea_partial_dq, rnea_partial_dv and rnea_partial_da must be first initialized with zeros (rnea_partial_dq.setZero(),etc).
-  ///         As for se3::crba, only the upper triangular part of rnea_partial_da is filled.
+  ///         As for pinocchio::crba, only the upper triangular part of rnea_partial_da is filled.
   ///
-  /// \sa se3::rnea
+  /// \sa pinocchio::rnea
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2,
   typename MatrixType1, typename MatrixType2, typename MatrixType3>
@@ -145,9 +145,9 @@ namespace se3
   ///
   /// \returns The results are stored in data.dtau_dq, data.dtau_dv and data.M which respectively correspond
   ///          to the partial derivatives of the joint torque vector with respect to the joint configuration, velocity and acceleration.
-  ///          As for se3::crba, only the upper triangular part of data.M is filled.
+  ///          As for pinocchio::crba, only the upper triangular part of data.M is filled.
   ///
-  /// \sa se3::rnea, se3::crba, se3::cholesky::decompose
+  /// \sa pinocchio::rnea, pinocchio::crba, pinocchio::cholesky::decompose
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2>
   inline void
@@ -179,9 +179,9 @@ namespace se3
   ///
   /// \returns The results are stored in data.dtau_dq, data.dtau_dv and data.M which respectively correspond
   ///          to the partial derivatives of the joint torque vector with respect to the joint configuration, velocity and acceleration.
-  ///          As for se3::crba, only the upper triangular part of data.M is filled.
+  ///          As for pinocchio::crba, only the upper triangular part of data.M is filled.
   ///
-  /// \sa se3::rnea, se3::crba, se3::cholesky::decompose
+  /// \sa pinocchio::rnea, pinocchio::crba, pinocchio::cholesky::decompose
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2>
   inline void
@@ -197,7 +197,7 @@ namespace se3
   }
 
 
-} // namespace se3 
+} // namespace pinocchio 
 
 #include "pinocchio/algorithm/rnea-derivatives.hxx"
 

--- a/src/algorithm/rnea-derivatives.hxx
+++ b/src/algorithm/rnea-derivatives.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_rnea_derivatives_hxx__
-#define __se3_rnea_derivatives_hxx__
+#ifndef __pinocchio_rnea_derivatives_hxx__
+#define __pinocchio_rnea_derivatives_hxx__
 
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/algorithm/check.hpp"
@@ -480,5 +480,5 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_rnea_derivatives_hxx__
+#endif // ifndef __pinocchio_rnea_derivatives_hxx__
 

--- a/src/algorithm/rnea-derivatives.hxx
+++ b/src/algorithm/rnea-derivatives.hxx
@@ -21,7 +21,7 @@
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/algorithm/check.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
@@ -478,7 +478,7 @@ namespace se3
   }
   
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_rnea_derivatives_hxx__
 

--- a/src/algorithm/rnea.hpp
+++ b/src/algorithm/rnea.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_rnea_hpp__
-#define __se3_rnea_hpp__
+#ifndef __pinocchio_rnea_hpp__
+#define __pinocchio_rnea_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -148,4 +148,4 @@ namespace se3
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/rnea.hxx"
 
-#endif // ifndef __se3_rnea_hpp__
+#endif // ifndef __pinocchio_rnea_hpp__

--- a/src/algorithm/rnea.hpp
+++ b/src/algorithm/rnea.hpp
@@ -21,7 +21,7 @@
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
   
-namespace se3
+namespace pinocchio
 {
   ///
   /// \brief The Recursive Newton-Euler algorithm. It computes the inverse dynamics, aka the joint torques according to the current state of the system and the desired joint accelerations.
@@ -78,7 +78,7 @@ namespace se3
   /// \brief Computes the non-linear effects (Corriolis, centrifual and gravitationnal effects), also called the bias terms \f$ b(q,\dot{q}) \f$ of the Lagrangian dynamics:
   /// <CENTER> \f$ \begin{eqnarray} M \ddot{q} + b(q, \dot{q}) = \tau  \end{eqnarray} \f$ </CENTER> <BR>
   ///
-  /// \note This function is equivalent to se3::rnea(model, data, q, v, 0).
+  /// \note This function is equivalent to pinocchio::rnea(model, data, q, v, 0).
   ///
   /// \tparam JointCollection Collection of Joint types.
   /// \tparam ConfigVectorType Type of the joint configuration vector.
@@ -102,7 +102,7 @@ namespace se3
   /// \brief Computes the generalized gravity contribution \f$ g(q) \f$ of the Lagrangian dynamics:
   /// <CENTER> \f$ \begin{eqnarray} M \ddot{q} + c(q, \dot{q}) + g(q) = \tau  \end{eqnarray} \f$ </CENTER> <BR>
   ///
-  /// \note This function is equivalent to se3::rnea(model, data, q, 0, 0).
+  /// \note This function is equivalent to pinocchio::rnea(model, data, q, 0, 0).
   ///
   /// \tparam JointCollection Collection of Joint types.
   /// \tparam ConfigVectorType Type of the joint configuration vector.
@@ -143,7 +143,7 @@ namespace se3
                         const Eigen::MatrixBase<ConfigVectorType> & q,
                         const Eigen::MatrixBase<TangentVectorType> & v);
 
-} // namespace se3 
+} // namespace pinocchio 
 
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/rnea.hxx"

--- a/src/algorithm/rnea.hxx
+++ b/src/algorithm/rnea.hxx
@@ -23,7 +23,7 @@
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/algorithm/check.hpp"
 
-namespace se3
+namespace pinocchio
 {
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2>
   struct RneaForwardStep
@@ -197,8 +197,8 @@ namespace se3
                                   > ArgsType;
     
     template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     se3::JointDataBase<typename JointModel::JointDataDerived> & jdata,
+    static void algo(const pinocchio::JointModelBase<JointModel> & jmodel,
+                     pinocchio::JointDataBase<typename JointModel::JointDataDerived> & jdata,
                      const Model & model,
                      Data & data,
                      const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -298,8 +298,8 @@ namespace se3
                                   > ArgsType;
     
     template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     se3::JointDataBase<typename JointModel::JointDataDerived> & jdata,
+    static void algo(const pinocchio::JointModelBase<JointModel> & jmodel,
+                     pinocchio::JointDataBase<typename JointModel::JointDataDerived> & jdata,
                      const Model & model,
                      Data & data,
                      const Eigen::MatrixBase<ConfigVectorType> & q)
@@ -388,8 +388,8 @@ namespace se3
                                   > ArgsType;
 
     template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     se3::JointDataBase<typename JointModel::JointDataDerived> & jdata,
+    static void algo(const pinocchio::JointModelBase<JointModel> & jmodel,
+                     pinocchio::JointDataBase<typename JointModel::JointDataDerived> & jdata,
                      const Model & model,
                      Data & data,
                      const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -518,7 +518,7 @@ namespace se3
     return data.C;
   }
   
-} // namespace se3
+} // namespace pinocchio
 
 /// @endcond
 

--- a/src/algorithm/rnea.hxx
+++ b/src/algorithm/rnea.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_rnea_hxx__
-#define __se3_rnea_hxx__
+#ifndef __pinocchio_rnea_hxx__
+#define __pinocchio_rnea_hxx__
 
 /// @cond DEV
 
@@ -522,4 +522,4 @@ namespace se3
 
 /// @endcond
 
-#endif // ifndef __se3_rnea_hxx__
+#endif // ifndef __pinocchio_rnea_hxx__

--- a/src/assert.hpp
+++ b/src/assert.hpp
@@ -18,7 +18,7 @@
 #ifndef __pinocchio_assert_hpp__
 #define __pinocchio_assert_hpp__
 
-namespace se3
+namespace pinocchio
 {
   namespace internal 
   {
@@ -44,9 +44,9 @@ namespace se3
   } // namespace internat
 
 
-} // namespace se3 
+} // namespace pinocchio 
 
 #define SE3_STATIC_ASSERT(CONDITION,MSG)			\
-  if(se3::internal::static_assertion<bool(CONDITION)>::MSG) {}
+  if(pinocchio::internal::static_assertion<bool(CONDITION)>::MSG) {}
 
 #endif // ifndef __pinocchio_assert_hpp__

--- a/src/assert.hpp
+++ b/src/assert.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_assert_hpp__
-#define __se3_assert_hpp__
+#ifndef __pinocchio_assert_hpp__
+#define __pinocchio_assert_hpp__
 
 namespace se3
 {
@@ -49,4 +49,4 @@ namespace se3
 #define SE3_STATIC_ASSERT(CONDITION,MSG)			\
   if(se3::internal::static_assertion<bool(CONDITION)>::MSG) {}
 
-#endif // ifndef __se3_assert_hpp__
+#endif // ifndef __pinocchio_assert_hpp__

--- a/src/codegen/code-generator-algo.hpp
+++ b/src/codegen/code-generator-algo.hpp
@@ -27,7 +27,7 @@
 #include "pinocchio/algorithm/rnea-derivatives.hpp"
 #include "pinocchio/algorithm/aba-derivatives.hpp"
 
-namespace se3
+namespace pinocchio
 {
   template<typename _Scalar>
   struct CodeGenRNEA : public CodeGenBase<_Scalar>
@@ -66,7 +66,7 @@ namespace se3
       ad_v = ad_X.segment(it,ad_model.nv); it += ad_model.nv;
       ad_a = ad_X.segment(it,ad_model.nv); it += ad_model.nv;
       
-      se3::rnea(ad_model,ad_data,ad_q,ad_v,ad_a);
+      pinocchio::rnea(ad_model,ad_data,ad_q,ad_v,ad_a);
       
       ad_Y = ad_data.tau;
       
@@ -164,7 +164,7 @@ namespace se3
       ad_v = ad_X.segment(it,ad_model.nv); it += ad_model.nv;
       ad_tau = ad_X.segment(it,ad_model.nv); it += ad_model.nv;
       
-      se3::aba(ad_model,ad_data,ad_q,ad_v,ad_tau);
+      pinocchio::aba(ad_model,ad_data,ad_q,ad_v,ad_tau);
       ad_Y = ad_data.ddq;
       
       ad_fun.Dependent(ad_X,ad_Y);
@@ -258,7 +258,7 @@ namespace se3
       Eigen::DenseIndex it = 0;
       ad_q = ad_X.segment(it,ad_model.nq); it += ad_model.nq;
       
-      se3::crba(ad_model,ad_data,ad_q);
+      pinocchio::crba(ad_model,ad_data,ad_q);
       Eigen::DenseIndex it_Y = 0;
       
       for(Eigen::DenseIndex i = 0; i < ad_model.nv; ++i)
@@ -346,7 +346,7 @@ namespace se3
       Eigen::DenseIndex it = 0;
       ad_q = ad_X.segment(it,ad_model.nq); it += ad_model.nq;
       
-      se3::computeMinverse(ad_model,ad_data,ad_q);
+      pinocchio::computeMinverse(ad_model,ad_data,ad_q);
       Eigen::DenseIndex it_Y = 0;
       for(Eigen::DenseIndex i = 0; i < ad_model.nv; ++i)
       {
@@ -447,7 +447,7 @@ namespace se3
       ad_v = ad_X.segment(it,ad_model.nv); it += ad_model.nv;
       ad_a = ad_X.segment(it,ad_model.nv); it += ad_model.nv;
       
-      se3::computeRNEADerivatives(ad_model,ad_data,
+      pinocchio::computeRNEADerivatives(ad_model,ad_data,
                                   ad_q,ad_v,ad_a,
                                   ad_dtau_dq,ad_dtau_dv,ad_dtau_da);
       
@@ -556,7 +556,7 @@ namespace se3
       ad_v = ad_X.segment(it,ad_model.nv); it += ad_model.nv;
       ad_tau = ad_X.segment(it,ad_model.nv); it += ad_model.nv;
       
-      se3::computeABADerivatives(ad_model,ad_data,
+      pinocchio::computeABADerivatives(ad_model,ad_data,
                                  ad_q,ad_v,ad_tau,
                                  ad_dddq_dq,ad_dddq_dv,ad_dddq_dtau);
       
@@ -616,7 +616,7 @@ namespace se3
     ADTangentVectorType ad_v, ad_tau;
   };
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifdef PINOCCHIO_WITH_CPPADCG_SUPPORT
 

--- a/src/codegen/code-generator-algo.hpp
+++ b/src/codegen/code-generator-algo.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_utils_code_generator_algo_hpp__
-#define __se3_utils_code_generator_algo_hpp__
+#ifndef __pinocchio_utils_code_generator_algo_hpp__
+#define __pinocchio_utils_code_generator_algo_hpp__
 
 #ifdef PINOCCHIO_WITH_CPPADCG_SUPPORT
 
@@ -620,4 +620,4 @@ namespace se3
 
 #endif // ifdef PINOCCHIO_WITH_CPPADCG_SUPPORT
 
-#endif // ifndef __se3_utils_code_generator_base_hpp__
+#endif // ifndef __pinocchio_utils_code_generator_base_hpp__

--- a/src/codegen/code-generator-base.hpp
+++ b/src/codegen/code-generator-base.hpp
@@ -23,7 +23,7 @@
 
 #ifdef PINOCCHIO_WITH_CPPADCG_SUPPORT
 
-namespace se3
+namespace pinocchio
 {
   
   template<typename _Scalar>
@@ -35,12 +35,12 @@ namespace se3
     
     enum { Options = 0 };
     
-    typedef se3::ModelTpl<Scalar,Options> Model;
-    typedef se3::DataTpl<Scalar,Options> Data;
-    typedef se3::ModelTpl<CGScalar,Options> CGModel;
-    typedef se3::DataTpl<CGScalar,Options> CGData;
-    typedef se3::ModelTpl<ADScalar,Options> ADModel;
-    typedef se3::DataTpl<ADScalar,Options> ADData;
+    typedef pinocchio::ModelTpl<Scalar,Options> Model;
+    typedef pinocchio::DataTpl<Scalar,Options> Data;
+    typedef pinocchio::ModelTpl<CGScalar,Options> CGModel;
+    typedef pinocchio::DataTpl<CGScalar,Options> CGData;
+    typedef pinocchio::ModelTpl<ADScalar,Options> ADModel;
+    typedef pinocchio::DataTpl<ADScalar,Options> ADData;
     
     typedef Eigen::Matrix<Scalar,Eigen::Dynamic,Eigen::Dynamic,Options> MatrixXs;
     typedef Eigen::Matrix<Scalar,Eigen::Dynamic,1,Options> VectorXs;
@@ -186,7 +186,7 @@ namespace se3
     
   }; // struct CodeGenBase
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // PINOCCHIO_WITH_CPPADCG_SUPPORT
 

--- a/src/codegen/code-generator-base.hpp
+++ b/src/codegen/code-generator-base.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_utils_code_generator_base_hpp__
-#define __se3_utils_code_generator_base_hpp__
+#ifndef __pinocchio_utils_code_generator_base_hpp__
+#define __pinocchio_utils_code_generator_base_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
@@ -190,4 +190,4 @@ namespace se3
 
 #endif // PINOCCHIO_WITH_CPPADCG_SUPPORT
 
-#endif // ifndef __se3_utils_code_generator_base_hpp__
+#endif // ifndef __pinocchio_utils_code_generator_base_hpp__

--- a/src/container/aligned-vector.hpp
+++ b/src/container/aligned-vector.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_container_aligned_vector_hpp__
-#define __se3_container_aligned_vector_hpp__
+#ifndef __pinocchio_container_aligned_vector_hpp__
+#define __pinocchio_container_aligned_vector_hpp__
 
 #include <vector>
 #include <Eigen/StdVector>
@@ -66,4 +66,4 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_container_aligned_vector_hpp__
+#endif // ifndef __pinocchio_container_aligned_vector_hpp__

--- a/src/container/aligned-vector.hpp
+++ b/src/container/aligned-vector.hpp
@@ -21,7 +21,7 @@
 #include <vector>
 #include <Eigen/StdVector>
 
-namespace se3
+namespace pinocchio
 {
   namespace container
   {
@@ -64,6 +64,6 @@ namespace se3
     
   } // namespace container
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_container_aligned_vector_hpp__

--- a/src/deprecated-macros.hpp
+++ b/src/deprecated-macros.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_deprecated_macros_hpp__
-#define __se3_deprecated_macros_hpp__
+#ifndef __pinocchio_deprecated_macros_hpp__
+#define __pinocchio_deprecated_macros_hpp__
 
 #ifdef PINOCCHIO_WITH_HPP_FCL
   #ifndef WITH_HPP_FCL
@@ -45,4 +45,4 @@
   #endif
 #endif
 
-#endif // ifndef __se3_deprecated_macros_hpp__
+#endif // ifndef __pinocchio_deprecated_macros_hpp__

--- a/src/deprecated-namespaces.hpp
+++ b/src/deprecated-namespaces.hpp
@@ -15,11 +15,11 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_deprecated_namespaces_hpp__
-#define __se3_deprecated_namespaces_hpp__
+#ifndef __pinocchio_deprecated_namespaces_hpp__
+#define __pinocchio_deprecated_namespaces_hpp__
 
 #ifdef PINOCCHIO_ENABLE_COMPATIBILITY_WITH_VERSION_1
 #define se3 PINOCCHIO_PRAGMA_MESSAGE_CALL("The se3 namespace has been set to deprecated since version 2.0.0. Please use namespace pinocchio instead") pinocchio
 #endif
 
-#endif // ifndef __se3_deprecated_namespaces_hpp__
+#endif // ifndef __pinocchio_deprecated_namespaces_hpp__

--- a/src/deprecated-namespaces.hpp
+++ b/src/deprecated-namespaces.hpp
@@ -18,8 +18,10 @@
 #ifndef __pinocchio_deprecated_namespaces_hpp__
 #define __pinocchio_deprecated_namespaces_hpp__
 
-#ifdef PINOCCHIO_ENABLE_COMPATIBILITY_WITH_VERSION_1
-#define se3 PINOCCHIO_PRAGMA_MESSAGE_CALL("The se3 namespace has been set to deprecated since version 2.0.0. Please use namespace pinocchio instead") pinocchio
+#if PINOCCHIO_ENABLE_COMPATIBILITY_WITH_VERSION_1 // do not warn
+  #define se3 ::pinocchio
+#else
+  #define se3 PINOCCHIO_PRAGMA_MESSAGE_CALL("The se3 namespace has been deprecated since version 2.0.0. Please use namespace pinocchio instead.") ::pinocchio
 #endif
 
 #endif // ifndef __pinocchio_deprecated_namespaces_hpp__

--- a/src/deprecated-namespaces.hpp
+++ b/src/deprecated-namespaces.hpp
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2018 INRIA
+//
+// This file is part of Pinocchio
+// Pinocchio is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// Pinocchio is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// Pinocchio If not, see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef __se3_deprecated_namespaces_hpp__
+#define __se3_deprecated_namespaces_hpp__
+
+#ifdef PINOCCHIO_ENABLE_COMPATIBILITY_WITH_VERSION_1
+#define se3 PINOCCHIO_PRAGMA_MESSAGE_CALL("The se3 namespace has been set to deprecated since version 2.0.0. Please use namespace pinocchio instead") pinocchio
+#endif
+
+#endif // ifndef __se3_deprecated_namespaces_hpp__

--- a/src/deprecated-namespaces.hpp
+++ b/src/deprecated-namespaces.hpp
@@ -19,9 +19,7 @@
 #define __pinocchio_deprecated_namespaces_hpp__
 
 #if PINOCCHIO_ENABLE_COMPATIBILITY_WITH_VERSION_1 // do not warn
-  #define se3 ::pinocchio
-#else
-  #define se3 PINOCCHIO_PRAGMA_MESSAGE_CALL("The se3 namespace has been deprecated since version 2.0.0. Please use namespace pinocchio instead.") ::pinocchio
+  namespace se3 = ::pinocchio;
 #endif
 
 #endif // ifndef __pinocchio_deprecated_namespaces_hpp__

--- a/src/deprecation.hpp
+++ b/src/deprecation.hpp
@@ -15,11 +15,11 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_deprecation_hpp__
-#define __se3_deprecation_hpp__
+#ifndef __pinocchio_deprecation_hpp__
+#define __pinocchio_deprecation_hpp__
 
 #include "pinocchio/deprecated.hpp"
 #include "pinocchio/deprecated-macros.hpp"
 #include "pinocchio/deprecated-namespaces.hpp"
 
-#endif // ifndef __se3_deprecation_hpp__
+#endif // ifndef __pinocchio_deprecation_hpp__

--- a/src/deprecation.hpp
+++ b/src/deprecation.hpp
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2018 INRIA
+//
+// This file is part of Pinocchio
+// Pinocchio is free software: you can redistribute it
+// and/or modify it under the terms of the GNU Lesser General Public
+// License as published by the Free Software Foundation, either version
+// 3 of the License, or (at your option) any later version.
+//
+// Pinocchio is distributed in the hope that it will be
+// useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+// of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+// General Lesser Public License for more details. You should have
+// received a copy of the GNU Lesser General Public License along with
+// Pinocchio If not, see
+// <http://www.gnu.org/licenses/>.
+
+#ifndef __se3_deprecation_hpp__
+#define __se3_deprecation_hpp__
+
+#include "pinocchio/deprecated.hpp"
+#include "pinocchio/deprecated-macros.hpp"
+#include "pinocchio/deprecated-namespaces.hpp"
+
+#endif // ifndef __se3_deprecation_hpp__

--- a/src/eigen-macros.hpp
+++ b/src/eigen-macros.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_eigen_macros_hpp__
-#define __se3_eigen_macros_hpp__
+#ifndef __pinocchio_eigen_macros_hpp__
+#define __pinocchio_eigen_macros_hpp__
 
 #include "pinocchio/utils/eigen-fix.hpp"
 
@@ -54,4 +54,4 @@ Eigen::internal::scalar_product_traits<typename Eigen::internal::traits< D1 >::S
 /// \brief Macro for an automatic const_cast
 #define EIGEN_CONST_CAST(TYPE,OBJ) const_cast<TYPE &>(OBJ.derived())
 
-#endif // ifndef __se3_eigen_macros_hpp__
+#endif // ifndef __pinocchio_eigen_macros_hpp__

--- a/src/eigen-macros.hpp
+++ b/src/eigen-macros.hpp
@@ -21,13 +21,13 @@
 #include "pinocchio/utils/eigen-fix.hpp"
 
 /// \brief Macro giving access to the equivalent plain type of D
-#define EIGEN_PLAIN_TYPE(D) Eigen::internal::plain_matrix_type< typename se3::helper::argument_type<void(D)>::type >::type
+#define EIGEN_PLAIN_TYPE(D) Eigen::internal::plain_matrix_type< typename pinocchio::helper::argument_type<void(D)>::type >::type
 
 /// \brief Similar to macro EIGEN_PLAIN_TYPE but with guaranty to provite a column major type
-#define EIGEN_PLAIN_COLUMN_MAJOR_TYPE(D) se3::helper::handle_return_type_without_typename<D,Eigen::internal::plain_matrix_type_column_major>::type
+#define EIGEN_PLAIN_COLUMN_MAJOR_TYPE(D) pinocchio::helper::handle_return_type_without_typename<D,Eigen::internal::plain_matrix_type_column_major>::type
 
 /// \brief Similar to macro EIGEN_PLAIN_TYPE but with guaranty to provite a row major type
-#define EIGEN_PLAIN_ROW_MAJOR_TYPE(D) se3::helper::handle_return_type_without_typename<D,Eigen::internal::fix::plain_matrix_type_row_major>::type
+#define EIGEN_PLAIN_ROW_MAJOR_TYPE(D) pinocchio::helper::handle_return_type_without_typename<D,Eigen::internal::fix::plain_matrix_type_row_major>::type
 
 /// \brief Macro giving access to the reference type of D
 #define EIGEN_REF_CONSTTYPE(D) Eigen::internal::ref_selector<D>::type

--- a/src/exception.hpp
+++ b/src/exception.hpp
@@ -21,7 +21,7 @@
 #include <exception>
 #include <string>
 
-namespace se3
+namespace pinocchio
 {
   class Exception : public std::exception
   {

--- a/src/exception.hpp
+++ b/src/exception.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_exception_hpp__
-#define __se3_exception_hpp__
+#ifndef __pinocchio_exception_hpp__
+#define __pinocchio_exception_hpp__
 
 #include <exception>
 #include <string>
@@ -42,4 +42,4 @@ namespace se3
 
 } // namespace 
 
-#endif // ifndef __se3_exception_hpp__
+#endif // ifndef __pinocchio_exception_hpp__

--- a/src/fwd.hpp
+++ b/src/fwd.hpp
@@ -31,7 +31,7 @@
 
 #include "pinocchio/eigen-macros.hpp"
 
-namespace se3
+namespace pinocchio
 {
   ///
   /// \brief Common traits structure to fully define base classes for CRTP.

--- a/src/fwd.hpp
+++ b/src/fwd.hpp
@@ -19,8 +19,7 @@
 #define __se3_fwd_hpp__
 
 #include "pinocchio/macros.hpp"
-#include "pinocchio/deprecated-macros.hpp"
-#include "pinocchio/deprecated.hpp"
+#include "pinocchio/deprecation.hpp"
 #include "pinocchio/warning.hpp"
 #include "pinocchio/config.hpp"
 

--- a/src/fwd.hpp
+++ b/src/fwd.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_fwd_hpp__
-#define __se3_fwd_hpp__
+#ifndef __pinocchio_fwd_hpp__
+#define __pinocchio_fwd_hpp__
 
 #include "pinocchio/macros.hpp"
 #include "pinocchio/deprecation.hpp"
@@ -56,4 +56,4 @@ namespace se3
   };
 }
 
-#endif // #ifndef __se3_fwd_hpp__
+#endif // #ifndef __pinocchio_fwd_hpp__

--- a/src/fwd.hpp
+++ b/src/fwd.hpp
@@ -18,6 +18,9 @@
 #ifndef __pinocchio_fwd_hpp__
 #define __pinocchio_fwd_hpp__
 
+/// Forward declarion of main pinocchio namespace
+namespace pinocchio {}
+
 #include "pinocchio/macros.hpp"
 #include "pinocchio/deprecation.hpp"
 #include "pinocchio/warning.hpp"

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_macros_hpp__
-#define __se3_macros_hpp__
+#ifndef __pinocchio_macros_hpp__
+#define __pinocchio_macros_hpp__
 
 #if __cplusplus >= 201103L
   #define PINOCCHIO_WITH_CXX11_SUPPORT
@@ -74,4 +74,4 @@ namespace se3
   }
 }
 
-#endif // ifndef __se3_macros_hpp__
+#endif // ifndef __pinocchio_macros_hpp__

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -22,6 +22,12 @@
   #define PINOCCHIO_WITH_CXX11_SUPPORT
 #endif
 
+#define PINOCCHIO_STRING_LITERAL(string) #string
+
+/// \remarks The following two macros should be adapted for WIN32
+#define PINOCCHIO_PRAGMA_MESSAGE(the_message) PINOCCHIO_STRING_LITERAL(message(the_message))
+#define PINOCCHIO_PRAGMA_MESSAGE_CALL(the_message) _Pragma(PINOCCHIO_PRAGMA_MESSAGE(the_message))
+
 /// \brief Macro to check the current Pinocchio version against a version provided by x.y.z
 #define PINOCCHIO_VERSION_AT_LEAST(x,y,z) \
           (PINOCCHIO_MAJOR_VERSION>x || (PINOCCHIO_MAJOR_VERSION>=x && \

--- a/src/macros.hpp
+++ b/src/macros.hpp
@@ -37,7 +37,7 @@
 // This macro can be used to prevent from macro expansion, similarly to EIGEN_NOT_A_MACRO
 #define PINOCCHIO_NOT_A_MACRO
 
-namespace se3
+namespace pinocchio
 {
   namespace helper
   {
@@ -62,7 +62,7 @@ namespace se3
 #define PINOCCHIO_STATIC_ASSERT(condition,msg)                                 \
   { int msg[(condition) ? 1 : -1]; /*avoid unused-variable warning*/ (void) msg; }
 
-namespace se3
+namespace pinocchio
 {
   namespace helper
   {

--- a/src/math/cppad.hpp
+++ b/src/math/cppad.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_math_ccpad_hpp__
-#define __se3_math_ccpad_hpp__
+#ifndef __pinocchio_math_ccpad_hpp__
+#define __pinocchio_math_ccpad_hpp__
 
 // Do not include this file directly.
 // Copy and use directly the intructions from <cppad/example/cppad_eigen.hpp>
@@ -123,4 +123,4 @@ namespace CppAD
   {  return x * x; }
 }
 
-#endif // #ifndef __se3_math_ccpad_hpp__
+#endif // #ifndef __pinocchio_math_ccpad_hpp__

--- a/src/math/cppadcg.hpp
+++ b/src/math/cppadcg.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_math_ccpadcg_hpp__
-#define __se3_math_ccpadcg_hpp__
+#ifndef __pinocchio_math_ccpadcg_hpp__
+#define __pinocchio_math_ccpadcg_hpp__
 
 #include <cmath>
 #include <cppad/cg/support/cppadcg_eigen.hpp>
@@ -40,4 +40,4 @@ namespace Eigen
   }
 }
 
-#endif // #ifndef __se3_math_ccpadcg_hpp__
+#endif // #ifndef __pinocchio_math_ccpadcg_hpp__

--- a/src/math/fwd.hpp
+++ b/src/math/fwd.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_math_fwd_hpp__
-#define __se3_math_fwd_hpp__
+#ifndef __pinocchio_math_fwd_hpp__
+#define __pinocchio_math_fwd_hpp__
 
 #include "pinocchio/fwd.hpp"
 #include <math.h>
@@ -86,4 +86,4 @@ namespace se3
   }
 }
 
-#endif //#ifndef __se3_math_fwd_hpp__
+#endif //#ifndef __pinocchio_math_fwd_hpp__

--- a/src/math/fwd.hpp
+++ b/src/math/fwd.hpp
@@ -45,7 +45,7 @@ namespace boost
 }
 #endif
 
-namespace se3
+namespace pinocchio
 {
   ///
   /// \brief Returns the value of PI according to the template parameters Scalar

--- a/src/math/matrix.hpp
+++ b/src/math/matrix.hpp
@@ -20,7 +20,7 @@
 
 #include <Eigen/Dense>
 
-namespace se3
+namespace pinocchio
 {
 
   template<typename Derived>

--- a/src/math/quaternion.hpp
+++ b/src/math/quaternion.hpp
@@ -20,7 +20,7 @@
 
 #include "pinocchio/math/fwd.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace quaternion
   {
@@ -130,7 +130,7 @@ namespace se3
     
   } // namespace quaternion
   
-  /// Deprecated functions. They are now in the se3::pinocchio namespace
+  /// Deprecated functions. They are now in the pinocchio::pinocchio namespace
   
   /// This function has been replaced by quaternion::angleBetweenQuaternions.
   template<typename D1, typename D2>

--- a/src/math/sincos.hpp
+++ b/src/math/sincos.hpp
@@ -22,7 +22,7 @@
 #include "pinocchio/fwd.hpp"
 #include <cmath>
 
-namespace se3
+namespace pinocchio
 {
   /// Forward declaration
   template<typename Scalar> struct SINCOSAlgo;

--- a/src/math/taylor-expansion.hpp
+++ b/src/math/taylor-expansion.hpp
@@ -21,7 +21,7 @@
 #include <cmath>
 #include <limits>
 
-namespace se3
+namespace pinocchio
 {
   
   ///

--- a/src/math/taylor-expansion.hpp
+++ b/src/math/taylor-expansion.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_math_taylor_expansion_hpp__
-#define __se3_math_taylor_expansion_hpp__
+#ifndef __pinocchio_math_taylor_expansion_hpp__
+#define __pinocchio_math_taylor_expansion_hpp__
 
 #include <cmath>
 #include <limits>
@@ -49,4 +49,4 @@ namespace se3
   
 }
 
-#endif // ifndef __se3_math_taylor_expansion_hpp__
+#endif // ifndef __pinocchio_math_taylor_expansion_hpp__

--- a/src/multibody/constraint.hpp
+++ b/src/multibody/constraint.hpp
@@ -30,7 +30,7 @@
 // S^T : f_J \in lie(Q)^* ~= R^nv -> f    \in F^6
 
 
-namespace se3
+namespace pinocchio
 {
   template<int _Dim, typename _Scalar, int _Options=0> class ConstraintTpl;
 
@@ -250,6 +250,6 @@ namespace se3
   typedef ConstraintTpl<6,double,0> Constraint6d;
   typedef ConstraintTpl<Eigen::Dynamic,double,0> ConstraintXd;
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_constraint_hpp__

--- a/src/multibody/constraint.hpp
+++ b/src/multibody/constraint.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_constraint_hpp__
-#define __se3_constraint_hpp__
+#ifndef __pinocchio_constraint_hpp__
+#define __pinocchio_constraint_hpp__
 
 
 #include "pinocchio/macros.hpp"
@@ -252,4 +252,4 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_constraint_hpp__
+#endif // ifndef __pinocchio_constraint_hpp__

--- a/src/multibody/data.hpp
+++ b/src/multibody/data.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_data_hpp__
-#define __se3_data_hpp__
+#ifndef __pinocchio_data_hpp__
+#define __pinocchio_data_hpp__
 
 #include "pinocchio/spatial/fwd.hpp"
 #include "pinocchio/spatial/se3.hpp"
@@ -353,5 +353,5 @@ namespace se3
 /* --- Details -------------------------------------------------------------- */
 #include "pinocchio/multibody/data.hxx"
 
-#endif // ifndef __se3_data_hpp__
+#endif // ifndef __pinocchio_data_hpp__
 

--- a/src/multibody/data.hpp
+++ b/src/multibody/data.hpp
@@ -31,7 +31,7 @@
 #include <iostream>
 #include <Eigen/Cholesky>
 
-namespace se3
+namespace pinocchio
 {
  
   template<typename _Scalar, int _Options, template<typename,int> class JointCollectionTpl>
@@ -52,10 +52,10 @@ namespace se3
     typedef InertiaTpl<Scalar,Options> Inertia;
     typedef FrameTpl<Scalar,Options> Frame;
     
-    typedef se3::Index Index;
-    typedef se3::JointIndex JointIndex;
-    typedef se3::GeomIndex GeomIndex;
-    typedef se3::FrameIndex FrameIndex;
+    typedef pinocchio::Index Index;
+    typedef pinocchio::JointIndex JointIndex;
+    typedef pinocchio::GeomIndex GeomIndex;
+    typedef pinocchio::FrameIndex FrameIndex;
     typedef std::vector<Index> IndexVector;
     
     typedef JointModelTpl<Scalar,Options,JointCollectionTpl> JointModel;
@@ -83,7 +83,7 @@ namespace se3
     typedef Eigen::Matrix<Scalar,6,6,Eigen::RowMajor | Options> RowMatrix6;
     typedef Eigen::Matrix<Scalar,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor | Options> RowMatrixXs;
     
-    /// \brief Vector of se3::JointData associated to the se3::JointModel stored in model, 
+    /// \brief Vector of pinocchio::JointData associated to the pinocchio::JointModel stored in model, 
     /// encapsulated in JointDataAccessor.
     JointDataVector joints;
     
@@ -254,7 +254,7 @@ namespace se3
     std::vector<int> nvSubtree_fromRow;
     
     /// \brief Jacobian of joint placements.
-    /// \note The columns of J corresponds to the basis of the spatial velocities of each joint and expressed at the origin of the inertial frame. In other words, if \f$ v_{J_{i}} = S_{i} \dot{q}_{i}\f$ is the relative velocity of the joint i regarding to its parent, then \f$J = \begin{bmatrix} ^{0}X_{1} S_{1} & \cdots & ^{0}X_{i} S_{i} & \cdots & ^{0}X_{\text{nj}} S_{\text{nj}} \end{bmatrix} \f$. This Jacobian has no special meaning. To get the jacobian of a precise joint, you need to call se3::getJointJacobian
+    /// \note The columns of J corresponds to the basis of the spatial velocities of each joint and expressed at the origin of the inertial frame. In other words, if \f$ v_{J_{i}} = S_{i} \dot{q}_{i}\f$ is the relative velocity of the joint i regarding to its parent, then \f$J = \begin{bmatrix} ^{0}X_{1} S_{1} & \cdots & ^{0}X_{i} S_{i} & \cdots & ^{0}X_{\text{nj}} S_{\text{nj}} \end{bmatrix} \f$. This Jacobian has no special meaning. To get the jacobian of a precise joint, you need to call pinocchio::getJointJacobian
     Matrix6x J;
     
     /// \brief Derivative of the Jacobian with respect to the time.
@@ -315,7 +315,7 @@ namespace se3
     /// \brief Cholesky decompostion of \f$\JMinvJt\f$.
     Eigen::LLT<MatrixXs> llt_JMinvJt;
     
-    /// \brief Lagrange Multipliers corresponding to the contact forces in se3::forwardDynamics.
+    /// \brief Lagrange Multipliers corresponding to the contact forces in pinocchio::forwardDynamics.
     VectorXs lambda_c;
     
     /// \brief Temporary corresponding to \f$ \sqrt{D} U^{-1} J^{\top} \f$.
@@ -327,14 +327,14 @@ namespace se3
     /// \brief Generalized velocity after impact.
     TangentVectorType dq_after;
     
-    /// \brief Lagrange Multipliers corresponding to the contact impulses in se3::impulseDynamics.
+    /// \brief Lagrange Multipliers corresponding to the contact impulses in pinocchio::impulseDynamics.
     VectorXs impulse_c;
     
     // data related to regressor
     Matrix3x staticRegressor;
     
     ///
-    /// \brief Default constructor of se3::Data from a se3::Model.
+    /// \brief Default constructor of pinocchio::Data from a pinocchio::Model.
     ///
     /// \param[in] model The model structure of the rigid body system.
     ///
@@ -346,7 +346,7 @@ namespace se3
 
   };
 
-} // namespace se3
+} // namespace pinocchio
 
 /* --- Details -------------------------------------------------------------- */
 /* --- Details -------------------------------------------------------------- */

--- a/src/multibody/data.hxx
+++ b/src/multibody/data.hxx
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_data_hxx__
-#define __se3_data_hxx__
+#ifndef __pinocchio_data_hxx__
+#define __pinocchio_data_hxx__
 
 #include "pinocchio/spatial/fwd.hpp"
 #include "pinocchio/multibody/model.hpp"
@@ -192,4 +192,4 @@ namespace se3
 
 /// @endcond
 
-#endif // ifndef __se3_data_hxx__
+#endif // ifndef __pinocchio_data_hxx__

--- a/src/multibody/data.hxx
+++ b/src/multibody/data.hxx
@@ -29,7 +29,7 @@
 
 /// @cond DEV
 
-namespace se3
+namespace pinocchio
 {
   
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
@@ -188,7 +188,7 @@ namespace se3
     }
   }
 
-} // namespace se3
+} // namespace pinocchio
 
 /// @endcond
 

--- a/src/multibody/fcl.hpp
+++ b/src/multibody/fcl.hpp
@@ -39,7 +39,7 @@
 #include <boost/foreach.hpp>
 #include <boost/shared_ptr.hpp>
 
-namespace se3
+namespace pinocchio
 {
   struct CollisionPair: public std::pair<GeomIndex, GeomIndex>
   {
@@ -161,7 +161,7 @@ struct GeometryObject
 };
   
 
-} // namespace se3
+} // namespace pinocchio
 
 /* --- Details -------------------------------------------------------------- */
 /* --- Details -------------------------------------------------------------- */

--- a/src/multibody/fcl.hpp
+++ b/src/multibody/fcl.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_fcl_hpp__
-#define __se3_fcl_hpp__
+#ifndef __pinocchio_fcl_hpp__
+#define __pinocchio_fcl_hpp__
 
 #include "pinocchio/spatial/se3.hpp"
 #include "pinocchio/multibody/fwd.hpp"
@@ -169,4 +169,4 @@ struct GeometryObject
 #include "pinocchio/multibody/fcl.hxx"
 
 
-#endif // ifndef __se3_fcl_hpp__
+#endif // ifndef __pinocchio_fcl_hpp__

--- a/src/multibody/fcl.hxx
+++ b/src/multibody/fcl.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_fcl_hxx__
-#define __se3_fcl_hxx__
+#ifndef __pinocchio_fcl_hxx__
+#define __pinocchio_fcl_hxx__
 
 
 #include <iostream>
@@ -92,4 +92,4 @@ namespace se3
 } // namespace se3
 
 
-#endif // ifndef __se3_fcl_hxx__
+#endif // ifndef __pinocchio_fcl_hxx__

--- a/src/multibody/fcl.hxx
+++ b/src/multibody/fcl.hxx
@@ -22,7 +22,7 @@
 #include <iostream>
 
 
-namespace se3
+namespace pinocchio
 {
 
   ///
@@ -89,7 +89,7 @@ namespace se3
   }
 
 
-} // namespace se3
+} // namespace pinocchio
 
 
 #endif // ifndef __pinocchio_fcl_hxx__

--- a/src/multibody/force-set.hpp
+++ b/src/multibody/force-set.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_force_set_hpp__
-#define __se3_force_set_hpp__
+#ifndef __pinocchio_force_set_hpp__
+#define __pinocchio_force_set_hpp__
 
 #include "pinocchio/spatial/fwd.hpp"
 #include <Eigen/Geometry>
@@ -177,5 +177,5 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_force_set_hpp__
+#endif // ifndef __pinocchio_force_set_hpp__
 

--- a/src/multibody/force-set.hpp
+++ b/src/multibody/force-set.hpp
@@ -21,7 +21,7 @@
 #include "pinocchio/spatial/fwd.hpp"
 #include <Eigen/Geometry>
 
-namespace se3
+namespace pinocchio
 {
   template<typename _Scalar, int _Options>
   class ForceSetTpl
@@ -175,7 +175,7 @@ namespace se3
   }
 
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_force_set_hpp__
 

--- a/src/multibody/frame.hpp
+++ b/src/multibody/frame.hpp
@@ -23,7 +23,7 @@
 
 #include <string>
 
-namespace se3
+namespace pinocchio
 {
   ///
   /// \brief Enum on the possible types of frame
@@ -44,7 +44,7 @@ namespace se3
   struct FrameTpl
   {
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-    typedef se3::JointIndex JointIndex;
+    typedef pinocchio::JointIndex JointIndex;
     enum { Options = _Options };
     typedef _Scalar Scalar;
     typedef SE3Tpl<Scalar,Options> SE3;
@@ -138,6 +138,6 @@ namespace se3
     return os;
   }
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_frame_hpp__

--- a/src/multibody/frame.hpp
+++ b/src/multibody/frame.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_frame_hpp__
-#define __se3_frame_hpp__
+#ifndef __pinocchio_frame_hpp__
+#define __pinocchio_frame_hpp__
 
 #include "pinocchio/spatial/se3.hpp"
 #include "pinocchio/multibody/fwd.hpp"
@@ -140,4 +140,4 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_frame_hpp__
+#endif // ifndef __pinocchio_frame_hpp__

--- a/src/multibody/fwd.hpp
+++ b/src/multibody/fwd.hpp
@@ -23,7 +23,7 @@
 # include <cstddef> // std::size_t
 #include "pinocchio/multibody/joint/fwd.hpp"
 
-namespace se3
+namespace pinocchio
 {
   typedef std::size_t Index;
   typedef Index JointIndex;
@@ -54,6 +54,6 @@ namespace se3
   // Forward declaration needed for Model::check
   template<class D> struct AlgorithmCheckerBase;
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // #ifndef __pinocchio_multibody_fwd_hpp__

--- a/src/multibody/fwd.hpp
+++ b/src/multibody/fwd.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_multibody_fwd_hpp__
-#define __se3_multibody_fwd_hpp__
+#ifndef __pinocchio_multibody_fwd_hpp__
+#define __pinocchio_multibody_fwd_hpp__
 
 #include "pinocchio/fwd.hpp"
 
@@ -56,4 +56,4 @@ namespace se3
 
 } // namespace se3
 
-#endif // #ifndef __se3_multibody_fwd_hpp__
+#endif // #ifndef __pinocchio_multibody_fwd_hpp__

--- a/src/multibody/geometry.hpp
+++ b/src/multibody/geometry.hpp
@@ -30,7 +30,7 @@
 #include <utility>
 #include <assert.h>
 
-namespace se3
+namespace pinocchio
 {
   
   struct GeometryModel
@@ -45,7 +45,7 @@ namespace se3
     typedef container::aligned_vector<GeometryObject> GeometryObjectVector;
     typedef std::vector<CollisionPair> CollisionPairVector;
     
-    typedef se3::GeomIndex GeomIndex;
+    typedef pinocchio::GeomIndex GeomIndex;
     
     /// \brief The number of GeometryObjects
     Index ngeoms;
@@ -313,7 +313,7 @@ namespace se3
     
   }; // struct GeometryData
 
-} // namespace se3
+} // namespace pinocchio
 
 /* --- Details -------------------------------------------------------------- */
 /* --- Details -------------------------------------------------------------- */

--- a/src/multibody/geometry.hpp
+++ b/src/multibody/geometry.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_multibody_geometry_hpp__
-#define __se3_multibody_geometry_hpp__
+#ifndef __pinocchio_multibody_geometry_hpp__
+#define __pinocchio_multibody_geometry_hpp__
 
 #include "pinocchio/multibody/fcl.hpp"
 #include "pinocchio/multibody/model.hpp"
@@ -320,4 +320,4 @@ namespace se3
 /* --- Details -------------------------------------------------------------- */
 #include "pinocchio/multibody/geometry.hxx"
 
-#endif // ifndef __se3_multibody_geometry_hpp__
+#endif // ifndef __pinocchio_multibody_geometry_hpp__

--- a/src/multibody/geometry.hxx
+++ b/src/multibody/geometry.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_multibody_geometry_hxx__
-#define __se3_multibody_geometry_hxx__
+#ifndef __pinocchio_multibody_geometry_hxx__
+#define __pinocchio_multibody_geometry_hxx__
 
 #include <iostream>
 #include <map>
@@ -245,4 +245,4 @@ namespace se3
 
 /// @endcond
 
-#endif // ifndef __se3_multibody_geometry_hxx__
+#endif // ifndef __pinocchio_multibody_geometry_hxx__

--- a/src/multibody/geometry.hxx
+++ b/src/multibody/geometry.hxx
@@ -25,7 +25,7 @@
 
 /// @cond DEV
 
-namespace se3
+namespace pinocchio
 {
   inline GeometryData::GeometryData(const GeometryModel & modelGeom)
   : oMg(modelGeom.ngeoms)
@@ -56,7 +56,7 @@ namespace se3
                                              const ModelTpl<S2,O2,JointCollectionTpl> & model)
   {
     assert( //TODO: reenable when relevant (object.parentFrame == -1) ||
-           (model.frames[object.parentFrame].type == se3::BODY)  );
+           (model.frames[object.parentFrame].type == pinocchio::BODY)  );
     assert( //TODO: reenable when relevant (object.parentFrame == -1) ||
            (model.frames[object.parentFrame].parent == object.parentJoint) );
     
@@ -241,7 +241,7 @@ namespace se3
   }
 
 #endif //PINOCCHIO_WITH_HPP_FCL
-} // namespace se3
+} // namespace pinocchio
 
 /// @endcond
 

--- a/src/multibody/joint/fwd.hpp
+++ b/src/multibody/joint/fwd.hpp
@@ -20,7 +20,7 @@
 
 #include "pinocchio/fwd.hpp"
 
-namespace se3
+namespace pinocchio
 {
   enum { MAX_JOINT_NV = 6 };
   

--- a/src/multibody/joint/fwd.hpp
+++ b/src/multibody/joint/fwd.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_fwd_hpp__
-#define __se3_joint_fwd_hpp__
+#ifndef __pinocchio_joint_fwd_hpp__
+#define __pinocchio_joint_fwd_hpp__
 
 #include "pinocchio/fwd.hpp"
 
@@ -99,4 +99,4 @@ namespace se3
   
 }
 
-#endif // ifndef __se3_joint_fwd_hpp__
+#endif // ifndef __pinocchio_joint_fwd_hpp__

--- a/src/multibody/joint/joint-base.hpp
+++ b/src/multibody/joint/joint-base.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_base_hpp__
-#define __se3_joint_base_hpp__
+#ifndef __pinocchio_joint_base_hpp__
+#define __pinocchio_joint_base_hpp__
 
 #include "pinocchio/multibody/fwd.hpp"
 #include "pinocchio/multibody/joint/fwd.hpp"
@@ -375,4 +375,4 @@ struct CastType< NewScalar, JointModelTpl<Scalar,Options> > \
 
 } // namespace se3
 
-#endif // ifndef __se3_joint_base_hpp__
+#endif // ifndef __pinocchio_joint_base_hpp__

--- a/src/multibody/joint/joint-base.hpp
+++ b/src/multibody/joint/joint-base.hpp
@@ -24,7 +24,7 @@
 
 #include <limits>
 
-namespace se3
+namespace pinocchio
 {
 
 #define SE3_JOINT_TYPEDEF_GENERIC(TYPENAME)              \
@@ -373,6 +373,6 @@ struct CastType< NewScalar, JointModelTpl<Scalar,Options> > \
 
   }; // struct JointModelBase
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_joint_base_hpp__

--- a/src/multibody/joint/joint-basic-visitors.hpp
+++ b/src/multibody/joint/joint-basic-visitors.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_basic_visitors_hpp__
-#define __se3_joint_basic_visitors_hpp__
+#ifndef __pinocchio_joint_basic_visitors_hpp__
+#define __pinocchio_joint_basic_visitors_hpp__
 
 #include "pinocchio/multibody/joint/fwd.hpp"
 
@@ -295,4 +295,4 @@ namespace se3
 // #include "pinocchio/multibody/joint/joint-basic-visitors.hxx"
 
 
-#endif // ifndef __se3_joint_basic_visitors_hpp__
+#endif // ifndef __pinocchio_joint_basic_visitors_hpp__

--- a/src/multibody/joint/joint-basic-visitors.hpp
+++ b/src/multibody/joint/joint-basic-visitors.hpp
@@ -20,7 +20,7 @@
 
 #include "pinocchio/multibody/joint/fwd.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   /**
@@ -287,7 +287,7 @@ namespace se3
   inline Eigen::Matrix<Scalar,6,Eigen::Dynamic,Options>
   udinv_inertia(const JointDataTpl<Scalar,Options,JointCollectionTpl> & jdata);
   
-} // namespace se3
+} // namespace pinocchio
 
 
 /* --- Details -------------------------------------------------------------------- */

--- a/src/multibody/joint/joint-basic-visitors.hxx
+++ b/src/multibody/joint/joint-basic-visitors.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_basic_visitors_hxx__
-#define __se3_joint_basic_visitors_hxx__
+#ifndef __pinocchio_joint_basic_visitors_hxx__
+#define __pinocchio_joint_basic_visitors_hxx__
 
 #include "pinocchio/assert.hpp"
 #include "pinocchio/multibody/joint/joint-basic-visitors.hpp"
@@ -542,4 +542,4 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_joint_basic_visitors_hxx__
+#endif // ifndef __pinocchio_joint_basic_visitors_hxx__

--- a/src/multibody/joint/joint-basic-visitors.hxx
+++ b/src/multibody/joint/joint-basic-visitors.hxx
@@ -22,7 +22,7 @@
 #include "pinocchio/multibody/joint/joint-basic-visitors.hpp"
 #include "pinocchio/multibody/visitor.hpp"
 
-namespace se3
+namespace pinocchio
 {
   /// @cond DEV
   
@@ -62,8 +62,8 @@ namespace se3
     typedef boost::fusion::vector<const ConfigVectorType &> ArgsType;
 
     template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     se3::JointDataBase<typename JointModel::JointDataDerived> & jdata,
+    static void algo(const pinocchio::JointModelBase<JointModel> & jmodel,
+                     pinocchio::JointDataBase<typename JointModel::JointDataDerived> & jdata,
                      const Eigen::MatrixBase<ConfigVectorType> & q)
     {
       jmodel.calc(jdata.derived(),q.derived());
@@ -93,8 +93,8 @@ namespace se3
                                   const TangentVectorType &> ArgsType;
 
     template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     se3::JointDataBase<typename JointModel::JointDataDerived> & jdata,
+    static void algo(const pinocchio::JointModelBase<JointModel> & jmodel,
+                     pinocchio::JointDataBase<typename JointModel::JointDataDerived> & jdata,
                      const Eigen::MatrixBase<ConfigVectorType> & q,
                      const Eigen::MatrixBase<TangentVectorType> & v
                      )
@@ -129,8 +129,8 @@ namespace se3
                                   const bool> ArgsType;
 
     template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     se3::JointDataBase<typename JointModel::JointDataDerived> & jdata,
+    static void algo(const pinocchio::JointModelBase<JointModel> & jmodel,
+                     pinocchio::JointDataBase<typename JointModel::JointDataDerived> & jdata,
                      const Eigen::MatrixBase<Matrix6Type> & I,
                      const bool update_I
                      )
@@ -540,6 +540,6 @@ namespace se3
 
   /// @endcond
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_joint_basic_visitors_hxx__

--- a/src/multibody/joint/joint-collection.hpp
+++ b/src/multibody/joint/joint-collection.hpp
@@ -33,7 +33,7 @@
 #include <boost/variant.hpp>
 #include <boost/variant/recursive_wrapper.hpp>
 
-namespace se3
+namespace pinocchio
 {
   
   template<typename _Scalar, int _Options>
@@ -152,6 +152,6 @@ namespace se3
   typedef JointCollectionDefault::JointModelVariant JointModelVariant;
   typedef JointCollectionDefault::JointDataVariant JointDataVariant;
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_joint_collection_hpp__

--- a/src/multibody/joint/joint-collection.hpp
+++ b/src/multibody/joint/joint-collection.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_collection_hpp__
-#define __se3_joint_collection_hpp__
+#ifndef __pinocchio_joint_collection_hpp__
+#define __pinocchio_joint_collection_hpp__
 
 #include "pinocchio/multibody/joint/fwd.hpp"
 #include "pinocchio/multibody/joint/joint-free-flyer.hpp"
@@ -154,4 +154,4 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_joint_collection_hpp__
+#endif // ifndef __pinocchio_joint_collection_hpp__

--- a/src/multibody/joint/joint-composite.hpp
+++ b/src/multibody/joint/joint-composite.hpp
@@ -24,7 +24,7 @@
 #include "pinocchio/container/aligned-vector.hpp"
 #include "pinocchio/spatial/act-on-set.hpp"
 
-namespace se3
+namespace pinocchio
 {
 
   template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
@@ -230,7 +230,7 @@ namespace se3
     {
       typename JointDataDerived::JointDataVector jdata(joints.size());
       for (int i = 0; i < (int)joints.size(); ++i)
-        jdata[(size_t)i] = ::se3::createData<Scalar,Options,JointCollectionTpl>(joints[(size_t)i]);
+        jdata[(size_t)i] = ::pinocchio::createData<Scalar,Options,JointCollectionTpl>(joints[(size_t)i]);
       return JointDataDerived(jdata,nq(),nv());
     }
 
@@ -269,7 +269,7 @@ namespace se3
       Scalar eps = 0;
       for(typename JointModelVector::const_iterator it = joints.begin();
           it != joints.end(); ++it)
-        eps = max((Scalar)::se3::finiteDifferenceIncrement(*it),eps);
+        eps = max((Scalar)::pinocchio::finiteDifferenceIncrement(*it),eps);
       
       return eps;
     }
@@ -414,9 +414,9 @@ namespace se3
         JointModelVariant & joint = joints[i];
         
         m_idx_q[i] = idx_q; m_idx_v[i] = idx_v;
-        ::se3::setIndexes(joint,i,idx_q,idx_v);
-        m_nqs[i] = ::se3::nq(joint);
-        m_nvs[i] = ::se3::nv(joint);
+        ::pinocchio::setIndexes(joint,i,idx_q,idx_v);
+        m_nqs[i] = ::pinocchio::nq(joint);
+        m_nvs[i] = ::pinocchio::nv(joint);
         idx_q += m_nqs[i]; idx_v += m_nvs[i];
       }
     }
@@ -455,26 +455,26 @@ namespace se3
     return os;
   }
 
-} // namespace se3
+} // namespace pinocchio
 
 #include <boost/type_traits.hpp>
 
 namespace boost
 {
   template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
-  struct has_nothrow_constructor< ::se3::JointModelCompositeTpl<Scalar,Options,JointCollectionTpl> >
+  struct has_nothrow_constructor< ::pinocchio::JointModelCompositeTpl<Scalar,Options,JointCollectionTpl> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
-  struct has_nothrow_copy< ::se3::JointModelCompositeTpl<Scalar,Options,JointCollectionTpl> >
+  struct has_nothrow_copy< ::pinocchio::JointModelCompositeTpl<Scalar,Options,JointCollectionTpl> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
-  struct has_nothrow_constructor< ::se3::JointDataCompositeTpl<Scalar,Options,JointCollectionTpl> >
+  struct has_nothrow_constructor< ::pinocchio::JointDataCompositeTpl<Scalar,Options,JointCollectionTpl> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
-  struct has_nothrow_copy< ::se3::JointDataCompositeTpl<Scalar,Options,JointCollectionTpl> >
+  struct has_nothrow_copy< ::pinocchio::JointDataCompositeTpl<Scalar,Options,JointCollectionTpl> >
   : public integral_constant<bool,true> {};
 }
 

--- a/src/multibody/joint/joint-composite.hpp
+++ b/src/multibody/joint/joint-composite.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_composite_hpp__
-#define __se3_joint_composite_hpp__
+#ifndef __pinocchio_joint_composite_hpp__
+#define __pinocchio_joint_composite_hpp__
 
 #include "pinocchio/multibody/joint/fwd.hpp"
 #include "pinocchio/multibody/joint/joint-collection.hpp"
@@ -483,4 +483,4 @@ namespace boost
 /* --- Details -------------------------------------------------------------- */
 #include "pinocchio/multibody/joint/joint-composite.hxx"
 
-#endif // ifndef __se3_joint_composite_hpp__
+#endif // ifndef __pinocchio_joint_composite_hpp__

--- a/src/multibody/joint/joint-composite.hxx
+++ b/src/multibody/joint/joint-composite.hxx
@@ -20,7 +20,7 @@
 
 #include "pinocchio/multibody/visitor.hpp"
 
-namespace se3 
+namespace pinocchio 
 {
 
   template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl, typename ConfigVectorType>
@@ -36,8 +36,8 @@ namespace se3
                                   > ArgsType;
 
     template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     se3::JointDataBase<typename JointModel::JointDataDerived> & jdata,
+    static void algo(const pinocchio::JointModelBase<JointModel> & jmodel,
+                     pinocchio::JointDataBase<typename JointModel::JointDataDerived> & jdata,
                      const JointModelComposite & model,
                      JointDataComposite & data,
                      const Eigen::MatrixBase<ConfigVectorType> & q)
@@ -99,8 +99,8 @@ namespace se3
                                   > ArgsType;
 
     template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     se3::JointDataBase<typename JointModel::JointDataDerived> & jdata,
+    static void algo(const pinocchio::JointModelBase<JointModel> & jmodel,
+                     pinocchio::JointDataBase<typename JointModel::JointDataDerived> & jdata,
                      const JointModelComposite & model,
                      JointDataComposite & data,
                      const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -161,6 +161,6 @@ namespace se3
     jdata.M = jdata.iMlast.front();
   }
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_joint_composite_hxx__

--- a/src/multibody/joint/joint-composite.hxx
+++ b/src/multibody/joint/joint-composite.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_composite_hxx__
-#define __se3_joint_composite_hxx__
+#ifndef __pinocchio_joint_composite_hxx__
+#define __pinocchio_joint_composite_hxx__
 
 #include "pinocchio/multibody/visitor.hpp"
 
@@ -163,4 +163,4 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_joint_composite_hxx__
+#endif // ifndef __pinocchio_joint_composite_hxx__

--- a/src/multibody/joint/joint-free-flyer.hpp
+++ b/src/multibody/joint/joint-free-flyer.hpp
@@ -27,7 +27,7 @@
 #include "pinocchio/math/fwd.hpp"
 #include "pinocchio/math/quaternion.hpp"
 
-namespace se3
+namespace pinocchio
 {
 
   template<typename Scalar, int Options> struct ConstraintIdentityTpl;
@@ -307,26 +307,26 @@ namespace se3
 
   }; // struct JointModelFreeFlyerTpl
 
-} // namespace se3
+} // namespace pinocchio
 
 #include <boost/type_traits.hpp>
 
 namespace boost
 {
   template<typename Scalar, int Options>
-  struct has_nothrow_constructor< ::se3::JointModelFreeFlyerTpl<Scalar,Options> >
+  struct has_nothrow_constructor< ::pinocchio::JointModelFreeFlyerTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_copy< ::se3::JointModelFreeFlyerTpl<Scalar,Options> >
+  struct has_nothrow_copy< ::pinocchio::JointModelFreeFlyerTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_constructor< ::se3::JointDataFreeFlyerTpl<Scalar,Options> >
+  struct has_nothrow_constructor< ::pinocchio::JointDataFreeFlyerTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_copy< ::se3::JointDataFreeFlyerTpl<Scalar,Options> >
+  struct has_nothrow_copy< ::pinocchio::JointDataFreeFlyerTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
 }
 

--- a/src/multibody/joint/joint-free-flyer.hpp
+++ b/src/multibody/joint/joint-free-flyer.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_free_flyer_hpp__
-#define __se3_joint_free_flyer_hpp__
+#ifndef __pinocchio_joint_free_flyer_hpp__
+#define __pinocchio_joint_free_flyer_hpp__
 
 #include "pinocchio/macros.hpp"
 #include "pinocchio/spatial/inertia.hpp"
@@ -330,4 +330,4 @@ namespace boost
   : public integral_constant<bool,true> {};
 }
 
-#endif // ifndef __se3_joint_free_flyer_hpp__
+#endif // ifndef __pinocchio_joint_free_flyer_hpp__

--- a/src/multibody/joint/joint-generic.hpp
+++ b/src/multibody/joint/joint-generic.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_generic_hpp__
-#define __se3_joint_generic_hpp__
+#ifndef __pinocchio_joint_generic_hpp__
+#define __pinocchio_joint_generic_hpp__
 
 #include "pinocchio/assert.hpp"
 #include "pinocchio/multibody/joint/joint-collection.hpp"
@@ -229,4 +229,4 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_joint_generic_hpp__
+#endif // ifndef __pinocchio_joint_generic_hpp__

--- a/src/multibody/joint/joint-generic.hpp
+++ b/src/multibody/joint/joint-generic.hpp
@@ -26,7 +26,7 @@
 
 #include <boost/mpl/contains.hpp>
 
-namespace se3
+namespace pinocchio
 {
 
   template<typename Scalar, int Options = 0, template<typename S, int O> class JointCollectionTpl = JointCollectionDefaultTpl>
@@ -178,7 +178,7 @@ namespace se3
     { return *static_cast<const JointModelVariant*>(this); }
 
     JointDataDerived createData() const
-    { return ::se3::createData<Scalar,Options,JointCollectionTpl>(*this); }
+    { return ::pinocchio::createData<Scalar,Options,JointCollectionTpl>(*this); }
 
     using Base::isEqual;
     bool isEqual(const JointModelTpl & other) const
@@ -200,21 +200,21 @@ namespace se3
     
     template<typename Matrix6Like>
     void calc_aba(JointDataDerived & data, const Eigen::MatrixBase<Matrix6Like> & I, const bool update_I) const
-    { ::se3::calc_aba(*this,data,EIGEN_CONST_CAST(Matrix6Like,I),update_I); }
+    { ::pinocchio::calc_aba(*this,data,EIGEN_CONST_CAST(Matrix6Like,I),update_I); }
     
-    std::string shortname() const { return ::se3::shortname(*this); }
+    std::string shortname() const { return ::pinocchio::shortname(*this); }
     static std::string classname() { return "JointModel"; }
 
-    int     nq_impl() const { return ::se3::nq(*this); }
-    int     nv_impl() const { return ::se3::nv(*this); }
+    int     nq_impl() const { return ::pinocchio::nq(*this); }
+    int     nv_impl() const { return ::pinocchio::nv(*this); }
 
-    int     idx_q()   const { return ::se3::idx_q(*this); }
-    int     idx_v()   const { return ::se3::idx_v(*this); }
+    int     idx_q()   const { return ::pinocchio::idx_q(*this); }
+    int     idx_v()   const { return ::pinocchio::idx_v(*this); }
 
-    JointIndex     id()      const { return ::se3::id(*this); }
+    JointIndex     id()      const { return ::pinocchio::id(*this); }
 
     void setIndexes(JointIndex id, int nq, int nv)
-    { ::se3::setIndexes(*this,id, nq, nv); }
+    { ::pinocchio::setIndexes(*this,id, nq, nv); }
     
     /// \returns An expression of *this with the Scalar type casted to NewScalar.
     template<typename NewScalar>
@@ -227,6 +227,6 @@ namespace se3
   typedef container::aligned_vector<JointData> JointDataVector;
   typedef container::aligned_vector<JointModel> JointModelVector;
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_joint_generic_hpp__

--- a/src/multibody/joint/joint-planar.hpp
+++ b/src/multibody/joint/joint-planar.hpp
@@ -26,7 +26,7 @@
 #include "pinocchio/spatial/motion.hpp"
 #include "pinocchio/spatial/inertia.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   template<typename Scalar, int Options = 0> struct MotionPlanarTpl;
@@ -546,26 +546,26 @@ namespace se3
 
   }; // struct JointModelPlanarTpl
 
-} // namespace se3
+} // namespace pinocchio
 
 #include <boost/type_traits.hpp>
 
 namespace boost
 {
   template<typename Scalar, int Options>
-  struct has_nothrow_constructor< ::se3::JointModelPlanarTpl<Scalar,Options> >
+  struct has_nothrow_constructor< ::pinocchio::JointModelPlanarTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_copy< ::se3::JointModelPlanarTpl<Scalar,Options> >
+  struct has_nothrow_copy< ::pinocchio::JointModelPlanarTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_constructor< ::se3::JointDataPlanarTpl<Scalar,Options> >
+  struct has_nothrow_constructor< ::pinocchio::JointDataPlanarTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_copy< ::se3::JointDataPlanarTpl<Scalar,Options> >
+  struct has_nothrow_copy< ::pinocchio::JointDataPlanarTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
 }
 

--- a/src/multibody/joint/joint-planar.hpp
+++ b/src/multibody/joint/joint-planar.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_planar_hpp__
-#define __se3_joint_planar_hpp__
+#ifndef __pinocchio_joint_planar_hpp__
+#define __pinocchio_joint_planar_hpp__
 
 #include "pinocchio/macros.hpp"
 #include "pinocchio/multibody/joint/joint-base.hpp"
@@ -569,4 +569,4 @@ namespace boost
   : public integral_constant<bool,true> {};
 }
 
-#endif // ifndef __se3_joint_planar_hpp__
+#endif // ifndef __pinocchio_joint_planar_hpp__

--- a/src/multibody/joint/joint-prismatic-unaligned.hpp
+++ b/src/multibody/joint/joint-prismatic-unaligned.hpp
@@ -25,7 +25,7 @@
 #include "pinocchio/multibody/constraint.hpp"
 #include "pinocchio/spatial/inertia.hpp"
 
-namespace se3
+namespace pinocchio
 {
 
   template<typename Scalar, int Options=0> struct MotionPrismaticUnalignedTpl;
@@ -535,26 +535,26 @@ namespace se3
     Vector3 axis;
   }; // struct JointModelPrismaticUnalignedTpl
   
-} //namespace se3
+} //namespace pinocchio
 
 #include <boost/type_traits.hpp>
 
 namespace boost
 {
   template<typename Scalar, int Options>
-  struct has_nothrow_constructor< ::se3::JointModelPrismaticUnalignedTpl<Scalar,Options> >
+  struct has_nothrow_constructor< ::pinocchio::JointModelPrismaticUnalignedTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_copy< ::se3::JointModelPrismaticUnalignedTpl<Scalar,Options> >
+  struct has_nothrow_copy< ::pinocchio::JointModelPrismaticUnalignedTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_constructor< ::se3::JointDataPrismaticUnalignedTpl<Scalar,Options> >
+  struct has_nothrow_constructor< ::pinocchio::JointDataPrismaticUnalignedTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_copy< ::se3::JointDataPrismaticUnalignedTpl<Scalar,Options> >
+  struct has_nothrow_copy< ::pinocchio::JointDataPrismaticUnalignedTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
 }
 

--- a/src/multibody/joint/joint-prismatic-unaligned.hpp
+++ b/src/multibody/joint/joint-prismatic-unaligned.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_prismatic_unaligned_hpp__
-#define __se3_joint_prismatic_unaligned_hpp__
+#ifndef __pinocchio_joint_prismatic_unaligned_hpp__
+#define __pinocchio_joint_prismatic_unaligned_hpp__
 
 #include "pinocchio/macros.hpp"
 #include "pinocchio/multibody/joint/joint-base.hpp"
@@ -559,4 +559,4 @@ namespace boost
 }
 
 
-#endif // ifndef __se3_joint_prismatic_unaligned_hpp__
+#endif // ifndef __pinocchio_joint_prismatic_unaligned_hpp__

--- a/src/multibody/joint/joint-prismatic.hpp
+++ b/src/multibody/joint/joint-prismatic.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_prismatic_hpp__
-#define __se3_joint_prismatic_hpp__
+#ifndef __pinocchio_joint_prismatic_hpp__
+#define __pinocchio_joint_prismatic_hpp__
 
 #include "pinocchio/macros.hpp"
 #include "pinocchio/multibody/joint/joint-base.hpp"
@@ -613,4 +613,4 @@ namespace boost
   : public integral_constant<bool,true> {};
 }
 
-#endif // ifndef __se3_joint_prismatic_hpp__
+#endif // ifndef __pinocchio_joint_prismatic_hpp__

--- a/src/multibody/joint/joint-prismatic.hpp
+++ b/src/multibody/joint/joint-prismatic.hpp
@@ -26,7 +26,7 @@
 #include "pinocchio/spatial/spatial-axis.hpp"
 #include "pinocchio/utils/axis-label.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   template<typename Scalar, int Options, int _axis> struct MotionPrismaticTpl;
@@ -590,26 +590,26 @@ namespace se3
   typedef JointDataPrismaticTpl<double,0,2> JointDataPZ;
   typedef JointModelPrismaticTpl<double,0,2> JointModelPZ;
 
-} //namespace se3
+} //namespace pinocchio
 
 #include <boost/type_traits.hpp>
 
 namespace boost
 {
   template<typename Scalar, int Options, int axis>
-  struct has_nothrow_constructor< ::se3::JointModelPrismaticTpl<Scalar,Options,axis> >
+  struct has_nothrow_constructor< ::pinocchio::JointModelPrismaticTpl<Scalar,Options,axis> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options, int axis>
-  struct has_nothrow_copy< ::se3::JointModelPrismaticTpl<Scalar,Options,axis> >
+  struct has_nothrow_copy< ::pinocchio::JointModelPrismaticTpl<Scalar,Options,axis> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options, int axis>
-  struct has_nothrow_constructor< ::se3::JointDataPrismaticTpl<Scalar,Options,axis> >
+  struct has_nothrow_constructor< ::pinocchio::JointDataPrismaticTpl<Scalar,Options,axis> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options, int axis>
-  struct has_nothrow_copy< ::se3::JointDataPrismaticTpl<Scalar,Options,axis> >
+  struct has_nothrow_copy< ::pinocchio::JointDataPrismaticTpl<Scalar,Options,axis> >
   : public integral_constant<bool,true> {};
 }
 

--- a/src/multibody/joint/joint-revolute-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unaligned.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_revolute_unaligned_hpp__
-#define __se3_joint_revolute_unaligned_hpp__
+#ifndef __pinocchio_joint_revolute_unaligned_hpp__
+#define __pinocchio_joint_revolute_unaligned_hpp__
 
 #include "pinocchio/fwd.hpp"
 #include "pinocchio/multibody/joint/joint-base.hpp"
@@ -576,4 +576,4 @@ namespace boost
 }
 
 
-#endif // ifndef __se3_joint_revolute_unaligned_hpp__
+#endif // ifndef __pinocchio_joint_revolute_unaligned_hpp__

--- a/src/multibody/joint/joint-revolute-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unaligned.hpp
@@ -24,7 +24,7 @@
 #include "pinocchio/multibody/constraint.hpp"
 #include "pinocchio/spatial/inertia.hpp"
 
-namespace se3
+namespace pinocchio
 {
 
   template<typename Scalar, int Options=0> struct MotionRevoluteUnalignedTpl;
@@ -552,26 +552,26 @@ namespace se3
     Vector3 axis;
   }; // struct JointModelRevoluteUnalignedTpl
 
-} //namespace se3
+} //namespace pinocchio
 
 #include <boost/type_traits.hpp>
 
 namespace boost
 {
   template<typename Scalar, int Options>
-  struct has_nothrow_constructor< ::se3::JointModelRevoluteUnalignedTpl<Scalar,Options> >
+  struct has_nothrow_constructor< ::pinocchio::JointModelRevoluteUnalignedTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_copy< ::se3::JointModelRevoluteUnalignedTpl<Scalar,Options> >
+  struct has_nothrow_copy< ::pinocchio::JointModelRevoluteUnalignedTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_constructor< ::se3::JointDataRevoluteUnalignedTpl<Scalar,Options> >
+  struct has_nothrow_constructor< ::pinocchio::JointDataRevoluteUnalignedTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_copy< ::se3::JointDataRevoluteUnalignedTpl<Scalar,Options> >
+  struct has_nothrow_copy< ::pinocchio::JointDataRevoluteUnalignedTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
 }
 

--- a/src/multibody/joint/joint-revolute-unbounded.hpp
+++ b/src/multibody/joint/joint-revolute-unbounded.hpp
@@ -24,7 +24,7 @@
 #include "pinocchio/multibody/joint/joint-base.hpp"
 #include "pinocchio/multibody/joint/joint-revolute.hpp"
 
-namespace se3
+namespace pinocchio
 {
 
   template<typename Scalar, int Options, int axis> struct JointRevoluteUnboundedTpl;
@@ -182,7 +182,7 @@ namespace se3
   typedef JointDataRevoluteUnboundedTpl<double,0,2> JointDataRUBZ;
   typedef JointModelRevoluteUnboundedTpl<double,0,2> JointModelRUBZ;
 
-} //namespace se3
+} //namespace pinocchio
 
 
 #include <boost/type_traits.hpp>
@@ -190,19 +190,19 @@ namespace se3
 namespace boost
 {
   template<typename Scalar, int Options, int axis>
-  struct has_nothrow_constructor< ::se3::JointModelRevoluteUnboundedTpl<Scalar,Options,axis> >
+  struct has_nothrow_constructor< ::pinocchio::JointModelRevoluteUnboundedTpl<Scalar,Options,axis> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options, int axis>
-  struct has_nothrow_copy< ::se3::JointModelRevoluteUnboundedTpl<Scalar,Options,axis> >
+  struct has_nothrow_copy< ::pinocchio::JointModelRevoluteUnboundedTpl<Scalar,Options,axis> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options, int axis>
-  struct has_nothrow_constructor< ::se3::JointDataRevoluteUnboundedTpl<Scalar,Options,axis> >
+  struct has_nothrow_constructor< ::pinocchio::JointDataRevoluteUnboundedTpl<Scalar,Options,axis> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options, int axis>
-  struct has_nothrow_copy< ::se3::JointDataRevoluteUnboundedTpl<Scalar,Options,axis> >
+  struct has_nothrow_copy< ::pinocchio::JointDataRevoluteUnboundedTpl<Scalar,Options,axis> >
   : public integral_constant<bool,true> {};
 }
 

--- a/src/multibody/joint/joint-revolute-unbounded.hpp
+++ b/src/multibody/joint/joint-revolute-unbounded.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_revolute_unbounded_hpp__
-#define __se3_joint_revolute_unbounded_hpp__
+#ifndef __pinocchio_joint_revolute_unbounded_hpp__
+#define __pinocchio_joint_revolute_unbounded_hpp__
 
 #include "pinocchio/math/fwd.hpp"
 #include "pinocchio/math/sincos.hpp"
@@ -206,4 +206,4 @@ namespace boost
   : public integral_constant<bool,true> {};
 }
 
-#endif // ifndef __se3_joint_revolute_unbounded_hpp__
+#endif // ifndef __pinocchio_joint_revolute_unbounded_hpp__

--- a/src/multibody/joint/joint-revolute.hpp
+++ b/src/multibody/joint/joint-revolute.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_revolute_hpp__
-#define __se3_joint_revolute_hpp__
+#ifndef __pinocchio_joint_revolute_hpp__
+#define __pinocchio_joint_revolute_hpp__
 
 #include "pinocchio/math/sincos.hpp"
 #include "pinocchio/spatial/inertia.hpp"
@@ -683,4 +683,4 @@ namespace boost
   : public integral_constant<bool,true> {};
 }
 
-#endif // ifndef __se3_joint_revolute_hpp__
+#endif // ifndef __pinocchio_joint_revolute_hpp__

--- a/src/multibody/joint/joint-revolute.hpp
+++ b/src/multibody/joint/joint-revolute.hpp
@@ -26,7 +26,7 @@
 #include "pinocchio/spatial/spatial-axis.hpp"
 #include "pinocchio/utils/axis-label.hpp"
 
-namespace se3
+namespace pinocchio
 {
 
   template<typename Scalar, int Options, int axis> struct MotionRevoluteTpl;
@@ -660,26 +660,26 @@ namespace se3
   typedef JointDataRevoluteTpl<double,0,2> JointDataRZ;
   typedef JointModelRevoluteTpl<double,0,2> JointModelRZ;
 
-} //namespace se3
+} //namespace pinocchio
 
 #include <boost/type_traits.hpp>
 
 namespace boost
 {
   template<typename Scalar, int Options, int axis>
-  struct has_nothrow_constructor< ::se3::JointModelRevoluteTpl<Scalar,Options,axis> >
+  struct has_nothrow_constructor< ::pinocchio::JointModelRevoluteTpl<Scalar,Options,axis> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options, int axis>
-  struct has_nothrow_copy< ::se3::JointModelRevoluteTpl<Scalar,Options,axis> >
+  struct has_nothrow_copy< ::pinocchio::JointModelRevoluteTpl<Scalar,Options,axis> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options, int axis>
-  struct has_nothrow_constructor< ::se3::JointDataRevoluteTpl<Scalar,Options,axis> >
+  struct has_nothrow_constructor< ::pinocchio::JointDataRevoluteTpl<Scalar,Options,axis> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options, int axis>
-  struct has_nothrow_copy< ::se3::JointDataRevoluteTpl<Scalar,Options,axis> >
+  struct has_nothrow_copy< ::pinocchio::JointDataRevoluteTpl<Scalar,Options,axis> >
   : public integral_constant<bool,true> {};
 }
 

--- a/src/multibody/joint/joint-spherical-ZYX.hpp
+++ b/src/multibody/joint/joint-spherical-ZYX.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_spherical_ZYX_hpp__
-#define __se3_joint_spherical_ZYX_hpp__
+#ifndef __pinocchio_joint_spherical_ZYX_hpp__
+#define __pinocchio_joint_spherical_ZYX_hpp__
 #include <iostream>
 #include "pinocchio/macros.hpp"
 #include "pinocchio/multibody/joint/joint-base.hpp"
@@ -451,4 +451,4 @@ namespace boost
   : public integral_constant<bool,true> {};
 }
 
-#endif // ifndef __se3_joint_spherical_ZYX_hpp__
+#endif // ifndef __pinocchio_joint_spherical_ZYX_hpp__

--- a/src/multibody/joint/joint-spherical-ZYX.hpp
+++ b/src/multibody/joint/joint-spherical-ZYX.hpp
@@ -27,7 +27,7 @@
 #include "pinocchio/spatial/inertia.hpp"
 #include "pinocchio/spatial/skew.hpp"
 
-namespace se3
+namespace pinocchio
 {
   template<typename Scalar, int Options> struct ConstraintSphericalZYXTpl;
   
@@ -428,26 +428,26 @@ namespace se3
 
   }; // struct JointModelSphericalZYXTpl
 
-} // namespace se3
+} // namespace pinocchio
 
 #include <boost/type_traits.hpp>
 
 namespace boost
 {
   template<typename Scalar, int Options>
-  struct has_nothrow_constructor< ::se3::JointModelSphericalZYXTpl<Scalar,Options> >
+  struct has_nothrow_constructor< ::pinocchio::JointModelSphericalZYXTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_copy< ::se3::JointModelSphericalZYXTpl<Scalar,Options> >
+  struct has_nothrow_copy< ::pinocchio::JointModelSphericalZYXTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_constructor< ::se3::JointDataSphericalZYXTpl<Scalar,Options> >
+  struct has_nothrow_constructor< ::pinocchio::JointDataSphericalZYXTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_copy< ::se3::JointDataSphericalZYXTpl<Scalar,Options> >
+  struct has_nothrow_copy< ::pinocchio::JointDataSphericalZYXTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
 }
 

--- a/src/multibody/joint/joint-spherical.hpp
+++ b/src/multibody/joint/joint-spherical.hpp
@@ -26,7 +26,7 @@
 #include "pinocchio/spatial/inertia.hpp"
 #include "pinocchio/spatial/skew.hpp"
 
-namespace se3
+namespace pinocchio
 {
 
   template<typename Scalar, int Options = 0> struct MotionSphericalTpl;
@@ -503,26 +503,26 @@ namespace se3
 
   }; // struct JointModelSphericalTpl
 
-} // namespace se3
+} // namespace pinocchio
 
 #include <boost/type_traits.hpp>
 
 namespace boost
 {
   template<typename Scalar, int Options>
-  struct has_nothrow_constructor< ::se3::JointModelSphericalTpl<Scalar,Options> >
+  struct has_nothrow_constructor< ::pinocchio::JointModelSphericalTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_copy< ::se3::JointModelSphericalTpl<Scalar,Options> >
+  struct has_nothrow_copy< ::pinocchio::JointModelSphericalTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_constructor< ::se3::JointDataSphericalTpl<Scalar,Options> >
+  struct has_nothrow_constructor< ::pinocchio::JointDataSphericalTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_copy< ::se3::JointDataSphericalTpl<Scalar,Options> >
+  struct has_nothrow_copy< ::pinocchio::JointDataSphericalTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
 }
 

--- a/src/multibody/joint/joint-spherical.hpp
+++ b/src/multibody/joint/joint-spherical.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_spherical_hpp__
-#define __se3_joint_spherical_hpp__
+#ifndef __pinocchio_joint_spherical_hpp__
+#define __pinocchio_joint_spherical_hpp__
 
 #include "pinocchio/macros.hpp"
 #include "pinocchio/multibody/joint/joint-base.hpp"
@@ -526,4 +526,4 @@ namespace boost
   : public integral_constant<bool,true> {};
 }
 
-#endif // ifndef __se3_joint_spherical_hpp__
+#endif // ifndef __pinocchio_joint_spherical_hpp__

--- a/src/multibody/joint/joint-translation.hpp
+++ b/src/multibody/joint/joint-translation.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_joint_translation_hpp__
-#define __se3_joint_translation_hpp__
+#ifndef __pinocchio_joint_translation_hpp__
+#define __pinocchio_joint_translation_hpp__
 
 #include "pinocchio/macros.hpp"
 #include "pinocchio/multibody/joint/joint-base.hpp"
@@ -585,4 +585,4 @@ namespace boost
   : public integral_constant<bool,true> {};
 }
 
-#endif // ifndef __se3_joint_translation_hpp__
+#endif // ifndef __pinocchio_joint_translation_hpp__

--- a/src/multibody/joint/joint-translation.hpp
+++ b/src/multibody/joint/joint-translation.hpp
@@ -25,7 +25,7 @@
 #include "pinocchio/spatial/inertia.hpp"
 #include "pinocchio/spatial/skew.hpp"
 
-namespace se3
+namespace pinocchio
 {
 
   template<typename Scalar, int Options=0> struct MotionTranslationTpl;
@@ -562,26 +562,26 @@ namespace se3
 
   }; // struct JointModelTranslationTpl
   
-} // namespace se3
+} // namespace pinocchio
 
 #include <boost/type_traits.hpp>
 
 namespace boost
 {
   template<typename Scalar, int Options>
-  struct has_nothrow_constructor< ::se3::JointModelTranslationTpl<Scalar,Options> >
+  struct has_nothrow_constructor< ::pinocchio::JointModelTranslationTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_copy< ::se3::JointModelTranslationTpl<Scalar,Options> >
+  struct has_nothrow_copy< ::pinocchio::JointModelTranslationTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_constructor< ::se3::JointDataTranslationTpl<Scalar,Options> >
+  struct has_nothrow_constructor< ::pinocchio::JointDataTranslationTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
   
   template<typename Scalar, int Options>
-  struct has_nothrow_copy< ::se3::JointDataTranslationTpl<Scalar,Options> >
+  struct has_nothrow_copy< ::pinocchio::JointDataTranslationTpl<Scalar,Options> >
   : public integral_constant<bool,true> {};
 }
 

--- a/src/multibody/liegroup/cartesian-product-variant.hpp
+++ b/src/multibody/liegroup/cartesian-product-variant.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_cartesian_product_variant_hpp__
-#define __se3_cartesian_product_variant_hpp__
+#ifndef __pinocchio_cartesian_product_variant_hpp__
+#define __pinocchio_cartesian_product_variant_hpp__
 
 #include "pinocchio/multibody/liegroup/operation-base.hpp"
 #include "pinocchio/multibody/liegroup/liegroup-variant.hpp"
@@ -155,4 +155,4 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_cartesian_product_variant_hpp__
+#endif // ifndef __pinocchio_cartesian_product_variant_hpp__

--- a/src/multibody/liegroup/cartesian-product-variant.hpp
+++ b/src/multibody/liegroup/cartesian-product-variant.hpp
@@ -24,7 +24,7 @@
 
 #include <vector>
 
-namespace se3
+namespace pinocchio
 {
   
   struct CartesianProductOperationVariant;
@@ -83,15 +83,15 @@ namespace se3
     void append(const LieGroupVariant & lg)
     {
       liegroups.push_back(lg);
-      const Index lg_nq = ::se3::nq(lg); lg_nqs.push_back(lg_nq); m_nq += lg_nq;
-      const Index lg_nv = ::se3::nv(lg); lg_nvs.push_back(lg_nv); m_nv += lg_nv;
+      const Index lg_nq = ::pinocchio::nq(lg); lg_nqs.push_back(lg_nq); m_nq += lg_nq;
+      const Index lg_nv = ::pinocchio::nv(lg); lg_nvs.push_back(lg_nv); m_nv += lg_nv;
       
       if(liegroups.size() > 1)
         m_name += " x ";
-      m_name += ::se3::name(lg);
+      m_name += ::pinocchio::name(lg);
       
       m_neutral.conservativeResize(m_nq);
-      m_neutral.tail(lg_nq) = ::se3::neutral(lg);
+      m_neutral.tail(lg_nq) = ::pinocchio::neutral(lg);
       
     }
     
@@ -117,7 +117,7 @@ namespace se3
       {
         const Index & nq = lg_nqs[k];
         const Index & nv = lg_nvs[k];
-        ::se3::integrate(liegroups[k],
+        ::pinocchio::integrate(liegroups[k],
                          q.segment(id_q,lg_nqs[k]),
                          v.segment(id_v,lg_nvs[k]),
                          qout_.segment(id_q,lg_nqs[k]));
@@ -153,6 +153,6 @@ namespace se3
     
   };
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_cartesian_product_variant_hpp__

--- a/src/multibody/liegroup/cartesian-product.hpp
+++ b/src/multibody/liegroup/cartesian-product.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_cartesian_product_operation_hpp__
-#define __se3_cartesian_product_operation_hpp__
+#ifndef __pinocchio_cartesian_product_operation_hpp__
+#define __pinocchio_cartesian_product_operation_hpp__
 
 #include <pinocchio/multibody/liegroup/liegroup-base.hpp>
 
@@ -228,4 +228,4 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_cartesian_product_operation_hpp__
+#endif // ifndef __pinocchio_cartesian_product_operation_hpp__

--- a/src/multibody/liegroup/cartesian-product.hpp
+++ b/src/multibody/liegroup/cartesian-product.hpp
@@ -20,7 +20,7 @@
 
 #include <pinocchio/multibody/liegroup/liegroup-base.hpp>
 
-namespace se3
+namespace pinocchio
 {
   template<int dim1, int dim2>
   struct eval_set_dim
@@ -226,6 +226,6 @@ namespace se3
 
   }; // struct CartesianProductOperation
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_cartesian_product_operation_hpp__

--- a/src/multibody/liegroup/fwd.hpp
+++ b/src/multibody/liegroup/fwd.hpp
@@ -20,7 +20,7 @@
 
 #include "pinocchio/fwd.hpp"
 
-namespace se3
+namespace pinocchio
 {
   template<typename LieGroupCollection> struct LieGroupGenericTpl;
 }

--- a/src/multibody/liegroup/fwd.hpp
+++ b/src/multibody/liegroup/fwd.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_lie_group_fwd_hpp__
-#define __se3_lie_group_fwd_hpp__
+#ifndef __pinocchio_lie_group_fwd_hpp__
+#define __pinocchio_lie_group_fwd_hpp__
 
 #include "pinocchio/fwd.hpp"
 
@@ -25,4 +25,4 @@ namespace se3
   template<typename LieGroupCollection> struct LieGroupGenericTpl;
 }
 
-#endif // ifndef __se3_lie_group_fwd_hpp__
+#endif // ifndef __pinocchio_lie_group_fwd_hpp__

--- a/src/multibody/liegroup/liegroup-algo.hpp
+++ b/src/multibody/liegroup/liegroup-algo.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_lie_group_algo_hpp__
-#define __se3_lie_group_algo_hpp__
+#ifndef __pinocchio_lie_group_algo_hpp__
+#define __pinocchio_lie_group_algo_hpp__
 
 #include "pinocchio/multibody/joint/joint-base.hpp"
 #include "pinocchio/multibody/liegroup/liegroup.hpp"
@@ -24,4 +24,4 @@
 /// Details
 #include "pinocchio/multibody/liegroup/liegroup-algo.hxx"
 
-#endif // ifndef __se3_lie_group_algo_hpp__
+#endif // ifndef __pinocchio_lie_group_algo_hpp__

--- a/src/multibody/liegroup/liegroup-algo.hxx
+++ b/src/multibody/liegroup/liegroup-algo.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_lie_group_algo_hxx__
-#define __se3_lie_group_algo_hxx__
+#ifndef __pinocchio_lie_group_algo_hxx__
+#define __pinocchio_lie_group_algo_hxx__
 
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/multibody/joint/joint-composite.hpp"
@@ -410,4 +410,4 @@ namespace se3
   
 }
 
-#endif // ifndef __se3_lie_group_algo_hxx__
+#endif // ifndef __pinocchio_lie_group_algo_hxx__

--- a/src/multibody/liegroup/liegroup-algo.hxx
+++ b/src/multibody/liegroup/liegroup-algo.hxx
@@ -21,7 +21,7 @@
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/multibody/joint/joint-composite.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   namespace details
@@ -49,7 +49,7 @@ namespace se3
   struct Algo <Visitor, JointModelCompositeTpl<JointCollection> > {           \
     typedef typename Visitor::ArgsType ArgsType;                              \
     static void run (SE3_DETAILS_WRITE_ARGS_1(JointModelCompositeTpl<JointCollection>))         \
-    { ::se3::details::Dispatch< Visitor >::run(jmodel.derived(), ArgsType(a0)); } \
+    { ::pinocchio::details::Dispatch< Visitor >::run(jmodel.derived(), ArgsType(a0)); } \
   }
    
 #define SE3_DETAILS_DISPATCH_JOINT_COMPOSITE_2(Algo)                 \
@@ -57,7 +57,7 @@ namespace se3
   struct Algo <Visitor, JointModelCompositeTpl<JointCollection> > {        \
     typedef typename Visitor::ArgsType ArgsType;                  \
     static void run (SE3_DETAILS_WRITE_ARGS_2(JointModelCompositeTpl<JointCollection>))         \
-    { ::se3::details::Dispatch< Visitor >::run(jmodel.derived(), ArgsType(a0,a1)); } \
+    { ::pinocchio::details::Dispatch< Visitor >::run(jmodel.derived(), ArgsType(a0,a1)); } \
   }
     
 #define SE3_DETAILS_DISPATCH_JOINT_COMPOSITE_3(Algo)                 \
@@ -65,7 +65,7 @@ namespace se3
   struct Algo <Visitor, JointModelCompositeTpl<JointCollection> > {        \
     typedef typename Visitor::ArgsType ArgsType;                  \
     static void run (SE3_DETAILS_WRITE_ARGS_3(JointModelCompositeTpl<JointCollection>))         \
-    { ::se3::details::Dispatch< Visitor >::run(jmodel.derived(), ArgsType(a0,a1,a2)); } \
+    { ::pinocchio::details::Dispatch< Visitor >::run(jmodel.derived(), ArgsType(a0,a1,a2)); } \
   }
     
 #define SE3_DETAILS_DISPATCH_JOINT_COMPOSITE_4(Algo)                 \
@@ -73,7 +73,7 @@ namespace se3
   struct Algo <Visitor, JointModelCompositeTpl<JointCollection> > {        \
     typedef typename Visitor::ArgsType ArgsType;                  \
     static void run (SE3_DETAILS_WRITE_ARGS_4(JointModelCompositeTpl<JointCollection>))         \
-    { ::se3::details::Dispatch< Visitor >::run(jmodel.derived(), ArgsType(a0,a1,a2,a3)); } \
+    { ::pinocchio::details::Dispatch< Visitor >::run(jmodel.derived(), ArgsType(a0,a1,a2,a3)); } \
   }
     
 #define SE3_DETAILS_VISITOR_METHOD_ALGO_1(Algo, Visitor)                      \

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -22,7 +22,7 @@
 
 #include <limits>
 
-namespace se3
+namespace pinocchio
 {
   
 #define SE3_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,TYPENAME)               \
@@ -343,7 +343,7 @@ SE3_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
     LieGroupBase( const LieGroupBase & /*clone*/) {}
   }; // struct LieGroupBase
 
-} // namespace se3
+} // namespace pinocchio
 
 #include "pinocchio/multibody/liegroup/liegroup-base.hxx"
 

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_lie_group_operation_base_hpp__
-#define __se3_lie_group_operation_base_hpp__
+#ifndef __pinocchio_lie_group_operation_base_hpp__
+#define __pinocchio_lie_group_operation_base_hpp__
 
 #include "pinocchio/multibody/liegroup/fwd.hpp"
 
@@ -347,4 +347,4 @@ SE3_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
 
 #include "pinocchio/multibody/liegroup/liegroup-base.hxx"
 
-#endif // ifndef __se3_lie_group_operation_base_hpp__
+#endif // ifndef __pinocchio_lie_group_operation_base_hpp__

--- a/src/multibody/liegroup/liegroup-base.hxx
+++ b/src/multibody/liegroup/liegroup-base.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_lie_group_operation_base_hxx__
-#define __se3_lie_group_operation_base_hxx__
+#ifndef __pinocchio_lie_group_operation_base_hxx__
+#define __pinocchio_lie_group_operation_base_hxx__
 
 #include "pinocchio/macros.hpp"
 
@@ -353,4 +353,4 @@ namespace se3 {
 
 } // namespace se3
 
-#endif // __se3_lie_group_operation_base_hxx__
+#endif // __pinocchio_lie_group_operation_base_hxx__

--- a/src/multibody/liegroup/liegroup-base.hxx
+++ b/src/multibody/liegroup/liegroup-base.hxx
@@ -20,7 +20,7 @@
 
 #include "pinocchio/macros.hpp"
 
-namespace se3 {
+namespace pinocchio {
 
   // --------------- API with return value as argument ---------------------- //
 
@@ -351,6 +351,6 @@ namespace se3 {
     return derived().name();
   }
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // __pinocchio_lie_group_operation_base_hxx__

--- a/src/multibody/liegroup/liegroup-collection.hpp
+++ b/src/multibody/liegroup/liegroup-collection.hpp
@@ -25,7 +25,7 @@
 
 #include <boost/variant.hpp>
 
-namespace se3
+namespace pinocchio
 {
   template<typename _Scalar, int _Options = 0>
   struct LieGroupCollectionDefaultTpl

--- a/src/multibody/liegroup/liegroup-collection.hpp
+++ b/src/multibody/liegroup/liegroup-collection.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_lie_group_collection_hpp__
-#define __se3_lie_group_collection_hpp__
+#ifndef __pinocchio_lie_group_collection_hpp__
+#define __pinocchio_lie_group_collection_hpp__
 
 #include "pinocchio/multibody/liegroup/vector-space.hpp"
 #include "pinocchio/multibody/liegroup/cartesian-product.hpp"
@@ -50,5 +50,5 @@ namespace se3
   
 }
 
-#endif // ifndef __se3_lie_group_collection_hpp__
+#endif // ifndef __pinocchio_lie_group_collection_hpp__
 

--- a/src/multibody/liegroup/liegroup-generic.hpp
+++ b/src/multibody/liegroup/liegroup-generic.hpp
@@ -21,7 +21,7 @@
 #include "pinocchio/multibody/liegroup/liegroup-base.hpp"
 #include "pinocchio/multibody/liegroup/liegroup-variant-visitors.hpp"
 
-namespace se3
+namespace pinocchio
 {
   template<typename LieGroupCollection> struct LieGroupGenericTpl;
   
@@ -62,8 +62,8 @@ namespace se3
     LieGroupVariant & toVariant()
     { return static_cast<LieGroupVariant &>(*this); }
     
-    int nq() const { return ::se3::nq(*this); }
-    int nv() const { return ::se3::nv(*this); }
+    int nq() const { return ::pinocchio::nq(*this); }
+    int nv() const { return ::pinocchio::nv(*this); }
   };
   
 }

--- a/src/multibody/liegroup/liegroup-generic.hpp
+++ b/src/multibody/liegroup/liegroup-generic.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_lie_group_generic_hpp__
-#define __se3_lie_group_generic_hpp__
+#ifndef __pinocchio_lie_group_generic_hpp__
+#define __pinocchio_lie_group_generic_hpp__
 
 #include "pinocchio/multibody/liegroup/liegroup-base.hpp"
 #include "pinocchio/multibody/liegroup/liegroup-variant-visitors.hpp"
@@ -68,5 +68,5 @@ namespace se3
   
 }
 
-#endif // ifndef __se3_lie_group_generic_hpp__
+#endif // ifndef __pinocchio_lie_group_generic_hpp__
 

--- a/src/multibody/liegroup/liegroup-variant-visitors.hpp
+++ b/src/multibody/liegroup/liegroup-variant-visitors.hpp
@@ -20,7 +20,7 @@
 
 #include "pinocchio/multibody/liegroup/fwd.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   /**

--- a/src/multibody/liegroup/liegroup-variant-visitors.hpp
+++ b/src/multibody/liegroup/liegroup-variant-visitors.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_lie_group_variant_visitor_hpp__
-#define __se3_lie_group_variant_visitor_hpp__
+#ifndef __pinocchio_lie_group_variant_visitor_hpp__
+#define __pinocchio_lie_group_variant_visitor_hpp__
 
 #include "pinocchio/multibody/liegroup/fwd.hpp"
 
@@ -85,4 +85,4 @@ namespace se3
 /// Details
 #include "pinocchio/multibody/liegroup/liegroup-variant-visitors.hxx"
 
-#endif // ifndef __se3_lie_group_variant_visitor_hpp__
+#endif // ifndef __pinocchio_lie_group_variant_visitor_hpp__

--- a/src/multibody/liegroup/liegroup-variant-visitors.hxx
+++ b/src/multibody/liegroup/liegroup-variant-visitors.hxx
@@ -27,7 +27,7 @@
 VISITOR(ArgsType & args) : args(args) {} \
 ArgsType & args
 
-namespace se3
+namespace pinocchio
 {
   
   namespace visitor

--- a/src/multibody/liegroup/liegroup-variant-visitors.hxx
+++ b/src/multibody/liegroup/liegroup-variant-visitors.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_lie_group_variant_visitor_hxx__
-#define __se3_lie_group_variant_visitor_hxx__
+#ifndef __pinocchio_lie_group_variant_visitor_hxx__
+#define __pinocchio_lie_group_variant_visitor_hxx__
 
 #include "pinocchio/multibody/liegroup/liegroup-base.hpp"
 #include "pinocchio/multibody/visitor.hpp"
@@ -174,5 +174,5 @@ namespace se3
   }
 }
 
-#endif // ifndef __se3_lie_group_variant_visitor_hxx__
+#endif // ifndef __pinocchio_lie_group_variant_visitor_hxx__
 

--- a/src/multibody/liegroup/liegroup-variant.hpp
+++ b/src/multibody/liegroup/liegroup-variant.hpp
@@ -25,7 +25,7 @@
 
 #include <boost/variant.hpp>
 
-namespace se3
+namespace pinocchio
 {
   typedef boost::variant< SpecialOrthogonalOperationTpl<2,double,0>
                          ,SpecialOrthogonalOperationTpl<3,double,0>

--- a/src/multibody/liegroup/liegroup-variant.hpp
+++ b/src/multibody/liegroup/liegroup-variant.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_lie_group_variant_hpp__
-#define __se3_lie_group_variant_hpp__
+#ifndef __pinocchio_lie_group_variant_hpp__
+#define __pinocchio_lie_group_variant_hpp__
 
 #include "pinocchio/multibody/liegroup/vector-space.hpp"
 #include "pinocchio/multibody/liegroup/cartesian-product.hpp"
@@ -39,4 +39,4 @@ namespace se3
   
 }
 
-#endif // ifndef __se3_lie_group_variant_hpp__
+#endif // ifndef __pinocchio_lie_group_variant_hpp__

--- a/src/multibody/liegroup/liegroup.hpp
+++ b/src/multibody/liegroup/liegroup.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_lie_group_hpp__
-#define __se3_lie_group_hpp__
+#ifndef __pinocchio_lie_group_hpp__
+#define __pinocchio_lie_group_hpp__
 
 #include "pinocchio/assert.hpp"
 #include "pinocchio/multibody/liegroup/vector-space.hpp"
@@ -73,4 +73,4 @@ namespace se3
   
 }
 
-#endif // ifndef __se3_lie_group_hpp__
+#endif // ifndef __pinocchio_lie_group_hpp__

--- a/src/multibody/liegroup/liegroup.hpp
+++ b/src/multibody/liegroup/liegroup.hpp
@@ -26,7 +26,7 @@
 
 #include "pinocchio/multibody/joint/fwd.hpp"
 
-namespace se3
+namespace pinocchio
 {
   struct LieGroupMap
   {

--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -29,7 +29,7 @@
 #include "pinocchio/multibody/liegroup/cartesian-product.hpp"
 #include "pinocchio/multibody/liegroup/special-orthogonal.hpp"
 
-namespace se3
+namespace pinocchio
 {
   template<int Dim, typename Scalar, int Options = 0>
   struct SpecialEuclideanOperationTpl
@@ -599,6 +599,6 @@ namespace se3
     }
   }; // struct SpecialEuclideanOperationTpl<3>
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_special_euclidean_operation_hpp__

--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_special_euclidean_operation_hpp__
-#define __se3_special_euclidean_operation_hpp__
+#ifndef __pinocchio_special_euclidean_operation_hpp__
+#define __pinocchio_special_euclidean_operation_hpp__
 
 #include <limits>
 
@@ -601,4 +601,4 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_special_euclidean_operation_hpp__
+#endif // ifndef __pinocchio_special_euclidean_operation_hpp__

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -24,7 +24,7 @@
 #include <pinocchio/math/quaternion.hpp>
 #include <pinocchio/multibody/liegroup/liegroup-base.hpp>
 
-namespace se3
+namespace pinocchio
 {
   template<int Dim, typename Scalar, int Options = 0>
   struct SpecialOrthogonalOperationTpl
@@ -450,6 +450,6 @@ namespace se3
     }
   }; // struct SpecialOrthogonalOperationTpl<3,_Scalar,_Options>
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_special_orthogonal_operation_hpp__

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_special_orthogonal_operation_hpp__
-#define __se3_special_orthogonal_operation_hpp__
+#ifndef __pinocchio_special_orthogonal_operation_hpp__
+#define __pinocchio_special_orthogonal_operation_hpp__
 
 #include <limits>
 
@@ -452,4 +452,4 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_special_orthogonal_operation_hpp__
+#endif // ifndef __pinocchio_special_orthogonal_operation_hpp__

--- a/src/multibody/liegroup/vector-space.hpp
+++ b/src/multibody/liegroup/vector-space.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_vector_space_operation_hpp__
-#define __se3_vector_space_operation_hpp__
+#ifndef __pinocchio_vector_space_operation_hpp__
+#define __pinocchio_vector_space_operation_hpp__
 
 #include <stdexcept>
 
@@ -175,4 +175,4 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_vector_space_operation_hpp__
+#endif // ifndef __pinocchio_vector_space_operation_hpp__

--- a/src/multibody/liegroup/vector-space.hpp
+++ b/src/multibody/liegroup/vector-space.hpp
@@ -24,7 +24,7 @@
 
 #include <boost/integer/static_min_max.hpp>
 
-namespace se3
+namespace pinocchio
 {
   template<int Dim, typename Scalar, int Options = 0> struct VectorSpaceOperationTpl;
   
@@ -173,6 +173,6 @@ namespace se3
     Eigen::internal::variable_if_dynamic<Index, Dim> size_;
   }; // struct VectorSpaceOperationTpl
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_vector_space_operation_hpp__

--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -33,7 +33,7 @@
 
 #include <iostream>
 
-namespace se3
+namespace pinocchio
 {
   
   template<typename _Scalar, int _Options, template<typename,int> class JointCollectionTpl>
@@ -53,10 +53,10 @@ namespace se3
     typedef InertiaTpl<Scalar,Options> Inertia;
     typedef FrameTpl<Scalar,Options> Frame;
     
-    typedef se3::Index Index;
-    typedef se3::JointIndex JointIndex;
-    typedef se3::GeomIndex GeomIndex;
-    typedef se3::FrameIndex FrameIndex;
+    typedef pinocchio::Index Index;
+    typedef pinocchio::JointIndex JointIndex;
+    typedef pinocchio::GeomIndex GeomIndex;
+    typedef pinocchio::FrameIndex FrameIndex;
     typedef std::vector<Index> IndexVector;
     
     typedef JointModelTpl<Scalar,Options,JointCollectionTpl> JointModel;
@@ -485,7 +485,7 @@ namespace se3
     void addJointIndexToParentSubtrees(const JointIndex joint_id);
   };
 
-} // namespace se3
+} // namespace pinocchio
 
 /* --- Details -------------------------------------------------------------- */
 /* --- Details -------------------------------------------------------------- */

--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_model_hpp__
-#define __se3_model_hpp__
+#ifndef __pinocchio_model_hpp__
+#define __pinocchio_model_hpp__
 
 #include "pinocchio/spatial/fwd.hpp"
 #include "pinocchio/spatial/se3.hpp"
@@ -492,4 +492,4 @@ namespace se3
 /* --- Details -------------------------------------------------------------- */
 #include "pinocchio/multibody/model.hxx"
 
-#endif // ifndef __se3_model_hpp__
+#endif // ifndef __pinocchio_model_hpp__

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -28,7 +28,7 @@
 
 /// @cond DEV
 
-namespace se3
+namespace pinocchio
 {
   namespace details
   {
@@ -279,7 +279,7 @@ namespace se3
       subtrees[parent].push_back(joint_id);
   }
 
-} // namespace se3
+} // namespace pinocchio
 
 /// @endcond
 

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_model_hxx__
-#define __se3_model_hxx__
+#ifndef __pinocchio_model_hxx__
+#define __pinocchio_model_hxx__
 
 #include "pinocchio/spatial/fwd.hpp"
 #include "pinocchio/utils/string-generator.hpp"
@@ -283,4 +283,4 @@ namespace se3
 
 /// @endcond
 
-#endif // ifndef __se3_model_hxx__
+#endif // ifndef __pinocchio_model_hxx__

--- a/src/multibody/visitor.hpp
+++ b/src/multibody/visitor.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_visitor_hpp__
-#define __se3_visitor_hpp__
+#ifndef __pinocchio_visitor_hpp__
+#define __pinocchio_visitor_hpp__
 
 #define BOOST_FUSION_INVOKE_MAX_ARITY 10
 
@@ -210,4 +210,4 @@ namespace se3
   } // namespace fusion
 } // namespace se3
 
-#endif // ifndef __se3_visitor_hpp__
+#endif // ifndef __pinocchio_visitor_hpp__

--- a/src/multibody/visitor.hpp
+++ b/src/multibody/visitor.hpp
@@ -47,7 +47,7 @@ namespace boost
   }
 }
 
-namespace se3
+namespace pinocchio
 {
   namespace fusion
   {
@@ -208,6 +208,6 @@ namespace se3
     }; // struct JointVisitorBase
     
   } // namespace fusion
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_visitor_hpp__

--- a/src/parsers/lua.cpp
+++ b/src/parsers/lua.cpp
@@ -28,8 +28,8 @@
 #include "pinocchio/spatial/inertia.hpp"
 #include "pinocchio/multibody/model.hpp"
 
-typedef se3::SE3::Vector3 Vector3;
-typedef se3::SE3::Matrix3 Matrix3;
+typedef pinocchio::SE3::Vector3 Vector3;
+typedef pinocchio::SE3::Matrix3 Matrix3;
 
 template<> Vector3 LuaTableNode::getDefault<Vector3> (const Vector3 & default_value)
 {
@@ -90,9 +90,9 @@ template<> Matrix3 LuaTableNode::getDefault<Matrix3> (const Matrix3 & default_va
   return result;
 }
 
-template<> se3::SE3 LuaTableNode::getDefault<se3::SE3> (const se3::SE3 & default_value)
+template<> pinocchio::SE3 LuaTableNode::getDefault<pinocchio::SE3> (const pinocchio::SE3 & default_value)
 {
-  se3::SE3 result (default_value);
+  pinocchio::SE3 result (default_value);
 
   if (stackQueryValue()) {
     LuaTable vector_table = LuaTable::fromLuaState (luaTable->L);
@@ -106,9 +106,9 @@ template<> se3::SE3 LuaTableNode::getDefault<se3::SE3> (const se3::SE3 & default
   return result;
 }
 
-template<> se3::Inertia LuaTableNode::getDefault<se3::Inertia> (const se3::Inertia & default_value)
+template<> pinocchio::Inertia LuaTableNode::getDefault<pinocchio::Inertia> (const pinocchio::Inertia & default_value)
 {
-  se3::Inertia result (default_value);
+  pinocchio::Inertia result (default_value);
 
   if (stackQueryValue()) {
     LuaTable vector_table = LuaTable::fromLuaState (luaTable->L);
@@ -121,7 +121,7 @@ template<> se3::Inertia LuaTableNode::getDefault<se3::Inertia> (const se3::Inert
     com = vector_table["com"].getDefault<Vector3> (Vector3::Zero ());
     inertia_matrix = vector_table["inertia"].getDefault<Matrix3> (Matrix3::Identity ());
 
-    result = se3::Inertia (mass, com, inertia_matrix);
+    result = pinocchio::Inertia (mass, com, inertia_matrix);
   }
 
   stackRestore();

--- a/src/parsers/lua.hpp
+++ b/src/parsers/lua.hpp
@@ -21,12 +21,12 @@
 #include <string>
 #include "pinocchio/multibody/model.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace lua
   {
     Model buildModel (const std::string & filename, bool freeFlyer = false, bool verbose = false);
   } // namespace lua
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_lua_hpp__

--- a/src/parsers/lua.hpp
+++ b/src/parsers/lua.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_lua_hpp__
-#define __se3_lua_hpp__
+#ifndef __pinocchio_lua_hpp__
+#define __pinocchio_lua_hpp__
 
 #include <string>
 #include "pinocchio/multibody/model.hpp"
@@ -29,4 +29,4 @@ namespace se3
   } // namespace lua
 } // namespace se3
 
-#endif // ifndef __se3_lua_hpp__
+#endif // ifndef __pinocchio_lua_hpp__

--- a/src/parsers/lua/lua_tables.hpp
+++ b/src/parsers/lua/lua_tables.hpp
@@ -25,8 +25,8 @@
  * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#ifndef __se3_parser_lua_tables_hpp____
-#define __se3_parser_lua_tables_hpp____
+#ifndef __pinocchio_parser_lua_tables_hpp____
+#define __pinocchio_parser_lua_tables_hpp____
 
 #include <iostream>
 #include <assert.h>
@@ -220,4 +220,4 @@ struct LuaTable {
 };
 
 
-#endif // ifndef __se3_parser_lua_tables_hpp____
+#endif // ifndef __pinocchio_parser_lua_tables_hpp____

--- a/src/parsers/sample-models.cpp
+++ b/src/parsers/sample-models.cpp
@@ -18,7 +18,7 @@
 
 #include "pinocchio/parsers/sample-models.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace buildModels
   {
@@ -359,4 +359,4 @@ namespace se3
 
   } // namespace buildModels
   
-} // namespace se3
+} // namespace pinocchio

--- a/src/parsers/sample-models.hpp
+++ b/src/parsers/sample-models.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_sample_models_hpp__
-#define __se3_sample_models_hpp__
+#ifndef __pinocchio_sample_models_hpp__
+#define __pinocchio_sample_models_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/geometry.hpp"
@@ -95,4 +95,4 @@ namespace se3
   } // namespace buildModels
 } // namespace se3
 
-#endif // ifndef __se3_sample_models_hpp__
+#endif // ifndef __pinocchio_sample_models_hpp__

--- a/src/parsers/sample-models.hpp
+++ b/src/parsers/sample-models.hpp
@@ -22,7 +22,7 @@
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/geometry.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace buildModels
   {  
@@ -70,7 +70,7 @@ namespace se3
      *
      * This method is only meant to be used in unittest. Due to random placement and masses,
      * the resulting model is likely to not correspond to any physically-plausible model. 
-     * You may want to consider se3::humanoid and se3::humanoidGeometries functions that
+     * You may want to consider pinocchio::humanoid and pinocchio::humanoidGeometries functions that
      * rather define a plain and non-random model. 
      * \param model: model, typically given empty, where the kinematic chain is added.
      * \param usingFF: if True, implement the chain with a plain JointModelFreeFloating; if False,
@@ -80,19 +80,19 @@ namespace se3
     void humanoidRandom(Model & model, bool usingFF = true);
 
     /** \brief Create a random humanoid tree with 2d limbs.
-     * \ deprecated This function has been replaced by the non-random se3::humanoid function.
+     * \ deprecated This function has been replaced by the non-random pinocchio::humanoid function.
      */
     PINOCCHIO_DEPRECATED
     void humanoid2d(Model & model);
 
     /** \brief Alias of humanoidRandom, for compatibility reasons.
-     * \deprecated use se3::humanoid or se3::humanoidRandom instead. 
+     * \deprecated use pinocchio::humanoid or pinocchio::humanoidRandom instead. 
      */
     PINOCCHIO_DEPRECATED
     inline void humanoidSimple(Model & model, bool usingFF = true)
     { humanoidRandom(model,usingFF); }
    
   } // namespace buildModels
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_sample_models_hpp__

--- a/src/parsers/srdf.hpp
+++ b/src/parsers/srdf.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_parser_srdf_hpp__
-#define __se3_parser_srdf_hpp__
+#ifndef __pinocchio_parser_srdf_hpp__
+#define __pinocchio_parser_srdf_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/geometry.hpp"
@@ -138,4 +138,4 @@ namespace se3
 
 #include "pinocchio/parsers/srdf.hxx"
 
-#endif // ifndef __se3_parser_srdf_hpp__
+#endif // ifndef __pinocchio_parser_srdf_hpp__

--- a/src/parsers/srdf.hpp
+++ b/src/parsers/srdf.hpp
@@ -21,7 +21,7 @@
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/geometry.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace srdf
   {
@@ -99,7 +99,7 @@ namespace se3
                             const std::string & filename,
                             const bool verbose = false) throw (std::invalid_argument);
     
-    /// \copydoc se3::srdf::getNeutralConfiguration
+    /// \copydoc pinocchio::srdf::getNeutralConfiguration
     template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
     PINOCCHIO_DEPRECATED
     typename ModelTpl<Scalar,Options,JointCollectionTpl>::ConfigVectorType
@@ -123,7 +123,7 @@ namespace se3
                              const std::string & filename,
                              const bool verbose = false) throw (std::invalid_argument);
     
-    /// \copydoc se3::srdf::loadRotorParameters
+    /// \copydoc pinocchio::srdf::loadRotorParameters
     template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
     PINOCCHIO_DEPRECATED
     bool loadRotorParamsFromSrdf(ModelTpl<Scalar,Options,JointCollectionTpl> & model,
@@ -134,7 +134,7 @@ namespace se3
     }
     
   }
-} // namespace se3
+} // namespace pinocchio
 
 #include "pinocchio/parsers/srdf.hxx"
 

--- a/src/parsers/srdf.hxx
+++ b/src/parsers/srdf.hxx
@@ -31,7 +31,7 @@
 #include <sstream>
 #include <boost/foreach.hpp>
 
-namespace se3
+namespace pinocchio
 {
   namespace srdf
   {
@@ -291,6 +291,6 @@ namespace se3
       return ModelTpl<Scalar,Options,JointCollectionTpl>::ConfigVectorType::Constant(model.nq,(Scalar)NAN); // warning : uninitialized vector is returned
     }
   }
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_parser_srdf_hxx__

--- a/src/parsers/srdf.hxx
+++ b/src/parsers/srdf.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_parser_srdf_hxx__
-#define __se3_parser_srdf_hxx__
+#ifndef __pinocchio_parser_srdf_hxx__
+#define __pinocchio_parser_srdf_hxx__
 
 #include "pinocchio/parsers/srdf.hpp"
 
@@ -293,4 +293,4 @@ namespace se3
   }
 } // namespace se3
 
-#endif // ifndef __se3_parser_srdf_hxx__
+#endif // ifndef __pinocchio_parser_srdf_hxx__

--- a/src/parsers/urdf.hpp
+++ b/src/parsers/urdf.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_parsers_urdf_hpp__
-#define __se3_parsers_urdf_hpp__
+#ifndef __pinocchio_parsers_urdf_hpp__
+#define __pinocchio_parsers_urdf_hpp__
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/geometry.hpp"
@@ -258,4 +258,4 @@ namespace se3
 #include "pinocchio/parsers/urdf/model.hxx"
 #include "pinocchio/parsers/urdf/geometry.hxx"
 
-#endif // ifndef __se3_parsers_urdf_hpp__
+#endif // ifndef __pinocchio_parsers_urdf_hpp__

--- a/src/parsers/urdf.hpp
+++ b/src/parsers/urdf.hpp
@@ -23,7 +23,7 @@
 #include "pinocchio/multibody/geometry.hpp"
 #include "pinocchio/parsers/urdf/types.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace urdf
   {
@@ -143,7 +143,7 @@ namespace se3
      * @param[in]  filename      The URDF complete (absolute) file path
      * @param[in]  packageDirs   A vector containing the different directories
      *                           where to search for models and meshes, typically 
-     *                           obtained from calling se3::rosPaths()
+     *                           obtained from calling pinocchio::rosPaths()
      *
      * @param[in]   type         The type of objects that must be loaded (must be VISUAL or COLLISION)
      * @param[out]  geomModel    Reference where to put the parsed information.
@@ -170,7 +170,7 @@ namespace se3
      *                           urdf::buildModel
      * @param[in]  filename      The URDF complete (absolute) file path
      * @param[in]  packageDir    A string containing the path to the directories of the meshes,
-     *                           typically obtained from calling se3::rosPaths().
+     *                           typically obtained from calling pinocchio::rosPaths().
      *
      * @param[in]   type         The type of objects that must be loaded (must be VISUAL or COLLISION)
      * @param[out]  geomModel    Reference where to put the parsed information.
@@ -202,7 +202,7 @@ namespace se3
      * @param[in]  xmlStream     Stream containing the URDF model
      * @param[in]  packageDirs   A vector containing the different directories
      *                           where to search for models and meshes, typically
-     *                           obtained from calling se3::rosPaths()
+     *                           obtained from calling pinocchio::rosPaths()
      *
      * @param[in]   type         The type of objects that must be loaded (must be VISUAL or COLLISION)
      * @param[out]  geomModel    Reference where to put the parsed information.
@@ -229,7 +229,7 @@ namespace se3
      *                           urdf::buildModel
      * @param[in]  xmlStream     Stream containing the URDF model
      * @param[in]  packageDir    A string containing the path to the directories of the meshes,
-     *                           typically obtained from calling se3::rosPaths().
+     *                           typically obtained from calling pinocchio::rosPaths().
      *
      * @param[in]   type         The type of objects that must be loaded (must be VISUAL or COLLISION)
      * @param[out]  geomModel    Reference where to put the parsed information.
@@ -253,7 +253,7 @@ namespace se3
 
 
   } // namespace urdf
-} // namespace se3
+} // namespace pinocchio
 
 #include "pinocchio/parsers/urdf/model.hxx"
 #include "pinocchio/parsers/urdf/geometry.hxx"

--- a/src/parsers/urdf/geometry.hxx
+++ b/src/parsers/urdf/geometry.hxx
@@ -38,7 +38,7 @@
   #include <hpp/fcl/mesh_loader/assimp.h>
 #endif // PINOCCHIO_WITH_HPP_FCL
 
-namespace se3
+namespace pinocchio
 {
   namespace urdf
   {
@@ -463,6 +463,6 @@ namespace se3
       }
 
   } // namespace urdf
-} // namespace se3
+} // namespace pinocchio
             
 #endif // ifndef __pinocchio_multibody_parsers_urdf_geometry_hxx__

--- a/src/parsers/urdf/geometry.hxx
+++ b/src/parsers/urdf/geometry.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_multibody_parsers_urdf_geometry_hxx__
-#define __se3_multibody_parsers_urdf_geometry_hxx__
+#ifndef __pinocchio_multibody_parsers_urdf_geometry_hxx__
+#define __pinocchio_multibody_parsers_urdf_geometry_hxx__
 
 #include "pinocchio/parsers/urdf.hpp"
 #include "pinocchio/parsers/urdf/utils.hpp"
@@ -465,4 +465,4 @@ namespace se3
   } // namespace urdf
 } // namespace se3
             
-#endif // ifndef __se3_multibody_parsers_urdf_geometry_hxx__
+#endif // ifndef __pinocchio_multibody_parsers_urdf_geometry_hxx__

--- a/src/parsers/urdf/model.hxx
+++ b/src/parsers/urdf/model.hxx
@@ -31,7 +31,7 @@
 #include <boost/foreach.hpp>
 #include <limits>
 
-namespace se3
+namespace pinocchio
 {
   namespace urdf
   {
@@ -727,6 +727,6 @@ namespace se3
     }
 
   } // namespace urdf
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_multibody_parsers_urdf_model_hxx__

--- a/src/parsers/urdf/model.hxx
+++ b/src/parsers/urdf/model.hxx
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_multibody_parsers_urdf_model_hxx__
-#define __se3_multibody_parsers_urdf_model_hxx__
+#ifndef __pinocchio_multibody_parsers_urdf_model_hxx__
+#define __pinocchio_multibody_parsers_urdf_model_hxx__
 
 #include "pinocchio/math/matrix.hpp"
 #include "pinocchio/parsers/urdf.hpp"
@@ -729,4 +729,4 @@ namespace se3
   } // namespace urdf
 } // namespace se3
 
-#endif // ifndef __se3_multibody_parsers_urdf_model_hxx__
+#endif // ifndef __pinocchio_multibody_parsers_urdf_model_hxx__

--- a/src/parsers/urdf/types.hpp
+++ b/src/parsers/urdf/types.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_parsers_urdf_types_hpp__
-#define __se3_parsers_urdf_types_hpp__
+#ifndef __pinocchio_parsers_urdf_types_hpp__
+#define __pinocchio_parsers_urdf_types_hpp__
 
 #include <urdf_model/model.h>
 
@@ -93,4 +93,4 @@ namespace urdf
 
 #endif // PINOCCHIO_URDFDOM_TYPEDEF_SHARED_PTR
 
-#endif // ifndef __se3_parsers_urdf_types_hpp__
+#endif // ifndef __pinocchio_parsers_urdf_types_hpp__

--- a/src/parsers/urdf/utils.hpp
+++ b/src/parsers/urdf/utils.hpp
@@ -23,7 +23,7 @@
 #include "pinocchio/spatial/se3.hpp"
 #include "pinocchio/spatial/inertia.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace urdf
   {
@@ -33,7 +33,7 @@ namespace se3
     ///
     /// \param[in] Y The input URDF Inertia.
     ///
-    /// \return The converted Spatial Inertia se3::Inertia.
+    /// \return The converted Spatial Inertia pinocchio::Inertia.
     ///
     inline Inertia convertFromUrdf (const ::urdf::Inertial & Y)
     {
@@ -55,7 +55,7 @@ namespace se3
     ///
     /// \param[in] M The input URDF Pose.
     ///
-    /// \return The converted pose/transform se3::SE3.
+    /// \return The converted pose/transform pinocchio::SE3.
     ///
     inline SE3 convertFromUrdf (const ::urdf::Pose & M)
     {
@@ -74,7 +74,7 @@ namespace se3
     ///
     /// \param[in] axis The input URDF axis.
     ///
-    /// \return The property of the particular axis se3::urdf::CartesianAxis.
+    /// \return The property of the particular axis pinocchio::urdf::CartesianAxis.
     ///
     inline CartesianAxis extractCartesianAxis (const ::urdf::Vector3 & axis)
     {

--- a/src/parsers/urdf/utils.hpp
+++ b/src/parsers/urdf/utils.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_parsers_urdf_utils_hpp__
-#define __se3_parsers_urdf_utils_hpp__
+#ifndef __pinocchio_parsers_urdf_utils_hpp__
+#define __pinocchio_parsers_urdf_utils_hpp__
 
 #include <urdf_model/model.h>
 
@@ -90,4 +90,4 @@ namespace se3
 
   } //urdf
 } // se3
-#endif // __se3_parsers_urdf_utils_hpp__
+#endif // __pinocchio_parsers_urdf_utils_hpp__

--- a/src/parsers/utils.hpp
+++ b/src/parsers/utils.hpp
@@ -32,7 +32,7 @@
 
 #include <exception>
 
-namespace se3
+namespace pinocchio
 {
   ///
   /// \brief Supported model file extensions
@@ -123,6 +123,6 @@ namespace se3
     return result_path;
    }
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // __pinocchio_parsers_utils_hpp__

--- a/src/parsers/utils.hpp
+++ b/src/parsers/utils.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_parsers_utils_hpp__
-#define __se3_parsers_utils_hpp__
+#ifndef __pinocchio_parsers_utils_hpp__
+#define __pinocchio_parsers_utils_hpp__
 
 #include <iostream>
 #include <limits>
@@ -125,4 +125,4 @@ namespace se3
 
 } // namespace se3
 
-#endif // __se3_parsers_utils_hpp__
+#endif // __pinocchio_parsers_utils_hpp__

--- a/src/spatial/act-on-set.hpp
+++ b/src/spatial/act-on-set.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_act_on_set_hpp__
-#define __se3_act_on_set_hpp__
+#ifndef __pinocchio_act_on_set_hpp__
+#define __pinocchio_act_on_set_hpp__
 
 #include "pinocchio/macros.hpp"
 #include "pinocchio/spatial/fwd.hpp"
@@ -166,4 +166,4 @@ namespace se3
 
 #include "pinocchio/spatial/act-on-set.hxx"
 
-#endif // ifndef __se3_act_on_set_hpp__
+#endif // ifndef __pinocchio_act_on_set_hpp__

--- a/src/spatial/act-on-set.hpp
+++ b/src/spatial/act-on-set.hpp
@@ -21,7 +21,7 @@
 #include "pinocchio/macros.hpp"
 #include "pinocchio/spatial/fwd.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   enum AssignmentOperatorType
@@ -162,7 +162,7 @@ namespace se3
     
   }  // namespace MotionSet
 
-} // namespace se3
+} // namespace pinocchio
 
 #include "pinocchio/spatial/act-on-set.hxx"
 

--- a/src/spatial/act-on-set.hxx
+++ b/src/spatial/act-on-set.hxx
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_act_on_set_hxx__
-#define __se3_act_on_set_hxx__
+#ifndef __pinocchio_act_on_set_hxx__
+#define __pinocchio_act_on_set_hxx__
 
 namespace se3
 {
@@ -656,4 +656,4 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_act_on_set_hxx__
+#endif // ifndef __pinocchio_act_on_set_hxx__

--- a/src/spatial/act-on-set.hxx
+++ b/src/spatial/act-on-set.hxx
@@ -18,7 +18,7 @@
 #ifndef __pinocchio_act_on_set_hxx__
 #define __pinocchio_act_on_set_hxx__
 
-namespace se3
+namespace pinocchio
 {
   
   namespace internal 
@@ -654,6 +654,6 @@ namespace se3
 
   }  // namespace motionSet
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_act_on_set_hxx__

--- a/src/spatial/cartesian-axis.hpp
+++ b/src/spatial/cartesian-axis.hpp
@@ -20,7 +20,7 @@
 
 #include "pinocchio/fwd.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   template<int _axis>

--- a/src/spatial/cartesian-axis.hpp
+++ b/src/spatial/cartesian-axis.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_cartesian_axis_hpp__
-#define __se3_cartesian_axis_hpp__
+#ifndef __pinocchio_cartesian_axis_hpp__
+#define __pinocchio_cartesian_axis_hpp__
 
 #include "pinocchio/fwd.hpp"
 
@@ -159,4 +159,4 @@ namespace se3
 
 }
 
-#endif // __se3_cartesian_axis_hpp__
+#endif // __pinocchio_cartesian_axis_hpp__

--- a/src/spatial/explog-quaternion.hpp
+++ b/src/spatial/explog-quaternion.hpp
@@ -20,7 +20,7 @@
 
 #include "pinocchio/math/quaternion.hpp"
 
-namespace se3
+namespace pinocchio
 {
   namespace quaternion
   {
@@ -193,7 +193,7 @@ namespace se3
       
       Scalar t;
       Vector3 w(log3(quat,t));
-      se3::Jlog3(t,w,Jlog);
+      pinocchio::Jlog3(t,w,Jlog);
     }
   } // namespace quaternion
 }

--- a/src/spatial/explog-quaternion.hpp
+++ b/src/spatial/explog-quaternion.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_spatial_explog_quaternion_hpp__
-#define __se3_spatial_explog_quaternion_hpp__
+#ifndef __pinocchio_spatial_explog_quaternion_hpp__
+#define __pinocchio_spatial_explog_quaternion_hpp__
 
 #include "pinocchio/math/quaternion.hpp"
 
@@ -198,4 +198,4 @@ namespace se3
   } // namespace quaternion
 }
 
-#endif // ifndef __se3_spatial_explog_quaternion_hpp__
+#endif // ifndef __pinocchio_spatial_explog_quaternion_hpp__

--- a/src/spatial/explog.hpp
+++ b/src/spatial/explog.hpp
@@ -29,7 +29,7 @@
 #include "pinocchio/spatial/skew.hpp"
 #include "pinocchio/spatial/se3.hpp"
 
-namespace se3
+namespace pinocchio
 {
   /// \brief Exp: so3 -> SO3.
   ///
@@ -527,7 +527,7 @@ namespace se3
     B.noalias() = C * A;
     C.setZero();
   }
-} // namespace se3
+} // namespace pinocchio
 
 #include "pinocchio/spatial/explog-quaternion.hpp"
 

--- a/src/spatial/fcl-pinocchio-conversions.hpp
+++ b/src/spatial/fcl-pinocchio-conversions.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_fcl_convertion_hpp__
-#define __se3_fcl_convertion_hpp__
+#ifndef __pinocchio_fcl_convertion_hpp__
+#define __pinocchio_fcl_convertion_hpp__
 
 #include <hpp/fcl/math/transform.h>
 #include "pinocchio/spatial/se3.hpp"
@@ -35,4 +35,4 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_fcl_convertion_hpp__
+#endif // ifndef __pinocchio_fcl_convertion_hpp__

--- a/src/spatial/fcl-pinocchio-conversions.hpp
+++ b/src/spatial/fcl-pinocchio-conversions.hpp
@@ -21,7 +21,7 @@
 #include <hpp/fcl/math/transform.h>
 #include "pinocchio/spatial/se3.hpp"
 
-namespace se3
+namespace pinocchio
 {
   inline fcl::Transform3f toFclTransform3f(const SE3 & m)
   {
@@ -33,6 +33,6 @@ namespace se3
     return SE3(tf.getRotation(), tf.getTranslation());
   }
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_fcl_convertion_hpp__

--- a/src/spatial/force-base.hpp
+++ b/src/spatial/force-base.hpp
@@ -27,7 +27,7 @@
  *
  */
 
-namespace se3
+namespace pinocchio
 {
   /**
    * @brief      Base interface for forces representation.
@@ -218,6 +218,6 @@ namespace se3
     
   }; // class ForceBase
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_force_base_hpp__

--- a/src/spatial/force-base.hpp
+++ b/src/spatial/force-base.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_force_base_hpp__
-#define __se3_force_base_hpp__
+#ifndef __pinocchio_force_base_hpp__
+#define __pinocchio_force_base_hpp__
 
 /** \addtogroup Force_group Force
  *
@@ -220,4 +220,4 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_force_base_hpp__
+#endif // ifndef __pinocchio_force_base_hpp__

--- a/src/spatial/force-dense.hpp
+++ b/src/spatial/force-dense.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_force_dense_hpp__
-#define __se3_force_dense_hpp__
+#ifndef __pinocchio_force_dense_hpp__
+#define __pinocchio_force_dense_hpp__
 
 namespace se3
 {
@@ -206,4 +206,4 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_force_dense_hpp__
+#endif // ifndef __pinocchio_force_dense_hpp__

--- a/src/spatial/force-dense.hpp
+++ b/src/spatial/force-dense.hpp
@@ -18,7 +18,7 @@
 #ifndef __pinocchio_force_dense_hpp__
 #define __pinocchio_force_dense_hpp__
 
-namespace se3
+namespace pinocchio
 {
   
   namespace internal
@@ -204,6 +204,6 @@ namespace se3
                                             const ForceDense<F1> & f)
   { return f.derived()*alpha; }
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_force_dense_hpp__

--- a/src/spatial/force-ref.hpp
+++ b/src/spatial/force-ref.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_force_ref_hpp__
-#define __se3_force_ref_hpp__
+#ifndef __pinocchio_force_ref_hpp__
+#define __pinocchio_force_ref_hpp__
 
 namespace se3
 {
@@ -144,4 +144,4 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_force_ref_hpp__
+#endif // ifndef __pinocchio_force_ref_hpp__

--- a/src/spatial/force-ref.hpp
+++ b/src/spatial/force-ref.hpp
@@ -18,7 +18,7 @@
 #ifndef __pinocchio_force_ref_hpp__
 #define __pinocchio_force_ref_hpp__
 
-namespace se3
+namespace pinocchio
 {
   
   template<typename Vector6ArgType>
@@ -142,6 +142,6 @@ namespace se3
     
   }; // class ForceRef<Vector6Like>
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_force_ref_hpp__

--- a/src/spatial/force-tpl.hpp
+++ b/src/spatial/force-tpl.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_force_tpl_hpp__
-#define __se3_force_tpl_hpp__
+#ifndef __pinocchio_force_tpl_hpp__
+#define __pinocchio_force_tpl_hpp__
 
 namespace se3
 {
@@ -130,4 +130,4 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_force_tpl_hpp__
+#endif // ifndef __pinocchio_force_tpl_hpp__

--- a/src/spatial/force-tpl.hpp
+++ b/src/spatial/force-tpl.hpp
@@ -19,7 +19,7 @@
 #ifndef __pinocchio_force_tpl_hpp__
 #define __pinocchio_force_tpl_hpp__
 
-namespace se3
+namespace pinocchio
 {
   template<typename _Scalar, int _Options>
   struct traits< ForceTpl<_Scalar, _Options> >
@@ -128,6 +128,6 @@ namespace se3
     
   }; // class ForceTpl
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_force_tpl_hpp__

--- a/src/spatial/force.hpp
+++ b/src/spatial/force.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_force_hpp__
-#define __se3_force_hpp__
+#ifndef __pinocchio_force_hpp__
+#define __pinocchio_force_hpp__
 
 #include "pinocchio/spatial/fwd.hpp"
 #include "pinocchio/spatial/se3.hpp"
@@ -51,5 +51,5 @@ FORCE_TYPEDEF_GENERIC(Derived,PINOCCHIO_MACRO_EMPTY_ARG)
 #include "pinocchio/spatial/force-tpl.hpp"
 #include "pinocchio/spatial/force-ref.hpp"
 
-#endif // ifndef __se3_force_hpp__
+#endif // ifndef __pinocchio_force_hpp__
 

--- a/src/spatial/fwd.hpp
+++ b/src/spatial/fwd.hpp
@@ -22,7 +22,7 @@
 #include "pinocchio/fwd.hpp"
 #include "pinocchio/macros.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   template<typename Scalar, int Options=0> struct SE3Tpl;
@@ -78,6 +78,6 @@ namespace se3
     SPATIAL_TYPEDEF_TEMPLATE_GENERIC(derived,PINOCCHIO_MACRO_EMPTY_ARG)
 
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_spatial_fwd_hpp__

--- a/src/spatial/fwd.hpp
+++ b/src/spatial/fwd.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_spatial_fwd_hpp__
-#define __se3_spatial_fwd_hpp__
+#ifndef __pinocchio_spatial_fwd_hpp__
+#define __pinocchio_spatial_fwd_hpp__
 
 #include "pinocchio/fwd.hpp"
 #include "pinocchio/macros.hpp"
@@ -80,4 +80,4 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_spatial_fwd_hpp__
+#endif // ifndef __pinocchio_spatial_fwd_hpp__

--- a/src/spatial/inertia.hpp
+++ b/src/spatial/inertia.hpp
@@ -27,7 +27,7 @@
 #include "pinocchio/spatial/motion.hpp"
 #include "pinocchio/spatial/skew.hpp"
 
-namespace se3
+namespace pinocchio
 {
 
   template< class Derived>
@@ -498,6 +498,6 @@ namespace se3
     
   }; // class InertiaTpl
     
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_inertia_hpp__

--- a/src/spatial/inertia.hpp
+++ b/src/spatial/inertia.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_inertia_hpp__
-#define __se3_inertia_hpp__
+#ifndef __pinocchio_inertia_hpp__
+#define __pinocchio_inertia_hpp__
 
 #include <iostream>
 
@@ -500,4 +500,4 @@ namespace se3
     
 } // namespace se3
 
-#endif // ifndef __se3_inertia_hpp__
+#endif // ifndef __pinocchio_inertia_hpp__

--- a/src/spatial/motion-base.hpp
+++ b/src/spatial/motion-base.hpp
@@ -19,7 +19,7 @@
 #ifndef __pinocchio_motion_base_hpp__
 #define __pinocchio_motion_base_hpp__
 
-namespace se3
+namespace pinocchio
 {
   
   template<class Derived>
@@ -107,6 +107,6 @@ namespace se3
     
   }; // class MotionBase
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_motion_base_hpp__

--- a/src/spatial/motion-base.hpp
+++ b/src/spatial/motion-base.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_motion_base_hpp__
-#define __se3_motion_base_hpp__
+#ifndef __pinocchio_motion_base_hpp__
+#define __pinocchio_motion_base_hpp__
 
 namespace se3
 {
@@ -109,4 +109,4 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_motion_base_hpp__
+#endif // ifndef __pinocchio_motion_base_hpp__

--- a/src/spatial/motion-dense.hpp
+++ b/src/spatial/motion-dense.hpp
@@ -20,7 +20,7 @@
 
 #include "pinocchio/spatial/skew.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   namespace internal
@@ -242,6 +242,6 @@ namespace se3
                                              const MotionDense<M1> & v)
   { return v*alpha; }
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_motion_dense_hpp__

--- a/src/spatial/motion-dense.hpp
+++ b/src/spatial/motion-dense.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_motion_dense_hpp__
-#define __se3_motion_dense_hpp__
+#ifndef __pinocchio_motion_dense_hpp__
+#define __pinocchio_motion_dense_hpp__
 
 #include "pinocchio/spatial/skew.hpp"
 
@@ -244,4 +244,4 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_motion_dense_hpp__
+#endif // ifndef __pinocchio_motion_dense_hpp__

--- a/src/spatial/motion-ref.hpp
+++ b/src/spatial/motion-ref.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_motion_ref_hpp__
-#define __se3_motion_ref_hpp__
+#ifndef __pinocchio_motion_ref_hpp__
+#define __pinocchio_motion_ref_hpp__
 
 namespace se3
 {
@@ -219,4 +219,4 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_motion_ref_hpp__
+#endif // ifndef __pinocchio_motion_ref_hpp__

--- a/src/spatial/motion-ref.hpp
+++ b/src/spatial/motion-ref.hpp
@@ -18,7 +18,7 @@
 #ifndef __pinocchio_motion_ref_hpp__
 #define __pinocchio_motion_ref_hpp__
 
-namespace se3
+namespace pinocchio
 {
   
   template<typename Vector6ArgType>
@@ -217,6 +217,6 @@ namespace se3
     
   }; // class MotionRef<const Vector6Like>
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_motion_ref_hpp__

--- a/src/spatial/motion-tpl.hpp
+++ b/src/spatial/motion-tpl.hpp
@@ -19,7 +19,7 @@
 #ifndef __pinocchio_motion_tpl_hpp__
 #define __pinocchio_motion_tpl_hpp__
 
-namespace se3
+namespace pinocchio
 {
   template<typename _Scalar, int _Options>
   struct traits< MotionTpl<_Scalar, _Options> >
@@ -177,6 +177,6 @@ namespace se3
     
   }; // class MotionTpl
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_motion_tpl_hpp__

--- a/src/spatial/motion-tpl.hpp
+++ b/src/spatial/motion-tpl.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_motion_tpl_hpp__
-#define __se3_motion_tpl_hpp__
+#ifndef __pinocchio_motion_tpl_hpp__
+#define __pinocchio_motion_tpl_hpp__
 
 namespace se3
 {
@@ -179,4 +179,4 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_motion_tpl_hpp__
+#endif // ifndef __pinocchio_motion_tpl_hpp__

--- a/src/spatial/motion-zero.hpp
+++ b/src/spatial/motion-zero.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_motion_zero_hpp__
-#define __se3_motion_zero_hpp__
+#ifndef __pinocchio_motion_zero_hpp__
+#define __pinocchio_motion_zero_hpp__
 
 namespace se3
 {
@@ -126,4 +126,4 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_motion_zero_hpp__
+#endif // ifndef __pinocchio_motion_zero_hpp__

--- a/src/spatial/motion-zero.hpp
+++ b/src/spatial/motion-zero.hpp
@@ -19,7 +19,7 @@
 #ifndef __pinocchio_motion_zero_hpp__
 #define __pinocchio_motion_zero_hpp__
 
-namespace se3
+namespace pinocchio
 {
   
   namespace internal
@@ -124,6 +124,6 @@ namespace se3
                               const MotionBase<M1> & v)
   { return v.derived(); }
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_motion_zero_hpp__

--- a/src/spatial/motion.hpp
+++ b/src/spatial/motion.hpp
@@ -47,7 +47,7 @@ MOTION_TYPEDEF_GENERIC(Derived,typename)
 #define MOTION_TYPEDEF(Derived) \
 MOTION_TYPEDEF_GENERIC(Derived,PINOCCHIO_MACRO_EMPTY_ARG)
 
-namespace se3
+namespace pinocchio
 {
   namespace internal
   {
@@ -58,7 +58,7 @@ namespace se3
     struct MotionAlgebraAction { typedef D ReturnType; };
   }
 
-} // namespace se3
+} // namespace pinocchio
 
 #include "pinocchio/spatial/motion-base.hpp"
 #include "pinocchio/spatial/motion-dense.hpp"

--- a/src/spatial/motion.hpp
+++ b/src/spatial/motion.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_motion_hpp__
-#define __se3_motion_hpp__
+#ifndef __pinocchio_motion_hpp__
+#define __pinocchio_motion_hpp__
 
 #include "pinocchio/spatial/fwd.hpp"
 #include "pinocchio/macros.hpp"
@@ -66,4 +66,4 @@ namespace se3
 #include "pinocchio/spatial/motion-ref.hpp"
 #include "pinocchio/spatial/motion-zero.hpp"
 
-#endif // ifndef __se3_motion_hpp__
+#endif // ifndef __pinocchio_motion_hpp__

--- a/src/spatial/se3-base.hpp
+++ b/src/spatial/se3-base.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_se3_base_hpp__
-#define __se3_se3_base_hpp__
+#ifndef __pinocchio_se3_base_hpp__
+#define __pinocchio_se3_base_hpp__
 
 namespace se3
 {
@@ -116,4 +116,4 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_se3_base_hpp__
+#endif // ifndef __pinocchio_se3_base_hpp__

--- a/src/spatial/se3-base.hpp
+++ b/src/spatial/se3-base.hpp
@@ -19,7 +19,7 @@
 #ifndef __pinocchio_se3_base_hpp__
 #define __pinocchio_se3_base_hpp__
 
-namespace se3
+namespace pinocchio
 {
   /** The rigid transform aMb can be seen in two ways:
    *
@@ -114,6 +114,6 @@ namespace se3
     
   }; // struct SE3Base
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_se3_base_hpp__

--- a/src/spatial/se3-tpl.hpp
+++ b/src/spatial/se3-tpl.hpp
@@ -22,7 +22,7 @@
 #include <Eigen/Geometry>
 #include "pinocchio/math/quaternion.hpp"
 
-namespace se3
+namespace pinocchio
 {
   template<typename _Scalar, int _Options>
   struct traits< SE3Tpl<_Scalar,_Options> >
@@ -273,7 +273,7 @@ namespace se3
     
   }; // class SE3Tpl
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_se3_tpl_hpp__
 

--- a/src/spatial/se3-tpl.hpp
+++ b/src/spatial/se3-tpl.hpp
@@ -16,8 +16,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_se3_tpl_hpp__
-#define __se3_se3_tpl_hpp__
+#ifndef __pinocchio_se3_tpl_hpp__
+#define __pinocchio_se3_tpl_hpp__
 
 #include <Eigen/Geometry>
 #include "pinocchio/math/quaternion.hpp"
@@ -275,5 +275,5 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_se3_tpl_hpp__
+#endif // ifndef __pinocchio_se3_tpl_hpp__
 

--- a/src/spatial/se3.hpp
+++ b/src/spatial/se3.hpp
@@ -43,7 +43,7 @@ SE3_TYPEDEF_GENERIC(Derived,typename)
 #define SE3_TYPEDEF(Derived) \
 SE3_TYPEDEF_GENERIC(Derived,PINOCCHIO_MACRO_EMPTY_ARG)
 
-namespace se3
+namespace pinocchio
 {
 
   /* Type returned by the "se3Action" and "se3ActionInverse" functions. */
@@ -53,7 +53,7 @@ namespace se3
     struct SE3GroupAction { typedef D ReturnType; };
   }
 
-} // namespace se3
+} // namespace pinocchio
 
 #include "pinocchio/spatial/se3-base.hpp"
 #include "pinocchio/spatial/se3-tpl.hpp"

--- a/src/spatial/se3.hpp
+++ b/src/spatial/se3.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_se3_hpp__
-#define __se3_se3_hpp__
+#ifndef __pinocchio_se3_hpp__
+#define __pinocchio_se3_hpp__
 
 #include "pinocchio/spatial/fwd.hpp"
 #include "pinocchio/macros.hpp"
@@ -58,4 +58,4 @@ namespace se3
 #include "pinocchio/spatial/se3-base.hpp"
 #include "pinocchio/spatial/se3-tpl.hpp"
 
-#endif // ifndef __se3_se3_hpp__
+#endif // ifndef __pinocchio_se3_hpp__

--- a/src/spatial/skew.hpp
+++ b/src/spatial/skew.hpp
@@ -20,7 +20,7 @@
 
 #include "pinocchio/macros.hpp"
 
-namespace se3
+namespace pinocchio
 {
   
   ///
@@ -254,6 +254,6 @@ namespace se3
     return res;
   }
   
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_skew_hpp__

--- a/src/spatial/skew.hpp
+++ b/src/spatial/skew.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_skew_hpp__
-#define __se3_skew_hpp__
+#ifndef __pinocchio_skew_hpp__
+#define __pinocchio_skew_hpp__
 
 #include "pinocchio/macros.hpp"
 
@@ -256,4 +256,4 @@ namespace se3
   
 } // namespace se3
 
-#endif // ifndef __se3_skew_hpp__
+#endif // ifndef __pinocchio_skew_hpp__

--- a/src/spatial/spatial-axis.hpp
+++ b/src/spatial/spatial-axis.hpp
@@ -23,7 +23,7 @@
 #include "pinocchio/spatial/motion.hpp"
 #include "pinocchio/spatial/force.hpp"
 
-namespace se3
+namespace pinocchio
 {
   template<int axis> struct SpatialAxis;
   

--- a/src/spatial/spatial-axis.hpp
+++ b/src/spatial/spatial-axis.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_spatial_axis_hpp__
-#define __se3_spatial_axis_hpp__
+#ifndef __pinocchio_spatial_axis_hpp__
+#define __pinocchio_spatial_axis_hpp__
 
 #include "pinocchio/spatial/fwd.hpp"
 #include "pinocchio/spatial/cartesian-axis.hpp"
@@ -160,4 +160,4 @@ namespace se3
   typedef SpatialAxis<5> AxisWZ;
 }
 
-#endif // __se3_spatial_axis_hpp__
+#endif // __pinocchio_spatial_axis_hpp__

--- a/src/spatial/symmetric3.hpp
+++ b/src/spatial/symmetric3.hpp
@@ -24,8 +24,8 @@
 // the Free Software Foundation, either version 3 of the License, or
 // (at your option) any later version.
 
-#ifndef __se3_symmetric3_hpp__
-#define __se3_symmetric3_hpp__
+#ifndef __pinocchio_symmetric3_hpp__
+#define __pinocchio_symmetric3_hpp__
 
 #include "pinocchio/macros.hpp"
 
@@ -490,5 +490,5 @@ namespace se3
 
 } // namespace se3
 
-#endif // ifndef __se3_symmetric3_hpp__
+#endif // ifndef __pinocchio_symmetric3_hpp__
 

--- a/src/spatial/symmetric3.hpp
+++ b/src/spatial/symmetric3.hpp
@@ -29,7 +29,7 @@
 
 #include "pinocchio/macros.hpp"
 
-namespace se3
+namespace pinocchio
 {
 
   template<typename _Scalar, int _Options>
@@ -488,7 +488,7 @@ namespace se3
     
   };
 
-} // namespace se3
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_symmetric3_hpp__
 

--- a/src/utils/axis-label.hpp
+++ b/src/utils/axis-label.hpp
@@ -18,7 +18,7 @@
 #ifndef __pinocchio_axis_label_hpp__
 #define __pinocchio_axis_label_hpp__
 
-namespace se3
+namespace pinocchio
 {
   
   ///

--- a/src/utils/axis-label.hpp
+++ b/src/utils/axis-label.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_axis_label_hpp__
-#define __se3_axis_label_hpp__
+#ifndef __pinocchio_axis_label_hpp__
+#define __pinocchio_axis_label_hpp__
 
 namespace se3
 {
@@ -35,4 +35,4 @@ namespace se3
   template<> inline char axisLabel<2>() { return 'Z'; }
 }
 
-#endif // __se3_axis_label_hpp__
+#endif // __pinocchio_axis_label_hpp__

--- a/src/utils/eigen-fix.hpp
+++ b/src/utils/eigen-fix.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_utils_eigen_fix_hpp__
-#define __se3_utils_eigen_fix_hpp__
+#ifndef __pinocchio_utils_eigen_fix_hpp__
+#define __pinocchio_utils_eigen_fix_hpp__
 
 /// \brief Fix issue concerning 3.2.90 and more versions of Eigen that do not define size_of_xpr_at_compile_time structure.
 #if EIGEN_VERSION_AT_LEAST(3,2,90) && !EIGEN_VERSION_AT_LEAST(3,3,0)
@@ -59,5 +59,5 @@ namespace Eigen
   }
 } // namespace fix
 
-#endif // ifndef __se3_utils_eigen_fix_hpp__
+#endif // ifndef __pinocchio_utils_eigen_fix_hpp__
 

--- a/src/utils/eigen-fix.hpp
+++ b/src/utils/eigen-fix.hpp
@@ -20,7 +20,7 @@
 
 /// \brief Fix issue concerning 3.2.90 and more versions of Eigen that do not define size_of_xpr_at_compile_time structure.
 #if EIGEN_VERSION_AT_LEAST(3,2,90) && !EIGEN_VERSION_AT_LEAST(3,3,0)
-namespace se3
+namespace pinocchio
 {
   namespace internal
   {

--- a/src/utils/file-explorer.hpp
+++ b/src/utils/file-explorer.hpp
@@ -22,7 +22,7 @@
 #include <iostream>
 #include <vector>
 
-namespace se3
+namespace pinocchio
 {
 
   /**

--- a/src/utils/file-explorer.hpp
+++ b/src/utils/file-explorer.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_file_explorer_hpp__
-#define __se3_file_explorer_hpp__
+#ifndef __pinocchio_file_explorer_hpp__
+#define __pinocchio_file_explorer_hpp__
 
 #include <string>
 #include <iostream>
@@ -73,4 +73,4 @@ namespace se3
 
 }
 
-#endif // __se3_file_explorer_hpp__
+#endif // __pinocchio_file_explorer_hpp__

--- a/src/utils/string-generator.hpp
+++ b/src/utils/string-generator.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_string_generator_hpp__
-#define __se3_string_generator_hpp__
+#ifndef __pinocchio_string_generator_hpp__
+#define __pinocchio_string_generator_hpp__
 
 #include <string>
 #include <cstdlib>
@@ -45,4 +45,4 @@ namespace se3
   }
 }
 
-#endif // __se3_string_generator_hpp__
+#endif // __pinocchio_string_generator_hpp__

--- a/src/utils/string-generator.hpp
+++ b/src/utils/string-generator.hpp
@@ -21,7 +21,7 @@
 #include <string>
 #include <cstdlib>
 
-namespace se3
+namespace pinocchio
 {
 
   ///

--- a/src/utils/version.hpp
+++ b/src/utils/version.hpp
@@ -23,7 +23,7 @@
 #include <string>
 #include <sstream>
 
-namespace se3
+namespace pinocchio
 {
   
   ///

--- a/src/utils/version.hpp
+++ b/src/utils/version.hpp
@@ -15,8 +15,8 @@
 // Pinocchio If not, see
 // <http://www.gnu.org/licenses/>.
 
-#ifndef __se3_utils_version_hpp__
-#define __se3_utils_version_hpp__
+#ifndef __pinocchio_utils_version_hpp__
+#define __pinocchio_utils_version_hpp__
 
 #include "pinocchio/config.hpp"
 
@@ -65,4 +65,4 @@ namespace se3
   }
 }
 
-#endif // __se3_utils_version_hpp__
+#endif // __pinocchio_utils_version_hpp__

--- a/unittest/aba-derivatives.cpp
+++ b/unittest/aba-derivatives.cpp
@@ -38,7 +38,7 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
 BOOST_AUTO_TEST_CASE(test_aba_derivatives)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
   Model model;
   buildModels::humanoidRandom(model);
@@ -136,7 +136,7 @@ BOOST_AUTO_TEST_CASE(test_aba_derivatives)
 BOOST_AUTO_TEST_CASE(test_aba_minimal_argument)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
   Model model;
   buildModels::humanoidRandom(model);
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(test_aba_minimal_argument)
 BOOST_AUTO_TEST_CASE(test_aba_derivatives_fext)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
   Model model;
   buildModels::humanoidRandom(model);

--- a/unittest/aba.cpp
+++ b/unittest/aba.cpp
@@ -38,11 +38,11 @@
 BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 
 template<typename JointModel>
-void test_joint_methods(const se3::JointModelBase<JointModel> & jmodel)
+void test_joint_methods(const pinocchio::JointModelBase<JointModel> & jmodel)
 {
-  typedef typename se3::JointModelBase<JointModel>::JointDataDerived JointData;
+  typedef typename pinocchio::JointModelBase<JointModel>::JointDataDerived JointData;
   typedef typename JointModel::ConfigVector_t ConfigVector_t;
-  typedef typename se3::LieGroup<JointModel>::type LieGroupType;
+  typedef typename pinocchio::LieGroup<JointModel>::type LieGroupType;
 
   JointData jdata = jmodel.createData();
 
@@ -50,8 +50,8 @@ void test_joint_methods(const se3::JointModelBase<JointModel> & jmodel)
   ConfigVector_t qu(ConfigVector_t::Constant(jmodel.nq(),M_PI));
 
   ConfigVector_t q = LieGroupType().randomConfiguration(ql,qu);
-  se3::Inertia::Matrix6 I(se3::Inertia::Random().matrix());
-  se3::Inertia::Matrix6 I_check = I;
+  pinocchio::Inertia::Matrix6 I(pinocchio::Inertia::Random().matrix());
+  pinocchio::Inertia::Matrix6 I_check = I;
 
   jmodel.calc(jdata,q);
   jmodel.calc_aba(jdata,I,true);
@@ -81,7 +81,7 @@ void test_joint_methods(const se3::JointModelBase<JointModel> & jmodel)
 struct TestJointMethods{
 
   template <typename JointModel>
-  void operator()(const se3::JointModelBase<JointModel> &) const
+  void operator()(const pinocchio::JointModelBase<JointModel> &) const
   {
     JointModel jmodel;
     jmodel.setIndexes(0,0,0);
@@ -89,11 +89,11 @@ struct TestJointMethods{
     test_joint_methods(jmodel);
   }
 
-  void operator()(const se3::JointModelBase<se3::JointModelComposite> &) const
+  void operator()(const pinocchio::JointModelBase<pinocchio::JointModelComposite> &) const
   {
-    se3::JointModelComposite jmodel_composite;
-    jmodel_composite.addJoint(se3::JointModelRX());
-    jmodel_composite.addJoint(se3::JointModelRY());
+    pinocchio::JointModelComposite jmodel_composite;
+    jmodel_composite.addJoint(pinocchio::JointModelRX());
+    jmodel_composite.addJoint(pinocchio::JointModelRY());
     jmodel_composite.setIndexes(0,0,0);
 
     //TODO: correct LieGroup
@@ -101,17 +101,17 @@ struct TestJointMethods{
 
   }
 
-  void operator()(const se3::JointModelBase<se3::JointModelRevoluteUnaligned> &) const
+  void operator()(const pinocchio::JointModelBase<pinocchio::JointModelRevoluteUnaligned> &) const
   {
-    se3::JointModelRevoluteUnaligned jmodel(1.5, 1., 0.);
+    pinocchio::JointModelRevoluteUnaligned jmodel(1.5, 1., 0.);
     jmodel.setIndexes(0,0,0);
 
     test_joint_methods(jmodel);
   }
 
-  void operator()(const se3::JointModelBase<se3::JointModelPrismaticUnaligned> &) const
+  void operator()(const pinocchio::JointModelBase<pinocchio::JointModelPrismaticUnaligned> &) const
   {
-    se3::JointModelPrismaticUnaligned jmodel(1.5, 1., 0.);
+    pinocchio::JointModelPrismaticUnaligned jmodel(1.5, 1., 0.);
     jmodel.setIndexes(0,0,0);
 
     test_joint_methods(jmodel);
@@ -121,7 +121,7 @@ struct TestJointMethods{
 
 BOOST_AUTO_TEST_CASE( test_joint_basic )
 {
-  using namespace se3;
+  using namespace pinocchio;
 
   typedef boost::variant< JointModelRX, JointModelRY, JointModelRZ, JointModelRevoluteUnaligned
   , JointModelSpherical, JointModelSphericalZYX
@@ -139,12 +139,12 @@ BOOST_AUTO_TEST_CASE( test_joint_basic )
 BOOST_AUTO_TEST_CASE ( test_aba_simple )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
-  se3::Model model; buildModels::humanoidRandom(model);
+  pinocchio::Model model; buildModels::humanoidRandom(model);
   
-  se3::Data data(model);
-  se3::Data data_ref(model);
+  pinocchio::Data data(model);
+  pinocchio::Data data_ref(model);
 
   VectorXd q = VectorXd::Ones(model.nq);
   q.segment<4>(3).normalize();
@@ -168,11 +168,11 @@ BOOST_AUTO_TEST_CASE ( test_aba_simple )
 BOOST_AUTO_TEST_CASE ( test_aba_with_fext )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
-  se3::Model model; buildModels::humanoidRandom(model);
+  pinocchio::Model model; buildModels::humanoidRandom(model);
   
-  se3::Data data(model);
+  pinocchio::Data data(model);
   
   VectorXd q = VectorXd::Random(model.nq);
   q.segment<4>(3).normalize();
@@ -203,12 +203,12 @@ BOOST_AUTO_TEST_CASE ( test_aba_with_fext )
 BOOST_AUTO_TEST_CASE ( test_aba_vs_rnea )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
-  se3::Model model; buildModels::humanoidRandom(model);
+  pinocchio::Model model; buildModels::humanoidRandom(model);
   
-  se3::Data data(model);
-  se3::Data data_ref(model);
+  pinocchio::Data data(model);
+  pinocchio::Data data_ref(model);
   
   VectorXd q = VectorXd::Ones(model.nq);
   VectorXd v = VectorXd::Ones(model.nv);
@@ -234,14 +234,14 @@ BOOST_AUTO_TEST_CASE ( test_aba_vs_rnea )
 BOOST_AUTO_TEST_CASE ( test_computeMinverse )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
-  se3::Model model;
+  pinocchio::Model model;
   buildModels::humanoidRandom(model);
   model.gravity.setZero();
   
-  se3::Data data(model);
-  se3::Data data_ref(model);
+  pinocchio::Data data(model);
+  pinocchio::Data data_ref(model);
   
   model.lowerPositionLimit.head<3>().fill(-1.);
   model.upperPositionLimit.head<3>().fill(1.);

--- a/unittest/algo-check.cpp
+++ b/unittest/algo-check.cpp
@@ -25,7 +25,7 @@
 #include <pinocchio/algorithm/default-check.hpp>
 #include <iostream>
 
-using namespace se3;
+using namespace pinocchio;
 
 #include <boost/test/unit_test.hpp>
 #include <boost/utility/binary.hpp>
@@ -42,7 +42,7 @@ BOOST_AUTO_TEST_CASE ( test_check )
 {
   using namespace boost::fusion;
 
-  se3::Model model; buildModels::humanoidRandom(model);
+  pinocchio::Model model; buildModels::humanoidRandom(model);
   
   BOOST_CHECK(model.check (Check1()));
   BOOST_CHECK(model.check (CRBAChecker()));
@@ -54,7 +54,7 @@ BOOST_AUTO_TEST_CASE ( test_check )
   BOOST_CHECK(model.check(makeAlgoCheckerList(Check1(),ParentChecker(),CRBAChecker()) ));
   BOOST_CHECK(model.check(DEFAULT_CHECKERS));
 
-  se3::Data data(model);
+  pinocchio::Data data(model);
   BOOST_CHECK(checkData(model,data));
   BOOST_CHECK(model.check(data));
   

--- a/unittest/centroidal.cpp
+++ b/unittest/centroidal.cpp
@@ -32,14 +32,14 @@
 #include <boost/utility/binary.hpp>
 
 template<typename JointModel>
-static void addJointAndBody(se3::Model & model,
-                            const se3::JointModelBase<JointModel> & joint,
+static void addJointAndBody(pinocchio::Model & model,
+                            const pinocchio::JointModelBase<JointModel> & joint,
                             const std::string & parent_name,
                             const std::string & name,
-                            const se3::SE3 placement = se3::SE3::Random(),
+                            const pinocchio::SE3 placement = pinocchio::SE3::Random(),
                             bool setRandomLimits = true)
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef typename JointModel::ConfigVector_t CV;
   typedef typename JointModel::TangentVector_t TV;
   
@@ -68,9 +68,9 @@ BOOST_AUTO_TEST_SUITE( BOOST_TEST_MODULE )
   
 BOOST_AUTO_TEST_CASE (test_ccrba)
 {
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model);
-  se3::Data data(model), data_ref(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model);
+  pinocchio::Data data(model), data_ref(model);
   
   Eigen::VectorXd q = Eigen::VectorXd::Ones(model.nq);
   q.segment <4> (3).normalize();
@@ -80,25 +80,25 @@ BOOST_AUTO_TEST_CASE (test_ccrba)
   data_ref.M.triangularView<Eigen::StrictlyLower>() = data_ref.M.transpose().triangularView<Eigen::StrictlyLower>();
   data_ref.Ycrb[0] = data_ref.liMi[1].act(data_ref.Ycrb[1]);
   
-  se3::SE3 cMo (se3::SE3::Matrix3::Identity(), -getComFromCrba(model, data_ref));
+  pinocchio::SE3 cMo (pinocchio::SE3::Matrix3::Identity(), -getComFromCrba(model, data_ref));
   
   ccrba(model, data, q, v);
   BOOST_CHECK(data.com[0].isApprox(-cMo.translation(),1e-12));
   BOOST_CHECK(data.Ycrb[0].matrix().isApprox(data_ref.Ycrb[0].matrix(),1e-12));
   
-  se3::Inertia Ig_ref (cMo.act(data.Ycrb[0]));
+  pinocchio::Inertia Ig_ref (cMo.act(data.Ycrb[0]));
   BOOST_CHECK(data.Ig.matrix().isApprox(Ig_ref.matrix(),1e-12));
   
-  se3::SE3 oM1 (data_ref.liMi[1]);
-  se3::SE3 cM1 (cMo * oM1);
+  pinocchio::SE3 oM1 (data_ref.liMi[1]);
+  pinocchio::SE3 cM1 (cMo * oM1);
   
-  se3::Data::Matrix6x Ag_ref (cM1.inverse().toActionMatrix().transpose() * data_ref.M.topRows <6> ());
+  pinocchio::Data::Matrix6x Ag_ref (cM1.inverse().toActionMatrix().transpose() * data_ref.M.topRows <6> ());
   BOOST_CHECK(data.Ag.isApprox(Ag_ref,1e-12));
 }
   
 BOOST_AUTO_TEST_CASE (test_dccrb)
 {
-  using namespace se3;
+  using namespace pinocchio;
   Model model;
   buildModels::humanoidRandom(model);
   addJointAndBody(model,JointModelSpherical(),"larm6_joint","larm7");
@@ -253,7 +253,7 @@ BOOST_AUTO_TEST_CASE (test_dccrb)
 
 BOOST_AUTO_TEST_CASE (test_computeCentroidalDynamics)
 {
-  using namespace se3;
+  using namespace pinocchio;
   Model model;
   buildModels::humanoidRandom(model);
   addJointAndBody(model,JointModelSpherical(),"larm6_joint","larm7");

--- a/unittest/cholesky.cpp
+++ b/unittest/cholesky.cpp
@@ -45,11 +45,11 @@ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 BOOST_AUTO_TEST_CASE ( test_cholesky )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model,true);
-  se3::Data data(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model,true);
+  pinocchio::Data data(model);
   
   model.lowerPositionLimit.head<3>().fill(-1.);
   model.upperPositionLimit.head<3>().fill(1.);
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE ( test_cholesky )
   data.M.fill(0); // Only nonzero coeff of M are initialized by CRBA.
   crba(model,data,q);
  
-  se3::cholesky::decompose(model,data);
+  pinocchio::cholesky::decompose(model,data);
   data.M.triangularView<Eigen::StrictlyLower>() = 
   data.M.triangularView<Eigen::StrictlyUpper>().transpose();
   
@@ -76,25 +76,25 @@ BOOST_AUTO_TEST_CASE ( test_cholesky )
   Eigen::VectorXd v = Eigen::VectorXd::Random(model.nv);
 // std::cout << "v = [" << v.transpose() << "]';" << std::endl;
 
-  Eigen::VectorXd Uv = v; se3::cholesky::Uv(model,data,Uv);
+  Eigen::VectorXd Uv = v; pinocchio::cholesky::Uv(model,data,Uv);
   BOOST_CHECK(Uv.isApprox(U*v, 1e-12));
 
-  Eigen::VectorXd Utv = v; se3::cholesky::Utv(model,data,Utv);
+  Eigen::VectorXd Utv = v; pinocchio::cholesky::Utv(model,data,Utv);
   BOOST_CHECK(Utv.isApprox(U.transpose()*v, 1e-12));
 
-  Eigen::VectorXd Uiv = v; se3::cholesky::Uiv(model,data,Uiv);
+  Eigen::VectorXd Uiv = v; pinocchio::cholesky::Uiv(model,data,Uiv);
   BOOST_CHECK(Uiv.isApprox(U.inverse()*v, 1e-12));
 
 
-  Eigen::VectorXd Utiv = v; se3::cholesky::Utiv(model,data,Utiv);
+  Eigen::VectorXd Utiv = v; pinocchio::cholesky::Utiv(model,data,Utiv);
   BOOST_CHECK(Utiv.isApprox(U.transpose().inverse()*v, 1e-12));
 
-  Eigen::VectorXd Miv = v; se3::cholesky::solve(model,data,Miv);
+  Eigen::VectorXd Miv = v; pinocchio::cholesky::solve(model,data,Miv);
   BOOST_CHECK(Miv.isApprox(M.inverse()*v, 1e-12));
 
-  Eigen::VectorXd Mv = v; Mv = se3::cholesky::Mv(model,data,Mv);
+  Eigen::VectorXd Mv = v; Mv = pinocchio::cholesky::Mv(model,data,Mv);
   BOOST_CHECK(Mv.isApprox(M*v, 1e-12));
-  Mv = v;                 se3::cholesky::UDUtv(model,data,Mv);
+  Mv = v;                 pinocchio::cholesky::UDUtv(model,data,Mv);
   BOOST_CHECK(Mv.isApprox(M*v, 1e-12));
 }
 
@@ -110,11 +110,11 @@ BOOST_AUTO_TEST_CASE ( test_cholesky )
 BOOST_AUTO_TEST_CASE ( test_timings )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model,true);
-  se3::Data data(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model,true);
+  pinocchio::Data data(model);
   
   model.lowerPositionLimit.head<3>().fill(-1.);
   model.upperPositionLimit.head<3>().fill(1.);
@@ -144,7 +144,7 @@ BOOST_AUTO_TEST_CASE ( test_timings )
       timer.tic();
       SMOOTH(NBT)
       {
-	se3::cholesky::decompose(model,data);
+	pinocchio::cholesky::decompose(model,data);
       }
       if(verbose) std::cout << "Decompose =\t";
       timer.toc(std::cout,NBT);
@@ -177,7 +177,7 @@ BOOST_AUTO_TEST_CASE ( test_timings )
 	  timer.tic();
 	  SMOOTH(NBT)
 	  {
-	    se3::cholesky::solve(model,data,randvec[_smooth]);
+	    pinocchio::cholesky::solve(model,data,randvec[_smooth]);
 	  }
 	  if(verbose) std::cout << "solve =\t\t";
 	  timer.toc(std::cout,NBT);
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE ( test_timings )
 	  timer.tic();
 	  SMOOTH(NBT)
 	  {
-	    se3::cholesky::Uv(model,data,randvec[_smooth]);
+	    pinocchio::cholesky::Uv(model,data,randvec[_smooth]);
 	  }
 	  if(verbose) std::cout << "Uv =\t\t";
 	  timer.toc(std::cout,NBT);
@@ -199,7 +199,7 @@ BOOST_AUTO_TEST_CASE ( test_timings )
 	  timer.tic();
 	  SMOOTH(NBT)
 	  {
-	    se3::cholesky::Uiv(model,data,randvec[_smooth]);
+	    pinocchio::cholesky::Uiv(model,data,randvec[_smooth]);
 	  }
 	  if(verbose) std::cout << "Uiv =\t\t";
 	  timer.toc(std::cout,NBT);
@@ -210,7 +210,7 @@ BOOST_AUTO_TEST_CASE ( test_timings )
 	  Eigen::VectorXd res;
 	  SMOOTH(NBT)
 	  {
-	    res = se3::cholesky::Mv(model,data,randvec[_smooth]);
+	    res = pinocchio::cholesky::Mv(model,data,randvec[_smooth]);
 	  }
 	  if(verbose) std::cout << "Mv =\t\t";
 	  timer.toc(std::cout,NBT);
@@ -220,7 +220,7 @@ BOOST_AUTO_TEST_CASE ( test_timings )
     timer.tic();
     SMOOTH(NBT)
     {
-      se3::cholesky::UDUtv(model,data,randvec[_smooth]);
+      pinocchio::cholesky::UDUtv(model,data,randvec[_smooth]);
     }
     if(verbose) std::cout << "UDUtv =\t\t";
     timer.toc(std::cout,NBT);
@@ -231,11 +231,11 @@ BOOST_AUTO_TEST_CASE ( test_timings )
   BOOST_AUTO_TEST_CASE(test_Minv_from_cholesky)
   {
     using namespace Eigen;
-    using namespace se3;
+    using namespace pinocchio;
     
-    se3::Model model;
-    se3::buildModels::humanoidRandom(model,true);
-    se3::Data data(model);
+    pinocchio::Model model;
+    pinocchio::buildModels::humanoidRandom(model,true);
+    pinocchio::Data data(model);
     
     model.lowerPositionLimit.head<3>().fill(-1.);
     model.upperPositionLimit.head<3>().fill(1.);

--- a/unittest/com.cpp
+++ b/unittest/com.cpp
@@ -34,11 +34,11 @@ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 BOOST_AUTO_TEST_CASE ( test_com )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model);
-  se3::Data data(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model);
+  pinocchio::Data data(model);
 
   VectorXd q = VectorXd::Ones(model.nq);
   q.middleRows<4> (3).normalize();
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE ( test_com )
   centerOfMass(model,data,q,v,a);
   nonLinearEffects(model, data, q, v);
   
-  se3::SE3::Vector3 acom_from_nle (data.nle.head <3> ()/data.mass[0]);
+  pinocchio::SE3::Vector3 acom_from_nle (data.nle.head <3> ()/data.mass[0]);
   BOOST_CHECK((data.liMi[1].rotation() * acom_from_nle).isApprox(data.acom[0], 1e-12));
 
 	/* Test Jcom against CRBA  */
@@ -93,11 +93,11 @@ BOOST_AUTO_TEST_CASE ( test_com )
 //BOOST_AUTO_TEST_CASE ( test_timings )
 //{
 //  using namespace Eigen;
-//  using namespace se3;
+//  using namespace pinocchio;
 //
-//  se3::Model model;
-//  se3::buildModels::humanoidRandom(model);
-//  se3::Data data(model);
+//  pinocchio::Model model;
+//  pinocchio::buildModels::humanoidRandom(model);
+//  pinocchio::Data data(model);
 //
 //  long flag = BOOST_BINARY(1111);
 //  PinocchioTicToc timer(PinocchioTicToc::US); 

--- a/unittest/compute-all-terms.cpp
+++ b/unittest/compute-all-terms.cpp
@@ -43,11 +43,11 @@ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 BOOST_AUTO_TEST_CASE ( test_against_algo )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
-  se3::Model model; buildModels::humanoidRandom(model);
-  se3::Data data(model); data.M.fill (0.);
-  se3::Data data_other(model); data_other.M.fill (0.);
+  pinocchio::Model model; buildModels::humanoidRandom(model);
+  pinocchio::Data data(model); data.M.fill (0.);
+  pinocchio::Data data_other(model); data_other.M.fill (0.);
 
   VectorXd q (VectorXd::Random(model.nq));
   VectorXd v (VectorXd::Random(model.nv));

--- a/unittest/constraint.cpp
+++ b/unittest/constraint.cpp
@@ -31,7 +31,7 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
 
 BOOST_AUTO_TEST_CASE (test_ForceSet)
 {
-  using namespace se3;
+  using namespace pinocchio;
 
   SE3 amb = SE3::Random();
   SE3 bmc = SE3::Random();
@@ -65,7 +65,7 @@ BOOST_AUTO_TEST_CASE (test_ForceSet)
 
 BOOST_AUTO_TEST_CASE ( test_ConstraintRX )
 {
-  using namespace se3;
+  using namespace pinocchio;
 
   Inertia Y = Inertia::Random();
   JointDataRX::Constraint_t S;

--- a/unittest/copy.cpp
+++ b/unittest/copy.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
 BOOST_AUTO_TEST_CASE(test_data_copy)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
   Model model;
   buildModels::humanoidRandom(model);

--- a/unittest/cppadcg-algo.cpp
+++ b/unittest/cppadcg-algo.cpp
@@ -45,14 +45,14 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
     
     typedef Eigen::Matrix<ADScalar,Eigen::Dynamic,1> ADVector;
     
-    typedef se3::ModelTpl<Scalar> Model;
+    typedef pinocchio::ModelTpl<Scalar> Model;
     typedef Model::Data Data;
     
-    typedef se3::ModelTpl<ADScalar> ADModel;
+    typedef pinocchio::ModelTpl<ADScalar> ADModel;
     typedef ADModel::Data ADData;
     
     Model model;
-    se3::buildModels::humanoidRandom(model);
+    pinocchio::buildModels::humanoidRandom(model);
     model.lowerPositionLimit.head<3>().fill(-1.);
     model.upperPositionLimit.head<3>().fill(1.);
     Data data(model);
@@ -64,7 +64,7 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
     typedef Model::ConfigVectorType CongigVectorType;
     typedef Model::TangentVectorType TangentVectorType;
     CongigVectorType q(model.nq);
-    q = se3::randomConfiguration(model);
+    q = pinocchio::randomConfiguration(model);
     
     TangentVectorType v(TangentVectorType::Random(model.nv));
     TangentVectorType a(TangentVectorType::Random(model.nv));
@@ -79,7 +79,7 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
     ADTangentVectorType & X = ad_a;
     CppAD::Independent(X);
     
-    se3::rnea(ad_model,ad_data,ad_q,ad_v,ad_a);
+    pinocchio::rnea(ad_model,ad_data,ad_q,ad_v,ad_a);
     ADVector Y(model.nv); Y = ad_data.tau;
     
     CppAD::ADFun<CGScalar> fun(X,Y);
@@ -112,10 +112,10 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
     CPPAD_TESTVECTOR(Scalar) tau = rnea_generated->ForwardZero(x);
     
     Eigen::Map<TangentVectorType> tau_map(tau.data(),model.nv,1);
-    Data::TangentVectorType tau_ref = se3::rnea(model,data,q,v,a);
+    Data::TangentVectorType tau_ref = pinocchio::rnea(model,data,q,v,a);
     BOOST_CHECK(tau_map.isApprox(tau_ref));
     
-    se3::crba(model,data,q);
+    pinocchio::crba(model,data,q);
     data.M.triangularView<Eigen::StrictlyLower>()
     = data.M.transpose().triangularView<Eigen::StrictlyLower>();
     

--- a/unittest/cppadcg-basic.cpp
+++ b/unittest/cppadcg-basic.cpp
@@ -118,20 +118,20 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
     typedef CppAD::cg::CG<double> CGScalar;
     typedef CppAD::AD<double> ADScalar;
     typedef CppAD::AD<float> ADFloat;
-    typedef se3::ModelTpl<CGScalar> CGModel;
+    typedef pinocchio::ModelTpl<CGScalar> CGModel;
     
-    se3::SE3 M(se3::SE3::Random());
-    typedef se3::SE3Tpl<CGScalar> CGSE3;
+    pinocchio::SE3 M(pinocchio::SE3::Random());
+    typedef pinocchio::SE3Tpl<CGScalar> CGSE3;
     
     CGSE3 cg_M = M.cast<CGScalar>();
     BOOST_CHECK(cg_M.cast<double>().isApprox(M));
     
-    se3::SE3::Vector3 axis(1.,1.,1.);
+    pinocchio::SE3::Vector3 axis(1.,1.,1.);
     axis.normalize();
     BOOST_CHECK(axis.isUnitary());
     
-    se3::JointModelPrismaticUnaligned jmodel_prismatic(axis);
-    typedef se3::JointModelPrismaticUnalignedTpl<CGScalar> CGJointModelPrismaticUnaligned;
+    pinocchio::JointModelPrismaticUnaligned jmodel_prismatic(axis);
+    typedef pinocchio::JointModelPrismaticUnalignedTpl<CGScalar> CGJointModelPrismaticUnaligned;
     
     CGScalar cg_value; cg_value = -1.;
     ADScalar ad_value; ad_value = -1.;
@@ -145,8 +145,8 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
     Eigen::numext::abs<CGScalar>(cg_value);
     CGJointModelPrismaticUnaligned cg_jmodel_prismatic(axis.cast<CGScalar>());
     
-    se3::Model model;
-    se3::buildModels::humanoidRandom(model);
+    pinocchio::Model model;
+    pinocchio::buildModels::humanoidRandom(model);
     
     CGModel cg_model = model.cast<CGScalar>();
     

--- a/unittest/crba.cpp
+++ b/unittest/crba.cpp
@@ -40,14 +40,14 @@
 #include <boost/utility/binary.hpp>
 
 template<typename JointModel>
-static void addJointAndBody(se3::Model & model,
-                            const se3::JointModelBase<JointModel> & joint,
+static void addJointAndBody(pinocchio::Model & model,
+                            const pinocchio::JointModelBase<JointModel> & joint,
                             const std::string & parent_name,
                             const std::string & name,
-                            const se3::SE3 placement = se3::SE3::Random(),
+                            const pinocchio::SE3 placement = pinocchio::SE3::Random(),
                             bool setRandomLimits = true)
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef typename JointModel::ConfigVector_t CV;
   typedef typename JointModel::TangentVector_t TV;
   
@@ -76,9 +76,9 @@ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 
 BOOST_AUTO_TEST_CASE ( test_crba )
 {
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model);
-  se3::Data data(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model);
+  pinocchio::Data data(model);
   
   #ifdef NDEBUG
     #ifdef _INTENSE_TESTING_
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE ( test_crba )
   #else
     const size_t NBT = 1;
     using namespace Eigen;
-    using namespace se3;
+    using namespace pinocchio;
 
     Eigen::MatrixXd M(model.nv,model.nv);
     Eigen::VectorXd q = Eigen::VectorXd::Ones(model.nq);
@@ -137,9 +137,9 @@ BOOST_AUTO_TEST_CASE ( test_crba )
   
 BOOST_AUTO_TEST_CASE(test_minimal_crba)
 {
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model);
-  se3::Data data(model), data_ref(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model);
+  pinocchio::Data data(model), data_ref(model);
   
   model.lowerPositionLimit.head<7>().fill(-1.);
   model.upperPositionLimit.head<7>().fill(1.);

--- a/unittest/dynamics.cpp
+++ b/unittest/dynamics.cpp
@@ -34,16 +34,16 @@ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 BOOST_AUTO_TEST_CASE ( test_FD )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model,true);
-  se3::Data data(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model,true);
+  pinocchio::Data data(model);
   
   VectorXd q = VectorXd::Ones(model.nq);
   q.segment <4> (3).normalize();
   
-  se3::computeJointJacobians(model, data, q);
+  pinocchio::computeJointJacobians(model, data, q);
   
   VectorXd v = VectorXd::Ones(model.nv);
   VectorXd tau = VectorXd::Zero(model.nv);
@@ -67,7 +67,7 @@ BOOST_AUTO_TEST_CASE ( test_FD )
   
   Eigen::MatrixXd H(J.transpose());
   
-  se3::forwardDynamics(model, data, q, v, tau, J, gamma, 0.,true);
+  pinocchio::forwardDynamics(model, data, q, v, tau, J, gamma, 0.,true);
   data.M.triangularView<Eigen::StrictlyLower>() = data.M.transpose().triangularView<Eigen::StrictlyLower>();
   
   MatrixXd Minv (data.M.inverse());
@@ -98,16 +98,16 @@ BOOST_AUTO_TEST_CASE ( test_FD )
 BOOST_AUTO_TEST_CASE ( test_FD_with_damping )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model,true);
-  se3::Data data(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model,true);
+  pinocchio::Data data(model);
   
   VectorXd q = VectorXd::Ones(model.nq);
   q.segment <4> (3).normalize();
   
-  se3::computeJointJacobians(model, data, q);
+  pinocchio::computeJointJacobians(model, data, q);
   
   VectorXd v = VectorXd::Ones(model.nv);
   VectorXd tau = VectorXd::Zero(model.nv);
@@ -126,7 +126,7 @@ BOOST_AUTO_TEST_CASE ( test_FD_with_damping )
   Eigen::VectorXd gamma (VectorXd::Ones(12));
 
   // Forward Dynamics with damping
-  se3::forwardDynamics(model, data, q, v, tau, J, gamma, 1e-12,true);
+  pinocchio::forwardDynamics(model, data, q, v, tau, J, gamma, 1e-12,true);
 
   // Matrix Definitions
   Eigen::MatrixXd H(J.transpose());
@@ -153,16 +153,16 @@ BOOST_AUTO_TEST_CASE ( test_FD_with_damping )
 BOOST_AUTO_TEST_CASE ( test_ID )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model,true);
-  se3::Data data(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model,true);
+  pinocchio::Data data(model);
   
   VectorXd q = VectorXd::Ones(model.nq);
   q.segment <4> (3).normalize();
   
-  se3::computeJointJacobians(model, data, q);
+  pinocchio::computeJointJacobians(model, data, q);
   
   VectorXd v_before = VectorXd::Ones(model.nv);
   
@@ -185,7 +185,7 @@ BOOST_AUTO_TEST_CASE ( test_ID )
   
   Eigen::MatrixXd H(J.transpose());
   
-  se3::impulseDynamics(model, data, q, v_before, J, r_coeff, true);
+  pinocchio::impulseDynamics(model, data, q, v_before, J, r_coeff, true);
   data.M.triangularView<Eigen::StrictlyLower>() = data.M.transpose().triangularView<Eigen::StrictlyLower>();
   
   MatrixXd Minv (data.M.inverse());
@@ -212,11 +212,11 @@ BOOST_AUTO_TEST_CASE ( test_ID )
 BOOST_AUTO_TEST_CASE (timings_fd_llt)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model,true);
-  se3::Data data(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model,true);
+  pinocchio::Data data(model);
   
 #ifdef NDEBUG
 #ifdef _INTENSE_TESTING_
@@ -233,7 +233,7 @@ BOOST_AUTO_TEST_CASE (timings_fd_llt)
   VectorXd q = VectorXd::Ones(model.nq);
   q.segment <4> (3).normalize();
   
-  se3::computeJointJacobians(model, data, q);
+  pinocchio::computeJointJacobians(model, data, q);
   
   VectorXd v = VectorXd::Ones(model.nv);
   VectorXd tau = VectorXd::Zero(model.nv);
@@ -255,12 +255,12 @@ BOOST_AUTO_TEST_CASE (timings_fd_llt)
   model.lowerPositionLimit.head<7>().fill(-1.);
   model.upperPositionLimit.head<7>().fill( 1.);
   
-  q = se3::randomConfiguration(model);
+  q = pinocchio::randomConfiguration(model);
   
   PinocchioTicToc timer(PinocchioTicToc::US); timer.tic();
   SMOOTH(NBT)
   {
-    se3::forwardDynamics(model, data, q, v, tau, J, gamma, 0., true);
+    pinocchio::forwardDynamics(model, data, q, v, tau, J, gamma, 0., true);
   }
   timer.toc(std::cout,NBT);
   

--- a/unittest/energy.cpp
+++ b/unittest/energy.cpp
@@ -29,11 +29,11 @@ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 BOOST_AUTO_TEST_CASE(test_kinetic_energy)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model);
-  se3::Data data(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model);
+  pinocchio::Data data(model);
   
   VectorXd q = VectorXd::Zero(model.nq);
   VectorXd v = VectorXd::Ones(model.nv);

--- a/unittest/explog.cpp
+++ b/unittest/explog.cpp
@@ -23,7 +23,7 @@
 
 #include "pinocchio/spatial/explog.hpp"
 
-using namespace se3;
+using namespace pinocchio;
 
 BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 
@@ -217,7 +217,7 @@ BOOST_AUTO_TEST_CASE(Jexp3_quat_fd)
   BOOST_CHECK(Jexp3.isApprox(Jexp3_fd,sqrt(eps)));
   
   SE3::Matrix3 Jlog;
-  se3::Jlog3(quat.toRotationMatrix(),Jlog);
+  pinocchio::Jlog3(quat.toRotationMatrix(),Jlog);
   
   Matrix43 Jexp_quat_local;
   Jexp3QuatLocal(quat,Jexp_quat_local);
@@ -361,38 +361,38 @@ BOOST_AUTO_TEST_CASE(Jexplog6)
 
 BOOST_AUTO_TEST_CASE (test_basic)
 {
-  typedef se3::SE3::Vector3 Vector3;
-  typedef se3::SE3::Matrix3 Matrix3;
+  typedef pinocchio::SE3::Vector3 Vector3;
+  typedef pinocchio::SE3::Matrix3 Matrix3;
   typedef Eigen::Matrix4d Matrix4;
-  typedef se3::Motion::Vector6 Vector6;
+  typedef pinocchio::Motion::Vector6 Vector6;
   
   const double EPSILON = 1e-12;
   
   // exp3 and log3.
   Vector3 v3(Vector3::Random());
-  Matrix3 R(se3::exp3(v3));
+  Matrix3 R(pinocchio::exp3(v3));
   BOOST_CHECK(R.transpose().isApprox(R.inverse(), EPSILON));
   BOOST_CHECK_SMALL(R.determinant() - 1.0, EPSILON);
-  Vector3 v3FromLog(se3::log3(R));
+  Vector3 v3FromLog(pinocchio::log3(R));
   BOOST_CHECK(v3.isApprox(v3FromLog, EPSILON));
   
   // exp6 and log6.
-  se3::Motion nu = se3::Motion::Random();
-  se3::SE3 m = se3::exp6(nu);
+  pinocchio::Motion nu = pinocchio::Motion::Random();
+  pinocchio::SE3 m = pinocchio::exp6(nu);
   BOOST_CHECK(m.rotation().transpose().isApprox(m.rotation().inverse(),
                                                 EPSILON));
   BOOST_CHECK_SMALL(m.rotation().determinant() - 1.0, EPSILON);
-  se3::Motion nuFromLog(se3::log6(m));
+  pinocchio::Motion nuFromLog(pinocchio::log6(m));
   BOOST_CHECK(nu.linear().isApprox(nuFromLog.linear(), EPSILON));
   BOOST_CHECK(nu.angular().isApprox(nuFromLog.angular(), EPSILON));
   
   Vector6 v6(Vector6::Random());
-  se3::SE3 m2(se3::exp6(v6));
+  pinocchio::SE3 m2(pinocchio::exp6(v6));
   BOOST_CHECK(m2.rotation().transpose().isApprox(m2.rotation().inverse(),
                                                  EPSILON));
   BOOST_CHECK_SMALL(m2.rotation().determinant() - 1.0, EPSILON);
   Matrix4 M = m2.toHomogeneousMatrix();
-  se3::Motion nu2FromLog(se3::log6(M));
+  pinocchio::Motion nu2FromLog(pinocchio::log6(M));
   Vector6 v6FromLog(nu2FromLog.toVector());
   BOOST_CHECK(v6.isApprox(v6FromLog, EPSILON));
 }

--- a/unittest/finite-differences.cpp
+++ b/unittest/finite-differences.cpp
@@ -26,7 +26,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/utility/binary.hpp>
 
-using namespace se3;
+using namespace pinocchio;
 using namespace Eigen;
 
 template<bool local>
@@ -143,10 +143,10 @@ void FiniteDiffJoint::operator()< JointModelComposite > (JointModelBase<JointMod
 //  typedef typename JointModel::ConfigVector_t CV;
 //  typedef typename JointModel::TangentVector_t TV;
 //
-//  se3::JointModelComposite jmodel((se3::JointModelRX())/*, (se3::JointModelRY())*/);
+//  pinocchio::JointModelComposite jmodel((pinocchio::JointModelRX())/*, (pinocchio::JointModelRY())*/);
 //  jmodel.setIndexes(0,0,0);
 //
-//  se3::JointModelComposite::JointDataDerived jdata = jmodel.createData();
+//  pinocchio::JointModelComposite::JointDataDerived jdata = jmodel.createData();
 //
 //  CV q = jmodel.random();
 //  jmodel.calc(jdata,q);
@@ -205,9 +205,9 @@ BOOST_AUTO_TEST_CASE (test_S_finit_diff)
 
 BOOST_AUTO_TEST_CASE (test_jacobian_vs_finit_diff)
 {
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model);
-  se3::Data data(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model);
+  pinocchio::Data data(model);
   
   const VectorXd fd_increment = finiteDifferenceIncrement(model);
 

--- a/unittest/frames.cpp
+++ b/unittest/frames.cpp
@@ -41,7 +41,7 @@ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 
 BOOST_AUTO_TEST_CASE(frame_basic)
 {
-  using namespace se3;
+  using namespace pinocchio;
   Model model;
   buildModels::humanoidRandom(model);
   
@@ -62,7 +62,7 @@ BOOST_AUTO_TEST_CASE(frame_basic)
 
 BOOST_AUTO_TEST_CASE(cast)
 {
-  using namespace se3;
+  using namespace pinocchio;
   Frame frame("toto",0,0,SE3::Random(),OP_FRAME);
   
   BOOST_CHECK(frame.cast<double>() == frame);
@@ -72,15 +72,15 @@ BOOST_AUTO_TEST_CASE(cast)
 BOOST_AUTO_TEST_CASE ( test_kinematics )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model);
   Model::Index parent_idx = model.existJointName("rarm2_joint")?model.getJointId("rarm2_joint"):(Model::Index)(model.njoints-1);
   const std::string & frame_name = std::string( model.names[parent_idx]+ "_frame");
   const SE3 & framePlacement = SE3::Random();
   model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
-  se3::Data data(model);
+  pinocchio::Data data(model);
 
   VectorXd q = VectorXd::Ones(model.nq);
   q.middleRows<4> (3).normalize();
@@ -93,17 +93,17 @@ BOOST_AUTO_TEST_CASE ( test_kinematics )
 BOOST_AUTO_TEST_CASE ( test_update_placements )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model);
   Model::Index parent_idx = model.existJointName("rarm2_joint")?model.getJointId("rarm2_joint"):(Model::Index)(model.njoints-1);
   const std::string & frame_name = std::string( model.names[parent_idx]+ "_frame");
   const SE3 & framePlacement = SE3::Random();
   model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
   Model::FrameIndex frame_idx = model.getFrameId(frame_name);
-  se3::Data data(model);
-  se3::Data data_ref(model);
+  pinocchio::Data data(model);
+  pinocchio::Data data_ref(model);
 
   VectorXd q = VectorXd::Ones(model.nq);
   q.middleRows<4> (3).normalize();
@@ -119,17 +119,17 @@ BOOST_AUTO_TEST_CASE ( test_update_placements )
 BOOST_AUTO_TEST_CASE ( test_update_single_placement )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model);
   Model::Index parent_idx = model.existJointName("rarm2_joint")?model.getJointId("rarm2_joint"):(Model::Index)(model.njoints-1);
   const std::string & frame_name = std::string( model.names[parent_idx]+ "_frame");
   const SE3 & framePlacement = SE3::Random();
   model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
   Model::FrameIndex frame_idx = model.getFrameId(frame_name);
-  se3::Data data(model);
-  se3::Data data_ref(model);
+  pinocchio::Data data(model);
+  pinocchio::Data data_ref(model);
 
   VectorXd q = VectorXd::Ones(model.nq);
   q.middleRows<4> (3).normalize();
@@ -145,16 +145,16 @@ BOOST_AUTO_TEST_CASE ( test_update_single_placement )
 BOOST_AUTO_TEST_CASE ( test_velocity )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model);
   Model::Index parent_idx = model.existJointName("rarm2_joint")?model.getJointId("rarm2_joint"):(Model::Index)(model.njoints-1);
   const std::string & frame_name = std::string( model.names[parent_idx]+ "_frame");
   const SE3 & framePlacement = SE3::Random();
   model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
   Model::FrameIndex frame_idx = model.getFrameId(frame_name);
-  se3::Data data(model);
+  pinocchio::Data data(model);
 
   VectorXd q = VectorXd::Ones(model.nq);
   q.middleRows<4> (3).normalize();
@@ -170,16 +170,16 @@ BOOST_AUTO_TEST_CASE ( test_velocity )
 BOOST_AUTO_TEST_CASE ( test_acceleration )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model);
   Model::Index parent_idx = model.existJointName("rarm2_joint")?model.getJointId("rarm2_joint"):(Model::Index)(model.njoints-1);
   const std::string & frame_name = std::string( model.names[parent_idx]+ "_frame");
   const SE3 & framePlacement = SE3::Random();
   model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
   Model::FrameIndex frame_idx = model.getFrameId(frame_name);
-  se3::Data data(model);
+  pinocchio::Data data(model);
 
   VectorXd q = VectorXd::Ones(model.nq);
   q.middleRows<4> (3).normalize();
@@ -196,7 +196,7 @@ BOOST_AUTO_TEST_CASE ( test_acceleration )
 BOOST_AUTO_TEST_CASE ( test_jacobian )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
   Model model;
   buildModels::humanoidRandom(model);
@@ -206,8 +206,8 @@ BOOST_AUTO_TEST_CASE ( test_jacobian )
   model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
   BOOST_CHECK(model.existFrame(frame_name));
   
-  se3::Data data(model);
-  se3::Data data_ref(model);
+  pinocchio::Data data(model);
+  pinocchio::Data data_ref(model);
   
   model.lowerPositionLimit.head<7>().fill(-1.);
   model.upperPositionLimit.head<7>().fill( 1.);
@@ -245,16 +245,16 @@ BOOST_AUTO_TEST_CASE ( test_jacobian )
 BOOST_AUTO_TEST_CASE ( test_frame_jacobian_time_variation )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model);
   Model::Index parent_idx = model.existJointName("rarm2_joint")?model.getJointId("rarm2_joint"):(Model::Index)(model.njoints-1);
   const std::string & frame_name = std::string( model.names[parent_idx]+ "_frame");
   const SE3 & framePlacement = SE3::Random();
   model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));  
-  se3::Data data(model);
-  se3::Data data_ref(model);
+  pinocchio::Data data(model);
+  pinocchio::Data data_ref(model);
   
   VectorXd q = randomConfiguration(model, -1 * Eigen::VectorXd::Ones(model.nq), Eigen::VectorXd::Ones(model.nq) );
   VectorXd v = VectorXd::Random(model.nv);

--- a/unittest/geom.cpp
+++ b/unittest/geom.cpp
@@ -30,15 +30,15 @@
 #include <vector>
 #include <boost/test/unit_test.hpp>
 
-using namespace se3;
+using namespace pinocchio;
 
-typedef std::map <std::string, se3::SE3> PositionsMap_t;
-typedef std::map <std::string, se3::SE3> JointPositionsMap_t;
-typedef std::map <std::string, se3::SE3> GeometryPositionsMap_t;
+typedef std::map <std::string, pinocchio::SE3> PositionsMap_t;
+typedef std::map <std::string, pinocchio::SE3> JointPositionsMap_t;
+typedef std::map <std::string, pinocchio::SE3> GeometryPositionsMap_t;
 typedef std::map <std::pair < std::string , std::string >, fcl::DistanceResult > PairDistanceMap_t;
-JointPositionsMap_t fillPinocchioJointPositions(const se3::Model& model, const se3::Data & data);
-GeometryPositionsMap_t fillPinocchioGeometryPositions(const se3::GeometryModel & geomModel,
-                                                      const se3::GeometryData & geomData);
+JointPositionsMap_t fillPinocchioJointPositions(const pinocchio::Model& model, const pinocchio::Data & data);
+GeometryPositionsMap_t fillPinocchioGeometryPositions(const pinocchio::GeometryModel & geomModel,
+                                                      const pinocchio::GeometryData & geomData);
 
 std::vector<std::string> getBodiesList();
 
@@ -46,7 +46,7 @@ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 
 BOOST_AUTO_TEST_CASE ( simple_boxes )
 {
-  using namespace se3;
+  using namespace pinocchio;
   Model model;
   GeometryModel geomModel;
 
@@ -81,8 +81,8 @@ BOOST_AUTO_TEST_CASE ( simple_boxes )
   BOOST_CHECK(geomModel.geometryObjects[idx_geom2].parentJoint == model.frames[body_id_2].parent);
 
   geomModel.addAllCollisionPairs();
-  se3::Data data(model);
-  se3::GeometryData geomData(geomModel);
+  pinocchio::Data data(model);
+  pinocchio::GeometryData geomData(geomModel);
 
   BOOST_CHECK(CollisionPair(0,1) == geomModel.collisionPairs[0]);
 
@@ -97,34 +97,34 @@ BOOST_AUTO_TEST_CASE ( simple_boxes )
   q <<  0, 0, 1, 0,
         0, 0, 1, 0 ;
 
-  se3::updateGeometryPlacements(model, data, geomModel, geomData, q);
+  pinocchio::updateGeometryPlacements(model, data, geomModel, geomData, q);
   BOOST_CHECK(computeCollision(geomModel,geomData,0) == true);
 
   q <<  2, 0, 1, 0,
         0, 0, 1, 0 ;
 
-  se3::updateGeometryPlacements(model, data, geomModel, geomData, q);
+  pinocchio::updateGeometryPlacements(model, data, geomModel, geomData, q);
   BOOST_CHECK(computeCollision(geomModel,geomData,0) == false);
 
   q <<  0.99, 0, 1, 0,
         0, 0, 1, 0 ;
 
-  se3::updateGeometryPlacements(model, data, geomModel, geomData, q);
+  pinocchio::updateGeometryPlacements(model, data, geomModel, geomData, q);
   BOOST_CHECK(computeCollision(geomModel,geomData,0) == true);
 
   q <<  1.01, 0, 1, 0,
         0, 0, 1, 0 ;
 
-  se3::updateGeometryPlacements(model, data, geomModel, geomData, q);
+  pinocchio::updateGeometryPlacements(model, data, geomModel, geomData, q);
   BOOST_CHECK(computeCollision(geomModel,geomData,0) == false);
 }
 
 BOOST_AUTO_TEST_CASE ( loading_model )
 {
-  typedef se3::Model Model;
-  typedef se3::GeometryModel GeometryModel;
-  typedef se3::Data Data;
-  typedef se3::GeometryData GeometryData;
+  typedef pinocchio::Model Model;
+  typedef pinocchio::GeometryModel GeometryModel;
+  typedef pinocchio::Data Data;
+  typedef pinocchio::GeometryData GeometryData;
 
   std::string filename = PINOCCHIO_SOURCE_DIR"/models/romeo/romeo_description/urdf/romeo_small.urdf";
   std::vector < std::string > packageDirs;
@@ -132,9 +132,9 @@ BOOST_AUTO_TEST_CASE ( loading_model )
   packageDirs.push_back(meshDir);
 
   Model model;
-  se3::urdf::buildModel(filename, se3::JointModelFreeFlyer(),model);
+  pinocchio::urdf::buildModel(filename, pinocchio::JointModelFreeFlyer(),model);
   GeometryModel geomModel;
-  se3::urdf::buildGeom(model, filename, se3::COLLISION, geomModel, packageDirs );
+  pinocchio::urdf::buildGeom(model, filename, pinocchio::COLLISION, geomModel, packageDirs );
   geomModel.addAllCollisionPairs();
 
   Data data(model);
@@ -146,8 +146,8 @@ BOOST_AUTO_TEST_CASE ( loading_model )
        0.6981317, -0.3490658, 0, 0, 1.5, 0.6, -0.5, -1.05, -0.4, -0.3, -0.2, 0, 0, 0, 0,
        1.5, -0.6, 0.5, 1.05, -0.4, -0.3, -0.2 ;
 
-  se3::updateGeometryPlacements(model, data, geomModel, geomData, q);
-  se3::Index idx = geomModel.findCollisionPair(CollisionPair(1,10));
+  pinocchio::updateGeometryPlacements(model, data, geomModel, geomData, q);
+  pinocchio::Index idx = geomModel.findCollisionPair(CollisionPair(1,10));
   BOOST_CHECK(computeCollision(geomModel,geomData,idx) == false);
 }
 
@@ -161,33 +161,33 @@ BOOST_AUTO_TEST_CASE (radius)
   std::string meshDir  = PINOCCHIO_SOURCE_DIR"/models/romeo/";
   packageDirs.push_back(meshDir);
 
-  se3::Model model;
-  se3::urdf::buildModel(filename, se3::JointModelFreeFlyer(),model);
-  se3::GeometryModel geom;
-  se3::urdf::buildGeom(model, filename, se3::COLLISION, geom, packageDirs);
+  pinocchio::Model model;
+  pinocchio::urdf::buildModel(filename, pinocchio::JointModelFreeFlyer(),model);
+  pinocchio::GeometryModel geom;
+  pinocchio::urdf::buildGeom(model, filename, pinocchio::COLLISION, geom, packageDirs);
   Data data(model);
   GeometryData geomData(geom);
 
   // Test that the algorithm does not crash
-  se3::computeBodyRadius(model, geom, geomData);
+  pinocchio::computeBodyRadius(model, geom, geomData);
   BOOST_FOREACH( double radius, geomData.radius) BOOST_CHECK(radius>=0.);
 }
 #endif // if defined(PINOCCHIO_WITH_URDFDOM) && defined(PINOCCHIO_WITH_HPP_FCL)
 
 BOOST_AUTO_TEST_SUITE_END ()
 
-JointPositionsMap_t fillPinocchioJointPositions(const se3::Model& model, const se3::Data & data)
+JointPositionsMap_t fillPinocchioJointPositions(const pinocchio::Model& model, const pinocchio::Data & data)
 {
   JointPositionsMap_t result;
-  for (se3::Model::Index i = 0; i < (se3::Model::Index)model.njoints; ++i)
+  for (pinocchio::Model::Index i = 0; i < (pinocchio::Model::Index)model.njoints; ++i)
   {
     result[model.names[i]] = data.oMi[i];
   }
   return result;
 }
 
-GeometryPositionsMap_t fillPinocchioGeometryPositions(const se3::GeometryModel & geomModel,
-                                                      const se3::GeometryData & geomData)
+GeometryPositionsMap_t fillPinocchioGeometryPositions(const pinocchio::GeometryModel & geomModel,
+                                                      const pinocchio::GeometryData & geomData)
 {
   GeometryPositionsMap_t result;
   for (std::size_t i = 0; i < geomModel.ngeoms ; ++i)

--- a/unittest/jacobian.cpp
+++ b/unittest/jacobian.cpp
@@ -41,11 +41,11 @@ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 BOOST_AUTO_TEST_CASE ( test_jacobian )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model);
-  se3::Data data(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model);
+  pinocchio::Data data(model);
 
   VectorXd q = VectorXd::Zero(model.nq);
   computeJointJacobians(model,data,q);
@@ -84,12 +84,12 @@ BOOST_AUTO_TEST_CASE ( test_jacobian )
 BOOST_AUTO_TEST_CASE ( test_jacobian_time_variation )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model);
-  se3::Data data(model);
-  se3::Data data_ref(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model);
+  pinocchio::Data data(model);
+  pinocchio::Data data_ref(model);
   
   VectorXd q = randomConfiguration(model, -1 * Eigen::VectorXd::Ones(model.nq), Eigen::VectorXd::Ones(model.nq) );
   VectorXd v = VectorXd::Random(model.nv);
@@ -159,11 +159,11 @@ BOOST_AUTO_TEST_CASE ( test_jacobian_time_variation )
 BOOST_AUTO_TEST_CASE ( test_timings )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model);
-  se3::Data data(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model);
+  pinocchio::Data data(model);
 
   long flag = BOOST_BINARY(1111);
   PinocchioTicToc timer(PinocchioTicToc::US); 

--- a/unittest/joint-composite.cpp
+++ b/unittest/joint-composite.cpp
@@ -22,7 +22,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/utility/binary.hpp>
 
-using namespace se3;
+using namespace pinocchio;
 using namespace Eigen;
 
 template<typename JointModel>
@@ -128,8 +128,8 @@ struct TestJointComposite{
 //  void operator()(const JointModelBase<JointModelComposite> &) const
 //  {
 //    JointModelComposite jmodel_composite;
-//    jmodel_composite.addJoint(se3::JointModelRX());
-//    jmodel_composite.addJoint(se3::JointModelRY());
+//    jmodel_composite.addJoint(pinocchio::JointModelRX());
+//    jmodel_composite.addJoint(pinocchio::JointModelRY());
 //    jmodel_composite.setIndexes(0,0,0);
 //
 //    test_joint_methods(jmodel_composite);

--- a/unittest/joint-configurations.cpp
+++ b/unittest/joint-configurations.cpp
@@ -23,7 +23,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/utility/binary.hpp>
 
-using namespace se3;
+using namespace pinocchio;
 
 bool configurations_are_equals(const Eigen::VectorXd & conf1, const Eigen::VectorXd & conf2)
 {
@@ -158,7 +158,7 @@ BOOST_AUTO_TEST_CASE ( normalize_test )
   Model model; buildModel(model);
 
   Eigen::VectorXd q (Eigen::VectorXd::Ones(model.nq));
-  se3::normalize(model, q);
+  pinocchio::normalize(model, q);
 
   BOOST_CHECK(q.head<3>().isApprox(Eigen::VectorXd::Ones(3)));
   BOOST_CHECK(fabs(q.segment<4>(3).norm() - 1) < Eigen::NumTraits<double>::epsilon()); // quaternion of freeflyer
@@ -172,7 +172,7 @@ BOOST_AUTO_TEST_CASE ( integrateCoeffWiseJacobian_test )
   Model model; buildModels::humanoidRandom(model);
   
   Eigen::VectorXd q(Eigen::VectorXd::Ones(model.nq));
-  se3::normalize(model, q);
+  pinocchio::normalize(model, q);
   
   Eigen::MatrixXd jac(model.nq,model.nv); jac.setZero();
  

--- a/unittest/joint-generic.cpp
+++ b/unittest/joint-generic.cpp
@@ -22,7 +22,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/utility/binary.hpp>
 
-using namespace se3;
+using namespace pinocchio;
 
 template <typename JointModel>
 void test_joint_methods(JointModel & jmodel, typename JointModel::JointDataDerived & jdata)
@@ -33,7 +33,7 @@ void test_joint_methods(JointModel & jmodel, typename JointModel::JointDataDeriv
   Eigen::VectorXd q1(Eigen::VectorXd::Random (jmodel.nq()));
   Eigen::VectorXd q1_dot(Eigen::VectorXd::Random (jmodel.nv()));
   Eigen::VectorXd q2(Eigen::VectorXd::Random (jmodel.nq()));
-  se3::Inertia::Matrix6 Ia(se3::Inertia::Random().matrix());
+  pinocchio::Inertia::Matrix6 Ia(pinocchio::Inertia::Random().matrix());
   bool update_I = false;
 
   q1 = LieGroupType().random();
@@ -42,8 +42,8 @@ void test_joint_methods(JointModel & jmodel, typename JointModel::JointDataDeriv
   jmodel.calc(jdata, q1, q1_dot);
   jmodel.calc_aba(jdata, Ia, update_I);
 
-  se3::JointModel jma(jmodel);
-  se3::JointData jda(jdata);
+  pinocchio::JointModel jma(jmodel);
+  pinocchio::JointData jda(jdata);
 
   jma.calc(jda, q1, q1_dot);
   jma.calc_aba(jda, Ia, update_I);
@@ -58,7 +58,7 @@ void test_joint_methods(JointModel & jmodel, typename JointModel::JointDataDeriv
 
   BOOST_CHECK_MESSAGE(jda.S().matrix().isApprox(jdata.S.matrix()),std::string(error_prefix + " - ConstraintXd "));
   BOOST_CHECK_MESSAGE( (jda.M()).isApprox((jdata.M)),std::string(error_prefix + " - Joint transforms ")); // ==  or isApprox ?
-  BOOST_CHECK_MESSAGE( (jda.v()).isApprox( (se3::Motion(jdata.v))),std::string(error_prefix + " - Joint motions "));
+  BOOST_CHECK_MESSAGE( (jda.v()).isApprox( (pinocchio::Motion(jdata.v))),std::string(error_prefix + " - Joint motions "));
   BOOST_CHECK_MESSAGE((jda.c()) == (jdata.c),std::string(error_prefix + " - Joint bias "));
 
   BOOST_CHECK_MESSAGE((jda.U()).isApprox(jdata.U),std::string(error_prefix + " - Joint U inertia matrix decomposition "));
@@ -98,43 +98,43 @@ struct TestJoint{
     test_joint_methods(jmodel, jdata);
   }
 
-  void operator()(const se3::JointModelComposite & ) const
+  void operator()(const pinocchio::JointModelComposite & ) const
   {
-    // se3::JointModelComposite jmodel(2);
-    // jmodel.addJointModel(se3::JointModelRX());
-    // jmodel.addJointModel(se3::JointModelRY());
+    // pinocchio::JointModelComposite jmodel(2);
+    // jmodel.addJointModel(pinocchio::JointModelRX());
+    // jmodel.addJointModel(pinocchio::JointModelRY());
 
-    se3::JointModelComposite jmodel((se3::JointModelRX()));
-    jmodel.addJoint(se3::JointModelRY());
+    pinocchio::JointModelComposite jmodel((pinocchio::JointModelRX()));
+    jmodel.addJoint(pinocchio::JointModelRY());
     jmodel.setIndexes(0,0,0);
 
-    se3::JointModelComposite::JointDataDerived jdata = jmodel.createData();
+    pinocchio::JointModelComposite::JointDataDerived jdata = jmodel.createData();
 
     // TODO: fixme when LieGroups will be implemented for JointModelComposite
 //    test_joint_methods(jmodel, jdata);
   }
 
-  void operator()(const se3::JointModelRevoluteUnaligned & ) const
+  void operator()(const pinocchio::JointModelRevoluteUnaligned & ) const
   {
-    se3::JointModelRevoluteUnaligned jmodel(1.5, 1., 0.);
+    pinocchio::JointModelRevoluteUnaligned jmodel(1.5, 1., 0.);
     jmodel.setIndexes(0,0,0);
-    se3::JointModelRevoluteUnaligned::JointDataDerived jdata = jmodel.createData();
+    pinocchio::JointModelRevoluteUnaligned::JointDataDerived jdata = jmodel.createData();
 
     test_joint_methods(jmodel, jdata);
   }
 
-  void operator()(const se3::JointModelPrismaticUnaligned & ) const
+  void operator()(const pinocchio::JointModelPrismaticUnaligned & ) const
   {
-    se3::JointModelPrismaticUnaligned jmodel(1.5, 1., 0.);
+    pinocchio::JointModelPrismaticUnaligned jmodel(1.5, 1., 0.);
     jmodel.setIndexes(0,0,0);
-    se3::JointModelPrismaticUnaligned::JointDataDerived jdata = jmodel.createData();
+    pinocchio::JointModelPrismaticUnaligned::JointDataDerived jdata = jmodel.createData();
 
     test_joint_methods(jmodel, jdata);
   }
 
 };
 
-namespace se3
+namespace pinocchio
 {
 
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl> struct JointTest;

--- a/unittest/joints.cpp
+++ b/unittest/joints.cpp
@@ -43,7 +43,7 @@
 
 //#define VERBOSE
 
-using namespace se3;
+using namespace pinocchio;
 
 template <typename JoinData_t>
 void printOutJointData(
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_SUITE(JointRevoluteUnaligned)
 
 BOOST_AUTO_TEST_CASE(vsRX)
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef Eigen::Matrix <double, 3, 1> Vector3;
   typedef Eigen::Matrix <double, 3, 3> Matrix3;
 
@@ -170,7 +170,7 @@ BOOST_AUTO_TEST_SUITE (JointPrismaticUnaligned)
 
 BOOST_AUTO_TEST_CASE (vsPX)
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef Eigen::Matrix <double, 3, 1> Vector3;
   typedef Eigen::Matrix <double, 3, 3> Matrix3;
 
@@ -259,7 +259,7 @@ BOOST_AUTO_TEST_SUITE (JointSpherical)
 
 BOOST_AUTO_TEST_CASE (vsFreeFlyer)
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef Eigen::Matrix <double, 3, 1> Vector3;
   typedef Eigen::Matrix <double, 6, 1> Vector6;
   typedef Eigen::Matrix <double, 7, 1> VectorFF;
@@ -367,7 +367,7 @@ BOOST_AUTO_TEST_CASE (vsFreeFlyer)
 {
   // WARNIG : Dynamic algorithm's results cannot be compared to FreeFlyer's ones because 
   // of the representation of the rotation and the ConstraintSubspace difference.
-  using namespace se3;
+  using namespace pinocchio;
   typedef Eigen::Matrix <double, 3, 1> Vector3;
   typedef Eigen::Matrix <double, 6, 1> Vector6;
   typedef Eigen::Matrix <double, 7, 1> VectorFF;
@@ -413,7 +413,7 @@ BOOST_AUTO_TEST_CASE (vsFreeFlyer)
 
 BOOST_AUTO_TEST_CASE ( test_rnea )
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef Eigen::Matrix <double, 3, 1> Vector3;
   typedef Eigen::Matrix <double, 3, 3> Matrix3;
 
@@ -454,7 +454,7 @@ BOOST_AUTO_TEST_CASE ( test_rnea )
 
 BOOST_AUTO_TEST_CASE ( test_crba )
 {
-  using namespace se3;
+  using namespace pinocchio;
   using namespace std;
   typedef Eigen::Matrix <double, 3, 1> Vector3;
   typedef Eigen::Matrix <double, 3, 3> Matrix3;
@@ -561,7 +561,7 @@ BOOST_AUTO_TEST_CASE(spatial)
 
 BOOST_AUTO_TEST_CASE ( test_kinematics )
 {
-  using namespace se3;
+  using namespace pinocchio;
 
 
   Motion expected_v_J (Motion::Zero ());
@@ -611,7 +611,7 @@ BOOST_AUTO_TEST_CASE ( test_kinematics )
 
 BOOST_AUTO_TEST_CASE ( test_rnea )
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef Eigen::Matrix <double, 3, 1> Vector3;
   typedef Eigen::Matrix <double, 3, 3> Matrix3;
 
@@ -655,7 +655,7 @@ BOOST_AUTO_TEST_CASE ( test_rnea )
 
 BOOST_AUTO_TEST_CASE ( test_crba )
 {
-  using namespace se3;
+  using namespace pinocchio;
   using namespace std;
   typedef Eigen::Matrix <double, 3, 1> Vector3;
   typedef Eigen::Matrix <double, 3, 3> Matrix3;
@@ -708,7 +708,7 @@ BOOST_AUTO_TEST_CASE(spatial)
 
 BOOST_AUTO_TEST_CASE (vsFreeFlyer)
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef Eigen::Matrix <double, 3, 1> Vector3;
   typedef Eigen::Matrix <double, 6, 1> Vector6;
   typedef Eigen::Matrix <double, 4, 1> VectorPl;
@@ -828,7 +828,7 @@ BOOST_AUTO_TEST_CASE(spatial)
 
 BOOST_AUTO_TEST_CASE (vsFreeFlyer)
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef Eigen::Matrix <double, 3, 1> Vector3;
   typedef Eigen::Matrix <double, 6, 1> Vector6;
   typedef Eigen::Matrix <double, 7, 1> VectorFF;
@@ -1108,7 +1108,7 @@ BOOST_AUTO_TEST_SUITE(JointModelBase_test)
   struct TestJointModelIsEqual
   {
     template<typename JointModel>
-    void operator()(const se3::JointModelBase<JointModel> &) const
+    void operator()(const pinocchio::JointModelBase<JointModel> &) const
     {
       JointModel jmodel;
       jmodel.setIndexes(0,0,0);
@@ -1182,7 +1182,7 @@ BOOST_AUTO_TEST_SUITE(JointModelBase_test)
   struct TestJointModelCast
   {
     template<typename JointModel>
-    void operator()(const se3::JointModelBase<JointModel> &) const
+    void operator()(const pinocchio::JointModelBase<JointModel> &) const
     {
       JointModel jmodel;
       jmodel.setIndexes(0,0,0);

--- a/unittest/kinematics-derivatives.cpp
+++ b/unittest/kinematics-derivatives.cpp
@@ -33,7 +33,7 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
 BOOST_AUTO_TEST_CASE(test_kinematics_derivatives_all)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
   Model model;
   buildModels::humanoidRandom(model);
@@ -68,7 +68,7 @@ BOOST_AUTO_TEST_CASE(test_kinematics_derivatives_all)
 BOOST_AUTO_TEST_CASE(test_kinematics_derivatives_velocity)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
   Model model;
   buildModels::humanoidRandom(model);
@@ -164,7 +164,7 @@ BOOST_AUTO_TEST_CASE(test_kinematics_derivatives_velocity)
 BOOST_AUTO_TEST_CASE(test_kinematics_derivatives_acceleration)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
   Model model;
   buildModels::humanoidRandom(model);
@@ -321,7 +321,7 @@ BOOST_AUTO_TEST_CASE(test_kinematics_derivatives_acceleration)
 BOOST_AUTO_TEST_CASE(test_kinematics_derivatives_against_classic_formula)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
   Model model;
   buildModels::humanoidRandom(model,true);

--- a/unittest/kinematics.cpp
+++ b/unittest/kinematics.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
 BOOST_AUTO_TEST_CASE(test_kinematics_zero)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
   Model model;
   buildModels::humanoidRandom(model);
@@ -57,7 +57,7 @@ BOOST_AUTO_TEST_CASE(test_kinematics_zero)
 BOOST_AUTO_TEST_CASE(test_kinematics_first)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
   Model model;
   buildModels::humanoidRandom(model);
@@ -80,7 +80,7 @@ BOOST_AUTO_TEST_CASE(test_kinematics_first)
 BOOST_AUTO_TEST_CASE(test_kinematics_second)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
   Model model;
   buildModels::humanoidRandom(model);

--- a/unittest/liegroups.cpp
+++ b/unittest/liegroups.cpp
@@ -29,7 +29,7 @@
       "check " #Va ".isApprox(" #Vb ") failed "                                \
       "[\n" << (Va).transpose() << "\n!=\n" << (Vb).transpose() << "\n]")
 
-using namespace se3;
+using namespace pinocchio;
 
 #define VERBOSE false
 #define IFVERBOSE if(VERBOSE)
@@ -51,7 +51,7 @@ void test_lie_group_methods (T & jmodel, typename T::JointDataDerived &)
   typedef typename LieGroup<T>::type LieGroupType;
   static ConfigVector_t Ones(ConfigVector_t::Ones(jmodel.nq()));
   const Scalar u = 0.3;
-  // se3::Inertia::Matrix6 Ia(se3::Inertia::Random().matrix());
+  // pinocchio::Inertia::Matrix6 Ia(pinocchio::Inertia::Random().matrix());
   // bool update_I = false;
   
   q1 = LieGroupType().randomConfiguration(-Ones, Ones);
@@ -158,20 +158,20 @@ struct TestJoint{
     test_lie_group_methods(jmodel, jdata);    
   }
 
-  void operator()(const se3::JointModelRevoluteUnaligned & ) const
+  void operator()(const pinocchio::JointModelRevoluteUnaligned & ) const
   {
-    se3::JointModelRevoluteUnaligned jmodel(1.5, 1., 0.);
+    pinocchio::JointModelRevoluteUnaligned jmodel(1.5, 1., 0.);
     jmodel.setIndexes(0,0,0);
-    se3::JointModelRevoluteUnaligned::JointDataDerived jdata = jmodel.createData();
+    pinocchio::JointModelRevoluteUnaligned::JointDataDerived jdata = jmodel.createData();
 
     test_lie_group_methods(jmodel, jdata);
   }
 
-  void operator()(const se3::JointModelPrismaticUnaligned & ) const
+  void operator()(const pinocchio::JointModelPrismaticUnaligned & ) const
   {
-    se3::JointModelPrismaticUnaligned jmodel(1.5, 1., 0.);
+    pinocchio::JointModelPrismaticUnaligned jmodel(1.5, 1., 0.);
     jmodel.setIndexes(0,0,0);
-    se3::JointModelPrismaticUnaligned::JointDataDerived jdata = jmodel.createData();
+    pinocchio::JointModelPrismaticUnaligned::JointDataDerived jdata = jmodel.createData();
 
     test_lie_group_methods(jmodel, jdata);
   }

--- a/unittest/model.cpp
+++ b/unittest/model.cpp
@@ -21,7 +21,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/utility/binary.hpp>
 
-using namespace se3;
+using namespace pinocchio;
 
 BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 

--- a/unittest/python_parser.cpp
+++ b/unittest/python_parser.cpp
@@ -32,7 +32,7 @@ BOOST_AUTO_TEST_CASE ( buildModel )
   #ifndef NDEBUG
    std::cout << "Parse filename \"" << filename << "\"" << std::endl;
   #endif
-  se3::Model model = se3::python::buildModel(filename,"model",false);
+  pinocchio::Model model = pinocchio::python::buildModel(filename,"model",false);
   #ifndef NDEBUG
    std::cout << "This model has \"" << model.nq << "\" DoF" << std::endl;
   #endif

--- a/unittest/regressor.cpp
+++ b/unittest/regressor.cpp
@@ -31,12 +31,12 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
 BOOST_AUTO_TEST_CASE(test_static_regressor)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
-  se3::Model model; buildModels::humanoidRandom(model);
+  pinocchio::Model model; buildModels::humanoidRandom(model);
   
-  se3::Data data(model);
-  se3::Data data_ref(model);
+  pinocchio::Data data(model);
+  pinocchio::Data data_ref(model);
   
   model.lowerPositionLimit.head<7>().fill(-1.);
   model.upperPositionLimit.head<7>().fill(1.);

--- a/unittest/rnea-derivatives.cpp
+++ b/unittest/rnea-derivatives.cpp
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
 BOOST_AUTO_TEST_CASE(test_generalized_gravity_derivatives)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
   Model model;
   buildModels::humanoidRandom(model);
@@ -78,7 +78,7 @@ BOOST_AUTO_TEST_CASE(test_generalized_gravity_derivatives)
 BOOST_AUTO_TEST_CASE(test_rnea_derivatives)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
   Model model;
   buildModels::humanoidRandom(model);
@@ -270,7 +270,7 @@ BOOST_AUTO_TEST_CASE(test_rnea_derivatives)
 BOOST_AUTO_TEST_CASE(test_rnea_derivatives_fext)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
   Model model;
   buildModels::humanoidRandom(model);
@@ -365,7 +365,7 @@ BOOST_AUTO_TEST_CASE(test_rnea_derivatives_fext)
 BOOST_AUTO_TEST_CASE(test_rnea_derivatives_vs_kinematics_derivatives)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
   Model model;
   buildModels::humanoidRandom(model);

--- a/unittest/rnea.cpp
+++ b/unittest/rnea.cpp
@@ -54,11 +54,11 @@ BOOST_AUTO_TEST_CASE ( test_rnea )
     _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
   #endif
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
 
-  se3::Model model; buildModels::humanoidRandom(model);
+  pinocchio::Model model; buildModels::humanoidRandom(model);
   
-  se3::Data data(model);
+  pinocchio::Data data(model);
   data.v[0] = Motion::Zero();
   data.a[0] = -model.gravity;
 
@@ -85,11 +85,11 @@ BOOST_AUTO_TEST_CASE ( test_rnea )
 BOOST_AUTO_TEST_CASE ( test_nle_vs_rnea )
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
-  se3::Model model; buildModels::humanoidRandom(model);
-  se3::Data data_nle(model);
-  se3::Data data_rnea(model);
+  pinocchio::Model model; buildModels::humanoidRandom(model);
+  pinocchio::Data data_nle(model);
+  pinocchio::Data data_rnea(model);
   
   VectorXd q (VectorXd::Random(model.nq));
   VectorXd v (VectorXd::Random(model.nv));
@@ -137,7 +137,7 @@ BOOST_AUTO_TEST_CASE ( test_nle_vs_rnea )
 BOOST_AUTO_TEST_CASE (test_rnea_with_fext)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
   Model model;
   buildModels::humanoidRandom(model);
@@ -175,7 +175,7 @@ BOOST_AUTO_TEST_CASE (test_rnea_with_fext)
 BOOST_AUTO_TEST_CASE(test_compute_gravity)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   
   Model model;
   buildModels::humanoidRandom(model);
@@ -202,7 +202,7 @@ BOOST_AUTO_TEST_CASE(test_compute_gravity)
   BOOST_AUTO_TEST_CASE(test_compute_coriolis)
   {
     using namespace Eigen;
-    using namespace se3;
+    using namespace pinocchio;
     
     const double prec = Eigen::NumTraits<double>::dummy_precision();
     

--- a/unittest/sample-models.cpp
+++ b/unittest/sample-models.cpp
@@ -29,14 +29,14 @@ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 
 BOOST_AUTO_TEST_CASE ( build_model_sample_humanoid_random )
 {
-  se3::Model model;
-  se3::buildModels::humanoidRandom(model,true);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model,true);
 
   BOOST_CHECK(model.nq == 33);
   BOOST_CHECK(model.nv == 32);
 
-  se3::Model modelff;
-  se3::buildModels::humanoidRandom(modelff,false);
+  pinocchio::Model modelff;
+  pinocchio::buildModels::humanoidRandom(modelff,false);
 
   BOOST_CHECK(modelff.nq == 32);
   BOOST_CHECK(modelff.nv == 32);
@@ -44,36 +44,36 @@ BOOST_AUTO_TEST_CASE ( build_model_sample_humanoid_random )
 
 BOOST_AUTO_TEST_CASE ( build_model_sample_manipulator )
 {
-  se3::Model model;
-  se3::buildModels::manipulator(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::manipulator(model);
 
   BOOST_CHECK(model.nq == 6);
   BOOST_CHECK(model.nv == 6);
 
 #ifdef PINOCCHIO_WITH_HPP_FCL
-  se3::Data data(model);
-  se3::GeometryModel geom;
-  se3::buildModels::manipulatorGeometries(model,geom);
+  pinocchio::Data data(model);
+  pinocchio::GeometryModel geom;
+  pinocchio::buildModels::manipulatorGeometries(model,geom);
 #endif
 }
 
 BOOST_AUTO_TEST_CASE ( build_model_sample_humanoid )
 {
-  se3::Model model;
-  se3::buildModels::humanoid(model);
-  se3::Data data(model);
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoid(model);
+  pinocchio::Data data(model);
 
   BOOST_CHECK(model.nq == 35);
   BOOST_CHECK(model.nv == 34);
 
 #ifdef PINOCCHIO_WITH_HPP_FCL
-  se3::GeometryModel geom;
-  se3::buildModels::humanoidGeometries(model,geom);
-  se3::GeometryData geomdata(geom);
+  pinocchio::GeometryModel geom;
+  pinocchio::buildModels::humanoidGeometries(model,geom);
+  pinocchio::GeometryData geomdata(geom);
   
-  Eigen::VectorXd q = se3::neutral(model);
-  se3::forwardKinematics(model,data,q);
-  se3::updateGeometryPlacements(model,data,geom,geomdata,q);
+  Eigen::VectorXd q = pinocchio::neutral(model);
+  pinocchio::forwardKinematics(model,data,q);
+  pinocchio::updateGeometryPlacements(model,data,geom,geomdata,q);
 #endif
 
   /* We might want to check here the joint namings, and validate the 

--- a/unittest/sincos.cpp
+++ b/unittest/sincos.cpp
@@ -29,7 +29,7 @@ void testSINCOS(int n)
   {
     Scalar sin_value, cos_value;
     Scalar alpha = (Scalar)std::rand()/(Scalar)RAND_MAX;
-    se3::SINCOS(alpha,&sin_value,&cos_value);
+    pinocchio::SINCOS(alpha,&sin_value,&cos_value);
     
     Scalar sin_value_ref = std::sin(alpha),
            cos_value_ref = std::cos(alpha);

--- a/unittest/srdf.cpp
+++ b/unittest/srdf.cpp
@@ -23,15 +23,15 @@
 
 #include <boost/test/unit_test.hpp>
 
-using namespace se3;
+using namespace pinocchio;
 using namespace std;
 
 BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 
 BOOST_AUTO_TEST_CASE(test_removeCollisionPairs)
 {
-  using namespace se3::urdf;
-  using namespace se3::srdf;
+  using namespace pinocchio::urdf;
+  using namespace pinocchio::srdf;
   const string model_filename = PINOCCHIO_SOURCE_DIR"/models/romeo/romeo_description/urdf/romeo_small.urdf";
   const string model_dir = PINOCCHIO_SOURCE_DIR"/models/romeo";
   const string srdf_filename = PINOCCHIO_SOURCE_DIR"/models/romeo/romeo_description/srdf/romeo.srdf";
@@ -55,8 +55,8 @@ BOOST_AUTO_TEST_CASE(test_removeCollisionPairs)
   
 BOOST_AUTO_TEST_CASE(readNeutralConfig)
 {
-  using namespace se3::urdf;
-  using namespace se3::srdf;
+  using namespace pinocchio::urdf;
+  using namespace pinocchio::srdf;
   const string model_filename = PINOCCHIO_SOURCE_DIR"/models/romeo/romeo_description/urdf/romeo_small.urdf";
   const string srdf_filename = PINOCCHIO_SOURCE_DIR"/models/romeo/romeo_description/srdf/romeo.srdf";
   
@@ -71,8 +71,8 @@ BOOST_AUTO_TEST_CASE(readNeutralConfig)
 
 BOOST_AUTO_TEST_CASE(readRotorParams)
 {
-  using namespace se3::urdf;
-  using namespace se3::srdf;
+  using namespace pinocchio::urdf;
+  using namespace pinocchio::srdf;
   const string model_filename = PINOCCHIO_SOURCE_DIR"/models/simple_humanoid.urdf";
   const string srdf_filename = PINOCCHIO_SOURCE_DIR"/models/simple_humanoid.srdf";
   

--- a/unittest/symmetric.cpp
+++ b/unittest/symmetric.cpp
@@ -45,11 +45,11 @@
 
 #include <Eigen/StdVector>
 EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(Eigen::Matrix3d)
-EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(se3::Symmetric3)
+EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(pinocchio::Symmetric3)
 
-void timeSym3(const se3::Symmetric3 & S,
-        const se3::Symmetric3::Matrix3 & R,
-        se3::Symmetric3 & res)
+void timeSym3(const pinocchio::Symmetric3 & S,
+        const pinocchio::Symmetric3::Matrix3 & R,
+        pinocchio::Symmetric3 & res)
 {
   res = S.rotate(R);
 }
@@ -88,7 +88,7 @@ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 /* --- PINOCCHIO ------------------------------------------------------------ */
 BOOST_AUTO_TEST_CASE ( test_pinocchio_Sym3 )
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef Symmetric3::Matrix3 Matrix3;
   typedef Symmetric3::Vector3 Vector3;
   
@@ -265,7 +265,7 @@ BOOST_AUTO_TEST_CASE ( test_pinocchio_Sym3 )
 
 BOOST_AUTO_TEST_CASE ( test_eigen_SelfAdj )
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef Eigen::Matrix3d Matrix3;
   typedef Eigen::SelfAdjointView<Matrix3,Eigen::Upper> Sym3;
 
@@ -306,7 +306,7 @@ BOOST_AUTO_TEST_CASE ( test_eigen_SelfAdj )
 
 BOOST_AUTO_TEST_CASE(comparison)
 {
-  using namespace se3;
+  using namespace pinocchio;
   Symmetric3 sym1(Symmetric3::Random());
   
   Symmetric3 sym2(sym1);
@@ -318,7 +318,7 @@ BOOST_AUTO_TEST_CASE(comparison)
 
 BOOST_AUTO_TEST_CASE(cast)
 {
-  using namespace se3;
+  using namespace pinocchio;
   Symmetric3 sym(Symmetric3::Random());
   
   BOOST_CHECK(sym.cast<double>() == sym);

--- a/unittest/tspatial.cpp
+++ b/unittest/tspatial.cpp
@@ -34,7 +34,7 @@ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 
 BOOST_AUTO_TEST_CASE ( test_SE3 )
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef SE3::HomogeneousMatrixType HomogeneousMatrixType;
   typedef SE3::ActionMatrixType ActionMatrixType;
   typedef SE3::Vector3 Vector3;
@@ -92,7 +92,7 @@ BOOST_AUTO_TEST_CASE ( test_SE3 )
 
 BOOST_AUTO_TEST_CASE ( test_Motion )
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef SE3::ActionMatrixType ActionMatrixType;
   typedef Motion::Vector6 Vector6;
 
@@ -212,7 +212,7 @@ BOOST_AUTO_TEST_CASE ( test_Motion )
 
 BOOST_AUTO_TEST_CASE (test_motion_ref)
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef Motion::Vector6 Vector6;
   
   typedef MotionRef<Vector6> MotionV6;
@@ -269,7 +269,7 @@ BOOST_AUTO_TEST_CASE (test_motion_ref)
 
 BOOST_AUTO_TEST_CASE(test_motion_zero)
 {
-  using namespace se3;
+  using namespace pinocchio;
   Motion v((BiasZero()));
   
   BOOST_CHECK(v.toVector().isZero());
@@ -287,7 +287,7 @@ BOOST_AUTO_TEST_CASE(test_motion_zero)
 
 BOOST_AUTO_TEST_CASE ( test_Force )
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef SE3::ActionMatrixType ActionMatrixType;
   typedef Force::Vector6 Vector6;
 
@@ -367,7 +367,7 @@ BOOST_AUTO_TEST_CASE ( test_Force )
 
 BOOST_AUTO_TEST_CASE (test_force_ref)
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef Force::Vector6 Vector6;
 
   typedef ForceRef<Vector6> ForceV6;
@@ -423,7 +423,7 @@ BOOST_AUTO_TEST_CASE (test_force_ref)
 
 BOOST_AUTO_TEST_CASE ( test_Inertia )
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef Inertia::Matrix6 Matrix6;
 
   Inertia aI = Inertia::Random();
@@ -573,7 +573,7 @@ BOOST_AUTO_TEST_CASE ( test_Inertia )
 
 BOOST_AUTO_TEST_CASE(cast_inertia)
 {
-  using namespace se3;
+  using namespace pinocchio;
   Inertia Y(Inertia::Random());
   
   BOOST_CHECK(Y.cast<double>() == Y);
@@ -582,7 +582,7 @@ BOOST_AUTO_TEST_CASE(cast_inertia)
 
 BOOST_AUTO_TEST_CASE ( test_ActOnSet )
 {
-  using namespace se3;
+  using namespace pinocchio;
   const int N = 20;
   typedef Eigen::Matrix<double,6,N> Matrix6N;
   SE3 jMi = SE3::Random();
@@ -736,7 +736,7 @@ BOOST_AUTO_TEST_CASE ( test_ActOnSet )
 
 BOOST_AUTO_TEST_CASE(test_skew)
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef SE3::Vector3 Vector3;
   typedef Motion::Vector6 Vector6;
   
@@ -762,7 +762,7 @@ BOOST_AUTO_TEST_CASE(test_skew)
 
 BOOST_AUTO_TEST_CASE(test_addSkew)
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef SE3::Vector3 Vector3;
   typedef SE3::Matrix3 Matrix3;
   
@@ -785,7 +785,7 @@ BOOST_AUTO_TEST_CASE(test_addSkew)
 
 BOOST_AUTO_TEST_CASE(test_skew_square)
 {
-  using namespace se3;
+  using namespace pinocchio;
   typedef SE3::Vector3 Vector3;
   typedef SE3::Matrix3 Matrix3;
   
@@ -802,7 +802,7 @@ BOOST_AUTO_TEST_CASE(test_skew_square)
 template<int axis>
 struct test_scalar_multiplication_cartesian_axis
 {
-  typedef se3::CartesianAxis<axis> Axis;
+  typedef pinocchio::CartesianAxis<axis> Axis;
   typedef double Scalar;
   typedef Eigen::Matrix<Scalar,3,1> Vector3;
   
@@ -833,7 +833,7 @@ struct test_scalar_multiplication_cartesian_axis
 BOOST_AUTO_TEST_CASE(test_cartesian_axis)
 {
   using namespace Eigen;
-  using namespace se3;
+  using namespace pinocchio;
   Vector3d v(Vector3d::Random());
   const double alpha = 3;
   Vector3d v2(alpha*v);
@@ -853,9 +853,9 @@ BOOST_AUTO_TEST_CASE(test_cartesian_axis)
 template<int axis>
 struct test_scalar_multiplication
 {
-  typedef se3::SpatialAxis<axis> Axis;
+  typedef pinocchio::SpatialAxis<axis> Axis;
   typedef double Scalar;
-  typedef se3::MotionTpl<Scalar> Motion;
+  typedef pinocchio::MotionTpl<Scalar> Motion;
   
   static void run()
   {
@@ -883,7 +883,7 @@ struct test_scalar_multiplication
 
 BOOST_AUTO_TEST_CASE(test_spatial_axis)
 {
-  using namespace se3;
+  using namespace pinocchio;
   
   Motion v(Motion::Random());
   Force f(Force::Random());

--- a/unittest/urdf.cpp
+++ b/unittest/urdf.cpp
@@ -34,10 +34,10 @@ BOOST_AUTO_TEST_CASE ( build_model )
   const std::string filename = PINOCCHIO_SOURCE_DIR"/models/romeo/romeo_description/urdf/romeo_small.urdf";
   const std::string dir = PINOCCHIO_SOURCE_DIR"/models/romeo";
   
-  se3::Model model;
-  se3::urdf::buildModel(filename, model);
-  se3::GeometryModel geomModel;
-  se3::urdf::buildGeom(model, filename, se3::COLLISION, geomModel, dir);
+  pinocchio::Model model;
+  pinocchio::urdf::buildModel(filename, model);
+  pinocchio::GeometryModel geomModel;
+  pinocchio::urdf::buildGeom(model, filename, pinocchio::COLLISION, geomModel, dir);
   
   BOOST_CHECK(model.nq == 31);
 }
@@ -46,13 +46,13 @@ BOOST_AUTO_TEST_CASE ( build_model_simple_humanoid )
 {
   const std::string filename = PINOCCHIO_SOURCE_DIR"/models/simple_humanoid.urdf";
 
-  se3::Model model;
-  se3::urdf::buildModel(filename, model);
+  pinocchio::Model model;
+  pinocchio::urdf::buildModel(filename, model);
 
   BOOST_CHECK(model.nq == 29);
   
-  se3::Model model_ff;
-  se3::urdf::buildModel(filename, se3::JointModelFreeFlyer(), model_ff);
+  pinocchio::Model model_ff;
+  pinocchio::urdf::buildModel(filename, pinocchio::JointModelFreeFlyer(), model_ff);
   
   BOOST_CHECK(model_ff.nq == 36);
 }
@@ -67,8 +67,8 @@ BOOST_AUTO_TEST_CASE ( build_model_from_XML )
   std::string filestr((std::istreambuf_iterator<char>(file)),
                       std::istreambuf_iterator<char>());
   
-  se3::Model model;
-  se3::urdf::buildModelFromXML(filestr, model);
+  pinocchio::Model model;
+  pinocchio::urdf::buildModelFromXML(filestr, model);
   
   BOOST_CHECK(model.nq == 31);
 }
@@ -79,8 +79,8 @@ BOOST_AUTO_TEST_CASE ( build_model_from_UDRFTree )
   
   ::urdf::ModelInterfaceSharedPtr urdfTree = ::urdf::parseURDFFile(filename);
   
-  se3::Model model;
-  se3::urdf::buildModel(urdfTree, model);
+  pinocchio::Model model;
+  pinocchio::urdf::buildModel(urdfTree, model);
   
   BOOST_CHECK(model.nq == 31);
 }
@@ -90,10 +90,10 @@ BOOST_AUTO_TEST_CASE ( build_model_with_joint )
   const std::string filename = PINOCCHIO_SOURCE_DIR"/models/romeo/romeo_description/urdf/romeo_small.urdf";
   const std::string dir = PINOCCHIO_SOURCE_DIR"/models/romeo";
   
-  se3::Model model;
-  se3::urdf::buildModel(filename, se3::JointModelFreeFlyer(), model);
-  se3::GeometryModel geomModel;
-  se3::urdf::buildGeom(model, filename, se3::COLLISION, geomModel, dir);
+  pinocchio::Model model;
+  pinocchio::urdf::buildModel(filename, pinocchio::JointModelFreeFlyer(), model);
+  pinocchio::GeometryModel geomModel;
+  pinocchio::urdf::buildGeom(model, filename, pinocchio::COLLISION, geomModel, dir);
   
   BOOST_CHECK(model.nq == 38);
 }
@@ -108,8 +108,8 @@ BOOST_AUTO_TEST_CASE ( build_model_with_joint_from_XML )
   std::string filestr((std::istreambuf_iterator<char>(file)),
                       std::istreambuf_iterator<char>());
   
-  se3::Model model;
-  se3::urdf::buildModelFromXML(filestr, se3::JointModelFreeFlyer(), model);
+  pinocchio::Model model;
+  pinocchio::urdf::buildModelFromXML(filestr, pinocchio::JointModelFreeFlyer(), model);
   
   BOOST_CHECK(model.nq == 38);
 }
@@ -120,8 +120,8 @@ BOOST_AUTO_TEST_CASE ( build_model_with_joint_from_UDRFTree )
   
   ::urdf::ModelInterfaceSharedPtr urdfTree = ::urdf::parseURDFFile(filename);
   
-  se3::Model model;
-  se3::urdf::buildModel(urdfTree, se3::JointModelFreeFlyer(), model);
+  pinocchio::Model model;
+  pinocchio::urdf::buildModel(urdfTree, pinocchio::JointModelFreeFlyer(), model);
   
   BOOST_CHECK(model.nq == 38);
 }

--- a/unittest/value.cpp
+++ b/unittest/value.cpp
@@ -45,10 +45,10 @@ BOOST_AUTO_TEST_CASE ( test_000 )
 {
   std::string filename = PINOCCHIO_SOURCE_DIR"/models/simple_humanoid.urdf";
 
-  se3::Model model;
-  se3::urdf::buildModel(filename,se3::JointModelFreeFlyer(),model);
+  pinocchio::Model model;
+  pinocchio::urdf::buildModel(filename,pinocchio::JointModelFreeFlyer(),model);
   model.gravity.linear( Eigen::Vector3d(0,0,-9.8));
-  se3::Data data(model);
+  pinocchio::Data data(model);
 
   
   Eigen::VectorXd q = Eigen::VectorXd::Zero(model.nq);
@@ -71,10 +71,10 @@ BOOST_AUTO_TEST_CASE( test_0V0 )
 {
   std::string filename = PINOCCHIO_SOURCE_DIR"/models/simple_humanoid.urdf";
 
-  se3::Model model;
-  se3::urdf::buildModel(filename,se3::JointModelFreeFlyer(),model);
+  pinocchio::Model model;
+  pinocchio::urdf::buildModel(filename,pinocchio::JointModelFreeFlyer(),model);
   model.gravity.linear( Eigen::Vector3d(0,0,-9.8));
-  se3::Data data(model);
+  pinocchio::Data data(model);
 
   
   Eigen::VectorXd q = Eigen::VectorXd::Zero(model.nq);
@@ -97,10 +97,10 @@ BOOST_AUTO_TEST_CASE( test_0VA )
 {
   std::string filename = PINOCCHIO_SOURCE_DIR"/models/simple_humanoid.urdf";
 
-  se3::Model model;
-  se3::urdf::buildModel(filename,se3::JointModelFreeFlyer(),model);
+  pinocchio::Model model;
+  pinocchio::urdf::buildModel(filename,pinocchio::JointModelFreeFlyer(),model);
   model.gravity.linear( Eigen::Vector3d(0,0,-9.8));
-  se3::Data data(model);
+  pinocchio::Data data(model);
 
   
   Eigen::VectorXd q = Eigen::VectorXd::Zero(model.nq);
@@ -121,10 +121,10 @@ BOOST_AUTO_TEST_CASE( test_Q00 )
 {
   std::string filename = PINOCCHIO_SOURCE_DIR"/models/simple_humanoid.urdf";
 
-  se3::Model model;
-  se3::urdf::buildModel(filename,se3::JointModelFreeFlyer(),model);
+  pinocchio::Model model;
+  pinocchio::urdf::buildModel(filename,pinocchio::JointModelFreeFlyer(),model);
   model.gravity.linear( Eigen::Vector3d(0,0,-9.8));
-  se3::Data data(model);
+  pinocchio::Data data(model);
 
   
   Eigen::VectorXd q = Eigen::VectorXd::Zero(model.nq);
@@ -150,10 +150,10 @@ BOOST_AUTO_TEST_CASE( test_QVA )
 {
   std::string filename = PINOCCHIO_SOURCE_DIR"/models/simple_humanoid.urdf";
 
-  se3::Model model;
-  se3::urdf::buildModel(filename,se3::JointModelFreeFlyer(),model);
+  pinocchio::Model model;
+  pinocchio::urdf::buildModel(filename,pinocchio::JointModelFreeFlyer(),model);
   model.gravity.linear( Eigen::Vector3d(0,0,-9.8));
-  se3::Data data(model);
+  pinocchio::Data data(model);
 
   
   Eigen::VectorXd q = Eigen::VectorXd::Zero(model.nq);

--- a/unittest/version.cpp
+++ b/unittest/version.cpp
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
 BOOST_AUTO_TEST_CASE(test_version)
 {
   using namespace std;
-  using namespace se3;
+  using namespace pinocchio;
   
   const string delimiter = ".";
   ostringstream version_ref;

--- a/unittest/visitor.cpp
+++ b/unittest/visitor.cpp
@@ -25,37 +25,37 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/utility/binary.hpp>
 
-namespace se3
+namespace pinocchio
 {
 
-  struct SimpleVisitor : public se3::fusion::JointVisitorBase<SimpleVisitor>
+  struct SimpleVisitor : public pinocchio::fusion::JointVisitorBase<SimpleVisitor>
   {
-    typedef boost::fusion::vector<const se3::Model &,
-                                  se3::Data &,
+    typedef boost::fusion::vector<const pinocchio::Model &,
+                                  pinocchio::Data &,
                                   JointIndex
                                   > ArgsType;
 
     template<typename JointModel>
-    static void algo(const se3::JointModelBase<JointModel> & jmodel,
-                     se3::JointDataBase<typename JointModel::JointDataDerived> & jdata,
-                     const se3::Model & model,
-                     se3::Data & data,
+    static void algo(const pinocchio::JointModelBase<JointModel> & jmodel,
+                     pinocchio::JointDataBase<typename JointModel::JointDataDerived> & jdata,
+                     const pinocchio::Model & model,
+                     pinocchio::Data & data,
                      JointIndex jointId);
   };
 
   template<typename JointModel>
-  void SimpleVisitor::algo(const se3::JointModelBase<JointModel> & /*jmodel*/,
-                           se3::JointDataBase<typename JointModel::JointDataDerived> & /*jdata*/,
-                           const se3::Model & /*model*/,
-                           se3::Data & /*data*/,
+  void SimpleVisitor::algo(const pinocchio::JointModelBase<JointModel> & /*jmodel*/,
+                           pinocchio::JointDataBase<typename JointModel::JointDataDerived> & /*jdata*/,
+                           const pinocchio::Model & /*model*/,
+                           pinocchio::Data & /*data*/,
                            JointIndex /*dummy*/)
   { /* --- do nothing --- */ }
 
   template<>
-  void SimpleVisitor::algo(const se3::JointModelBase<JointModelRevoluteUnaligned> & jmodel,
-                           se3::JointDataBase<JointDataRevoluteUnaligned> & /*jdata*/,
-                           const se3::Model & /*model*/,
-                           se3::Data & /*data*/,
+  void SimpleVisitor::algo(const pinocchio::JointModelBase<JointModelRevoluteUnaligned> & jmodel,
+                           pinocchio::JointDataBase<JointDataRevoluteUnaligned> & /*jdata*/,
+                           const pinocchio::Model & /*model*/,
+                           pinocchio::Data & /*data*/,
                            JointIndex /*dummy*/)
   {
     BOOST_CHECK( jmodel.shortname() == JointModelRevoluteUnaligned::classname() );
@@ -65,7 +65,7 @@ namespace se3
     BOOST_CHECK ( axis == axis_z );
   }
 
-} // namespace se3
+} // namespace pinocchio
 
 /* Validates the access to memory stored in joint models, by using the class
  * joint model revolute unaligned. 
@@ -75,10 +75,10 @@ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
 
 BOOST_AUTO_TEST_CASE ( test_runal )
 {
-  using namespace se3;
+  using namespace pinocchio;
 
-  se3::Model model;
-  model.addJoint(0,se3::JointModelRevoluteUnaligned(0,0,1),se3::SE3::Random(),"");
+  pinocchio::Model model;
+  model.addJoint(0,pinocchio::JointModelRevoluteUnaligned(0,0,1),pinocchio::SE3::Random(),"");
   Data data(model);
 
   for( Model::JointIndex i=1;i<(Model::JointIndex)model.njoints;++i )

--- a/utils/pinocchio_read_model.cpp
+++ b/utils/pinocchio_read_model.cpp
@@ -60,26 +60,26 @@ int main(int argc, char *argv[])
   }
   
   // Check extension of the file
-  se3::ModelFileExtensionType extension_type = se3::checkModelFileExtension(filename);
-  se3::Model model;
+  pinocchio::ModelFileExtensionType extension_type = pinocchio::checkModelFileExtension(filename);
+  pinocchio::Model model;
   
   switch(extension_type)
   {
-    case se3::URDF:
+    case pinocchio::URDF:
 #ifdef PINOCCHIO_WITH_URDFDOM
-      se3::urdf::buildModel(filename,model,verbose);
+      pinocchio::urdf::buildModel(filename,model,verbose);
 #else
       std::cerr << "It seems that the URDFDOM module has not been found during the Cmake process." << std::endl;
 #endif
       break;
-    case se3::LUA:
+    case pinocchio::LUA:
 #ifdef PINOCCHIO_WITH_LUA5
-      model = se3::lua::buildModel(filename, false, verbose);
+      model = pinocchio::lua::buildModel(filename, false, verbose);
 #else
       std::cerr << "It seems that the LUA module has not been found during the Cmake process." << std::endl;
 #endif
       break;
-    case se3::UNKNOWN:
+    case pinocchio::UNKNOWN:
       std::cerr << "Unknown extension of " << filename << std::endl;
       return -1;
       break;


### PR DESCRIPTION
Related to discussions in #570.

The former se3 is still valid. The deprecated message is not shown if `PINOCCHIO_ENABLE_COMPATIBILITY_WITH_VERSION_1` is defined.