### PR TITLE
Adding armature to computeallterms

### DIFF
--- a/bindings/python/multibody/model.hpp
+++ b/bindings/python/multibody/model.hpp
@@ -88,14 +88,10 @@ namespace pinocchio
                       make_getter(&Model::neutralConfiguration, bp::return_value_policy<bp::return_by_value>()),
                       make_setter(&Model::neutralConfiguration, bp::return_value_policy<bp::return_by_value>()),
                       "Joint's neutral configurations.")
-        .add_property("rotorInertia",
-                      make_getter(&Model::rotorInertia, bp::return_value_policy<bp::return_by_value>()),
-                      make_setter(&Model::rotorInertia, bp::return_value_policy<bp::return_by_value>()),
-                      "Vector of rotor inertia parameters.")
-        .add_property("rotorGearRatio",
-                      make_getter(&Model::rotorGearRatio, bp::return_value_policy<bp::return_by_value>()),
-                      make_setter(&Model::rotorGearRatio, bp::return_value_policy<bp::return_by_value>()),
-                      "Vector of rotor gear ratio parameters.")
+        .add_property("armature",
+                      make_getter(&Model::armature, bp::return_value_policy<bp::return_by_value>()),
+                      make_setter(&Model::armature, bp::return_value_policy<bp::return_by_value>()),
+                      "Vector of armature parameters.")
         .add_property("effortLimit",
                       make_getter(&Model::effortLimit, bp::return_value_policy<bp::return_by_value>()),
                       make_setter(&Model::effortLimit, bp::return_value_policy<bp::return_by_value>()),

--- a/models/simple_humanoid.srdf
+++ b/models/simple_humanoid.srdf
@@ -72,35 +72,35 @@
     </group_state>
     
     <rotor_params>
-        <joint name="WAIST_P" mass="1.0" gear_ratio="0.0" />
-        <joint name="WAIST_R" mass="0.0" gear_ratio="1.0" />
-        <joint name="CHEST" mass="0.0" gear_ratio="0.0" />
-        <joint name="LARM_SHOULDER_P" mass="0.0" gear_ratio="0.0" />
-        <joint name="LARM_SHOULDER_R" mass="0.0" gear_ratio="0.0" />
-        <joint name="LARM_SHOULDER_Y" mass="0.0" gear_ratio="0.0" />
-        <joint name="LARM_ELBOW" mass="0.0" gear_ratio="0.0" />
-        <joint name="LARM_WRIST_Y" mass="0.0" gear_ratio="0.0" />
-        <joint name="LARM_WRIST_P" mass="0.0" gear_ratio="0.0" />
-        <joint name="LARM_WRIST_R" mass="0.0" gear_ratio="0.0" />
-        <joint name="RARM_SHOULDER_P" mass="0.0" gear_ratio="0.0" />
-        <joint name="RARM_SHOULDER_R" mass="0.0" gear_ratio="0.0" />
-        <joint name="RARM_SHOULDER_Y" mass="0.0" gear_ratio="0.0" />
-        <joint name="RARM_ELBOW" mass="0.0" gear_ratio="0.0" />
-        <joint name="RARM_WRIST_Y" mass="0.0" gear_ratio="0.0" />
-        <joint name="RARM_WRIST_P" mass="0.0" gear_ratio="0.0" />
-        <joint name="RARM_WRIST_R" mass="0.0" gear_ratio="0.0" />
-        <joint name="LLEG_HIP_R" mass="0.0" gear_ratio="0.0" />
-        <joint name="LLEG_HIP_P" mass="0.0" gear_ratio="0.0" />
-        <joint name="LLEG_HIP_Y" mass="0.0" gear_ratio="0.0" />
-        <joint name="LLEG_KNEE" mass="0.0" gear_ratio="0.0" />
-        <joint name="LLEG_ANKLE_P" mass="0.0" gear_ratio="0.0" />
-        <joint name="LLEG_ANKLE_R" mass="0.0" gear_ratio="0.0" />
-        <joint name="RLEG_HIP_R" mass="0.0" gear_ratio="0.0" />
-        <joint name="RLEG_HIP_P" mass="0.0" gear_ratio="0.0" />
-        <joint name="RLEG_HIP_Y" mass="0.0" gear_ratio="0.0" />
-        <joint name="RLEG_KNEE" mass="0.0" gear_ratio="0.0" />
-        <joint name="RLEG_ANKLE_P" mass="0.0" gear_ratio="0.0" />
-        <joint name="RLEG_ANKLE_R" mass="0.0" gear_ratio="0.0" />
+        <joint name="WAIST_P" mass="1e-5" gear_ratio="100." />
+        <joint name="WAIST_R" mass="1e-5" gear_ratio="100.0" />
+        <joint name="CHEST" mass="1e-5" gear_ratio="100." />
+        <joint name="LARM_SHOULDER_P" mass="1e-5" gear_ratio="100." />
+        <joint name="LARM_SHOULDER_R" mass="1e-5" gear_ratio="100." />
+        <joint name="LARM_SHOULDER_Y" mass="1e-5" gear_ratio="100." />
+        <joint name="LARM_ELBOW" mass="1e-5" gear_ratio="100." />
+        <joint name="LARM_WRIST_Y" mass="1e-5" gear_ratio="100." />
+        <joint name="LARM_WRIST_P" mass="1e-5" gear_ratio="100." />
+        <joint name="LARM_WRIST_R" mass="1e-5" gear_ratio="100." />
+        <joint name="RARM_SHOULDER_P" mass="1e-5" gear_ratio="100." />
+        <joint name="RARM_SHOULDER_R" mass="1e-5" gear_ratio="100." />
+        <joint name="RARM_SHOULDER_Y" mass="1e-5" gear_ratio="100." />
+        <joint name="RARM_ELBOW" mass="1e-5" gear_ratio="100." />
+        <joint name="RARM_WRIST_Y" mass="1e-5" gear_ratio="100." />
+        <joint name="RARM_WRIST_P" mass="1e-5" gear_ratio="100." />
+        <joint name="RARM_WRIST_R" mass="1e-5" gear_ratio="100." />
+        <joint name="LLEG_HIP_R" mass="1e-5" gear_ratio="100." />
+        <joint name="LLEG_HIP_P" mass="1e-5" gear_ratio="100." />
+        <joint name="LLEG_HIP_Y" mass="1e-5" gear_ratio="100." />
+        <joint name="LLEG_KNEE" mass="1e-5" gear_ratio="100." />
+        <joint name="LLEG_ANKLE_P" mass="1e-5" gear_ratio="100." />
+        <joint name="LLEG_ANKLE_R" mass="1e-5" gear_ratio="100." />
+        <joint name="RLEG_HIP_R" mass="1e-5" gear_ratio="100." />
+        <joint name="RLEG_HIP_P" mass="1e-5" gear_ratio="100." />
+        <joint name="RLEG_HIP_Y" mass="1e-5" gear_ratio="100." />
+        <joint name="RLEG_KNEE" mass="1e-5" gear_ratio="100." />
+        <joint name="RLEG_ANKLE_P" mass="1e-5" gear_ratio="100." />
+        <joint name="RLEG_ANKLE_R" mass="1e-5" gear_ratio="100." />
     </rotor_params>
 
 </robot>

--- a/src/algorithm/compute-all-terms.hpp
+++ b/src/algorithm/compute-all-terms.hpp
@@ -233,6 +233,10 @@ namespace pinocchio
       Pass2::run(model.joints[i],data.joints[i],
                  typename Pass2::ArgsType(model,data));
     }
+
+    //Add the armature value. By default, this is a zero vector.
+    assert((model.armature.array() >= 0.0).all());
+    data.M.diagonal() += model.armature;
     
     // CoM
     data.com[0] /= data.mass[0];

--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -104,11 +104,8 @@ namespace pinocchio
     /// \brief Map of reference configurations, indexed by user given names.
     ConfigVectorMap referenceConfigurations;
 
-    /// \brief Vector of rotor inertia parameters
-    VectorXs rotorInertia;
-    
-    /// \brief Vector of rotor gear ratio parameters
-    VectorXs rotorGearRatio;
+    /// \brief Vector of armature parameters
+    VectorXs armature;
     
     /// \brief Vector of maximal joint torques
     TangentVectorType effortLimit;
@@ -184,8 +181,7 @@ namespace pinocchio
       
       /// Eigen Vectors
       res.neutralConfiguration = neutralConfiguration.template cast<NewScalar>();
-      res.rotorInertia = rotorInertia.template cast<NewScalar>();
-      res.rotorGearRatio = rotorGearRatio.template cast<NewScalar>();
+      res.armature = armature.template cast<NewScalar>();
       res.effortLimit = effortLimit.template cast<NewScalar>();
       res.velocityLimit = velocityLimit.template cast<NewScalar>();
       res.lowerPositionLimit = lowerPositionLimit.template cast<NewScalar>();
@@ -244,8 +240,7 @@ namespace pinocchio
 
       && other.neutralConfiguration == neutralConfiguration
       && other.referenceConfigurations == referenceConfigurations
-      && other.rotorInertia == rotorInertia
-      && other.rotorGearRatio == rotorGearRatio
+      && other.armature == armature
       && other.effortLimit == effortLimit
       && other.velocityLimit == velocityLimit
       && other.lowerPositionLimit == lowerPositionLimit

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -105,10 +105,8 @@ namespace pinocchio
     typedef NeutralStep<LieGroupMap,ConfigVectorType> NeutralVisitor;
     NeutralStepAlgo<NeutralVisitor,JointModelDerived>::run(jmodel,neutralConfiguration);
 
-    rotorInertia.conservativeResize(nv);
-    jmodel.jointVelocitySelector(rotorInertia).setZero();
-    rotorGearRatio.conservativeResize(nv);
-    jmodel.jointVelocitySelector(rotorGearRatio).setZero();
+    armature.conservativeResize(nv);
+    jmodel.jointVelocitySelector(armature).setZero();
     
     // Init and add joint index to its parent subtrees.
     subtrees.push_back(IndexVector(1));

--- a/src/parsers/srdf.hxx
+++ b/src/parsers/srdf.hxx
@@ -185,8 +185,7 @@ namespace pinocchio
               {
                 const JointModel & joint = model.joints[joint_id];
                 assert(joint.nv()==1);
-                model.rotorInertia(joint.idx_v()) = rotor_mass;
-                model.rotorGearRatio(joint.idx_v()) = rotor_gr;  // joint with 1 dof
+                model.armature(joint.idx_v()) = rotor_mass*rotor_gr*rotor_gr;
               }
               else
               {

--- a/unittest/compute-all-terms.cpp
+++ b/unittest/compute-all-terms.cpp
@@ -8,6 +8,7 @@
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
 #include "pinocchio/algorithm/crba.hpp"
+#include "pinocchio/algorithm/joint-configuration.hpp"
 #include "pinocchio/algorithm/rnea.hpp"
 #include "pinocchio/algorithm/jacobian.hpp"
 #include "pinocchio/algorithm/compute-all-terms.hpp"
@@ -158,6 +159,62 @@ BOOST_AUTO_TEST_CASE ( test_against_algo )
     BOOST_CHECK_CLOSE(data.mass[(size_t)k], data_other.mass[(size_t)k], 1e-12);
   }
   
+  BOOST_CHECK_CLOSE(data.kinetic_energy, data_other.kinetic_energy, 1e-12);
+  BOOST_CHECK_CLOSE(data.potential_energy, data_other.potential_energy, 1e-12);
+}
+
+BOOST_AUTO_TEST_CASE ( test_with_armature_algo )
+{
+  using namespace Eigen;
+  using namespace pinocchio;
+
+  pinocchio::Model model; buildModels::humanoidRandom(model);
+  pinocchio::Data data(model); data.M.fill (0.);
+  pinocchio::Data data_other(model); data_other.M.fill (0.);
+
+  VectorXd q (VectorXd::Random(model.nq));
+  pinocchio::normalize(model, q);
+  VectorXd v (VectorXd::Random(model.nv));
+
+  // ----Check that Original computeAllTerms still works-
+
+  computeAllTerms(model,data,q,v);
+
+  nonLinearEffects(model,data_other,q,v);
+  crba(model,data_other,q);
+  getJacobianComFromCrba(model, data_other);
+  computeJointJacobians(model,data_other,q);
+  centerOfMass(model, data_other, q, v, true);
+  kineticEnergy(model, data_other, q, v, true);
+  potentialEnergy(model, data_other, q, true);
+
+  BOOST_CHECK (data.nle.isApprox(data_other.nle, 1e-12));
+  BOOST_CHECK (Eigen::MatrixXd(data.M.triangularView<Eigen::Upper>())
+              .isApprox(Eigen::MatrixXd(data_other.M.triangularView<Eigen::Upper>()), 1e-12));
+  BOOST_CHECK (data.J.isApprox(data_other.J, 1e-12));
+  BOOST_CHECK (data.Jcom.isApprox(data_other.Jcom, 1e-12));
+  // ----Check that computeAllTerms with armature works---
+  VectorXd armature(VectorXd::Random(model.nv));  //Random between -1,1
+  armature.array() += 1.0;  armature /=2.0;   //Move armature between 0, 1.
+  armature.head<6>().setZero();              // Set ff to zero
+  model.armature = armature;
+  computeAllTerms(model, data, q, v);
+  
+  nonLinearEffects(model,data_other,q,v);
+  crba(model,data_other,q);
+  getJacobianComFromCrba(model, data_other);
+  computeJointJacobians(model,data_other,q);
+  centerOfMass(model, data_other, q, v, true);
+  kineticEnergy(model, data_other, q, v, true);
+  potentialEnergy(model, data_other, q, true);
+
+  data_other.M.diagonal() += armature;
+
+  BOOST_CHECK (data.nle.isApprox(data_other.nle, 1e-12));
+  BOOST_CHECK (Eigen::MatrixXd(data.M.triangularView<Eigen::Upper>())
+              .isApprox(Eigen::MatrixXd(data_other.M.triangularView<Eigen::Upper>()), 1e-12));
+  BOOST_CHECK (data.J.isApprox(data_other.J, 1e-12));
+  BOOST_CHECK (data.Jcom.isApprox(data_other.Jcom, 1e-12));
   BOOST_CHECK_CLOSE(data.kinetic_energy, data_other.kinetic_energy, 1e-12);
   BOOST_CHECK_CLOSE(data.potential_energy, data_other.potential_energy, 1e-12);
 }

--- a/unittest/srdf.cpp
+++ b/unittest/srdf.cpp
@@ -71,11 +71,9 @@ BOOST_AUTO_TEST_CASE(readRotorParams)
   
   Model model;
   buildModel(model_filename, model);
-
   loadRotorParameters(model,srdf_filename,false);
   
-  BOOST_CHECK(model.rotorInertia(model.joints[model.getJointId("WAIST_P")].idx_v())==1.0);
-  BOOST_CHECK(model.rotorGearRatio(model.joints[model.getJointId("WAIST_R")].idx_v())==1.0);
+  BOOST_CHECK(model.armature(model.joints[model.getJointId("WAIST_P")].idx_v())==0.1);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
1) Remove rotorInertia and rotorGearRatio. Replace with armature.
2) add armature to compute all terms
3) test.

Currently it only adds the armature to the mass diagonal. In case you decide to add the coriolis and centrifugal effects, please reflect it in the computeallterms as well.

For now, this deals partially with what was discussed in #671 