### PR TITLE
Algorithm to compute the derivatives of the COM velocity

### DIFF
--- a/bindings/python/algorithm/expose-kinematics-derivatives.cpp
+++ b/bindings/python/algorithm/expose-kinematics-derivatives.cpp
@@ -4,6 +4,7 @@
 
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
 #include "pinocchio/algorithm/kinematics-derivatives.hpp"
+#include "pinocchio/algorithm/center-of-mass-derivatives.hpp"
 
 #include <boost/python/tuple.hpp>
 
@@ -47,6 +48,15 @@ namespace pinocchio
 
       return bp::make_tuple(v_partial_dq,a_partial_dq,a_partial_dv,a_partial_da);
     }
+    Data::Matrix3x getCoMVelocityDerivatives_proxy(const Model & model,
+                                                   Data & data)
+    {
+      typedef Data::Matrix3x Matrix3x;
+      Matrix3x partial_dq(Matrix3x::Zero(3,model.nv));
+      getCenterOfMassVelocityDerivatives(model,data,partial_dq);
+      return partial_dq;
+    }
+    
     
     void exposeKinematicsDerivatives()
     {
@@ -83,6 +93,15 @@ namespace pinocchio
               "the joint configuration, velocity and acceleration and returns them as a tuple.\n"
               "The Jacobians can be either expressed in the LOCAL frame of the joint or in the WORLD coordinate frame depending on the value of the Reference Frame.\n"
               "You must first call computForwardKinematicsDerivatives before calling this function");
+
+      bp::def("getCenterOfMassVelocityDerivatives",
+              getCoMVelocityDerivatives_proxy,
+              bp::args("Model","Data"),
+              "Computes the partial derivaties of the com velocity of a given with respect to\n"
+              "the joint configuration.\n"
+              "You must first call computForwardKinematicsDerivatives and centerOfMass(q,vq) "
+              "before calling this function");
+
     }
     
     

--- a/src/algorithm/center-of-mass-derivatives.hpp
+++ b/src/algorithm/center-of-mass-derivatives.hpp
@@ -1,0 +1,38 @@
+//
+// Copyright (c) 2019 CNRS
+//
+
+#ifndef __pinocchio_center_of_mass_derivatives_hpp__
+#define __pinocchio_center_of_mass_derivatives_hpp__
+
+#include "pinocchio/multibody/model.hpp"
+#include "pinocchio/multibody/data.hpp"
+
+namespace pinocchio
+{
+  ///
+  /// \brief Computes the partial derivatie of the center-of-mass velocity with respect to 
+  ///        the joint configuration q.
+  ///        You must first call computForwardKinematicsDerivatives and computeCenterOfMass(q,vq)
+  ///        before calling this function.
+  ///
+  /// \tparam JointCollection Collection of Joint types.
+  /// \tparam Matrix3xOut Matrix3x containing the partial derivatives of the CoM velocity with respect to the joint configuration vector.
+  ///
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  /// \param[out] v_partial_dq Partial derivative of the CoM velocity w.r.t. \f$ q \f$.
+  ///
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl,
+           typename Matrix3xOut>
+  inline void getCenterOfMassVelocityDerivatives(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                                                 DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                                                 const Eigen::MatrixBase<Matrix3xOut> & vcom_partial_dq);
+
+
+
+} // namespace pinocchio 
+
+#include "pinocchio/algorithm/center-of-mass-derivatives.hxx"
+
+#endif // ifndef __pinocchio_center_of_mass_derivatives_hpp__

--- a/src/algorithm/center-of-mass-derivatives.hxx
+++ b/src/algorithm/center-of-mass-derivatives.hxx
@@ -1,0 +1,82 @@
+//
+// Copyright (c) 2019 CNRS
+//
+
+#ifndef __pinocchio_center_of_mass_derivatives_hxx__
+#define __pinocchio_center_of_mass_derivatives_hxx__
+
+#include "pinocchio/multibody/visitor.hpp"
+#include "pinocchio/algorithm/check.hpp"
+
+namespace pinocchio
+{
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl,
+           typename Matrix3xOut>
+  struct CoMVelocityDerivativesForwardStep
+    : public fusion::JointVisitorBase< CoMVelocityDerivativesForwardStep<Scalar,Options,JointCollectionTpl,Matrix3xOut> >
+  {
+    /* Assumes that both computeForwardKinematicsDerivatives and centerOfMass (or
+     * equivalent methods like computeAllTerms) have been computed beforehand. */
+
+    typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
+    typedef DataTpl<Scalar,Options,JointCollectionTpl> Data;
+    
+    typedef boost::fusion::vector<const Model &,
+                                  Data &,
+                                  Matrix3xOut &
+                                  > ArgsType;
+    
+    template<typename JointModel>
+    static void algo(const JointModelBase<JointModel> & jmodel,
+                     JointDataBase<typename JointModel::JointDataDerived> & jdata,
+                     const Model & model,
+                     Data & data,
+                     const Eigen::MatrixBase<Matrix3xOut> & vcom_partial_dq_CONST)
+    {
+      typedef typename Model::JointIndex JointIndex;
+      typedef typename Data::Motion Motion;
+      
+      const JointIndex & i = jmodel.id();
+
+      Matrix3xOut & dvcom_dq = PINOCCHIO_EIGEN_CONST_CAST(Matrix3xOut,vcom_partial_dq_CONST);
+      typename SizeDepType<JointModel::NV>::template ColsReturn<typename Data::Matrix3x>::Type
+        dvcom_dqi = jmodel.jointCols(dvcom_dq);
+
+      Motion vpc = (model.parents[i]>0) ? (data.v[i]-(Motion)jdata.v()) : Motion::Zero();
+      vpc.linear() -= data.vcom[i]; // vpc = v_{parent+c} = [ v_parent+vc; w_parent ]
+      const Eigen::Matrix<Scalar,6,JointModel::NV,Options> & vxS = vpc.cross(jdata.S());
+      
+      dvcom_dqi = data.mass[i]*data.oMi[i].rotation()
+        *( vxS.template topRows<3>() - cross( data.com[i], vxS.template bottomRows<3>()) );
+    }
+  };
+  
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl,
+           typename Matrix3xOut>
+  inline void getCenterOfMassVelocityDerivatives(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                                                 DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                                                 const Eigen::MatrixBase<Matrix3xOut> & vcom_partial_dq_CONST)
+  {
+    EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix3xOut,Data::Matrix3x);
+    
+    assert(vcom_partial_dq.cols() ==  model.nv);
+    assert(model.check(data) && "data is not consistent with model.");
+    
+    typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
+    typedef typename Model::JointIndex JointIndex;
+
+    Matrix3xOut & vcom_partial_dq = PINOCCHIO_EIGEN_CONST_CAST(Matrix3xOut,vcom_partial_dq_CONST);
+      
+    typedef CoMVelocityDerivativesForwardStep<Scalar,Options,JointCollectionTpl,Matrix3xOut> Pass1;
+    for(JointIndex i = 1; i < (JointIndex)model.njoints; i ++)
+      {
+        Pass1::run(model.joints[i],data.joints[i],
+                   typename Pass1::ArgsType(model,data,vcom_partial_dq));
+      }
+    vcom_partial_dq /= data.mass[0];
+  }
+
+} // namespace pinocchio
+
+#endif // ifndef __pinocchio_center_of_mass_derivatives_hxx__
+

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -107,6 +107,7 @@ ADD_PINOCCHIO_UNIT_TEST(kinematics-derivatives eigen3)
 ADD_PINOCCHIO_UNIT_TEST(rnea-derivatives eigen3)
 ADD_PINOCCHIO_UNIT_TEST(aba-derivatives eigen3)
 ADD_PINOCCHIO_UNIT_TEST(centroidal-derivatives eigen3)
+ADD_PINOCCHIO_UNIT_TEST(center-of-mass-derivatives eigen3)
 
 # Automatic differentiation
 IF(CPPAD_FOUND)

--- a/unittest/center-of-mass-derivatives.cpp
+++ b/unittest/center-of-mass-derivatives.cpp
@@ -1,0 +1,71 @@
+//
+// Copyright (c) 2019 CNRS
+//
+
+#include "pinocchio/multibody/model.hpp"
+#include "pinocchio/multibody/data.hpp"
+#include "pinocchio/algorithm/jacobian.hpp"
+#include "pinocchio/algorithm/center-of-mass.hpp"
+#include "pinocchio/algorithm/joint-configuration.hpp"
+#include "pinocchio/algorithm/kinematics.hpp"
+#include "pinocchio/algorithm/kinematics-derivatives.hpp"
+#include "pinocchio/algorithm/center-of-mass-derivatives.hpp"
+#include "pinocchio/parsers/sample-models.hpp"
+
+#include <iostream>
+
+#include <boost/test/unit_test.hpp>
+#include <boost/utility/binary.hpp>
+
+BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+
+BOOST_AUTO_TEST_CASE(test_kinematics_derivatives_vcom)
+{
+  using namespace Eigen;
+  using namespace pinocchio;
+  
+  Model model;
+  buildModels::humanoid(model);
+  
+  Data data(model), data_ref(model);
+  
+  model.lowerPositionLimit.head<3>().fill(-1.);
+  model.upperPositionLimit.head<3>().fill(1.);
+  VectorXd q = randomConfiguration(model);
+  VectorXd vq(VectorXd::Random(model.nv));
+  VectorXd aq(VectorXd::Random(model.nv));
+
+  q.fill(1);
+  q.head<7>() << 0,0,0,1,0,0,0;
+  vq.fill(2);
+  aq.fill(0);
+    
+  // Compute dvcom_dq using the algorithm
+  Data::Matrix3x dvcom_dq = Data::Matrix3x::Zero(3,model.nv);
+  computeForwardKinematicsDerivatives(model,data,q,vq,aq);
+  centerOfMass(model,data,q,vq);
+  getCenterOfMassVelocityDerivatives(model,data,dvcom_dq);
+
+  // Approximate dvcom_dq by finite diff.
+  Eigen::Vector3d vcom0 = data.vcom[0];
+  const double alpha = 1e-6;
+  Eigen::VectorXd dq = VectorXd::Zero(model.nv);
+  Data::Matrix3x dvcom_dqn(3,model.nv);
+
+  for(int k = 0; k < model.nv; ++k)
+  {
+    dq[k] = alpha;
+    centerOfMass(model,data,integrate(model,q,dq),vq);
+    dvcom_dqn.col(k) = (data.vcom[0]-vcom0)/alpha;
+    dq[k] = 0;
+  }
+
+  // Check that algo result and finite-diff approx are similar.
+  //std::cout << dvcom_dqn << std::endl<< std::endl<< std::endl;
+  //std::cout << dvcom_dq << std::endl;
+  BOOST_CHECK(dvcom_dq.isApprox(dvcom_dqn,sqrt(alpha)));
+}
+
+
+
+BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/center-of-mass-derivatives.cpp
+++ b/unittest/center-of-mass-derivatives.cpp
@@ -35,11 +35,6 @@ BOOST_AUTO_TEST_CASE(test_kinematics_derivatives_vcom)
   VectorXd vq(VectorXd::Random(model.nv));
   VectorXd aq(VectorXd::Random(model.nv));
 
-  q.fill(1);
-  q.head<7>() << 0,0,0,1,0,0,0;
-  vq.fill(2);
-  aq.fill(0);
-    
   // Compute dvcom_dq using the algorithm
   Data::Matrix3x dvcom_dq = Data::Matrix3x::Zero(3,model.nv);
   computeForwardKinematicsDerivatives(model,data,q,vq,aq);
@@ -48,7 +43,7 @@ BOOST_AUTO_TEST_CASE(test_kinematics_derivatives_vcom)
 
   // Approximate dvcom_dq by finite diff.
   Eigen::Vector3d vcom0 = data.vcom[0];
-  const double alpha = 1e-6;
+  const double alpha = 1e-8;
   Eigen::VectorXd dq = VectorXd::Zero(model.nv);
   Data::Matrix3x dvcom_dqn(3,model.nv);
 
@@ -61,8 +56,6 @@ BOOST_AUTO_TEST_CASE(test_kinematics_derivatives_vcom)
   }
 
   // Check that algo result and finite-diff approx are similar.
-  //std::cout << dvcom_dqn << std::endl<< std::endl<< std::endl;
-  //std::cout << dvcom_dq << std::endl;
   BOOST_CHECK(dvcom_dq.isApprox(dvcom_dqn,sqrt(alpha)));
 }
 

--- a/unittest/python/bindings_com_velocity_derivatives.py
+++ b/unittest/python/bindings_com_velocity_derivatives.py
@@ -1,0 +1,55 @@
+import unittest
+import pinocchio as pio
+from pinocchio.utils import *
+from numpy.linalg import norm
+
+def df_dq(model,func,q,h=1e-9):
+    """ Perform df/dq by num_diff. q is in the lie manifold.
+    :params func: function to differentiate f : np.matrix -> np.matrix
+    :params q: configuration value at which f is differentiated. type np.matrix
+    :params h: eps
+    
+    :returns df/dq
+    """
+    dq = zero(model.nv)
+    f0 = func(q)
+    res = zero([len(f0),model.nv])
+    for iq in range(model.nv):
+        dq[iq] = h
+        res[:,iq] = (func(pio.integrate(model,q,dq)) - f0)/h
+        dq[iq] = 0
+    return res
+
+class TestVComDerivativesBindings(unittest.TestCase):
+    def setUp(self):
+        self.rmodel = rmodel = pio.buildSampleModelHumanoid()
+        self.rdata  = rmodel.createData()
+
+        self.q = pio.randomConfiguration(rmodel)
+        self.vq = rand(rmodel.nv)*2-1
+        self.aq = zero(rmodel.nv)
+        self.dq = rand(rmodel.nv)*2-1
+
+        self.precision = 1e-8
+        
+    def test_numdiff(self):
+        rmodel,rdata = self.rmodel,self.rdata
+        q,vq,aq,dq= self.q,self.vq,self.aq,self.dq
+
+        #### Compute d/dq VCOM with the algo.
+        pio.computeAllTerms(rmodel,rdata,q,vq)
+        pio.computeForwardKinematicsDerivatives(rmodel,rdata,q,vq,aq)
+        dvc_dq = pio.getCenterOfMassVelocityDerivatives(rmodel,rdata)
+        
+        #### Approximate d/dq VCOM by finite diff.
+        def calc_vc(q,vq):
+            """ Compute COM velocity """
+            pio.centerOfMass(rmodel,rdata,q,vq)
+            return rdata.vcom[0]
+        dvc_dqn = df_dq(rmodel,lambda _q: calc_vc(_q,vq),q)
+        
+        self.assertTrue(np.allclose(dvc_dq,dvc_dqn,atol=np.sqrt(self.precision)))
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/unittest/python/tests.py
+++ b/unittest/python/tests.py
@@ -15,6 +15,7 @@ from bindings_geometry_object_urdf import TestGeometryObjectUrdfBindings
 from bindings_dynamics import TestDynamicsBindings
 from bindings_com import TestComBindings
 from bindings_joint_composite import TestJointCompositeBindings
+from bindings_com_velocity_derivatives import TestVComDerivativesBindings
 from explog import TestExpLog
 from model import TestModel
 from rpy import TestRPY


### PR DESCRIPTION
I put the algo in a new center-of-mass-derivative.hpp/xx file, with new unittest file, following the policy used for other *-derivatives.hpp/xx files.
I put the binding in expose-kinematic-derivatives because creating a new file at this point seemed overkilled, but I can modify that choice if need be.
The algorithm is computed in the local frame, which makes it compact and elegant. I validated it for the simple humanoid in the unittest, but also for talos arm and legs in python.