### PR TITLE
bindings/python: fix bug related to eigenpy

### DIFF
--- a/bindings/python/spatial/explog.hpp
+++ b/bindings/python/spatial/explog.hpp
@@ -14,8 +14,8 @@ namespace pinocchio
   {
     
     template<typename Vector3Like>
-    typename Eigen::Matrix<typename Vector3Like::Scalar,3,3,EIGEN_PLAIN_TYPE(Vector3Like)::Options>
-    Jexp3_proxy(const Eigen::MatrixBase<Vector3Like> & v)
+    Eigen::Matrix<typename Vector3Like::Scalar,3,3,EIGEN_PLAIN_TYPE(Vector3Like)::Options>
+    Jexp3_proxy(const Vector3Like & v)
     {
       typedef Eigen::Matrix<typename Vector3Like::Scalar,3,3,EIGEN_PLAIN_TYPE(Vector3Like)::Options> ReturnType;
       ReturnType res; Jexp3(v,res);
@@ -23,7 +23,8 @@ namespace pinocchio
     }
     
     template<typename Matrix3Like>
-    typename EIGEN_PLAIN_TYPE(Matrix3Like) Jlog3_proxy(const Eigen::MatrixBase<Matrix3Like> & M)
+    typename EIGEN_PLAIN_TYPE(Matrix3Like)
+    Jlog3_proxy(const Matrix3Like & M)
     {
       typedef typename EIGEN_PLAIN_TYPE(Matrix3Like) ReturnType;
       ReturnType res; Jlog3(M,res);

--- a/bindings/python/spatial/explog.hpp
+++ b/bindings/python/spatial/explog.hpp
@@ -54,9 +54,18 @@ namespace pinocchio
       return res;
     }
     
-    Eigen::Vector3d log3_proxy(const Eigen::Matrix3d & R)
+    template<typename Matrix3Like>
+    Eigen::Matrix<typename Matrix3Like::Scalar,3,1,EIGEN_PLAIN_TYPE(Matrix3Like)::Options>
+    log3_proxy(const Matrix3Like & R)
     {
       return log3(R);
+    }
+    
+    template<typename Matrix4Like>
+    MotionTpl<typename Matrix4Like::Scalar,EIGEN_PLAIN_TYPE(Matrix4Like)::Options>
+    log6_proxy(const Matrix4Like & homegenous_matrix)
+    {
+      return log6(homegenous_matrix);
     }
     
   } // namespace python

--- a/bindings/python/spatial/expose-explog.cpp
+++ b/bindings/python/spatial/expose-explog.cpp
@@ -25,7 +25,7 @@ namespace pinocchio
               "Jacobian of exp(R) which maps from the tangent of SO(3) at exp(v) to"
               " the tangent of SO(3) at Identity.");
       
-      bp::def("log3",&log3_proxy,
+      bp::def("log3",&log3_proxy<Eigen::Matrix3d>,
               bp::arg("Rotation matrix (matrix of size 3x3))"),
               "Log: SO3 -> so3. Pseudo-inverse of log from SO3"
               " -> { v in so3, ||v|| < 2pi }.Exp: so3 -> SO3.");
@@ -50,7 +50,7 @@ namespace pinocchio
               "Log: SE3 -> se3. Pseudo-inverse of exp from SE3"
               " -> { v,w in se3, ||w|| < 2pi }.");
       
-      bp::def("log6",&log6<Eigen::Matrix4d>,
+      bp::def("log6",&log6_proxy<Eigen::Matrix4d>,
               bp::arg("Homegenious matrix (matrix 4x4)"),
               "Log: SE3 -> se3. Pseudo-inverse of exp from SE3"
               " -> { v,w in se3, ||w|| < 2pi }.");


### PR DESCRIPTION
It seems that the desctructor invoked by eigenpy does not fit with the constructor invoked in Pinocchio.

This PR is related to #597 