### PR TITLE
WIP: use const ref in boost::fusion::vector, fix #511

### DIFF
--- a/src/algorithm/center-of-mass.hxx
+++ b/src/algorithm/center-of-mass.hxx
@@ -179,7 +179,7 @@ namespace pinocchio
                      JointDataBase<typename JointModel::JointDataDerived> & jdata,
                      const Model & model,
                      Data & data,
-                     const bool computeSubtreeComs)
+                     const bool & computeSubtreeComs)
     {
       const JointIndex & i      = (JointIndex) jmodel.id();
       const JointIndex & parent = model.parents[i];

--- a/src/algorithm/center-of-mass.hxx
+++ b/src/algorithm/center-of-mass.hxx
@@ -171,7 +171,7 @@ namespace pinocchio
     
     typedef boost::fusion::vector<const Model &,
                                   Data &,
-                                  const bool
+                                  const bool &
                                   > ArgsType;
   
     template<typename JointModel>

--- a/src/algorithm/kinematics-derivatives.hxx
+++ b/src/algorithm/kinematics-derivatives.hxx
@@ -110,8 +110,8 @@ namespace pinocchio
     
     typedef boost::fusion::vector<const Model &,
                                   Data &,
-                                  const typename Model::JointIndex,
-                                  const ReferenceFrame,
+                                  const typename Model::JointIndex &,
+                                  const ReferenceFrame &,
                                   Matrix6xOut1 &,
                                   Matrix6xOut2 &
                                   > ArgsType;
@@ -216,8 +216,8 @@ namespace pinocchio
     
     typedef boost::fusion::vector<const Model &,
                                   Data &,
-                                  const typename Model::JointIndex,
-                                  const ReferenceFrame,
+                                  const typename Model::JointIndex &,
+                                  const ReferenceFrame &,
                                   Matrix6xOut1 &,
                                   Matrix6xOut2 &,
                                   Matrix6xOut3 &,
@@ -377,4 +377,3 @@ namespace pinocchio
 } // namespace pinocchio
 
 #endif // ifndef __pinocchio_kinematics_derivatives_hxx__
-

--- a/src/algorithm/kinematics-derivatives.hxx
+++ b/src/algorithm/kinematics-derivatives.hxx
@@ -120,8 +120,8 @@ namespace pinocchio
     static void algo(const JointModelBase<JointModel> & jmodel,
                      const Model & model,
                      Data & data,
-                     const typename Model::JointIndex jointId,
-                     const ReferenceFrame rf,
+                     const typename Model::JointIndex & jointId,
+                     const ReferenceFrame & rf,
                      const Eigen::MatrixBase<Matrix6xOut1> & v_partial_dq,
                      const Eigen::MatrixBase<Matrix6xOut2> & v_partial_dv)
     {
@@ -228,8 +228,8 @@ namespace pinocchio
     static void algo(const JointModelBase<JointModel> & jmodel,
                      const Model & model,
                      Data & data,
-                     const typename Model::JointIndex jointId,
-                     const ReferenceFrame rf,
+                     const typename Model::JointIndex & jointId,
+                     const ReferenceFrame & rf,
                      const Eigen::MatrixBase<Matrix6xOut1> & v_partial_dq,
                      const Eigen::MatrixBase<Matrix6xOut2> & a_partial_dq,
                      const Eigen::MatrixBase<Matrix6xOut3> & a_partial_dv,

--- a/src/multibody/joint/joint-basic-visitors.hxx
+++ b/src/multibody/joint/joint-basic-visitors.hxx
@@ -113,7 +113,7 @@ namespace pinocchio
   {
     
     typedef boost::fusion::vector<Matrix6Type &,
-                                  const bool> ArgsType;
+                                  const bool &> ArgsType;
 
     template<typename JointModel>
     static void algo(const pinocchio::JointModelBase<JointModel> & jmodel,

--- a/src/multibody/joint/joint-basic-visitors.hxx
+++ b/src/multibody/joint/joint-basic-visitors.hxx
@@ -119,7 +119,7 @@ namespace pinocchio
     static void algo(const pinocchio::JointModelBase<JointModel> & jmodel,
                      pinocchio::JointDataBase<typename JointModel::JointDataDerived> & jdata,
                      const Eigen::MatrixBase<Matrix6Type> & I,
-                     const bool update_I
+                     const bool & update_I
                      )
     {
       Matrix6Type & I_ = const_cast<Matrix6Type &>(I.derived());

--- a/src/multibody/liegroup/liegroup-algo.hxx
+++ b/src/multibody/liegroup/liegroup-algo.hxx
@@ -262,7 +262,7 @@ namespace pinocchio
   {
     template<typename ConfigVectorIn1, typename ConfigVectorIn2, typename DistanceVectorOut>
     static void run(const JointModelBase<JointModel> & jmodel,
-                    const JointIndex i,
+                    const JointIndex & i,
                     const Eigen::MatrixBase<ConfigVectorIn1> & q0,
                     const Eigen::MatrixBase<ConfigVectorIn2> & q1,
                     const Eigen::MatrixBase<DistanceVectorOut> & distances)

--- a/src/multibody/liegroup/liegroup-algo.hxx
+++ b/src/multibody/liegroup/liegroup-algo.hxx
@@ -248,7 +248,7 @@ namespace pinocchio
   struct SquaredDistanceStep
   : public fusion::JointVisitorBase<SquaredDistanceStep<LieGroup_t,ConfigVectorIn1,ConfigVectorIn2,DistanceVectorOut> >
   {
-    typedef boost::fusion::vector<const JointIndex,
+    typedef boost::fusion::vector<const JointIndex &,
                                   const ConfigVectorIn1 &,
                                   const ConfigVectorIn2 &,
                                   DistanceVectorOut &


### PR DESCRIPTION
This follows #575 

This is a work in progress, as for now unittest/joint-configurations is not passing:

```
joint-configurations: /usr/include/eigen3/Eigen/src/Core/DenseCoeffsBase.h:396: Eigen::DenseCoeffsBase<Derived, 1>::Scalar& Eigen::DenseCoeffsBase<Derived, 1>::operator[](Eigen::Index) [with Derived = Eigen::Matrix<double, -1, 1>; Eigen::DenseCoeffsBase<Derived, 1>::Scalar = double; Eigen::Index = long int]: Assertion `index >= 0 && index < size()' failed.
```

