### PR TITLE
Update CI, fix #629

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -18,7 +18,7 @@ cache:
     - cd /root/robotpkg/math
     - git pull
     - cd pinocchio
-    - make checkout MASTER_REPOSITORY="dir ${CI_PROJECT_DIR}"
+    - make checkout MASTER_REPOSITORY="git ${CI_PROJECT_DIR}/.git"
     - make install
     - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
     - make test
@@ -43,10 +43,10 @@ robotpkg-pinocchio-18.04-release:
     - cd /root/robotpkg/math
     - git pull
     - cd pinocchio
-    - make checkout MASTER_REPOSITORY="dir ${CI_PROJECT_DIR}"
+    - make checkout MASTER_REPOSITORY="git ${CI_PROJECT_DIR}/.git"
     - cd ..
     - cd py-pinocchio
-    - make checkout MASTER_REPOSITORY="dir ${CI_PROJECT_DIR}"
+    - make checkout MASTER_REPOSITORY="git ${CI_PROJECT_DIR}/.git"
     - make install
     - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
     - make test

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ cache:
     - cd pinocchio
     - make checkout MASTER_REPOSITORY="git ${CI_PROJECT_DIR}/.git"
     - make install
-    - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
+    - cd $(make show-var VARNAME=WRKSRC)
     - make test
 
 robotpkg-pinocchio-14.04-release:
@@ -48,7 +48,7 @@ robotpkg-pinocchio-18.04-release:
     - cd py-pinocchio
     - make checkout MASTER_REPOSITORY="git ${CI_PROJECT_DIR}/.git"
     - make install
-    - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
+    - cd $(make show-var VARNAME=WRKSRC)
     - make test
 
 robotpkg-py-pinocchio-14.04-release:
@@ -85,7 +85,7 @@ doc-coverage:
     - echo -e 'CXXFLAGS+= --coverage\nLDFLAGS+= --coverage\nPKG_DEFAULT_OPTIONS= debug' >> /opt/openrobots/etc/robotpkg.conf
   after_script:
     - cd /root/robotpkg/math/py-pinocchio
-    - cd work.$(hostname)/$(make show-var VARNAME=DISTNAME)
+    - cd $(make show-var VARNAME=WRKSRC)
     - make doc
     - mv doc/doxygen-html ${CI_PROJECT_DIR}
     - mkdir -p ${CI_PROJECT_DIR}/coverage/

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: generic
 python:
   - "2.7"
 sudo: required
-dist: trusty
+dist: xenial
 git:
   depth: false
 compiler:

--- a/travis_custom/custom_before_install
+++ b/travis_custom/custom_before_install
@@ -5,8 +5,8 @@ set -e
 set -x
 set -v
 
-# Add robotpkg 
-sudo sh -c "echo \"deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub trusty robotpkg\" >> /etc/apt/sources.list "
+# Add robotpkg
+sudo sh -c "echo \"deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub xenial robotpkg\" >> /etc/apt/sources.list "
 curl http://robotpkg.openrobots.org/packages/debian/robotpkg.key | sudo apt-key add -
 
 # show memory usage before install


### PR DESCRIPTION
Hi,

This PR fixes #629 by switching Travis CI builds from trusty to xenial.

While here, I am also pushing a way to fix gitlab-ci cloning process, and therefore version detection, which was required for the build since https://github.com/jrl-umi3218/jrl-cmakemodules/pull/169

Unfortunately, this only makes pinocchio tests working on Gitlab-CI, and not py-pinocchio ones, because of a separate issue.