### PR TITLE
Joint bindings + fix explog

### DIFF
--- a/bindings/python/multibody/joint/joints-models.hpp
+++ b/bindings/python/multibody/joint/joints-models.hpp
@@ -8,6 +8,7 @@
 #include <eigenpy/exception.hpp>
 #include <eigenpy/eigenpy.hpp>
 #include "pinocchio/multibody/joint/joint-collection.hpp"
+#include "pinocchio/multibody/joint/joint-composite.hpp"
 
 namespace pinocchio
 {
@@ -23,6 +24,7 @@ namespace pinocchio
       return cl;
     }
 
+    // specialization for JointModelRevoluteUnaligned
     template<>
     inline bp::class_<JointModelRevoluteUnaligned>& expose_model<JointModelRevoluteUnaligned> (bp::class_<JointModelRevoluteUnaligned> & cl)
     {
@@ -36,6 +38,7 @@ namespace pinocchio
                ;
     }
 
+    // specialization for JointModelPrismaticUnaligned
     template<>
     inline bp::class_<JointModelPrismaticUnaligned>& expose_model<JointModelPrismaticUnaligned> (bp::class_<JointModelPrismaticUnaligned> & cl)
     {
@@ -46,6 +49,46 @@ namespace pinocchio
                              make_getter(&JointModelPrismaticUnaligned::axis, bp::return_value_policy<bp::return_by_value>()),
                              make_setter(&JointModelPrismaticUnaligned::axis, bp::return_value_policy<bp::return_by_value>()),
                              "Translation axis of the JointModelPrismaticUnaligned.")
+               ;
+    }
+
+    // specialization for JointModelComposite
+
+    struct JointModelCompositeAddJointVisitor : public boost::static_visitor<void>
+    {
+      JointModelComposite & m_joint_composite;
+      const SE3 & m_joint_placement;
+
+      JointModelCompositeAddJointVisitor(JointModelComposite & joint_composite,
+                      const SE3 & joint_placement)
+      : m_joint_composite(joint_composite)
+      , m_joint_placement(joint_placement)
+      {}
+
+      template <typename JointModelDerived>
+      void operator()(JointModelDerived & jmodel) const
+      {
+        return m_joint_composite.addJoint(jmodel,m_joint_placement);
+      }
+    }; // struct JointModelCompositeAddJointVisitor
+
+    static void addJoint_proxy(JointModelComposite & joint_composite,
+                         bp::object jmodel,
+                         const SE3 & joint_placement = SE3::Identity())
+    {
+      JointModelVariant jmodel_variant = bp::extract<JointModelVariant> (jmodel)();
+      boost::apply_visitor(JointModelCompositeAddJointVisitor(joint_composite,joint_placement), jmodel_variant);
+    }
+
+    BOOST_PYTHON_FUNCTION_OVERLOADS(addJoint_proxy_overloads,addJoint_proxy,2,3)
+
+    template<>
+    inline bp::class_<JointModelComposite>& expose_model<JointModelComposite> (bp::class_<JointModelComposite> & cl)
+    {
+      return cl
+               .def(bp::init<const size_t> (bp::args("size"), "Init JointModelComposite with a defined size"))
+               .add_property("joints",&JointModelComposite::joints)
+               .def("addJoint",&addJoint_proxy,addJoint_proxy_overloads(bp::args("joint_model","joint_placement"),"Add a joint to the vector of joints."))
                ;
     }
   } // namespace python

--- a/bindings/python/multibody/joint/joints-models.hpp
+++ b/bindings/python/multibody/joint/joints-models.hpp
@@ -16,17 +16,37 @@ namespace pinocchio
     namespace bp = boost::python;
 
 
-    // generic expose_constructor : do nothing special
+    // generic expose_model : do nothing special
     template <class T>
-    inline bp::class_<T>& expose_constructors(bp::class_<T>& cl)
+    inline bp::class_<T>& expose_model(bp::class_<T>& cl)
     {
       return cl;
     }
 
     template<>
-    inline bp::class_<JointModelRevoluteUnaligned>& expose_constructors<JointModelRevoluteUnaligned> (bp::class_<JointModelRevoluteUnaligned> & cl)
+    inline bp::class_<JointModelRevoluteUnaligned>& expose_model<JointModelRevoluteUnaligned> (bp::class_<JointModelRevoluteUnaligned> & cl)
     {
-      return cl.def(bp::init<double, double, double> ((bp::args("x"), bp::args("y"), bp::args("z")), "Init JointRevoluteUnaligned from the components x, y, z of the axis"));
+      return cl
+               .def(bp::init<double, double, double> (bp::args("x", "y", "z"), "Init JointModelRevoluteUnaligned from the components x, y, z of the axis"))
+               .def(bp::init<Eigen::Vector3d> (bp::args("axis"), "Init JointModelRevoluteUnaligned from an axis with x-y-z components"))
+               .add_property("axis",
+                             make_getter(&JointModelRevoluteUnaligned::axis, bp::return_value_policy<bp::return_by_value>()),
+                             make_setter(&JointModelRevoluteUnaligned::axis, bp::return_value_policy<bp::return_by_value>()),
+                             "Rotation axis of the JointModelRevoluteUnaligned.")
+               ;
+    }
+
+    template<>
+    inline bp::class_<JointModelPrismaticUnaligned>& expose_model<JointModelPrismaticUnaligned> (bp::class_<JointModelPrismaticUnaligned> & cl)
+    {
+      return cl
+               .def(bp::init<double, double, double> (bp::args("x", "y", "z"), "Init JointModelPrismaticUnaligned from the components x, y, z of the axis"))
+               .def(bp::init<Eigen::Vector3d> (bp::args("axis"), "Init JointModelPrismaticUnaligned from an axis with x-y-z components"))
+               .add_property("axis",
+                             make_getter(&JointModelPrismaticUnaligned::axis, bp::return_value_policy<bp::return_by_value>()),
+                             make_setter(&JointModelPrismaticUnaligned::axis, bp::return_value_policy<bp::return_by_value>()),
+                             "Translation axis of the JointModelPrismaticUnaligned.")
+               ;
     }
   } // namespace python
 } // namespace pinocchio

--- a/bindings/python/multibody/joint/joints-models.hpp
+++ b/bindings/python/multibody/joint/joints-models.hpp
@@ -17,16 +17,16 @@ namespace pinocchio
     namespace bp = boost::python;
 
 
-    // generic expose_model : do nothing special
+    // generic expose_joint_model : do nothing special
     template <class T>
-    inline bp::class_<T>& expose_model(bp::class_<T>& cl)
+    inline bp::class_<T>& expose_joint_model(bp::class_<T>& cl)
     {
       return cl;
     }
 
     // specialization for JointModelRevoluteUnaligned
     template<>
-    inline bp::class_<JointModelRevoluteUnaligned>& expose_model<JointModelRevoluteUnaligned> (bp::class_<JointModelRevoluteUnaligned> & cl)
+    inline bp::class_<JointModelRevoluteUnaligned>& expose_joint_model<JointModelRevoluteUnaligned> (bp::class_<JointModelRevoluteUnaligned> & cl)
     {
       return cl
                .def(bp::init<double, double, double> (bp::args("x", "y", "z"), "Init JointModelRevoluteUnaligned from the components x, y, z of the axis"))
@@ -40,7 +40,7 @@ namespace pinocchio
 
     // specialization for JointModelPrismaticUnaligned
     template<>
-    inline bp::class_<JointModelPrismaticUnaligned>& expose_model<JointModelPrismaticUnaligned> (bp::class_<JointModelPrismaticUnaligned> & cl)
+    inline bp::class_<JointModelPrismaticUnaligned>& expose_joint_model<JointModelPrismaticUnaligned> (bp::class_<JointModelPrismaticUnaligned> & cl)
     {
       return cl
                .def(bp::init<double, double, double> (bp::args("x", "y", "z"), "Init JointModelPrismaticUnaligned from the components x, y, z of the axis"))
@@ -83,7 +83,7 @@ namespace pinocchio
     BOOST_PYTHON_FUNCTION_OVERLOADS(addJoint_proxy_overloads,addJoint_proxy,2,3)
 
     template<>
-    inline bp::class_<JointModelComposite>& expose_model<JointModelComposite> (bp::class_<JointModelComposite> & cl)
+    inline bp::class_<JointModelComposite>& expose_joint_model<JointModelComposite> (bp::class_<JointModelComposite> & cl)
     {
       return cl
                .def(bp::init<const size_t> (bp::args("size"), "Init JointModelComposite with a defined size"))

--- a/bindings/python/multibody/joint/joints-variant.hpp
+++ b/bindings/python/multibody/joint/joints-variant.hpp
@@ -35,7 +35,7 @@ namespace pinocchio
       template<class T>
       void operator()(T)
       {
-        expose_model<T>(bp::class_<T>(T::classname().c_str(),bp::init<>()).def(JointPythonVisitor<T>()));
+        expose_joint_model<T>(bp::class_<T>(T::classname().c_str(),bp::init<>()).def(JointPythonVisitor<T>()));
         bp::implicitly_convertible<T,pinocchio::JointModelVariant>();
       }
     };

--- a/bindings/python/multibody/joint/joints-variant.hpp
+++ b/bindings/python/multibody/joint/joints-variant.hpp
@@ -35,7 +35,7 @@ namespace pinocchio
       template<class T>
       void operator()(T)
       {
-        expose_constructors<T>(bp::class_<T>(T::classname().c_str(),bp::init<>()).def(JointPythonVisitor<T>()));
+        expose_model<T>(bp::class_<T>(T::classname().c_str(),bp::init<>()).def(JointPythonVisitor<T>()));
         bp::implicitly_convertible<T,pinocchio::JointModelVariant>();
       }
     };

--- a/bindings/python/scripts/deprecated.py
+++ b/bindings/python/scripts/deprecated.py
@@ -6,89 +6,104 @@
 
 from __future__ import print_function
 
-from . import libpinocchio_pywrap as se3 
+from . import libpinocchio_pywrap as pin 
 from .deprecation import deprecated
 
 @deprecated("This function has been renamed to impulseDynamics for consistency with the C++ interface. Please change for impulseDynamics.")
 def impactDynamics(model, data, q, v_before, J, r_coeff=0.0, update_kinematics=True):
-  return se3.impulseDynamics(model, data, q, v_before, J, r_coeff, update_kinematics)
+  return pin.impulseDynamics(model, data, q, v_before, J, r_coeff, update_kinematics)
 
 @deprecated("This function has been deprecated. Please use buildSampleModelHumanoid or buildSampleModelHumanoidRandom instead.")
 def buildSampleModelHumanoidSimple(usingFF=True):
-    return se3.buildSampleModelHumanoidRandom(usingFF)
+    return pin.buildSampleModelHumanoidRandom(usingFF)
 
 @deprecated("Static method Model.BuildHumanoidSimple has been deprecated. Please use function buildSampleModelHumanoid or buildSampleModelHumanoidRandom instead.")
 def _Model__BuildHumanoidSimple(usingFF=True):
-    return se3.buildSampleModelHumanoidRandom(usingFF)
+    return pin.buildSampleModelHumanoidRandom(usingFF)
 
-se3.Model.BuildHumanoidSimple = staticmethod(_Model__BuildHumanoidSimple)
+pin.Model.BuildHumanoidSimple = staticmethod(_Model__BuildHumanoidSimple)
 
 @deprecated("Static method Model.BuildEmptyModel has been deprecated. Please use the empty Model constructor instead.")
 def _Model__BuildEmptyModel():
-    return se3.Model()
+    return pin.Model()
 
-se3.Model.BuildEmptyModel = staticmethod(_Model__BuildEmptyModel)
+pin.Model.BuildEmptyModel = staticmethod(_Model__BuildEmptyModel)
 
 @deprecated("This function has been renamed updateFramePlacements when taking two arguments, and framesForwardKinematics when taking three. Please change your code to the appropriate method.")
 def framesKinematics(model,data,q=None):
   if q is None:
-    se3.updateFramePlacements(model,data)
+    pin.updateFramePlacements(model,data)
   else:
-    se3.framesForwardKinematics(model,data,q)
+    pin.framesForwardKinematics(model,data,q)
 
 @deprecated("This function has been renamed computeJointJacobians and will be removed in future releases of Pinocchio. Please change for new computeJointJacobians.")
 def computeJacobians(model,data,q=None):
   if q is None:
-    return se3.computeJointJacobians(model,data)
+    return pin.computeJointJacobians(model,data)
   else:
-    return se3.computeJointJacobians(model,data,q)
+    return pin.computeJointJacobians(model,data,q)
 
 @deprecated("This function has been renamed jointJacobian and will be removed in future releases of Pinocchio. Please change for new jointJacobian function.")
 def jacobian(model,data,q,jointId,local,update_kinematics):
   if local:
-    return se3.jointJacobian(model,data,q,jointId,se3.ReferenceFrame.LOCAL,update_kinematics)
+    return pin.jointJacobian(model,data,q,jointId,pin.ReferenceFrame.LOCAL,update_kinematics)
   else:
-    return se3.jointJacobian(model,data,q,jointId,se3.ReferenceFrame.WORLD,update_kinematics)
+    return pin.jointJacobian(model,data,q,jointId,pin.ReferenceFrame.WORLD,update_kinematics)
 
 @deprecated("This function has been renamed getJointJacobian and will be removed in future releases of Pinocchio. Please change for new getJointJacobian function.")
 def getJacobian(model,data,jointId,local):
   if local:
-    return se3.getJointJacobian(model,data,jointId,se3.ReferenceFrame.LOCAL)
+    return pin.getJointJacobian(model,data,jointId,pin.ReferenceFrame.LOCAL)
   else:
-    return se3.getJointJacobian(model,data,jointId,se3.ReferenceFrame.WORLD)
+    return pin.getJointJacobian(model,data,jointId,pin.ReferenceFrame.WORLD)
 
 @deprecated("This function has been renamed computeJacobiansTimeVariation and will be removed in future releases of Pinocchio. Please change for new computeJointJacobiansTimeVariation.")
 def computeJacobiansTimeVariation(model,data,q,v):
-  return se3.computeJointJacobiansTimeVariation(model,data,q,v)
+  return pin.computeJointJacobiansTimeVariation(model,data,q,v)
 
 @deprecated("This function has been renamed getJointJacobianTimeVariation and will be removed in future releases of Pinocchio. Please change for new getJointJacobianTimeVariation function.")
 def getJacobianTimeVariation(model,data,jointId,local):
   if local:
-    return se3.getJointJacobianTimeVariation(model,data,jointId,se3.ReferenceFrame.LOCAL)
+    return pin.getJointJacobianTimeVariation(model,data,jointId,pin.ReferenceFrame.LOCAL)
   else:
-    return se3.getJointJacobianTimeVariation(model,data,jointId,se3.ReferenceFrame.WORLD)
+    return pin.getJointJacobianTimeVariation(model,data,jointId,pin.ReferenceFrame.WORLD)
 
 @deprecated("This function has been renamed difference and will be removed in future releases of Pinocchio. Please change for new difference function.")
 def differentiate(model,q0,q1):
-  return se3.difference(model,q0,q1)
+  return pin.difference(model,q0,q1)
 
 @deprecated("This function has been renamed difference and will be removed in future releases of Pinocchio. Please change for new getNeutralConfiguration function.")
 def getNeutralConfigurationFromSrdf(model, filename, verbose):
-  return se3.getNeutralConfiguration(model,filename,verbose)
+  return pin.getNeutralConfiguration(model,filename,verbose)
 
 @deprecated("This function has been renamed difference and will be removed in future releases of Pinocchio. Please change for new loadRotorParameters function.")
 def loadRotorParamsFromSrdf(model, filename, verbose):
-  return se3.loadRotorParams(model,filename,verbose)
+  return pin.loadRotorParams(model,filename,verbose)
 
 @deprecated("This function has been renamed difference and will be removed in future releases of Pinocchio. Please change for new removeCollisionPairs function.")
 def removeCollisionPairsFromSrdf(model, geomModel, filename, verbose):
-  return se3.removeCollisionPairs(model,geomModel,filename,verbose)
+  return pin.removeCollisionPairs(model,geomModel,filename,verbose)
 
 @deprecated("This function signature has been changed and will be removed in future releases of Pinocchio. Please change for new signature of the jacobianCenterOfMass function.")
 def jacobianCenterOfMass(model, data, q, computeSubtreeComs, updateKinematics):
-  return se3.jacobianCenterOfMass(model,data,q,computeSubtreeComs,updateKinematics)
+  return pin.jacobianCenterOfMass(model,data,q,computeSubtreeComs,updateKinematics)
+
+@deprecated("This function will be removed in future releases of Pinocchio. You can use exp or exp6.")
+def exp6FromMotion(motion):
+  return pin.exp6(motion)
+
+@deprecated("This function will be removed in future releases of Pinocchio. You can build a Motion object from a 6D vector and use the standard exp function to recover the same behavior.")
+def exp6FromVector(vector6):
+  v = pin.Motion(vector6)
+  return pin.exp6(v)
+
+@deprecated("This function will be removed in future releases of Pinocchio. You can use log or log6.")
+def log6FromSE3(transform):
+  return pin.log6(transform)
 
 @deprecated("This function will be removed in future releases of Pinocchio. You can build a SE3 transform from a rotation matrix and a translation vector and use the standard log function to recover the same behavior.")
-def exp6FromVector(vector6):
-  v = se3.Motion(vector6)
-  return se3.exp6(v)
+def log6FromMatrix(vector6):
+  M = pin.SE3()
+  M.rotation = x[:3,:3]
+  M.translation = x[:3,-1]
+  return pin.log6(M)

--- a/bindings/python/scripts/deprecated.py
+++ b/bindings/python/scripts/deprecated.py
@@ -102,8 +102,8 @@ def log6FromSE3(transform):
   return pin.log6(transform)
 
 @deprecated("This function will be removed in future releases of Pinocchio. You can build a SE3 transform from a rotation matrix and a translation vector and use the standard log function to recover the same behavior.")
-def log6FromMatrix(vector6):
+def log6FromMatrix(matrix4):
   M = pin.SE3()
-  M.rotation = x[:3,:3]
-  M.translation = x[:3,-1]
+  M.rotation = matrix4[:3,:3]
+  M.translation = np.matrix(matrix4[:3,-1]).T
   return pin.log6(M)

--- a/bindings/python/scripts/explog.py
+++ b/bindings/python/scripts/explog.py
@@ -32,7 +32,7 @@ def log(x):
         if x.shape == (4, 4):
             M = pin.SE3()
             M.rotation = x[:3,:3]
-            M.translation = x[:3,-1]
+            M.translation = np.matrix(x[:3,-1]).T
             return pin.log6(M)
         if x.shape == (3, 3):
             return pin.log3(x)

--- a/bindings/python/spatial/explog.hpp
+++ b/bindings/python/spatial/explog.hpp
@@ -53,7 +53,7 @@ namespace pinocchio
       return res;
     }
     
-    Eigen::Vector3d log3_proxy(Eigen::Matrix3d R)
+    Eigen::Vector3d log3_proxy(const Eigen::Matrix3d & R)
     {
       return log3(R);
     }

--- a/bindings/python/spatial/explog.hpp
+++ b/bindings/python/spatial/explog.hpp
@@ -53,6 +53,11 @@ namespace pinocchio
       return res;
     }
     
+    Eigen::Vector3d log3_proxy(Eigen::Matrix3d R)
+    {
+      return log3(R);
+    }
+    
   } // namespace python
 } //namespace pinocchio
 

--- a/bindings/python/spatial/expose-explog.cpp
+++ b/bindings/python/spatial/expose-explog.cpp
@@ -25,7 +25,7 @@ namespace pinocchio
               "Jacobian of exp(R) which maps from the tangent of SO(3) at exp(v) to"
               " the tangent of SO(3) at Identity.");
       
-      bp::def("log3",(Eigen::Vector3d (*)(const Eigen::MatrixBase<Eigen::Matrix3d> &))&log3<Eigen::Matrix3d>,
+      bp::def("log3",&log3_proxy,
               bp::arg("Rotation matrix (matrix of size 3x3))"),
               "Log: SO3 -> so3. Pseudo-inverse of log from SO3"
               " -> { v in so3, ||v|| < 2pi }.Exp: so3 -> SO3.");

--- a/src/multibody/joint/joint-composite.hpp
+++ b/src/multibody/joint/joint-composite.hpp
@@ -273,7 +273,7 @@ namespace pinocchio
       updateJointIndexes();
     }
 
-    static std::string classname() { return std::string("JointModelCompositeTpl"); }
+    static std::string classname() { return std::string("JointModelComposite"); }
     std::string shortname() const { return classname(); }
 
     JointModelCompositeTpl & operator=(const JointModelCompositeTpl & other)

--- a/src/multibody/joint/joint-prismatic-unaligned.hpp
+++ b/src/multibody/joint/joint-prismatic-unaligned.hpp
@@ -439,16 +439,17 @@ namespace pinocchio
     
     typedef Eigen::Matrix<Scalar,3,1,_Options> Vector3;
     
-    JointModelPrismaticUnalignedTpl() : axis(Vector3::Constant(NAN))   {}
+    JointModelPrismaticUnalignedTpl() {}
     JointModelPrismaticUnalignedTpl(Scalar x, Scalar y, Scalar z)
+    : axis(x,y,z)
     {
-      axis << x, y, z ;
       axis.normalize();
       assert(axis.isUnitary() && "Translation axis is not unitary");
     }
     
     template<typename Vector3Like>
-    JointModelPrismaticUnalignedTpl(const Eigen::MatrixBase<Vector3Like> & axis) : axis(axis)
+    JointModelPrismaticUnalignedTpl(const Eigen::MatrixBase<Vector3Like> & axis)
+    : axis(axis)
     {
       EIGEN_STATIC_ASSERT_VECTOR_ONLY(Vector3Like);
       assert(axis.isUnitary() && "Translation axis is not unitary");
@@ -501,7 +502,7 @@ namespace pinocchio
       return sqrt(Eigen::NumTraits<Scalar>::epsilon());
     }
 
-    static std::string classname() { return std::string("JointModelPrismaticUnalignedTpl"); }
+    static std::string classname() { return std::string("JointModelPrismaticUnaligned"); }
     std::string shortname() const { return classname(); }
     
     /// \returns An expression of *this with the Scalar type casted to NewScalar.

--- a/src/multibody/joint/joint-revolute-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unaligned.hpp
@@ -468,6 +468,7 @@ namespace pinocchio
     JointModelRevoluteUnalignedTpl(const Eigen::MatrixBase<Vector3Like> & axis)
     : axis(axis)
     {
+      EIGEN_STATIC_ASSERT_VECTOR_ONLY(Vector3Like);
       assert(axis.isUnitary() && "Rotation axis is not unitary");
     }
 

--- a/unittest/python/bindings.py
+++ b/unittest/python/bindings.py
@@ -1,3 +1,4 @@
+import unittest
 import pinocchio as se3
 from pinocchio.utils import np, npl, rand, skew, zero
 
@@ -91,10 +92,6 @@ class TestSE3(TestCase):
         self.assertApprox(m ^ f, m.cross(f))
         with self.assertRaises(TypeError):
             m ^ 2
-
-    def test_exp(self):
-        m = se3.Motion.Random()
-        self.assertApprox(se3.exp(m), se3.exp6FromMotion(m))
 
 if __name__ == '__main__':
     unittest.main()

--- a/unittest/python/bindings_joint_composite.py
+++ b/unittest/python/bindings_joint_composite.py
@@ -1,0 +1,47 @@
+import unittest
+import pinocchio as se3
+import numpy as np
+
+class TestJointCompositeBindings(unittest.TestCase):
+
+    def test_basic(self):
+        jc = se3.JointModelComposite()
+        self.assertTrue(hasattr(jc,'joints'))
+
+    def test_empty_constructor(self):
+        jc = se3.JointModelComposite()
+        self.assertTrue(jc.nq==0)
+        self.assertTrue(len(jc.joints)==0)
+
+    def test_reserve_constructor(self):
+        jc = se3.JointModelComposite(2)
+        self.assertTrue(jc.nq==0)
+        self.assertTrue(len(jc.joints)==0)
+
+    def test_add_joint(self):
+        j1 = se3.JointModelRX()
+        self.assertTrue(j1.nq==1)
+        j2 = se3.JointModelRY()
+        self.assertTrue(j2.nq==1)
+        j3 = se3.JointModelRZ()
+        self.assertTrue(j3.nq==1)
+
+        jc = se3.JointModelComposite(2)
+        self.assertTrue(jc.nq==0)
+        self.assertTrue(len(jc.joints)==0)
+
+        jc.addJoint(j1)
+        self.assertTrue(jc.nq==1)
+        self.assertTrue(len(jc.joints)==1)
+
+        jc.addJoint(j2)
+        self.assertTrue(jc.nq==2)
+        self.assertTrue(len(jc.joints)==2)
+
+        jc.addJoint(j3,se3.SE3.Identity())
+        self.assertTrue(jc.nq==3)
+        self.assertTrue(len(jc.joints)==3)
+        
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unittest/python/explog.py
+++ b/unittest/python/explog.py
@@ -1,3 +1,4 @@
+import unittest
 import math
 
 import numpy as np

--- a/unittest/python/model.py
+++ b/unittest/python/model.py
@@ -1,3 +1,4 @@
+import unittest
 import pinocchio as se3
 from pinocchio.utils import np, zero
 

--- a/unittest/python/rpy.py
+++ b/unittest/python/rpy.py
@@ -1,3 +1,4 @@
+import unittest
 from math import pi
 
 import numpy as np

--- a/unittest/python/tests.py
+++ b/unittest/python/tests.py
@@ -13,6 +13,7 @@ from bindings_frame import TestFrameBindings
 from bindings_geometry_object import TestGeometryObjectBindings
 from bindings_geometry_object_urdf import TestGeometryObjectUrdfBindings
 from bindings_dynamics import TestDynamicsBindings
+from bindings_joint_composite import TestJointCompositeBindings
 from explog import TestExpLog
 from model import TestModel
 from rpy import TestRPY

--- a/unittest/python/utils.py
+++ b/unittest/python/utils.py
@@ -1,3 +1,4 @@
+import unittest
 from math import sqrt
 
 import numpy as np


### PR DESCRIPTION
- exposed constructors and axis for JointModelPrismaticUnaligned and JointModelRevoluteUnaligned
- exposed some constructors and addJoint for JointModelComposite
- fixed bugs in python's explog
- related minor stuff

While working on the unit test for JointModelComposite, I found the unit tests using explog were not working any more, so I fixed them.
As a rule of thumb, If we have unit tests, better use them
