### PR TITLE
[bindings] fix explog

### DIFF
--- a/bindings/python/scripts/deprecated.py
+++ b/bindings/python/scripts/deprecated.py
@@ -101,9 +101,6 @@ def exp6FromVector(vector6):
 def log6FromSE3(transform):
   return pin.log6(transform)
 
-@deprecated("This function will be removed in future releases of Pinocchio. You can build a SE3 transform from a rotation matrix and a translation vector and use the standard log function to recover the same behavior.")
+@deprecated("This function will be removed in future releases of Pinocchio. You can use log or log6.")
 def log6FromMatrix(matrix4):
-  M = pin.SE3()
-  M.rotation = matrix4[:3,:3]
-  M.translation = np.matrix(matrix4[:3,-1]).T
-  return pin.log6(M)
+  return pin.log6(matrix4)

--- a/bindings/python/scripts/explog.py
+++ b/bindings/python/scripts/explog.py
@@ -30,10 +30,7 @@ def log(x):
         return math.log(x)
     if isinstance(x, np.ndarray):
         if x.shape == (4, 4):
-            M = pin.SE3()
-            M.rotation = x[:3,:3]
-            M.translation = np.matrix(x[:3,-1]).T
-            return pin.log6(M)
+            return pin.log6(x)
         if x.shape == (3, 3):
             return pin.log3(x)
         raise ValueError('Error only 3 and 4 matrices are allowed.')

--- a/src/spatial/explog.hpp
+++ b/src/spatial/explog.hpp
@@ -373,12 +373,7 @@ namespace pinocchio
   {
     PINOCCHIO_ASSERT_MATRIX_SPECIFIC_SIZE (Matrix4Like, M, 4, 4);
 
-    typedef typename SE3Tpl<typename Matrix4Like::Scalar,Matrix4Like::Options>::Vector3 Vector3;
-    typedef typename SE3Tpl<typename Matrix4Like::Scalar,Matrix4Like::Options>::Matrix3 Matrix3;
-
-    Matrix3 rot(M.template block<3,3>(0,0));
-    Vector3 trans(M.template block<3,1>(0,3));
-    SE3Tpl<typename Matrix4Like::Scalar,Eigen::internal::traits<Matrix4Like>::Options> m(rot, trans);
+    SE3Tpl<typename Matrix4Like::Scalar,Eigen::internal::traits<Matrix4Like>::Options> m(M);
     return log6(m);
   }
 

--- a/unittest/explog.cpp
+++ b/unittest/explog.cpp
@@ -157,6 +157,10 @@ BOOST_AUTO_TEST_CASE(Jexp3_fd)
   Motion::Vector3 v = log3(R);
 
   SE3::Matrix3 Jexp_fd, Jexp;
+
+  Jexp3(Motion::Vector3::Zero(), Jexp);
+  BOOST_CHECK(Jexp.isIdentity());
+
   Jexp3(v, Jexp);
 
   Motion::Vector3 dv; dv.setZero();

--- a/unittest/python/explog.py
+++ b/unittest/python/explog.py
@@ -3,13 +3,58 @@ import math
 
 import numpy as np
 import pinocchio as se3
-from pinocchio.utils import rand
+from pinocchio.utils import rand, zero, eye
 from pinocchio.explog import exp, log
 
 from test_case import TestCase
 
 
 class TestExpLog(TestCase):
+    def test_exp3(self):
+        v = zero(3)
+        m = se3.exp3(v)
+        self.assertApprox(m, eye(3))
+
+    def test_Jexp3(self):
+        v = zero(3)
+        m = se3.Jexp3(v)
+        self.assertApprox(m, eye(3))
+
+    def test_log3(self):
+        m = eye(3)
+        v = se3.log3(m)
+        self.assertApprox(v, zero(3))
+
+    def test_Jlog3(self):
+        m = eye(3)
+        J = se3.Jlog3(m)
+        self.assertApprox(J, eye(3))
+
+    def test_exp6(self):
+        v = se3.Motion.Zero()
+        m = se3.exp6(v)
+        self.assertTrue(m.isIdentity())
+
+    def test_Jexp6(self):
+        v = se3.Motion.Zero()
+        J = se3.Jexp6(v)
+        self.assertApprox(J,eye(6))
+    
+    def test_log6(self):
+        m = se3.SE3.Identity()
+        v = se3.log6(m)
+        self.assertApprox(v.vector, zero(6))
+    
+    def test_log6_homogeneous(self):
+        m = eye(4)
+        v = se3.log6(m)
+        self.assertApprox(v.vector, zero(6))
+    
+    def test_Jlog6(self):
+        m = se3.SE3.Identity()
+        J = se3.Jlog6(m)
+        self.assertApprox(J, eye(6))
+
     def test_explog(self):
         self.assertApprox(exp(42), math.exp(42))
         self.assertApprox(log(42), math.log(42))
@@ -23,18 +68,19 @@ class TestExpLog(TestCase):
         m = rand(6)
         self.assertTrue(np.linalg.norm(m) < np.pi) # necessary for next test (actually, only angular part)
         self.assertApprox(log(exp(m)), m)
-        m = np.eye(4)
+        m = eye(4)
         self.assertApprox(exp(log(m)).homogeneous, m)
         with self.assertRaises(ValueError):
-            exp(np.eye(4))
+            exp(eye(4))
         with self.assertRaises(ValueError):
             exp(list(range(3)))
         with self.assertRaises(ValueError):
             log(list(range(3)))
         with self.assertRaises(ValueError):
-            log(np.zeros(5))
+            log(zero(5))
         with self.assertRaises(ValueError):
-            log(np.zeros((3,1)))
+            log(zero((3,1)))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
The bindings for explog were not working.
I obtained segmentation faults and/or wrong results when using fixed-size types as template parameters, so I had to switch to dynamic size (tested on my computer and on @jmirabel's laptop).

Apparently, this only happens when Pinocchio is compiled in *Release* mode. It does not happen in Debug mode, and it does not happen when neither Debug nor Release is specified.

It seems the problem is related to eigenpy. We only tested for eigenpy in Release mode.
This pull request patches the problem for explog in Pinocchio, but the problem in eigenpy should be investigated.