### PR TITLE
Fix python unit tests, fix #677

### DIFF
--- a/bindings/python/spatial/se3.hpp
+++ b/bindings/python/spatial/se3.hpp
@@ -25,6 +25,8 @@ namespace pinocchio
   {
     namespace bp = boost::python;
 
+    BOOST_PYTHON_MEMBER_FUNCTION_OVERLOADS(isIdentity_overload,SE3::isIdentity,0,1)
+
     template<typename SE3>
     struct SE3PythonVisitor
       : public boost::python::def_visitor< SE3PythonVisitor<SE3> >
@@ -96,8 +98,7 @@ namespace pinocchio
         .def("isApprox",(bool (SE3::*)(const SE3 & other, const Scalar & prec)) &SE3::isApprox,bp::args("other","prec"),"Returns true if *this is approximately equal to other, within the precision given by prec.")
         .def("isApprox",(bool (SE3::*)(const SE3 & other)) &SE3::isApprox,bp::args("other"),"Returns true if *this is approximately equal to other.")
         
-        .def("isIdentity",(bool (SE3::*)(const Scalar & prec)) &SE3::isIdentity,bp::args("prec"),"Returns true if *this is approximately equal to the identity placement, within the precision given by prec.")
-        .def("isIdentity",(bool (SE3::*)(void)) &SE3::isIdentity,"Returns true if *this is approximately equal to the identity placement.")
+        .def("isIdentity",&SE3::isIdentity,isIdentity_overload(bp::args("prec"),"Returns true if *this is approximately equal to the identity placement, within the precision given by prec."))
         
         .def("__invert__",&SE3::inverse,"Returns the inverse of *this.")
         .def(bp::self * bp::self)

--- a/unittest/python/bindings_com.py
+++ b/unittest/python/bindings_com.py
@@ -17,7 +17,7 @@ class TestComBindings(TestCase):
         self.model = pin.buildSampleModelHumanoidRandom()
         self.data = self.model.createData()
 
-        qmax = np.matrix(np.full((self.model.nv,1),np.pi))
+        qmax = np.matrix(np.full((self.model.nq,1),np.pi))
         self.q = pin.randomConfiguration(self.model,-qmax,qmax)
 
     def test_Jcom_update3(self):

--- a/unittest/python/bindings_dynamics.py
+++ b/unittest/python/bindings_dynamics.py
@@ -17,7 +17,7 @@ class TestDynamicsBindings(TestCase):
         self.model = pin.buildSampleModelHumanoidRandom()
         self.data = self.model.createData()
 
-        qmax = np.matrix(np.full((self.model.nv,1),np.pi))
+        qmax = np.matrix(np.full((self.model.nq,1),np.pi))
         self.q = pin.randomConfiguration(self.model,-qmax,qmax)
         self.v = rand(self.model.nv)
         self.tau = rand(self.model.nv)

--- a/unittest/python/test_case.py
+++ b/unittest/python/test_case.py
@@ -2,6 +2,9 @@ import unittest
 
 from pinocchio.utils import isapprox
 
+def tracefunc(frame, event, arg):
+    print "%s, %s: %d" % (event, frame.f_code.co_filename, frame.f_lineno)
+    return tracefunc
 
 class TestCase(unittest.TestCase):
     def assertApprox(self, a, b):


### PR DESCRIPTION
Fixes #677. Related to #673. The error on `explog.py` was actually due to the binding of `SE3.isIdentity()` which was crashing. I do not understand why there was this problem and why only in Debug mode, but I fixed it.

The error on `bindings_com.py` and `bindings_dynamics.py` was just a trivial error in the unit test itself (wrong vector size). I corrected it. Which makes me think, wouldn't it be better to enable assertions the Python library? If yes, is there any way to treat a failing assertion as an exception instead of having Python crash completely when one fails?
