### PR TITLE
[python] [JointModelComposite] Various fixes

### DIFF
--- a/bindings/python/multibody/joint/joint-derived.hpp
+++ b/bindings/python/multibody/joint/joint-derived.hpp
@@ -26,7 +26,6 @@ namespace pinocchio
       void visit(PyClass& cl) const 
       {
         cl
-        //.def(bp::init<>()) // this should be already exposed
         // All are add_properties cause ReadOnly
         .add_property("id",&JointPythonVisitor::getId)
         .add_property("idx_q",&JointPythonVisitor::getIdx_q)

--- a/bindings/python/multibody/joint/joint-derived.hpp
+++ b/bindings/python/multibody/joint/joint-derived.hpp
@@ -26,15 +26,16 @@ namespace pinocchio
       void visit(PyClass& cl) const 
       {
         cl
-        .def(bp::init<>())
+        //.def(bp::init<>()) // this should be already exposed
         // All are add_properties cause ReadOnly
         .add_property("id",&JointPythonVisitor::getId)
         .add_property("idx_q",&JointPythonVisitor::getIdx_q)
         .add_property("idx_v",&JointPythonVisitor::getIdx_v)
         .add_property("nq",&JointPythonVisitor::getNq)
         .add_property("nv",&JointPythonVisitor::getNv)
-        .def("setIndexes",&JointModelDerived::setIndexes);
-
+        .def("setIndexes",&JointModelDerived::setIndexes)
+        .def("shortname",&JointModelDerived::shortname)
+        ;
       }
 
       static JointIndex getId( const JointModelDerived & self ) { return self.id(); }

--- a/bindings/python/multibody/joint/joint.hpp
+++ b/bindings/python/multibody/joint/joint.hpp
@@ -34,7 +34,6 @@ namespace pinocchio
         .add_property("idx_v",&JointModelPythonVisitor::getIdx_v)
         .add_property("nq",&JointModelPythonVisitor::getNq)
         .add_property("nv",&JointModelPythonVisitor::getNv)
-
         .def("setIndexes",&JointModel::setIndexes)
         .def("shortname",&JointModel::shortname)
         ;

--- a/bindings/python/multibody/joint/joints-models.hpp
+++ b/bindings/python/multibody/joint/joints-models.hpp
@@ -60,7 +60,7 @@ namespace pinocchio
       const SE3 & m_joint_placement;
 
       JointModelCompositeAddJointVisitor(JointModelComposite & joint_composite,
-                      const SE3 & joint_placement)
+                                         const SE3 & joint_placement)
       : m_joint_composite(joint_composite)
       , m_joint_placement(joint_placement)
       {}
@@ -73,22 +73,66 @@ namespace pinocchio
     }; // struct JointModelCompositeAddJointVisitor
 
     static void addJoint_proxy(JointModelComposite & joint_composite,
-                         bp::object jmodel,
-                         const SE3 & joint_placement = SE3::Identity())
+                               const JointModelVariant & jmodel_variant,
+                               const SE3 & joint_placement = SE3::Identity())
     {
-      JointModelVariant jmodel_variant = bp::extract<JointModelVariant> (jmodel)();
-      boost::apply_visitor(JointModelCompositeAddJointVisitor(joint_composite,joint_placement), jmodel_variant);
+      return boost::apply_visitor(JointModelCompositeAddJointVisitor(joint_composite,joint_placement), jmodel_variant);
     }
 
     BOOST_PYTHON_FUNCTION_OVERLOADS(addJoint_proxy_overloads,addJoint_proxy,2,3)
+
+    struct JointModelCompositeConstructorVisitor : public boost::static_visitor<boost::shared_ptr<JointModelComposite> >
+    {
+      const SE3 & m_joint_placement;
+
+      JointModelCompositeConstructorVisitor(const SE3 & joint_placement)
+      : m_joint_placement(joint_placement)
+      {}
+
+      template <typename JointModelDerived>
+      boost::shared_ptr<JointModelComposite> operator()(JointModelDerived & jmodel) const
+      {
+        return boost::shared_ptr<JointModelComposite>(new JointModelComposite(jmodel,m_joint_placement));
+      }
+    }; // struct JointModelCompositeConstructorVisitor
+
+    static boost::shared_ptr<JointModelComposite> init_proxy1(const JointModelVariant & jmodel_variant)
+    {
+      return boost::apply_visitor(JointModelCompositeConstructorVisitor(SE3::Identity()), jmodel_variant);
+    }
+
+    static boost::shared_ptr<JointModelComposite> init_proxy2(const JointModelVariant & jmodel_variant,
+                                                              const SE3 & joint_placement)
+    {
+      return boost::apply_visitor(JointModelCompositeConstructorVisitor(joint_placement), jmodel_variant);
+    }
 
     template<>
     inline bp::class_<JointModelComposite>& expose_joint_model<JointModelComposite> (bp::class_<JointModelComposite> & cl)
     {
       return cl
                .def(bp::init<const size_t> (bp::args("size"), "Init JointModelComposite with a defined size"))
+               .def("__init__",
+                    bp::make_constructor(init_proxy1,
+                                         bp::default_call_policies(),
+                                         bp::args("joint_model")
+                                        ),
+                    "Init JointModelComposite from a joint"
+                   )
+               .def("__init__",
+                    bp::make_constructor(init_proxy2,
+                                         bp::default_call_policies(),
+                                         bp::args("joint_model","joint_placement")
+                                        ),
+                    "Init JointModelComposite from a joint and a placement"
+                   )
                .add_property("joints",&JointModelComposite::joints)
-               .def("addJoint",&addJoint_proxy,addJoint_proxy_overloads(bp::args("joint_model","joint_placement"),"Add a joint to the vector of joints."))
+               .def("addJoint",
+                    &addJoint_proxy,
+                    addJoint_proxy_overloads(bp::args("joint_model","joint_placement"),
+                                             "Add a joint to the vector of joints."
+                                            )
+                   )
                ;
     }
   } // namespace python

--- a/bindings/python/multibody/joint/joints-variant.hpp
+++ b/bindings/python/multibody/joint/joints-variant.hpp
@@ -9,6 +9,7 @@
 #include <eigenpy/eigenpy.hpp>
 #include "pinocchio/multibody/joint/joint-collection.hpp"
 #include "pinocchio/bindings/python/multibody/joint/joints-models.hpp"
+#include "pinocchio/bindings/python/utils/printable.hpp"
 
 namespace pinocchio
 {
@@ -35,7 +36,13 @@ namespace pinocchio
       template<class T>
       void operator()(T)
       {
-        expose_joint_model<T>(bp::class_<T>(T::classname().c_str(),bp::init<>()).def(JointPythonVisitor<T>()));
+        expose_joint_model<T>(
+            bp::class_<T>(T::classname().c_str(),
+                          T::classname().c_str(),
+                          bp::init<>())
+            .def(JointPythonVisitor<T>())
+            .def(PrintableVisitor<T>())
+        );
         bp::implicitly_convertible<T,pinocchio::JointModelVariant>();
       }
     };

--- a/bindings/python/scripts/robot_wrapper.py
+++ b/bindings/python/scripts/robot_wrapper.py
@@ -12,6 +12,12 @@ import numpy as np
 
 class RobotWrapper(object):
 
+    @staticmethod
+    def BuildFromURDF(filename, package_dirs=None, root_joint=None, verbose=False):
+        robot = RobotWrapper()
+        robot.initFromURDF(filename, package_dirs, root_joint, verbose)
+        return robot
+
     def initFromURDF(self,filename, package_dirs=None, root_joint=None, verbose=False):
         if root_joint is None:
             model = pin.buildModelFromUrdf(filename)
@@ -179,11 +185,11 @@ class RobotWrapper(object):
         else:
             return pin.jointJacobian(self.model, self.data, q, index, pin.ReferenceFrame.WORLD, update_kinematics)
 
-    def jointJacobian(self, q, index, update_kinematics=True, local_frame=True):
-        if local_frame:
-            return pin.jointJacobian(self.model, self.data, q, index, pin.ReferenceFrame.LOCAL, update_kinematics)
-        else:
-            return pin.jointJacobian(self.model, self.data, q, index, pin.ReferenceFrame.WORLD, update_kinematics)
+    def jointJacobian(self, q, index, rf_frame=pin.ReferenceFrame.LOCAL, update_kinematics=True):
+        return pin.jointJacobian(self.model, self.data, q, index, rf_frame, update_kinematics)
+
+    def getJointJacobian(self, index, rf_frame=pin.ReferenceFrame.LOCAL):
+        return pin.getFrameJacobian(self.model, self.data, index, rf_frame)
 
     @deprecated("This method is now deprecated. Please use computeJointJacobians instead. It will be removed in release 1.4.0 of Pinocchio.")
     def computeJacobians(self, q):
@@ -216,14 +222,14 @@ class RobotWrapper(object):
         It computes the Jacobian of frame given by its id (frame_id) either expressed in the
         local coordinate frame or in the world coordinate frame.
     '''
-    def getFrameJacobian(self, frame_id, rf_frame):
+    def getFrameJacobian(self, frame_id, rf_frame=pin.ReferenceFrame.LOCAL):
         return pin.getFrameJacobian(self.model, self.data, frame_id, rf_frame)
 
     '''
         Similar to getFrameJacobian but it also calls before pin.computeJointJacobians and
-        pin.framesForwardKinematics to update internal value of self.data related to frames.
+        pin.updateFramePlacements to update internal value of self.data related to frames.
     '''
-    def frameJacobian(self, q, frame_id, rf_frame):
+    def frameJacobian(self, q, frame_id, rf_frame=pin.ReferenceFrame.LOCAL):
         return pin.frameJacobian(self.model, self.data, q, frame_id, rf_frame)
 
   

--- a/bindings/python/scripts/romeo_wrapper.py
+++ b/bindings/python/scripts/romeo_wrapper.py
@@ -10,8 +10,8 @@ from .robot_wrapper import RobotWrapper
 
 class RomeoWrapper(RobotWrapper):
 
-    def __init__(self, filename, package_dirs=None):
-        RobotWrapper.__init__(self, filename, package_dirs=package_dirs, root_joint=pin.JointModelFreeFlyer())
+    def __init__(self, filename, package_dirs=None, verbose=False):
+        self.initFromURDF(filename, package_dirs=package_dirs, root_joint=pin.JointModelFreeFlyer(), verbose=verbose)
         self.q0 = np.matrix([
             0, 0, 0.840252, 0, 0, 0, 1,                      # Free flyer
             0, 0, -0.3490658, 0.6981317, -0.3490658, 0,      # left leg

--- a/examples/python/load-urdf.py
+++ b/examples/python/load-urdf.py
@@ -22,7 +22,7 @@
 ##
 
 import pinocchio as pin
-from pinocchio.romeo_wrapper import RobotWrapper
+from pinocchio.robot_wrapper import RobotWrapper
 
 DISPLAY = False
 
@@ -36,8 +36,7 @@ mesh_dir = model_path
 urdf_filename = "romeo_small.urdf"
 urdf_model_path = model_path + "/romeo_description/urdf/" + urdf_filename
 
-robot = RobotWrapper()
-robot.initFromURDF(urdf_model_path, [mesh_dir])
+robot = RobotWrapper.BuildFromURDF(urdf_model_path, [mesh_dir], pin.JointModelFreeFlyer())
 
 # alias
 model = robot.model

--- a/src/multibody/joint/joint-composite.hpp
+++ b/src/multibody/joint/joint-composite.hpp
@@ -200,9 +200,11 @@ namespace pinocchio
     /// \param jmodel Model of the joint to add.
     /// \param placement Placement of the joint relatively to its predecessor.
     ///
+    /// \return A reference to *this
+    ///
     template<typename JointModel>
-    void addJoint(const JointModelBase<JointModel> & jmodel,
-                  const SE3 & placement = SE3::Identity())
+    JointModelDerived & addJoint(const JointModelBase<JointModel> & jmodel,
+                                 const SE3 & placement = SE3::Identity())
     {
       joints.push_back((JointModelVariant)jmodel.derived());
       jointPlacements.push_back(placement);
@@ -211,6 +213,8 @@ namespace pinocchio
       
       updateJointIndexes();
       njoints++;
+
+      return *this;
     }
     
     JointDataDerived createData() const

--- a/unittest/joint-composite.cpp
+++ b/unittest/joint-composite.cpp
@@ -157,6 +157,15 @@ BOOST_AUTO_TEST_CASE(test_basic)
   boost::mpl::for_each<Variant::types>(TestJointComposite());
 }
 
+BOOST_AUTO_TEST_CASE(chain)
+{
+  JointModelComposite jmodel_composite;
+  jmodel_composite.addJoint(JointModelRZ()).addJoint(JointModelRY(),SE3::Random()).addJoint(JointModelRX());
+  BOOST_CHECK_MESSAGE( jmodel_composite.nq() == 3, "Chain did not work");
+  BOOST_CHECK_MESSAGE( jmodel_composite.nv() == 3, "Chain did not work");
+  BOOST_CHECK_MESSAGE( jmodel_composite.njoints == 3, "Chain did not work");
+}
+
 BOOST_AUTO_TEST_CASE(vsZYX)
 {
   JointModelSphericalZYX jmodel_spherical;

--- a/unittest/python/bindings_joint_composite.py
+++ b/unittest/python/bindings_joint_composite.py
@@ -7,16 +7,20 @@ class TestJointCompositeBindings(unittest.TestCase):
     def test_basic(self):
         jc = pin.JointModelComposite()
         self.assertTrue(hasattr(jc,'joints'))
+        self.assertTrue(hasattr(jc,'njoints'))
+        self.assertTrue(hasattr(jc,'jointPlacements'))
 
     def test_empty_constructor(self):
         jc = pin.JointModelComposite()
         self.assertTrue(jc.nq==0)
         self.assertTrue(len(jc.joints)==0)
+        self.assertTrue(jc.njoints==len(jc.joints))
 
     def test_reserve_constructor(self):
         jc = pin.JointModelComposite(2)
         self.assertTrue(jc.nq==0)
         self.assertTrue(len(jc.joints)==0)
+        self.assertTrue(jc.njoints==len(jc.joints))
 
     def test_joint_constructor(self):
         j1 = pin.JointModelRX()
@@ -25,13 +29,15 @@ class TestJointCompositeBindings(unittest.TestCase):
         jc1 = pin.JointModelComposite(j1)
         self.assertTrue(jc1.nq==1)
         self.assertTrue(len(jc1.joints)==1)
+        self.assertTrue(jc1.njoints==len(jc1.joints))
 
         j2 = pin.JointModelRX()
         self.assertTrue(j2.nq==1)
 
-        jc2 = pin.JointModelComposite(j1,pin.SE3.Identity())
+        jc2 = pin.JointModelComposite(j1,pin.SE3.Random())
         self.assertTrue(jc2.nq==1)
         self.assertTrue(len(jc2.joints)==1)
+        self.assertTrue(jc2.njoints==len(jc2.joints))
 
     def test_add_joint(self):
         j1 = pin.JointModelRX()
@@ -44,19 +50,50 @@ class TestJointCompositeBindings(unittest.TestCase):
         jc = pin.JointModelComposite(2)
         self.assertTrue(jc.nq==0)
         self.assertTrue(len(jc.joints)==0)
+        self.assertTrue(jc.njoints==len(jc.joints))
 
         jc.addJoint(j1)
         self.assertTrue(jc.nq==1)
         self.assertTrue(len(jc.joints)==1)
+        self.assertTrue(jc.njoints==len(jc.joints))
 
         jc.addJoint(j2)
         self.assertTrue(jc.nq==2)
         self.assertTrue(len(jc.joints)==2)
+        self.assertTrue(jc.njoints==len(jc.joints))
 
-        jc.addJoint(j3,pin.SE3.Identity())
+        jc.addJoint(j3,pin.SE3.Random())
+        self.assertTrue(jc.nq==3)
+        self.assertTrue(jc.njoints==len(jc.joints))
+        
+    def test_add_joint_return(self):
+        jc1 = pin.JointModelComposite()
+        jc2 = jc1.addJoint(pin.JointModelRX())
+        jc3 = jc2.addJoint(pin.JointModelRY())
+        jc4 = jc1.addJoint(pin.JointModelRZ())
+        self.assertTrue(jc1.njoints==3)
+        self.assertTrue(jc2.njoints==3)
+        self.assertTrue(jc3.njoints==3)
+        self.assertTrue(jc4.njoints==3)
+        
+        del jc1
+        del jc3
+        del jc4
+        self.assertTrue(jc2.njoints==3)
+
+    def test_add_joint_concat(self):
+        j1 = pin.JointModelRX()
+        self.assertTrue(j1.nq==1)
+        j2 = pin.JointModelRY()
+        self.assertTrue(j2.nq==1)
+        j3 = pin.JointModelRZ()
+        self.assertTrue(j3.nq==1)
+
+        jc = pin.JointModelComposite(j1).addJoint(j2,pin.SE3.Random()).addJoint(j3)
+
         self.assertTrue(jc.nq==3)
         self.assertTrue(len(jc.joints)==3)
-        
+        self.assertTrue(jc.njoints==len(jc.joints))
 
 if __name__ == '__main__':
     unittest.main()

--- a/unittest/python/bindings_joint_composite.py
+++ b/unittest/python/bindings_joint_composite.py
@@ -18,6 +18,21 @@ class TestJointCompositeBindings(unittest.TestCase):
         self.assertTrue(jc.nq==0)
         self.assertTrue(len(jc.joints)==0)
 
+    def test_joint_constructor(self):
+        j1 = pin.JointModelRX()
+        self.assertTrue(j1.nq==1)
+
+        jc1 = pin.JointModelComposite(j1)
+        self.assertTrue(jc1.nq==1)
+        self.assertTrue(len(jc1.joints)==1)
+
+        j2 = pin.JointModelRX()
+        self.assertTrue(j2.nq==1)
+
+        jc2 = pin.JointModelComposite(j1,pin.SE3.Identity())
+        self.assertTrue(jc2.nq==1)
+        self.assertTrue(len(jc2.joints)==1)
+
     def test_add_joint(self):
         j1 = pin.JointModelRX()
         self.assertTrue(j1.nq==1)


### PR DESCRIPTION
Mostly python fixes
- Fixed a few things in `RobotWrapper` and `RomeoWrapper`
- Finished exposing `JointModelComposite` constructors and data
- Additionally, I slightly modified `addJoint` in `JointModelComposite`.
It now returns a reference to the same joint being modified, so that the expressions can be easily chained, as in
`joint_composite.addJoint(joint1).addJoint(joint2).addJoint(joint3);`