### PR TITLE
Improve link for Python examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ If you want to follow the current developments, you can directly refer to the [d
 
 ## Examples
 
-We provide some basic examples on how to use **Pinocchio** in Python in the [examples/python](./examples/python/README.md) directory.
+We provide some basic examples on how to use **Pinocchio** in Python in the [examples/python](./examples/python) directory.
 
 ## Tutorials
 


### PR DESCRIPTION
I find pointing to the folder rather than the README.md is clearer. Note: you still see the README.md at the bottom of the page with the new link.

I was a bit confused when I clicked and only saw the README and thought "but where are the examples I wanted to look at?".