### PR TITLE
Set of minor fixes

### DIFF
--- a/doc/Doxyfile.extra.in
+++ b/doc/Doxyfile.extra.in
@@ -524,7 +524,7 @@ FORMULA_FONTSIZE       = 12
 # If the GENERATE_LATEX tag is set to YES (the default) Doxygen will
 # generate Latex output.
 
-GENERATE_LATEX         = YES
+GENERATE_LATEX         = NO
 
 # The EXTRA_PACKAGES tag can be to specify one or more names of LaTeX
 # packages that should be included in the LaTeX output.

--- a/src/multibody/data.hxx
+++ b/src/multibody/data.hxx
@@ -95,7 +95,7 @@ namespace pinocchio
     
     /* Create data strcture associated to the joints */
     for(JointIndex i=0;i<(JointIndex)(model.njoints);++i)
-      joints.push_back(CreateJointData<Scalar,Options,JointCollectionDefaultTpl>::run(model.joints[i]));
+      joints.push_back(CreateJointData<Scalar,Options,JointCollectionTpl>::run(model.joints[i]));
 
     /* Init for CRBA */
     M.setZero(); Minv.setZero();

--- a/src/multibody/joint/joint-collection.hpp
+++ b/src/multibody/joint/joint-collection.hpp
@@ -66,7 +66,7 @@ namespace pinocchio
     typedef JointModelPlanarTpl<Scalar,Options> JointModelPlanar;
     
     // Joint Composite
-    typedef JointModelCompositeTpl<Scalar,Options,JointCollectionDefaultTpl> JointModelComposite;
+    typedef JointModelCompositeTpl<Scalar,Options,::pinocchio::JointCollectionDefaultTpl> JointModelComposite;
     
     typedef boost::variant<
 //    JointModelVoid,
@@ -119,7 +119,7 @@ namespace pinocchio
     typedef JointDataPlanarTpl<Scalar,Options> JointDataPlanar;
     
     // Joint Composite
-    typedef JointDataCompositeTpl<Scalar,Options,JointCollectionDefaultTpl> JointDataComposite;
+    typedef JointDataCompositeTpl<Scalar,Options,::pinocchio::JointCollectionDefaultTpl> JointDataComposite;
     
     typedef boost::variant<
 //    JointDataVoid

--- a/src/multibody/joint/joint-revolute.hpp
+++ b/src/multibody/joint/joint-revolute.hpp
@@ -102,34 +102,7 @@ namespace pinocchio
     PlainType plain() const
     {
       PlainType res(PlainType::Identity());
-      typename PlainType::AngularRef rot = res.rotation();
-      switch(axis)
-      {
-        case 0:
-        {
-          rot.coeffRef(1,1) = m_cos; rot.coeffRef(1,2) = -m_sin;
-          rot.coeffRef(2,1) = m_sin; rot.coeffRef(2,2) =  m_cos;
-          break;
-        }
-        case 1:
-        {
-          rot.coeffRef(0,0) =  m_cos; rot.coeffRef(0,2) = m_sin;
-          rot.coeffRef(2,0) = -m_sin; rot.coeffRef(2,2) = m_cos;
-          break;
-        }
-        case 2:
-        {
-          rot.coeffRef(0,0) = m_cos; rot.coeffRef(0,1) = -m_sin;
-          rot.coeffRef(1,0) = m_sin; rot.coeffRef(1,1) =  m_cos;
-          break;
-        }
-        default:
-        {
-          assert(false && "must nerver happened");
-          break;
-        }
-      }
-      
+      _setRotation (res.rotation());
       return res;
     }
     
@@ -180,10 +153,46 @@ namespace pinocchio
     template<typename OtherScalar>
     void setValues(const OtherScalar & sin, const OtherScalar & cos)
     { m_sin = sin; m_cos = cos; }
+
+    LinearType translation() const { return LinearType::Zero(3); };
+    AngularType rotation() const {
+      AngularType m(AngularType::Identity(3));
+      _setRotation (m);
+      return m;
+    }
     
   protected:
     
     Scalar m_sin, m_cos;
+    inline void _setRotation (typename PlainType::AngularRef& rot) const
+    {
+      switch(axis)
+      {
+        case 0:
+        {
+          rot.coeffRef(1,1) = m_cos; rot.coeffRef(1,2) = -m_sin;
+          rot.coeffRef(2,1) = m_sin; rot.coeffRef(2,2) =  m_cos;
+          break;
+        }
+        case 1:
+        {
+          rot.coeffRef(0,0) =  m_cos; rot.coeffRef(0,2) = m_sin;
+          rot.coeffRef(2,0) = -m_sin; rot.coeffRef(2,2) = m_cos;
+          break;
+        }
+        case 2:
+        {
+          rot.coeffRef(0,0) = m_cos; rot.coeffRef(0,1) = -m_sin;
+          rot.coeffRef(1,0) = m_sin; rot.coeffRef(1,1) =  m_cos;
+          break;
+        }
+        default:
+        {
+          assert(false && "must nerver happened");
+          break;
+        }
+      }
+    }
   };
 
   template<typename _Scalar, int _Options, int axis>

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -88,7 +88,7 @@ SE3_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *
      * @param[in]  q    configuration vector.
      * @param[in]  v    tangent vector.
-     * @tparam[in] arg  ARG0 (resp. ARG1) to get the Jacobian with respect to q (resp. v).
+     * @tparam     arg  ARG0 (resp. ARG1) to get the Jacobian with respect to q (resp. v).
      *
      * @param[out] J    the Jacobian of the Integrate operation w.r.t. the argument arg.
      */
@@ -226,7 +226,7 @@ SE3_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *
      * @param[in]  q0    the initial configuration vector.
      * @param[in]  q1    the terminal configuration vector.
-     * @tparam[in] arg   ARG0 (resp. ARG1) to get the Jacobian with respect to q0 (resp. q1).
+     * @tparam     arg   ARG0 (resp. ARG1) to get the Jacobian with respect to q0 (resp. q1).
      *
      * @param[out] J     the Jacobian of the difference operation.
      */

--- a/src/parsers/sample-models.cpp
+++ b/src/parsers/sample-models.cpp
@@ -9,41 +9,13 @@ namespace pinocchio
 {
   namespace buildModels
   {
-    static const SE3 Id = SE3::Identity();
-
-    template<typename JointModel>
-    static void addJointAndBody(Model & model,
-                                const JointModelBase<JointModel> & joint,
-                                const std::string & parent_name,
-                                const std::string & name,
-                                const SE3 & placement = SE3::Random(),
-                                bool setRandomLimits = true)
-    {
-      typedef typename JointModel::ConfigVector_t CV;
-      typedef typename JointModel::TangentVector_t TV;
-      
-      Model::JointIndex idx;
-      
-      if(setRandomLimits)
-        idx = model.addJoint(model.getJointId(parent_name),joint,
-                             placement, name + "_joint",
-                             TV::Random(joint.nv(),1) + TV::Constant(joint.nv(),1,1), // effort
-                             TV::Random(joint.nv(),1) + TV::Constant(joint.nv(),1,1), // vel
-                             CV::Random(joint.nq(),1) - CV::Constant(joint.nq(),1,1), // qmin
-                             CV::Random(joint.nq(),1) + CV::Constant(joint.nq(),1,1)  // qmax
-                             );
-      else
-        idx = model.addJoint(model.getJointId(parent_name),joint,
-                             placement, name + "_joint");
-        
-      model.addJointFrame(idx);
-      
-      model.appendBodyToJoint(idx,Inertia::Random(),SE3::Identity());
-      model.addBodyFrame(name + "_body", idx);
-    }
+    using details::addJointAndBody;
 
     void humanoid2d(Model & model)
     {
+      using details::addJointAndBody;
+      static const SE3 Id = SE3::Identity();
+
       // root
       addJointAndBody(model, JointModelRX(), "universe", "ff1", Id, false);
       addJointAndBody(model, JointModelRY(), "ff1_joint", "root", Id, false);
@@ -70,59 +42,6 @@ namespace pinocchio
 
     }
 
-    void humanoidRandom(Model & model, bool usingFF)
-    {
-      // root
-      if(! usingFF )
-      {
-        JointModelComposite jff((JointModelTranslation()));
-        jff.addJoint(JointModelSphericalZYX());
-        addJointAndBody(model, jff, "universe", "root", Id);
-      }
-      else
-      {
-        addJointAndBody(model, JointModelFreeFlyer(), "universe", "root", Id);
-        model.lowerPositionLimit.segment<4>(3).fill(-1.);
-        model.upperPositionLimit.segment<4>(3).fill( 1.);
-      }
-
-      // lleg
-      addJointAndBody(model,JointModelRX(),"root_joint","lleg1");
-      addJointAndBody(model,JointModelRY(),"lleg1_joint","lleg2");
-      addJointAndBody(model,JointModelRZ(),"lleg2_joint","lleg3");
-      addJointAndBody(model,JointModelRY(),"lleg3_joint","lleg4");
-      addJointAndBody(model,JointModelRY(),"lleg4_joint","lleg5");
-      addJointAndBody(model,JointModelRX(),"lleg5_joint","lleg6");
-      
-      // rleg
-      addJointAndBody(model,JointModelRX(),"root_joint","rleg1");
-      addJointAndBody(model,JointModelRY(),"rleg1_joint","rleg2");
-      addJointAndBody(model,JointModelRZ(),"rleg2_joint","rleg3");
-      addJointAndBody(model,JointModelRY(),"rleg3_joint","rleg4");
-      addJointAndBody(model,JointModelRY(),"rleg4_joint","rleg5");
-      addJointAndBody(model,JointModelRX(),"rleg5_joint","rleg6");
-
-      // trunc
-      addJointAndBody(model,JointModelRY(),"root_joint","torso1");
-      addJointAndBody(model,JointModelRZ(),"torso1_joint","chest");
-      
-      // rarm
-      addJointAndBody(model,JointModelRX(),"chest_joint","rarm1");
-      addJointAndBody(model,JointModelRY(),"rarm1_joint","rarm2");
-      addJointAndBody(model,JointModelRZ(),"rarm2_joint","rarm3");
-      addJointAndBody(model,JointModelRY(),"rarm3_joint","rarm4");
-      addJointAndBody(model,JointModelRY(),"rarm4_joint","rarm5");
-      addJointAndBody(model,JointModelRX(),"rarm5_joint","rarm6");
-      
-      // larm
-      addJointAndBody(model,JointModelRX(),"chest_joint","larm1");
-      addJointAndBody(model,JointModelRY(),"larm1_joint","larm2");
-      addJointAndBody(model,JointModelRZ(),"larm2_joint","larm3");
-      addJointAndBody(model,JointModelRY(),"larm3_joint","larm4");
-      addJointAndBody(model,JointModelRY(),"larm4_joint","larm5");
-      addJointAndBody(model,JointModelRX(),"larm5_joint","larm6");
-
-    }
 
     static void addManipulator(Model & model,
                                Model::JointIndex rootJoint = 0,

--- a/src/parsers/sample-models.hpp
+++ b/src/parsers/sample-models.hpp
@@ -64,7 +64,8 @@ namespace pinocchio
      * uses a composite joint translation + roll-pitch-yaw.
      * This changes the size of the configuration space (33 vs 32).
      */
-    void humanoidRandom(Model & model, bool usingFF = true);
+    template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+    void humanoidRandom(ModelTpl<Scalar,Options,JointCollectionTpl> & model, bool usingFF = true);
 
     /** \brief Create a random humanoid tree with 2d limbs.
      * \ deprecated This function has been replaced by the non-random pinocchio::humanoid function.
@@ -75,11 +76,13 @@ namespace pinocchio
     /** \brief Alias of humanoidRandom, for compatibility reasons.
      * \deprecated use pinocchio::humanoid or pinocchio::humanoidRandom instead. 
      */
-    PINOCCHIO_DEPRECATED
-    inline void humanoidSimple(Model & model, bool usingFF = true)
-    { humanoidRandom(model,usingFF); }
+    template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+    inline void humanoidSimple(ModelTpl<Scalar,Options,JointCollectionTpl> & model, bool usingFF = true)
+    PINOCCHIO_DEPRECATED;
    
   } // namespace buildModels
 } // namespace pinocchio
+
+#include "pinocchio/parsers/sample-models.hxx"
 
 #endif // ifndef __pinocchio_sample_models_hpp__

--- a/src/parsers/sample-models.hxx
+++ b/src/parsers/sample-models.hxx
@@ -1,0 +1,116 @@
+//
+// Copyright (c) 2015-2018 CNRS
+// Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
+//
+
+#ifndef __pinocchio_sample_models_hxx__
+#define __pinocchio_sample_models_hxx__
+
+namespace pinocchio
+{
+  namespace buildModels
+  {
+    namespace details
+    {
+      template<typename Scalar, int Options,
+               template<typename,int> class JointCollectionTpl,
+               typename JointModel>
+      static void addJointAndBody(ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                                  const JointModelBase<JointModel> & joint,
+                                  const std::string & parent_name,
+                                  const std::string & name,
+                                  const SE3 & placement = SE3::Random(),
+                                  bool setRandomLimits = true)
+      {
+        typedef typename JointModel::ConfigVector_t CV;
+        typedef typename JointModel::TangentVector_t TV;
+        
+        JointIndex idx;
+        
+        if(setRandomLimits)
+          idx = model.addJoint(model.getJointId(parent_name),joint,
+                               placement, name + "_joint",
+                               TV::Random(joint.nv(),1) + TV::Constant(joint.nv(),1,1), // effort
+                               TV::Random(joint.nv(),1) + TV::Constant(joint.nv(),1,1), // vel
+                               CV::Random(joint.nq(),1) - CV::Constant(joint.nq(),1,1), // qmin
+                               CV::Random(joint.nq(),1) + CV::Constant(joint.nq(),1,1)  // qmax
+                               );
+        else
+          idx = model.addJoint(model.getJointId(parent_name),joint,
+                               placement, name + "_joint");
+          
+        model.addJointFrame(idx);
+        
+        model.appendBodyToJoint(idx,Inertia::Random(),SE3::Identity());
+        model.addBodyFrame(name + "_body", idx);
+      }
+    } // namespace details
+
+    template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+    inline void humanoidSimple(ModelTpl<Scalar,Options,JointCollectionTpl> & model, bool usingFF)
+    { humanoidRandom(model,usingFF); }
+
+    template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+    void humanoidRandom(ModelTpl<Scalar,Options,JointCollectionTpl> & model, bool usingFF)
+    {
+      using details::addJointAndBody;
+      static const SE3 Id = SE3::Identity();
+      typedef JointCollectionTpl<Scalar, Options> JC;
+
+      // root
+      if(! usingFF )
+      {
+        typename JC::JointModelComposite jff((typename JC::JointModelTranslation()));
+        jff.addJoint(typename JC::JointModelSphericalZYX());
+        addJointAndBody(model, jff, "universe", "root", Id);
+      }
+      else
+      {
+        addJointAndBody(model, typename JC::JointModelFreeFlyer(), "universe", "root", Id);
+        model.lowerPositionLimit.template segment<4>(3).fill(-1.);
+        model.upperPositionLimit.template segment<4>(3).fill( 1.);
+      }
+
+      // lleg
+      addJointAndBody(model,typename JC::JointModelRX(),"root_joint","lleg1");
+      addJointAndBody(model,typename JC::JointModelRY(),"lleg1_joint","lleg2");
+      addJointAndBody(model,typename JC::JointModelRZ(),"lleg2_joint","lleg3");
+      addJointAndBody(model,typename JC::JointModelRY(),"lleg3_joint","lleg4");
+      addJointAndBody(model,typename JC::JointModelRY(),"lleg4_joint","lleg5");
+      addJointAndBody(model,typename JC::JointModelRX(),"lleg5_joint","lleg6");
+      
+      // rleg
+      addJointAndBody(model,typename JC::JointModelRX(),"root_joint","rleg1");
+      addJointAndBody(model,typename JC::JointModelRY(),"rleg1_joint","rleg2");
+      addJointAndBody(model,typename JC::JointModelRZ(),"rleg2_joint","rleg3");
+      addJointAndBody(model,typename JC::JointModelRY(),"rleg3_joint","rleg4");
+      addJointAndBody(model,typename JC::JointModelRY(),"rleg4_joint","rleg5");
+      addJointAndBody(model,typename JC::JointModelRX(),"rleg5_joint","rleg6");
+
+      // trunc
+      addJointAndBody(model,typename JC::JointModelRY(),"root_joint","torso1");
+      addJointAndBody(model,typename JC::JointModelRZ(),"torso1_joint","chest");
+      
+      // rarm
+      addJointAndBody(model,typename JC::JointModelRX(),"chest_joint","rarm1");
+      addJointAndBody(model,typename JC::JointModelRY(),"rarm1_joint","rarm2");
+      addJointAndBody(model,typename JC::JointModelRZ(),"rarm2_joint","rarm3");
+      addJointAndBody(model,typename JC::JointModelRY(),"rarm3_joint","rarm4");
+      addJointAndBody(model,typename JC::JointModelRY(),"rarm4_joint","rarm5");
+      addJointAndBody(model,typename JC::JointModelRX(),"rarm5_joint","rarm6");
+      
+      // larm
+      addJointAndBody(model,typename JC::JointModelRX(),"chest_joint","larm1");
+      addJointAndBody(model,typename JC::JointModelRY(),"larm1_joint","larm2");
+      addJointAndBody(model,typename JC::JointModelRZ(),"larm2_joint","larm3");
+      addJointAndBody(model,typename JC::JointModelRY(),"larm3_joint","larm4");
+      addJointAndBody(model,typename JC::JointModelRY(),"larm4_joint","larm5");
+      addJointAndBody(model,typename JC::JointModelRX(),"larm5_joint","larm6");
+
+    }
+
+  } // namespace buildModels
+  
+} // namespace pinocchio
+
+#endif // ifndef __pinocchio_sample_models_hxx__


### PR DESCRIPTION
I am finalizing the tests in HPP using Pinocchio v2.

I played a bit with JointCollection. I have one minor question. Is there a reason to use:
```cpp
template<typename Scalar, int Options=0,
                template<typename,int> class JointCollectionTpl = JointCollectionDefaultTpl>
struct Model
```
rather than this:
```cpp
template<typename Scalar, int Options=0,
               class JointCollection = JointCollectionDefaultTpl<Scalar, Options> >
struct Model
```
?

With the current option, it is not possible to do:
```cpp
template <template<typename,int> class JointCollectionTpl>
void some_function_I_want_to_call (...)

some_function_I_want_to_call <Model::JointCollection> (...)
```