### PR TITLE
Added bindings to derivative algorithms

### DIFF
--- a/bindings/python/algorithm/expose-aba-derivatives.cpp
+++ b/bindings/python/algorithm/expose-aba-derivatives.cpp
@@ -17,7 +17,7 @@ namespace pinocchio
       computeABADerivatives(model,data,q,v,tau);
     }
     typedef container::aligned_vector<Force> ForceAlignedVector;
-   void computeABADerivatives_fext(const Model & model, Data & data,
+    void computeABADerivatives_fext(const Model & model, Data & data,
                                     const Eigen::VectorXd & q,
                                     const Eigen::VectorXd & v,
                                     const Eigen::VectorXd & tau,
@@ -25,7 +25,7 @@ namespace pinocchio
     {
       computeABADerivatives(model,data,q,v,tau,fext);
     }
-    
+
     void exposeABADerivatives()
     {
       using namespace Eigen;
@@ -53,6 +53,5 @@ namespace pinocchio
               "velocity and torque vectors.\n"
               "The forces are of type StdVect_Force.");
     }
-    
   } // namespace python
 } // namespace pinocchio

--- a/bindings/python/algorithm/expose-aba-derivatives.cpp
+++ b/bindings/python/algorithm/expose-aba-derivatives.cpp
@@ -16,6 +16,15 @@ namespace pinocchio
     {
       computeABADerivatives(model,data,q,v,tau);
     }
+    typedef container::aligned_vector<Force> ForceAlignedVector;
+   void computeABADerivatives_fext(const Model & model, Data & data,
+                                    const Eigen::VectorXd & q,
+                                    const Eigen::VectorXd & v,
+                                    const Eigen::VectorXd & tau,
+                                    const ForceAlignedVector & fext)
+    {
+      computeABADerivatives(model,data,q,v,tau,fext);
+    }
     
     void exposeABADerivatives()
     {
@@ -30,9 +39,20 @@ namespace pinocchio
               "Computes the ABA derivatives, put the result in data.ddq_dq, data.ddq_dv and data.Minv\n"
               "which correspond to the partial derivatives of the joint acceleration vector output with respect to the joint configuration,\n"
               "velocity and torque vectors.");
+
+      bp::def("computeABADerivatives",
+              computeABADerivatives_fext,
+              bp::args("Model","Data",
+                       "q: configuration vector (size model.nq)",
+                       "v: velocity vector (size model.nv)",
+                       "a: acceleration vector (size model.nv)",
+                       "fext: vector external forces (size model.njoints)"),
+              "Computes the ABA derivatives with external contact foces,\n"
+              "put the result in data.ddq_dq, data.ddq_dv and data.Minv\n"
+              "which correspond to the partial derivatives of the acceleration output with respect to the joint configuration,\n"
+              "velocity and torque vectors.\n"
+              "The forces are of type StdVect_Force.");
     }
-    
-    
     
   } // namespace python
 } // namespace pinocchio

--- a/bindings/python/algorithm/expose-joints.cpp
+++ b/bindings/python/algorithm/expose-joints.cpp
@@ -23,6 +23,19 @@ namespace pinocchio
       return randomConfiguration(model);
     }
 
+    bp::tuple dIntegrate_proxy(const Model & model,
+                               const Eigen::VectorXd& q,
+                               const Eigen::VectorXd& dq)
+    {
+      Eigen::MatrixXd J0(Eigen::MatrixXd::Zero(model.nv,model.nv));
+      Eigen::MatrixXd J1(Eigen::MatrixXd::Zero(model.nv,model.nv));
+
+      dIntegrate(model,q,dq,J0,ARG0);
+      dIntegrate(model,q,dq,J1,ARG1);
+
+      return bp::make_tuple(J0,J1);
+    }
+
     void exposeJointsAlgo()
     {
       using namespace Eigen;
@@ -34,6 +47,22 @@ namespace pinocchio
                        "Velocity v (size Model::nv)"),
               "Integrate the model for a tangent vector during one unit time .");
       
+      bp::enum_<ArgumentPosition>("ArgumentPosition")
+        .value("ARG0",ARG0)
+        .value("ARG1",ARG1)
+        .value("ARG2",ARG2)
+        .value("ARG3",ARG3)
+        .value("ARG4",ARG4)
+        ;
+
+      bp::def("dIntegrate",
+              &dIntegrate_proxy,
+              bp::args("Model",
+                       "Configuration q (size Model::nq)",
+                       "Velocity v (size Model::nv)"),
+              "Compute the partial derivatives of integrate function with respect to first "
+              "and second argument, and return the two jacobian as a tuple. ");
+
       bp::def("interpolate",
               &interpolate<double,0,JointCollectionDefaultTpl,VectorXd,VectorXd>,
               bp::args("Model",


### PR DESCRIPTION
I worked a bit with the derivative algos that I never tried before. Very nice work. It like them a lot!

I added a direct and naive binding to the derivative of the joint integration. I believe that it follows the naive joint algorithm implemented in src/algo. Should we had some comment in the documentation (both of the python and the c++ function) to specify that this algorithm is best used at the joint level, using the sparsity of the kinematic tree?
I added a copy of the current ABA derivative to account for external forces, following the pattern of the rnea algorithm. 

NB: 
Meanwhile, I noticed that some StdVector bindings are named StdVec while others are named StdVect. I guess we should unified. I would be interest to now the best way for creating a filled StdVec. I was not able to imagine something convenient from a generator, similar to StdVect_Force([ Force.Random() for j in model.joints]). I rather used fs=StdVect_Force(); for j in model.joints: fs.append(Force.Random()), which is less convenient.

I tested both python bindings, and validate them (again) against finite differences. I also validated that ddq_dq = -M^-1 dtau_dq. I would be wanted to add these unit-tests as python examples. What is the current policy? Should I add them naively in pinocchio/python?

 

