### PR TITLE
[doc] Work on Doxygen

### DIFF
--- a/doc/Doxyfile.extra.in
+++ b/doc/Doxyfile.extra.in
@@ -425,8 +425,20 @@ HTML_FOOTER            =
 # will generate a default style sheet. Note that doxygen will try to copy
 # the style sheet file to the HTML output directory, so don't put your own
 # style sheet in the HTML output directory as well, or it will be erased!
+# NOTE: It is recommended to use HTML_EXTRA_STYLESHEET instead of this tag,
+# as it is more robust and this tag (HTML_STYLESHEET)
+# will in the future become obsolete.
 
 #HTML_STYLESHEET        = @PROJECT_SOURCE_DIR@/doc/package.css
+
+# The HTML_EXTRA_STYLESHEET tag can be used to specify additional user-defined
+# cascading style sheets that are included after the standard style sheets
+# created by doxygen. Using this option one can overrule certain style aspects.
+# This is preferred over using HTML_STYLESHEET since it does not replace
+# the standard style sheet and is therefore more robust against future updates.
+# Doxygen will copy the style sheet files to the output directory.
+
+HTML_EXTRA_STYLESHEET        = @PROJECT_SOURCE_DIR@/doc/customdoxygen.css
 
 # The HTML_COLORSTYLE_HUE tag controls the color of the HTML output.
 # Doxygen will adjust the colors in the style sheet and background images

--- a/doc/Doxyfile.extra.in
+++ b/doc/Doxyfile.extra.in
@@ -100,7 +100,7 @@ HIDE_UNDOC_MEMBERS     = NO
 # If set to NO (the default) these classes will be included in the various
 # overviews. This option has no effect if EXTRACT_ALL is enabled.
 
-#HIDE_UNDOC_CLASSES     = NO
+HIDE_UNDOC_CLASSES     = YES
 
 # If the HIDE_FRIEND_COMPOUNDS tag is set to YES, Doxygen will hide all
 # friend (class|struct|union) declarations.
@@ -316,6 +316,7 @@ FILE_PATTERNS          = *.cc *.cpp *.h *.hpp *.hxx *.hh *.dox *.md *.py
 # for example use the pattern */test/*
 
 EXCLUDE_PATTERNS      += CMake* \
+                         */d-practical-exercises/src/* \
                          *.txt \
                          *.sh \
                          *.orig \
@@ -338,7 +339,8 @@ EXCLUDE_PATTERNS      += CMake* \
 # wildcard * is used, a substring. Examples: ANamespace, AClass,
 # AClass::ANamespace, ANamespace::*Test
 
-EXCLUDE_SYMBOLS        = internal::*
+EXCLUDE_SYMBOLS        = internal::* \
+                         *Visitor
 
 # The IMAGE_PATH tag can be used to specify one or more files or
 # directories that contain image that are included in the documentation (see

--- a/doc/customdoxygen.css
+++ b/doc/customdoxygen.css
@@ -1,0 +1,19 @@
+/* Customizing Doxygen output */
+
+/* Needed to allow line breaks in tables*/
+.memberdecls {
+  table-layout: fixed;
+  width: 100%;
+}
+
+/* Needed to break long template names*/
+.memTemplItemLeft {
+  white-space: normal !important;
+  word-wrap: break-word;
+}
+
+/* Needed to break long template names*/
+.memItemLeft {
+  white-space: normal !important;
+  word-wrap: break-word;
+}

--- a/doc/treeview.dox
+++ b/doc/treeview.dox
@@ -103,9 +103,9 @@ namespace pinocchio {
   // Modules organization
   //
 
-  /** \defgroup spatial_group Spatial */
-  /** \defgroup multibody_group Multibody */
-  /** \defgroup joint_group Joint */
-  /** \defgroup parsers_group Parsers */
-  /** \defgroup algorithms_group Algorithms */
+  /** \defgroup spatial Spatial */
+  /** \defgroup multibody Multibody */
+  /** \defgroup joint Joint */
+  /** \defgroup parsers Parsers */
+  /** \defgroup algorithms Algorithms */
 }

--- a/src/algorithm/centroidal-derivatives.hpp
+++ b/src/algorithm/centroidal-derivatives.hpp
@@ -19,9 +19,9 @@ namespace pinocchio
   /// \details Computes the first order approximation of the centroidal dynamics time derivative
   ///          and corresponds to the following equation
   ///          \f$
-  ///               d\dot{h_{g}} = \frac{\partial \dot{h_{g}}}{\partial \bm{q}} d\bm{q}
-  ///                            + \frac{\partial \dot{h_{g}}}{\partial \bm{v}} d\bm{v}
-  ///                            + \frac{\partial \dot{h_{g}}}{\partial \bm{a}} d\bm{a}
+  ///               d\dot{h_{g}} = \frac{\partial \dot{h_{g}}}{\partial \mathbf{q}} d\mathbf{q}
+  ///                            + \frac{\partial \dot{h_{g}}}{\partial \mathbf{v}} d\mathbf{v}
+  ///                            + \frac{\partial \dot{h_{g}}}{\partial \mathbf{a}} d\mathbf{a}
   ///          \f$
   ///
   /// \tparam JointCollection Collection of Joint types.
@@ -60,9 +60,9 @@ namespace pinocchio
   /// \details Computes the first order approximation of the centroidal dynamics time derivative
   ///          and corresponds to the following equation
   ///          \f$
-  ///               d\dot{h_{g}} = \frac{\partial \dot{h_{g}}}{\partial \bm{q}} d\bm{q}
-  ///                            + \frac{\partial \dot{h_{g}}}{\partial \bm{v}} d\bm{v}
-  ///                            + \frac{\partial \dot{h_{g}}}{\partial \bm{a}} d\bm{a}
+  ///               d\dot{h_{g}} = \frac{\partial \dot{h_{g}}}{\partial \mathbf{q}} d\mathbf{q}
+  ///                            + \frac{\partial \dot{h_{g}}}{\partial \mathbf{v}} d\mathbf{v}
+  ///                            + \frac{\partial \dot{h_{g}}}{\partial \mathbf{a}} d\mathbf{a}
   ///          \f$
   ///
   /// \param[in] model The model structure of the rigid body system.

--- a/src/multibody/fwd.hpp
+++ b/src/multibody/fwd.hpp
@@ -12,21 +12,28 @@
 
 namespace pinocchio
 {
+
+  template<typename Scalar, int Options=0> struct FrameTpl;
+
+  template<typename Scalar, int Options = 0, template<typename S, int O> class JointCollectionTpl = JointCollectionDefaultTpl>
+  struct ModelTpl;
+  template<typename Scalar, int Options = 0, template<typename S, int O> class JointCollectionTpl = JointCollectionDefaultTpl>
+  struct DataTpl;
+
+  /**
+   * \addtogroup multibody
+   * @{
+   */
+
   typedef std::size_t Index;
   typedef Index JointIndex;
   typedef Index GeomIndex;
   typedef Index FrameIndex;
   typedef Index PairIndex;
   
-  template<typename Scalar, int Options=0> struct FrameTpl;
   typedef FrameTpl<double> Frame;
   
-  template<typename Scalar, int Options = 0, template<typename S, int O> class JointCollectionTpl = JointCollectionDefaultTpl>
-  struct ModelTpl;
   typedef ModelTpl<double> Model;
-  
-  template<typename Scalar, int Options = 0, template<typename S, int O> class JointCollectionTpl = JointCollectionDefaultTpl>
-  struct DataTpl;
   typedef DataTpl<double> Data;
   
   struct GeometryModel;
@@ -37,6 +44,11 @@ namespace pinocchio
     WORLD = 0,
     LOCAL = 1
   };
+
+  /**
+   * @}
+   */
+  // end of group multibody
 
   // Forward declaration needed for Model::check
   template<class D> struct AlgorithmCheckerBase;

--- a/src/multibody/joint/fwd.hpp
+++ b/src/multibody/joint/fwd.hpp
@@ -9,6 +9,12 @@
 
 namespace pinocchio
 {
+
+  /**
+   * \addtogroup joint
+   * @{
+   */
+
   enum { MAX_JOINT_NV = 6 };
   
   struct JointModelVoid {};
@@ -84,6 +90,10 @@ namespace pinocchio
   struct JointDataTpl;
   typedef JointDataTpl<double> JointData;
   
+  /**
+   * @}
+   */
+  // end of group joint
 }
 
 #endif // ifndef __pinocchio_joint_fwd_hpp__

--- a/src/spatial/explog.hpp
+++ b/src/spatial/explog.hpp
@@ -434,16 +434,18 @@ namespace pinocchio
   /** \brief Derivative of log6
    *  \f[
    *  \left(\begin{array}{cc}
-   *  Jlog3(R) & J * Jlog3(R) \\
-   *      0    &     Jlog3(R) \\
+   *  \text{Jlog3}(R) & J * \text{Jlog3}(R) \\
+   *            0     &     \text{Jlog3}(R) \\
    *  \end{array}\right)
+   *  \f]
    *  where
    *  \f[
+   *  \def\rot{R}
    *  \begin{eqnarray}
    *  J &=& 
-   *  \frac{1}{2}[\mathbf{p}]_{\times} + \dot{\beta} (\normr) \frac{\rot^T\mathbf{p}}{\normr}\rot\rot^T
-   *  - (\normr\dot{\beta} (\normr) + 2 \beta(\normr)) \mathbf{p}\rot^T\right.\\
-   *  &&\left. + \rot^T\mathbf{p}\beta (\normr)I_3 + \beta (\normr)\rot\mathbf{p}^T
+   *  \left.\frac{1}{2}[\mathbf{p}]_{\times} + \dot{\beta} (||r||) \frac{\rot^T\mathbf{p}}{||r||}\rot\rot^T
+   *  - (||r||\dot{\beta} (||r||) + 2 \beta(||r||)) \mathbf{p}\rot^T\right.\\
+   *  &&\left. + \rot^T\mathbf{p}\beta (||r||)I_3 + \beta (||r||)\rot\mathbf{p}^T\right.
    *  \end{eqnarray}
    *  \f]
    *  and

--- a/src/spatial/fwd.hpp
+++ b/src/spatial/fwd.hpp
@@ -28,12 +28,22 @@ namespace pinocchio
   template<typename Scalar, int Options=0> class InertiaTpl;
   template<typename Scalar, int Options=0> class Symmetric3Tpl;
 
+  /**
+   * \addtogroup spatial
+   * @{
+   */
+
   typedef SE3Tpl        <double,0> SE3;
   typedef MotionTpl     <double,0> Motion;
   typedef ForceTpl      <double,0> Force;
   typedef InertiaTpl    <double,0> Inertia;
   typedef Symmetric3Tpl <double,0> Symmetric3;
   typedef BiasZeroTpl   <double,0> BiasZero;
+
+  /**
+   * @}
+   */
+  // end of group spatial
 
   #define SPATIAL_TYPEDEF_TEMPLATE_GENERIC(derived,TYPENAME)              \
     typedef TYPENAME traits<derived>::Scalar Scalar; \

--- a/src/spatial/skew.hpp
+++ b/src/spatial/skew.hpp
@@ -51,7 +51,7 @@ namespace pinocchio
   
   ///
   /// \brief Add skew matrix represented by a 3d vector to a given matrix,
-  ///        i.e. add the antisymmetric matrix representation of the cross product operator (\f$ [v]_{\cross} x = v \cross x \f$)
+  ///        i.e. add the antisymmetric matrix representation of the cross product operator (\f$ [v]_{\times} x = v \times x \f$)
   ///
   /// \param[in]  v a vector of dimension 3.
   /// \param[out] M the 3x3 matrix to which the skew matrix is added.


### PR DESCRIPTION
Hi,
I've started working on cleaning the Doxygen-generated documentation, turns out it will require more work than I expected.

As for now, I have hidden a few irrelevant things and added the typedefs to their groups, and fixed some latex-related errors. Also, I've added a custom CSS style sheet. I used it to break ling template names inside tables which were making the whole thing unreadable. It is a bit less messy now.

Notice the documentation for /d-practical-exercises/src/ was generated too. I explicitly ignored it, but an alternative would be to move it to a top-level directory, called, e.g., exercises or labs.