### PR TITLE
Support for catkinized hpp-fcl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,7 +69,7 @@ MACRO(TAG_LIBRARY_VERSION target)
 ENDMACRO(TAG_LIBRARY_VERSION)
 
 # ----------------------------------------------------
-# --- DEPENDANCIES -----------------------------------
+# --- DEPENDENCIES -----------------------------------
 # ----------------------------------------------------
 ADD_REQUIRED_DEPENDENCY("eigen3 >= 3.0.5")
 ADD_OPTIONAL_DEPENDENCY("urdfdom >= 0.2.0")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,7 +73,10 @@ ENDMACRO(TAG_LIBRARY_VERSION)
 # ----------------------------------------------------
 ADD_REQUIRED_DEPENDENCY("eigen3 >= 3.0.5")
 ADD_OPTIONAL_DEPENDENCY("urdfdom >= 0.2.0")
+
+find_package(catkin QUIET COMPONENTS hpp-fcl)  # compatability with catkin-packaged hpp-fcl
 ADD_OPTIONAL_DEPENDENCY("hpp-fcl >= 0.5.1")
+
 ADD_OPTIONAL_DEPENDENCY("cppad >= 20180000.0")
 
 IF(CPPAD_FOUND)


### PR DESCRIPTION
This PR adds support for both the existing/robotpkg hpp-fcl as well as the [catkinized hpp-fcl](https://github.com/ipab-slmc/hpp-fcl_catkin). The default behaviour does not change.