### PR TITLE
[geometry] fix addGeometryObject

### DIFF
--- a/src/multibody/geometry.hpp
+++ b/src/multibody/geometry.hpp
@@ -86,9 +86,9 @@ namespace pinocchio
                                 const bool autofillJointParent)
     {
       if(autofillJointParent)
-        addGeometryObject(object,model);
+        return addGeometryObject(object,model);
       else
-        addGeometryObject(object);
+        return addGeometryObject(object);
     }
     
     /**


### PR DESCRIPTION
Method `addGeometryObject(object,model,bool);` is now deprecated, but it contained a small bug, so I fixed it (it was causing a warning)