### PR TITLE
get the inverse of MJtJ matrix using the matrix decompositions performed in forwardDynamics or impulsedynamics

### DIFF
--- a/bindings/python/algorithm/expose-dynamics.cpp
+++ b/bindings/python/algorithm/expose-dynamics.cpp
@@ -27,6 +27,16 @@ namespace pinocchio
 
     BOOST_PYTHON_FUNCTION_OVERLOADS(impulseDynamics_overloads, impulseDynamics_proxy, 5, 7)
 
+    static const Eigen::MatrixXd getKKTContactDynamicMatrixInverse_proxy(const Model & model,
+                                                                         Data & data,
+                                                                         const Eigen::MatrixXd & J)
+    {
+      Eigen::MatrixXd MJtJ_inv(model.nv+J.rows(), model.nv+J.rows());
+      getKKTContactDynamicMatrixInverse(model, data, J, MJtJ_inv);
+      return MJtJ_inv;
+    }
+    
+
     void exposeDynamics()
     {
       using namespace Eigen;
@@ -56,6 +66,10 @@ namespace pinocchio
                        "Update kinematics (if true, it updates only the joint space inertia matrix)"),
               "Solve the impact dynamics problem with contacts, put the result in Data::dq_after and return it. The contact impulses are stored in data.impulse_c"
               )[bp::return_value_policy<bp::return_by_value>()]);
+      bp::def("getKKTContactDynamicMatrixInverse",getKKTContactDynamicMatrixInverse_proxy,
+              bp::args("Model","Data",
+                       "Contact Jacobian J(size nb_constraint * Model::nv)"),
+              "Computes the inverse of the constraint matrix [[M JT], [J 0]]. forward/impulseDynamics must be called first. The jacobian should be the same that was provided to forward/impulseDynamics.");
     }
     
   } // namespace python

--- a/src/algorithm/dynamics.hpp
+++ b/src/algorithm/dynamics.hpp
@@ -103,46 +103,47 @@ namespace pinocchio
     a.noalias() = J.transpose() * lambda_c;
     cholesky::solve(model, data, a);
     a += data.torque_residual;
+
     
     return a;
   }
 
   ///
-  /// \brief Computes the inverse of the constraint matrix [[M JT], [J 0]].
-  /// The matrix is defined when we call forwardDynamics. This method makes use of
-  /// the matrix decompositions performed during the forwardDynamics and returns the inverse.
-  /// The jacobian should be the same that was provided to forwardDynamics.
-  /// Thus you should call forward Dynamics first.
+  /// \brief Computes the inverse of the KKT matrix for dynamics with contact constraints, [[M JT], [J 0]].
+  /// The matrix is defined when we call forwardDynamics/impulsedynamics. This method makes use of
+  /// the matrix decompositions performed during the forwardDynamics/impulasedynamics and returns the inverse.
+  /// The jacobian should be the same that was provided to forwardDynamics/impulasedynamics.
+  /// Thus you should call forward Dynamics/impulsedynamics first.
   /// \param[in] model The model structure of the rigid body system.
   /// \param[in] data The data structure of the rigid body system.
   /// \param[out] MJtJ_inv inverse of the MJtJ matrix.
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl,
-           typename ConstraintMatrixType>
-  inline void getMJtJInverse(const ModelTpl<Scalar,Options,JointCollectionTpl> &
-                             model,
-                             const DataTpl<Scalar,Options,JointCollectionTpl> & data,
-                             const Eigen::MatrixBase<ConstraintMatrixType> & J,
-                             typename DataTpl<Scalar,Options,JointCollectionTpl>::MatrixXs& MJtJ_inv)
+           typename ConstraintMatrixType, typename KKTMatrixType>
+  inline void getKKTContactDynamicMatrixInverse(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                                                const DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                                                const Eigen::MatrixBase<ConstraintMatrixType> & J,
+                                                const Eigen::MatrixBase<KKTMatrixType> & MJtJ_inv)
   {
     typedef DataTpl<Scalar,Options,JointCollectionTpl> Data;
     assert(MJtJ_inv.cols() == data.JMinvJt.cols() + model.nv);
     assert(MJtJ_inv.rows() == data.JMinvJt.rows() + model.nv);
-    typename Data::MatrixXs::Index nc = data.JMinvJt.cols();
+    const typename Data::MatrixXs::Index& nc = data.JMinvJt.cols();
 
-    Eigen::Block<typename Data::MatrixXs> topLeft = MJtJ_inv.topLeftCorner(model.nv, model.nv);
-    Eigen::Block<typename Data::MatrixXs> topRight = MJtJ_inv.topRightCorner(model.nv, nc);
-    Eigen::Block<typename Data::MatrixXs> bottomLeft = MJtJ_inv.bottomLeftCorner(nc, model.nv);
-    Eigen::Block<typename Data::MatrixXs> bottomRight = MJtJ_inv.bottomRightCorner(nc, nc); 
+    KKTMatrixType& MJtJ_inv_ = PINOCCHIO_EIGEN_CONST_CAST(KKTMatrixType,MJtJ_inv);
+    
+    Eigen::Block<typename Data::MatrixXs> topLeft = MJtJ_inv_.topLeftCorner(model.nv, model.nv);
+    Eigen::Block<typename Data::MatrixXs> topRight = MJtJ_inv_.topRightCorner(model.nv, nc);
+    Eigen::Block<typename Data::MatrixXs> bottomLeft = MJtJ_inv_.bottomLeftCorner(nc, model.nv);
+    Eigen::Block<typename Data::MatrixXs> bottomRight = MJtJ_inv_.bottomRightCorner(nc, nc); 
 
-    bottomRight.setIdentity(); topLeft.setIdentity();
+    bottomRight = -Data::MatrixXs::Identity(nc,nc);    topLeft.setIdentity();
     data.llt_JMinvJt.solveInPlace(bottomRight);    cholesky::solve(model, data, topLeft);
 
     bottomLeft.noalias() = J*topLeft;
-    topRight.noalias() = bottomLeft.transpose() * bottomRight;
+    topRight.noalias() = bottomLeft.transpose() * (-bottomRight);
     topLeft.noalias() -= topRight*bottomLeft;
     bottomLeft = topRight.transpose();
-    bottomRight *=-1;
   }
 
   ///

--- a/unittest/dynamics.cpp
+++ b/unittest/dynamics.cpp
@@ -70,7 +70,7 @@ BOOST_AUTO_TEST_CASE ( test_FD )
   BOOST_CHECK(data.lambda_c.isApprox(lambda_ref, 1e-12));
     
   VectorXd a_ref = Minv*(tau - data.nle + J.transpose()*lambda_ref);
-  
+
   Eigen::VectorXd dynamics_residual_ref (data.M * a_ref + data.nle - tau - J.transpose()*lambda_ref);
   BOOST_CHECK(dynamics_residual_ref.norm() <= 1e-11); // previously 1e-12, may be due to numerical approximations, i obtain 2.03e-12
 
@@ -79,7 +79,16 @@ BOOST_AUTO_TEST_CASE ( test_FD )
   
   Eigen::VectorXd dynamics_residual (data.M * data.ddq + data.nle - tau - J.transpose()*data.lambda_c);
   BOOST_CHECK(dynamics_residual.norm() <= 1e-12);
-  
+
+  ///
+  Eigen::MatrixXd MJtJ(model.nv+12, model.nv+12);
+  MJtJ << data.M, J.transpose(),
+    J, Eigen::MatrixXd::Zero(12, 12);
+
+  Eigen::MatrixXd MJtJ_inv(model.nv+12, model.nv+12);
+  getMJtJInverse(model, data, J, MJtJ_inv);
+
+  BOOST_CHECK((MJtJ.inverse()-MJtJ_inv).norm() <=1e-12);
 }
 
 BOOST_AUTO_TEST_CASE ( test_FD_with_damping )


### PR DESCRIPTION
Currently the matrix decompositions done in forwardDynamics are wasted when computing the inverse of the MJtJ matrix. This PR adds a function that returns the analytical inverse of MJtJ (via schur complement) using the computations already done in forwardDynamics. This is also true for impulsedynamics.

I add the unittest and python bindings for this function as well.