### PR TITLE
[Python] Update to changes in hpp-fcl.

### DIFF
--- a/bindings/python/multibody/fcl/collision-geometry.hpp
+++ b/bindings/python/multibody/fcl/collision-geometry.hpp
@@ -34,7 +34,6 @@ namespace pinocchio
           .def("getNodeType",&CollisionGeometry::getNodeType,"Get the node type.")
           
           .def("computeLocalAABB",&CollisionGeometry::computeLocalAABB)
-          .def("isOccupied",&CollisionGeometry::isOccupied)
           .def("isFree",&CollisionGeometry::isFree)
           .def("isUncertain",&CollisionGeometry::isUncertain)
           

--- a/bindings/python/multibody/fcl/collision-result.hpp
+++ b/bindings/python/multibody/fcl/collision-result.hpp
@@ -34,7 +34,6 @@ namespace pinocchio
           .def("addContact",&CollisionResult::addContact,bp::arg("contact"),"Adds one contact into result structure")
           .def("isCollision",&CollisionResult::isCollision,"Returns binary collision result")
           .def("numContacts",&CollisionResult::numContacts,"Returns the number of contacts found")
-          .def("numCostSources",&CollisionResult::numCostSources,"Returns the number of cost sources found")
           
           .def("clear",&CollisionResult::clear,"Clears the results obtained")
           


### PR DESCRIPTION
There are some work being done in hpp-fcl currently. It should be stabilized by the end of the week. It should not impact Pinocchio except for the following changes.

The following three functions are now marked as deprecated.
```
          .def("isOccupied",&CollisionGeometry::isOccupied)
          .def("isFree",&CollisionGeometry::isFree)
          .def("isUncertain",&CollisionGeometry::isUncertain)
```
Should I remove them from the bindings ?

The reason why only `isOccupied` is removed for now is historical. I will change this once we agree on the strategy.