### PR TITLE
Fix center of mass derivatives debug compilation error

### DIFF
--- a/src/algorithm/center-of-mass-derivatives.hxx
+++ b/src/algorithm/center-of-mass-derivatives.hxx
@@ -56,7 +56,7 @@ namespace pinocchio
            typename Matrix3xOut>
   inline void getCenterOfMassVelocityDerivatives(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                                                  DataTpl<Scalar,Options,JointCollectionTpl> & data,
-                                                 const Eigen::MatrixBase<Matrix3xOut> & vcom_partial_dq_CONST)
+                                                 const Eigen::MatrixBase<Matrix3xOut> & vcom_partial_dq)
   {
     EIGEN_STATIC_ASSERT_SAME_MATRIX_SIZE(Matrix3xOut,Data::Matrix3x);
     
@@ -66,15 +66,15 @@ namespace pinocchio
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
 
-    Matrix3xOut & vcom_partial_dq = PINOCCHIO_EIGEN_CONST_CAST(Matrix3xOut,vcom_partial_dq_CONST);
+    Matrix3xOut & dvcom_dq = PINOCCHIO_EIGEN_CONST_CAST(Matrix3xOut,vcom_partial_dq);
       
     typedef CoMVelocityDerivativesForwardStep<Scalar,Options,JointCollectionTpl,Matrix3xOut> Pass1;
     for(JointIndex i = 1; i < (JointIndex)model.njoints; i ++)
       {
         Pass1::run(model.joints[i],data.joints[i],
-                   typename Pass1::ArgsType(model,data,vcom_partial_dq));
+                   typename Pass1::ArgsType(model,data,dvcom_dq));
       }
-    vcom_partial_dq /= data.mass[0];
+    dvcom_dq /= data.mass[0];
     data.v[0].setZero();
   }
 

--- a/unittest/python/bindings_com_velocity_derivatives.py
+++ b/unittest/python/bindings_com_velocity_derivatives.py
@@ -1,5 +1,5 @@
 import unittest
-import pinocchio as pio
+import pinocchio as pin
 from pinocchio.utils import *
 from numpy.linalg import norm
 
@@ -16,16 +16,16 @@ def df_dq(model,func,q,h=1e-9):
     res = zero([len(f0),model.nv])
     for iq in range(model.nv):
         dq[iq] = h
-        res[:,iq] = (func(pio.integrate(model,q,dq)) - f0)/h
+        res[:,iq] = (func(pin.integrate(model,q,dq)) - f0)/h
         dq[iq] = 0
     return res
 
 class TestVComDerivativesBindings(unittest.TestCase):
     def setUp(self):
-        self.rmodel = rmodel = pio.buildSampleModelHumanoid()
+        self.rmodel = rmodel = pin.buildSampleModelHumanoid()
         self.rdata  = rmodel.createData()
 
-        self.q = pio.randomConfiguration(rmodel)
+        self.q = pin.randomConfiguration(rmodel)
         self.vq = rand(rmodel.nv)*2-1
         self.aq = zero(rmodel.nv)
         self.dq = rand(rmodel.nv)*2-1
@@ -37,14 +37,14 @@ class TestVComDerivativesBindings(unittest.TestCase):
         q,vq,aq,dq= self.q,self.vq,self.aq,self.dq
 
         #### Compute d/dq VCOM with the algo.
-        pio.computeAllTerms(rmodel,rdata,q,vq)
-        pio.computeForwardKinematicsDerivatives(rmodel,rdata,q,vq,aq)
-        dvc_dq = pio.getCenterOfMassVelocityDerivatives(rmodel,rdata)
+        pin.computeAllTerms(rmodel,rdata,q,vq)
+        pin.computeForwardKinematicsDerivatives(rmodel,rdata,q,vq,aq)
+        dvc_dq = pin.getCenterOfMassVelocityDerivatives(rmodel,rdata)
         
         #### Approximate d/dq VCOM by finite diff.
         def calc_vc(q,vq):
             """ Compute COM velocity """
-            pio.centerOfMass(rmodel,rdata,q,vq)
+            pin.centerOfMass(rmodel,rdata,q,vq)
             return rdata.vcom[0]
         dvc_dqn = df_dq(rmodel,lambda _q: calc_vc(_q,vq),q)
         


### PR DESCRIPTION
With assertions enabled, center-of-mass-derivatives gave a compilation error due to a misnamed variable (which was not seen in Release mode because the assertion is simply skipped).
I fixed it. I grabbed the occasion to change `import pinocchio as pio` -> `import pinocchio as pin` in the corresponding unit test.