### PR TITLE
[doc] Update porting notes

### DIFF
--- a/doc/_porting.md
+++ b/doc/_porting.md
@@ -18,10 +18,6 @@ Relevant changes are listed below.
 \subsection PortingCHeaderonly Header-only
 Pinocchio is now fully header-only. This means you do not have to link to the Pinocchio library when compiling your code.
 On the other hand, you might need to link to additional system libraries.
-For instance, when using URDF, you now need to add
-```
--lboost_system -lurdfdom_model
-```
 
 \subsection PortingCNamespace Namespace
 The most important change is the namespace.
@@ -48,14 +44,12 @@ The following marcos are not employed anymore
 WITH_HPP_FCL
 WITH_URDFDOM
 WITH_LUA5
-URDFDOM_TYPEDEF_SHARED_PTR
 ```
 in favor of
 ```
 PINOCCHIO_WITH_HPP_FCL
 PINOCCHIO_WITH_URDFDOM
 PINOCCHIO_WITH_LUA5
-PINOCCHIO_URDFDOM_TYPEDEF_SHARED_PTR
 ```
 Therefore, you now need to issue the new macros in your compilation commands.
 

--- a/doc/_porting.md
+++ b/doc/_porting.md
@@ -1,5 +1,7 @@
 # Porting from Pinocchio 1.3.3 to 2.0.0
 
+\section PortingIntro What is included
+
 This section describes how to port your code from the latest Pinocchio 1 release (1.3.3) to 2.0.
 
 Note that this section does not cover API changes that were made *before* Pinocchio 1.3.3.
@@ -9,11 +11,19 @@ In particular, remove all calls to deprecated methods and replace them appropria
 
 The vast majority of the changes took place in C++.
 
-# Changes in C++
+\section PortingC Changes in C++
 Although the class system was heavily re-worked, it should not make a lot of difference from the user's point of view.
 Relevant changes are listed below.
 
-## Namespace
+\subsection PortingCHeaderonly Header-only
+Pinocchio is now fully header-only. This means you do not have to link to the Pinocchio library when compiling your code.
+On the other hand, you might need to link to additional system libraries.
+For instance, when using URDF, you now need to add
+```
+-lboost_system -lurdfdom_model
+```
+
+\subsection PortingCNamespace Namespace
 The most important change is the namespace.
 Now, the top-level Pinocchio namespace is not `se3` anymore, but `pinocchio`.
 
@@ -31,26 +41,30 @@ In order to make it work, you need to compile it with the following flag
 -DPINOCCHIO_ENABLE_COMPATIBILITY_WITH_VERSION_1
 ```
 
-## Deprecated macros
+\subsection PortingCMacros Deprecated macros
 
 The following marcos are not employed anymore
 ```
 WITH_HPP_FCL
 WITH_URDFDOM
 WITH_LUA5
+URDFDOM_TYPEDEF_SHARED_PTR
 ```
 in favor of
 ```
 PINOCCHIO_WITH_HPP_FCL
 PINOCCHIO_WITH_URDFDOM
 PINOCCHIO_WITH_LUA5
+PINOCCHIO_URDFDOM_TYPEDEF_SHARED_PTR
 ```
-In order to make them work, you can still do
+Therefore, you now need to issue the new macros in your compilation commands.
+
+If you are using them in your code, in order to make them work, you can do
 ```
 -DPINOCCHIO_ENABLE_COMPATIBILITY_WITH_VERSION_1
 ```
 
-## Method signatures
+\subsection PortingCSignature Method signatures
 Many methods which were taking a `ReferenceFrame = {WORLD/LOCAL}` enum as template parameter, such as `getJointJacobian`,
 are now deprecated. The reference frame is now passed as an input.
 For instance, you should switch from
@@ -64,16 +78,16 @@ getJointJacobian(model,data,jointId,LOCAL,J);
 
 Notice that in principle your old code will still work, but you will get deprecation warnings.
 
-# Changes in Python
+\section PortingPython Changes in Python
 Changes in Python are relatively minor.
 
-## Namespace
+\subsection PortingPythonNamespace Namespace
 
 No real changes took place, but you are encouraged to stop using the idiom `import pinocchio as se3`.
 
 From now on, the recommended practice is `import pinocchio as pin`.
 
-## RobotWrapper
+\subsection PortingPythonRobotWrapper RobotWrapper
 
 The constructor signature has changed from
 ```


### PR DESCRIPTION
Update the porting notes.
Mostly cosmetic changes, but I added a subsection explaining Pinocchio is now header-only, plus additional clarifications on the deprecated macros. @jcarpent may you check it is correct?

I'm directly updating the devel branch, rather than topic/doc-v2 (see PR #605). This is to make the changes immediately available to anybody working with devel.