### PR TITLE
Introduce support for MeshCat viewer in RobotWrapper.

### DIFF
--- a/bindings/python/pinocchio/robot_wrapper.py
+++ b/bindings/python/pinocchio/robot_wrapper.py
@@ -287,7 +287,7 @@ class RobotWrapper(object):
             visualizer: the meshcat.Visualizer instance to use.
             robot_name: name to give to the robot in the viewer
             robot_color: optional, color to give to the robot. This overwrites the color present in the urdf.
-                         Format is a list of three RGB floats (between 0 and 1)
+                         Format is a list of four RGBA floats (between 0 and 1)
         """
         import meshcat.geometry
         # Set viewer to use to gepetto-gui.
@@ -302,11 +302,11 @@ class RobotWrapper(object):
                 raise IOError("Visual mesh file not found for link {}.".format(visual.name))
             # Get file type from filename extension.
             _, file_extension = os.path.splitext(visual.meshPath)
-            if file_extension == ".dae" or file_extension == ".DAE":
+            if file_extension.lower() == ".dae":
                 obj = meshcat.geometry.DaeMeshGeometry.from_file(visual.meshPath)
-            elif file_extension == ".obj" or file_extension == ".OBJ":
+            elif file_extension.lower() == ".obj":
                 obj = meshcat.geometry.ObjMeshGeometry.from_file(visual.meshPath)
-            elif file_extension == ".stl" or file_extension == ".STL":
+            elif file_extension.lower() == ".stl":
                 obj = meshcat.geometry.StlMeshGeometry.from_file(visual.meshPath)
             else:
                 raise ImportError("Unknown mesh file format: {}.".format(visual.meshPath))
@@ -317,6 +317,10 @@ class RobotWrapper(object):
             else:
                 meshColor = robot_color
             material.color = int(meshColor[0] * 255) * 256**2 + int(meshColor[1] * 255) * 256 + int(meshColor[2] * 255)
+            # Add transparency, if needed.
+            if float(meshColor[3]) != 1.0:
+                material.transparent = True
+                material.opacity = float(meshColor[3])
             self.meshcat_viewer[viewer_name].set_object(obj, material)
 
     # Create the scene displaying the robot meshes in gepetto-viewer

--- a/examples/python/gepetto-viewer.py
+++ b/examples/python/gepetto-viewer.py
@@ -8,15 +8,17 @@ import os
 
 from pinocchio.robot_wrapper import RobotWrapper
 
+# Load the URDF model.
 current_file =  os.path.dirname(os.path.abspath(__file__))
 romeo_model_dir = os.path.abspath(os.path.join(current_file, '../../models/romeo'))
 romeo_model_path = os.path.abspath(os.path.join(romeo_model_dir, 'romeo_description/urdf/romeo.urdf'))
-hint_list = [romeo_model_dir, "wrong/hint"] # hint list
-robot = RobotWrapper(romeo_model_path, hint_list, se3.JointModelFreeFlyer())
+robot = RobotWrapper.BuildFromURDF(romeo_model_path, [romeo_model_dir], se3.JointModelFreeFlyer())
 
+# Initialize the robot display.
 robot.initDisplay()
 robot.loadDisplayModel("pinocchio")
 
+# Display a robot configuration.
 q0 = np.matrix([
     0, 0, 0.840252, 0, 0, 0, 1,  # Free flyer
     0, 0, -0.3490658, 0.6981317, -0.3490658, 0,  # left leg
@@ -26,5 +28,4 @@ q0 = np.matrix([
     0, 0, 0, 0,  # head
     1.5, -0.6, 0.5, 1.05, -0.4, -0.3, -0.2,  # right arm
 ]).T
-
 robot.display(q0)

--- a/examples/python/meshcat-viewer.py
+++ b/examples/python/meshcat-viewer.py
@@ -24,7 +24,9 @@ robot = RobotWrapper.BuildFromURDF(romeo_model_path, [romeo_model_dir], se3.Join
 vis = meshcat.Visualizer()
 
 # Load the robot in the viewer.
-robot.initMeshcatDisplay(vis)
+# Color is needed here because the Romeo URDF doesn't contain any color, so the default color results in an
+# invisible robot (alpha value set to 0).
+robot.initMeshcatDisplay(vis, robot_color = [0.0, 0.0, 0.0, 1.0])
 
 q = robot.q0
 # Separate between freeflyer and robot links.
@@ -35,8 +37,8 @@ robot.display(q)
 input("Displaying a single random robot configuration. Press enter to continue")
 
 red_robot = RobotWrapper.BuildFromURDF(romeo_model_path, [romeo_model_dir], se3.JointModelFreeFlyer())
-robot.initMeshcatDisplay(vis, robot_name = "red_robot", robot_color = [1.0, 0.0, 0.0])
+robot.initMeshcatDisplay(vis, robot_name = "red_robot", robot_color = [1.0, 0.0, 0.0, 0.5])
 q[1] = 1.0
 q[n_freeflyer:] = np.matrix(np.random.rand(n_links)).T
 robot.display(q)
-input("Displaying a second robot with color red. Press enter to exit")
+input("Displaying a second robot with color red, semi-transparent. Press enter to exit")

--- a/examples/python/meshcat-viewer.py
+++ b/examples/python/meshcat-viewer.py
@@ -1,0 +1,42 @@
+# pinocchio.RobotWrapper is interfaced with the web-based mesh viewer Meshcat.
+# This examples shows how to load and move a robot in meshcat.
+# Note: this feature requires Meshcat to be installed, this can be done using
+# pip install --user meshcat
+
+import pinocchio as se3
+import numpy as np
+import os
+from future.builtins import input
+
+from pinocchio.robot_wrapper import RobotWrapper
+
+import meshcat
+
+# Load the URDF model.
+current_file =  os.path.dirname(os.path.abspath(__file__))
+romeo_model_dir = os.path.abspath(os.path.join(current_file, '../../models/romeo'))
+romeo_model_path = os.path.abspath(os.path.join(romeo_model_dir, 'romeo_description/urdf/romeo.urdf'))
+robot = RobotWrapper.BuildFromURDF(romeo_model_path, [romeo_model_dir], se3.JointModelFreeFlyer())
+
+# Start a new MeshCat server and client.
+# Note: the server can also be started separately using the "meshcat-server" command in a terminal:
+# this enables the server to remain active after the current script ends.
+vis = meshcat.Visualizer()
+
+# Load the robot in the viewer.
+robot.initMeshcatDisplay(vis)
+
+q = robot.q0
+# Separate between freeflyer and robot links.
+n_freeflyer = 7
+n_links = len(q) - n_freeflyer
+q[n_freeflyer:] = np.matrix(np.random.rand(n_links)).T
+robot.display(q)
+input("Displaying a single random robot configuration. Press enter to continue")
+
+red_robot = RobotWrapper.BuildFromURDF(romeo_model_path, [romeo_model_dir], se3.JointModelFreeFlyer())
+robot.initMeshcatDisplay(vis, robot_name = "red_robot", robot_color = [1.0, 0.0, 0.0])
+q[1] = 1.0
+q[n_freeflyer:] = np.matrix(np.random.rand(n_links)).T
+robot.display(q)
+input("Displaying a second robot with color red. Press enter to exit")


### PR DESCRIPTION
RobotWrapper now supports transparently the use of MeshCat as a 3D viewer, alongside of gepetto-gui.

Added example script to show how to use the MeshCat viewer.
Fix the gepetto-gui example script.

Linked to https://github.com/stack-of-tasks/pinocchio/issues/657