### PR TITLE
Reimplement joint-configuration algorithms, fix #658

### DIFF
--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -15,11 +15,11 @@ namespace pinocchio
   /// \{
 
   /**
-   * @brief      Integrate a configuration for the specified model for a tangent vector during one unit time
+   * @brief      Integrate a configuration vector for the specified model for a tangent vector during one unit time
    *
    * @param[in]  model   Model that must be integrated
    * @param[in]  q       Initial configuration (size model.nq)
-   * @param[in]  v       Velocity (size model.nv)
+   * @param[in]  v       Joint velocity (size model.nv)
    * @param[out] qout    The integrated configuration (size model.nq)
    */
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename ReturnType>
@@ -30,11 +30,11 @@ namespace pinocchio
             const Eigen::MatrixBase<ReturnType> & qout);
 
   /**
-   * @brief      Integrate a configuration for the specified model for a tangent vector during one unit time
+   * @brief      Integrate a configuration vector for the specified model for a tangent vector during one unit time
    *
    * @param[in]  model   Model that must be integrated
    * @param[in]  q       Initial configuration (size model.nq)
-   * @param[in]  v       Velocity (size model.nv)
+   * @param[in]  v       Joint velocity (size model.nv)
    * @param[out] qout    The integrated configuration (size model.nq)
    */
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename ReturnType>
@@ -48,7 +48,7 @@ namespace pinocchio
   }
 
   /**
-   * @brief      Interpolate the model between two configurations
+   * @brief      Interpolate two configurations for a given model
    *
    * @param[in]  model   Model to be interpolated
    * @param[in]  q0      Initial configuration vector (size model.nq)
@@ -65,7 +65,7 @@ namespace pinocchio
               const Eigen::MatrixBase<ReturnType> & qout);
 
   /**
-   * @brief      Interpolate the model between two configurations
+   * @brief      Interpolate two configurations for a given model
    *
    * @param[in]  model   Model to be interpolated
    * @param[in]  q0      Initial configuration vector (size model.nq)
@@ -87,34 +87,34 @@ namespace pinocchio
   /**
    * @brief      Compute the tangent vector that must be integrated during one unit time to go from q0 to q1
    *
-   * @param[in]  model   Model to be differenced
+   * @param[in]  model   Model of the system
    * @param[in]  q0      Initial configuration (size model.nq)
    * @param[in]  q1      Wished configuration (size model.nq)
-   * @param[out] dqout   The corresponding velocity (size model.nv)
+   * @param[out] dvout   The corresponding velocity (size model.nv)
    */
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2, typename ReturnType>
   void
   difference(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
              const Eigen::MatrixBase<ConfigVectorIn1> & q0,
              const Eigen::MatrixBase<ConfigVectorIn2> & q1,
-             const Eigen::MatrixBase<ReturnType> & dqout);
+             const Eigen::MatrixBase<ReturnType> & dvout);
 
   /**
    * @brief      Compute the tangent vector that must be integrated during one unit time to go from q0 to q1
    *
-   * @param[in]  model   Model to be differenced
+   * @param[in]  model   Model of the system
    * @param[in]  q0      Initial configuration (size model.nq)
    * @param[in]  q1      Wished configuration (size model.nq)
-   * @param[out] dqout   The corresponding velocity (size model.nv)
+   * @param[out] dvout   The corresponding velocity (size model.nv)
    */
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2, typename ReturnType>
   void
   difference(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
              const Eigen::MatrixBase<ConfigVectorIn1> & q0,
              const Eigen::MatrixBase<ConfigVectorIn2> & q1,
-             const Eigen::MatrixBase<ReturnType> & dqout)
+             const Eigen::MatrixBase<ReturnType> & dvout)
   {
-    difference<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2,ReturnType>(model,q0.derived(),q1.derived(),dqout.derived());
+    difference<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2,ReturnType>(model,q0.derived(),q1.derived(),dvout.derived());
   }
 
   /**
@@ -219,7 +219,7 @@ namespace pinocchio
    *
    * @param[in]  model   Model that must be integrated
    * @param[in]  q       Initial configuration (size model.nq)
-   * @param[in]  v       Velocity (size model.nv)
+   * @param[in]  v       Joint velocity (size model.nv)
    * @param[out] J       Jacobian of the Integrate operation, either with respect to q or v (size model.nv x model.nv).
    * @param[in]  arg     Argument (either q or v) with respect to which the
    *
@@ -236,7 +236,7 @@ namespace pinocchio
    *
    * @param[in]  model   Model that must be integrated
    * @param[in]  q       Initial configuration (size model.nq)
-   * @param[in]  v       Velocity (size model.nv)
+   * @param[in]  v       Joint velocity (size model.nv)
    * @param[out] J       Jacobian of the Integrate operation, either with respect to q or v (size model.nv x model.nv).
    * @param[in]  arg     Argument (either q or v) with respect to which the
    *
@@ -316,7 +316,7 @@ namespace pinocchio
   }
 
   /**
-   * @brief         Normalize a configuration
+   * @brief         Normalize a configuration vector
    *
    * @param[in]     model      Model
    * @param[in,out] q          Configuration to normalize
@@ -327,7 +327,7 @@ namespace pinocchio
                         const Eigen::MatrixBase<ConfigVectorType> & qout);
 
   /**
-   * @brief         Normalize a configuration
+   * @brief         Normalize a configuration vector
    *
    * @param[in]     model      Model
    * @param[in,out] q          Configuration to normalize
@@ -346,10 +346,10 @@ namespace pinocchio
    *
    * @param[in]     model     Model
    * @param[in]     q1        The first configuraiton to compare
-   * @param[in]     q2        The Second configuraiton to compare
+   * @param[in]     q2        The second configuration to compare
    * @param[in]     prec      precision of the comparison
    *
-   * @return     Wheter the configurations are equivalent or not
+   * @return     Whether the configurations are equivalent or not
    */
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
   inline bool
@@ -364,10 +364,10 @@ namespace pinocchio
    *
    * @param[in]     model     Model
    * @param[in]     q1        The first configuraiton to compare
-   * @param[in]     q2        The Second configuraiton to compare
+   * @param[in]     q2        The second configuration to compare
    * @param[in]     prec      precision of the comparison
    *
-   * @return     Wheter the configurations are equivalent or not
+   * @return     Whether the configurations are equivalent or not
    */
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
   inline bool
@@ -420,11 +420,11 @@ namespace pinocchio
   /// \{
 
   /**
-   * @brief      Integrate a configuration for the specified model for a tangent vector during one unit time
+   * @brief      Integrate a configuration vector for the specified model for a tangent vector during one unit time
    *
    * @param[in]  model   Model that must be integrated
    * @param[in]  q       Initial configuration (size model.nq)
-   * @param[in]  v       Velocity (size model.nv)
+   * @param[in]  v       Joint velocity (size model.nv)
    *
    * @return     The integrated configuration (size model.nq)
    */
@@ -435,11 +435,11 @@ namespace pinocchio
             const Eigen::MatrixBase<TangentVectorType> & v);
 
   /**
-   * @brief      Integrate a configuration for the specified model for a tangent vector during one unit time
+   * @brief      Integrate a configuration vector for the specified model for a tangent vector during one unit time
    *
    * @param[in]  model   Model that must be integrated
    * @param[in]  q       Initial configuration (size model.nq)
-   * @param[in]  v       Velocity (size model.nv)
+   * @param[in]  v       Joint velocity (size model.nv)
    *
    * @return     The integrated configuration (size model.nq)
    */
@@ -453,7 +453,7 @@ namespace pinocchio
   }
 
   /**
-   * @brief      Interpolate the model between two configurations
+   * @brief      Interpolate two configurations for a given model
    *
    * @param[in]  model   Model to be interpolated
    * @param[in]  q0      Initial configuration vector (size model.nq)
@@ -470,7 +470,7 @@ namespace pinocchio
               const Scalar & u);
 
   /**
-   * @brief      Interpolate the model between two configurations
+   * @brief      Interpolate two configurations for a given model
    *
    * @param[in]  model   Model to be interpolated
    * @param[in]  q0      Initial configuration vector (size model.nq)
@@ -492,7 +492,7 @@ namespace pinocchio
   /**
    * @brief      Compute the tangent vector that must be integrated during one unit time to go from q0 to q1
    *
-   * @param[in]  model   Model to be differenced
+   * @param[in]  model   Model of the system
    * @param[in]  q0      Initial configuration (size model.nq)
    * @param[in]  q1      Wished configuration (size model.nq)
    *
@@ -507,7 +507,7 @@ namespace pinocchio
   /**
    * @brief      Compute the tangent vector that must be integrated during one unit time to go from q0 to q1
    *
-   * @param[in]  model   Model to be differenced
+   * @param[in]  model   Model of the system
    * @param[in]  q0      Initial configuration (size model.nq)
    * @param[in]  q1      Wished configuration (size model.nq)
    *

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -266,6 +266,24 @@ namespace pinocchio
                   const Eigen::MatrixBase<ConfigVectorIn2> & q1);
 
   /**
+   * @brief      Distance between two configuration vectors
+   *
+   * @param[in]  model      Model we want to compute the distance
+   * @param[in]  q0         Configuration 0 (size model.nq)
+   * @param[in]  q1         Configuration 1 (size model.nq)
+   *
+   * @return     The distance between the two configurations
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
+  inline Scalar
+  distance(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+           const Eigen::MatrixBase<ConfigVectorIn1> & q0,
+           const Eigen::MatrixBase<ConfigVectorIn2> & q1)
+  {
+    return distance<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2>(model, q0.derived(), q1.derived());
+  }
+
+  /**
    * @brief         Normalize a configuration
    *
    * @param[in]     model      Model

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -6,25 +6,14 @@
 #define __pinocchio_joint_configuration_hpp__
 
 #include "pinocchio/multibody/fwd.hpp"
+#include "pinocchio/multibody/liegroup/liegroup.hpp"
 
 namespace pinocchio
 {
 
-  /**
-   * @brief      Integrate a configuration for the specified model for a tangent vector during one unit time
-   *
-   * @param[in]  model   Model that must be integrated
-   * @param[in]  q       Initial configuration (size model.nq)
-   * @param[in]  v       Velocity (size model.nv)
-   *
-   * @return     The integrated configuration (size model.nq)
-   */
-  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType>
-  inline typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorType)
-  integrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-            const Eigen::MatrixBase<ConfigVectorType> & q,
-            const Eigen::MatrixBase<TangentVectorType> & v);
-  
+  /// \name API with return value as argument
+  /// \{
+
   /**
    * @brief      Computes the Jacobian of a small variation of the configuration vector or the tangent vector into the tangent space at identity.
    *
@@ -41,7 +30,178 @@ namespace pinocchio
                   const Eigen::MatrixBase<TangentVectorType> & v,
                   const Eigen::MatrixBase<JacobianMatrixType> & J,
                   const ArgumentPosition arg);
-  
+
+  /**
+   * @brief      Computes the Jacobian of a small variation of the configuration vector or the tangent vector into the tangent space at identity.
+   *
+   * @param[in]  model   Model that must be integrated
+   * @param[in]  q       Initial configuration (size model.nq)
+   * @param[in]  v       Velocity (size model.nv)
+   * @param[out] J       Jacobian of the Integrate operation, either with respect to q or v (size model.nv x model.nv).
+   * @param[in]  arg     Argument (either q or v) with respect to which the
+   *
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
+  void dIntegrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                  const Eigen::MatrixBase<ConfigVectorType> & q,
+                  const Eigen::MatrixBase<TangentVectorType> & v,
+                  const Eigen::MatrixBase<JacobianMatrixType> & J,
+                  const ArgumentPosition arg)
+  {
+    return dIntegrate<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), J.derived(),arg);
+  }
+
+  /**
+   * @brief      Distance between two configuration vectors
+   *
+   * @param[in]  model      Model we want to compute the distance
+   * @param[in]  q0         Configuration 0 (size model.nq)
+   * @param[in]  q1         Configuration 1 (size model.nq)
+   *
+   * @return     The distance between the two configurations
+   */
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
+  Scalar distance(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                  const Eigen::MatrixBase<ConfigVectorIn1> & q0,
+                  const Eigen::MatrixBase<ConfigVectorIn2> & q1);
+
+  /**
+   * @brief         Normalize a configuration
+   *
+   * @param[in]     model      Model
+   * @param[in,out] q          Configuration to normalize
+   *
+   */
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
+  inline void normalize(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                        const Eigen::MatrixBase<ConfigVectorType> & qout);
+
+  /**
+   * @brief         Normalize a configuration
+   *
+   * @param[in]     model      Model
+   * @param[in,out] q          Configuration to normalize
+   *
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
+  inline void normalize(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                        const Eigen::MatrixBase<ConfigVectorType> & qout)
+  {
+    return normalize<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType>(model,qout.derived());
+  }
+
+  /**
+   * @brief         Return true if the given configurations are equivalents
+   * @warning       Two configurations can be equivalent but not equally coefficient wise (e.g for quaternions)
+   *
+   * @param[in]     model     Model
+   * @param[in]     q1        The first configuraiton to compare
+   * @param[in]     q2        The Second configuraiton to compare
+   * @param[in]     prec      precision of the comparison
+   *
+   * @return     Wheter the configurations are equivalent or not
+   */
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
+  inline bool
+  isSameConfiguration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                      const Eigen::MatrixBase<ConfigVectorIn1> & q1,
+                      const Eigen::MatrixBase<ConfigVectorIn2> & q2,
+                      const Scalar & prec);
+
+  /**
+   * @brief         Return true if the given configurations are equivalents
+   * @warning       Two configurations can be equivalent but not equally coefficient wise (e.g for quaternions)
+   *
+   * @param[in]     model     Model
+   * @param[in]     q1        The first configuraiton to compare
+   * @param[in]     q2        The Second configuraiton to compare
+   * @param[in]     prec      precision of the comparison
+   *
+   * @return     Wheter the configurations are equivalent or not
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
+  inline bool
+  isSameConfiguration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                      const Eigen::MatrixBase<ConfigVectorIn1> & q1,
+                      const Eigen::MatrixBase<ConfigVectorIn2> & q2,
+                      const Scalar & prec = Eigen::NumTraits<Scalar>::dummy_precision())
+  {
+    return isSameConfiguration<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2>(model, q1.derived(), q2.derived(), prec);
+  }
+
+  /**
+   * @brief         Return the Jacobian of the integrate function for the components of the config vector.
+   *
+   * @param[in]     model      Model of rigid body system.
+   * @param[out]    jacobian   The Jacobian of the integrate operation.
+   *
+   * @details       This function is often required for the numerical solvers that are working on the
+   *                tangent of the configuration space, instead of the configuration space itself.
+   *
+   */
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVector, typename JacobianMatrix>
+  inline void
+  integrateCoeffWiseJacobian(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                             const Eigen::MatrixBase<ConfigVector> & q,
+                             const Eigen::MatrixBase<JacobianMatrix> & jacobian);
+
+  /**
+   * @brief         Return the Jacobian of the integrate function for the components of the config vector.
+   *
+   * @param[in]     model      Model of rigid body system.
+   * @param[out]    jacobian   The Jacobian of the integrate operation.
+   *
+   * @details       This function is often required for the numerical solvers that are working on the
+   *                tangent of the configuration space, instead of the configuration space itself.
+   *
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVector, typename JacobianMatrix>
+  inline void
+  integrateCoeffWiseJacobian(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                             const Eigen::MatrixBase<ConfigVector> & q,
+                             const Eigen::MatrixBase<JacobianMatrix> & jacobian)
+  {
+    return integrateCoeffWiseJacobian<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVector,JacobianMatrix>(model,q,jacobian);
+  }
+
+  /// \}
+
+  /// \name API that allocates memory
+  /// \{
+
+  /**
+   * @brief      Integrate a configuration for the specified model for a tangent vector during one unit time
+   *
+   * @param[in]  model   Model that must be integrated
+   * @param[in]  q       Initial configuration (size model.nq)
+   * @param[in]  v       Velocity (size model.nv)
+   *
+   * @return     The integrated configuration (size model.nq)
+   */
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType>
+  inline typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorType)
+  integrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+            const Eigen::MatrixBase<ConfigVectorType> & q,
+            const Eigen::MatrixBase<TangentVectorType> & v);
+
+  /**
+   * @brief      Integrate a configuration for the specified model for a tangent vector during one unit time
+   *
+   * @param[in]  model   Model that must be integrated
+   * @param[in]  q       Initial configuration (size model.nq)
+   * @param[in]  v       Velocity (size model.nv)
+   *
+   * @return     The integrated configuration (size model.nq)
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType>
+  inline typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorType)
+  integrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+            const Eigen::MatrixBase<ConfigVectorType> & q,
+            const Eigen::MatrixBase<TangentVectorType> & v)
+  {
+    return integrate<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType>(model, q.derived(), v.derived());
+  }
+
   /**
    * @brief      Interpolate the model between two configurations
    *
@@ -60,6 +220,26 @@ namespace pinocchio
               const Scalar & u);
 
   /**
+   * @brief      Interpolate the model between two configurations
+   *
+   * @param[in]  model   Model to be interpolated
+   * @param[in]  q0      Initial configuration vector (size model.nq)
+   * @param[in]  q1      Final configuration vector (size model.nq)
+   * @param[in]  u       u in [0;1] position along the interpolation.
+   *
+   * @return     The interpolated configuration (q0 if u = 0, q1 if u = 1)
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
+  inline typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorIn1)
+  interpolate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+              const Eigen::MatrixBase<ConfigVectorIn1> & q0,
+              const Eigen::MatrixBase<ConfigVectorIn2> & q1,
+              const Scalar & u)
+  {
+    return interpolate<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2>(model, q0, q1, u);
+  }
+
+  /**
    * @brief      Compute the tangent vector that must be integrated during one unit time to go from q0 to q1
    *
    * @param[in]  model   Model to be differenced
@@ -74,6 +254,23 @@ namespace pinocchio
              const Eigen::MatrixBase<ConfigVectorIn1> & q0,
              const Eigen::MatrixBase<ConfigVectorIn2> & q1);
 
+  /**
+   * @brief      Compute the tangent vector that must be integrated during one unit time to go from q0 to q1
+   *
+   * @param[in]  model   Model to be differenced
+   * @param[in]  q0      Initial configuration (size model.nq)
+   * @param[in]  q1      Wished configuration (size model.nq)
+   *
+   * @return     The corresponding velocity (size model.nv)
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
+  inline typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorIn1)
+  difference(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+             const Eigen::MatrixBase<ConfigVectorIn1> & q0,
+             const Eigen::MatrixBase<ConfigVectorIn2> & q1)
+  {
+    return difference<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2>(model,q0.derived(),q1.derived());
+  }
 
   /**
    * @brief      Squared distance between two configuration vectors
@@ -89,19 +286,24 @@ namespace pinocchio
   squaredDistance(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                   const Eigen::MatrixBase<ConfigVectorIn1> & q0,
                   const Eigen::MatrixBase<ConfigVectorIn2> & q1);
+
   /**
-   * @brief      Distance between two configuration vectors
+   * @brief      Squared distance between two configuration vectors
    *
    * @param[in]  model      Model we want to compute the distance
    * @param[in]  q0         Configuration 0 (size model.nq)
    * @param[in]  q1         Configuration 1 (size model.nq)
    *
-   * @return     The distance between the two configurations
+   * @return     The corresponding squared distances for each joint (size model.njoints-1 = number of joints)
    */
-  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
-  Scalar distance(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
+  inline typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorIn1)
+  squaredDistance(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                   const Eigen::MatrixBase<ConfigVectorIn1> & q0,
-                  const Eigen::MatrixBase<ConfigVectorIn2> & q1);
+                  const Eigen::MatrixBase<ConfigVectorIn2> & q1)
+  {
+    return squaredDistance<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2>(model,q0.derived(),q1.derived());
+  }
 
   /**
    * @brief      Generate a configuration vector uniformly sampled among provided limits.
@@ -122,6 +324,28 @@ namespace pinocchio
                       const Eigen::MatrixBase<ConfigVectorIn1> & lowerLimits,
                       const Eigen::MatrixBase<ConfigVectorIn2> & upperLimits);
 
+ /**
+   * @brief      Generate a configuration vector uniformly sampled among provided limits.
+   *
+   * @remarks    Limits are not taken into account for rotational transformations (typically SO(2),SO(3)), because they are by definition unbounded.
+   *
+   * @warning     If limits are infinite, exceptions may be thrown in the joint implementation of uniformlySample
+   *
+   * @param[in]  model        Model for which we want to generate a configuration vector.
+   * @param[in]  lowerLimits  Joints lower limits
+   * @param[in]  upperLimits  Joints upper limits
+   *
+   * @return     The resulted configuration vector (size model.nq)
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
+  typename PINOCCHIO_EIGEN_PLAIN_TYPE((typename ModelTpl<Scalar,Options,JointCollectionTpl>::ConfigVectorType))
+  randomConfiguration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                      const Eigen::MatrixBase<ConfigVectorIn1> & lowerLimits,
+                      const Eigen::MatrixBase<ConfigVectorIn2> & upperLimits)
+  {
+    return randomConfiguration<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2>(model, lowerLimits.derived(), upperLimits.derived());
+  }
+
   /**
    * @brief      Generate a configuration vector uniformly sampled among the joint limits of the specified Model.
    *
@@ -139,34 +363,24 @@ namespace pinocchio
   randomConfiguration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model);
 
   /**
-   * @brief         Normalize a configuration
+   * @brief      Generate a configuration vector uniformly sampled among the joint limits of the specified Model.
    *
-   * @param[in]     model      Model
-   * @param[in,out] q          Configuration to normalize
+   * @remarks    Limits are not taken into account for rotational transformations (typically SO(2),SO(3)), because they are by definition unbounded.
    *
+   * @warning    If limits are infinite (no one specified when adding a body or no modification directly in my_model.{lowerPositionLimit,upperPositionLimit},
+   *             exceptions may be thrown in the joint implementation of uniformlySample
+   *
+   * @param[in]  model   Model for which we want to generate a configuration vector.
+   *
+   * @return     The resulted configuration vector (size model.nq)
    */
-  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
-  inline void normalize(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                        const Eigen::MatrixBase<ConfigVectorType> & qout);
-  
-  /**
-   * @brief         Return true if the given configurations are equivalents
-   * @warning       Two configurations can be equivalent but not equally coefficient wise (e.g for quaternions)
-   *
-   * @param[in]     model     Model
-   * @param[in]     q1        The first configuraiton to compare
-   * @param[in]     q2        The Second configuraiton to compare
-   * @param[in]     prec      precision of the comparison
-   *
-   * @return     Wheter the configurations are equivalent or not
-   */
-  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
-  inline bool
-  isSameConfiguration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                      const Eigen::MatrixBase<ConfigVectorIn1> & q1,
-                      const Eigen::MatrixBase<ConfigVectorIn2> & q2,
-                      const Scalar & prec);
-  
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  typename PINOCCHIO_EIGEN_PLAIN_TYPE((typename ModelTpl<Scalar,Options,JointCollectionTpl>::ConfigVectorType))
+  randomConfiguration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model)
+  {
+    return randomConfiguration<LieGroupMap,Scalar,Options,JointCollectionTpl>(model);
+  }
+
   /**
    * @brief         Return the neutral configuration element related to the model configuration space.
    *
@@ -177,22 +391,8 @@ namespace pinocchio
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
   inline Eigen::Matrix<Scalar,Eigen::Dynamic,1,Options>
   neutral(const ModelTpl<Scalar,Options,JointCollectionTpl> & model);
-  
-  /**
-   * @brief         Return the Jacobian of the integrate function for the components of the config vector.
-   *
-   * @param[in]     model      Model of rigid body system.
-   * @param[out]    jacobian   The Jacobian of the integrate operation.
-   *
-   * @details       This function is often required for the numerical solvers that are working on the
-   *                tangent of the configuration space, instead of the configuration space itself.
-   *
-   */
-  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVector, typename JacobianMatrix>
-  inline void
-  integrateCoeffWiseJacobian(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                             const Eigen::MatrixBase<ConfigVector> & q,
-                             const Eigen::MatrixBase<JacobianMatrix> & jacobian);
+
+  /// \}
 
 } // namespace pinocchio
 

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -15,6 +15,206 @@ namespace pinocchio
   /// \{
 
   /**
+   * @brief      Integrate a configuration for the specified model for a tangent vector during one unit time
+   *
+   * @param[in]  model   Model that must be integrated
+   * @param[in]  q       Initial configuration (size model.nq)
+   * @param[in]  v       Velocity (size model.nv)
+   * @param[out] qout    The integrated configuration (size model.nq)
+   */
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename ReturnType>
+  void
+  integrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+            const Eigen::MatrixBase<ConfigVectorType> & q,
+            const Eigen::MatrixBase<TangentVectorType> & v,
+            const Eigen::MatrixBase<ReturnType> & qout);
+
+  /**
+   * @brief      Integrate a configuration for the specified model for a tangent vector during one unit time
+   *
+   * @param[in]  model   Model that must be integrated
+   * @param[in]  q       Initial configuration (size model.nq)
+   * @param[in]  v       Velocity (size model.nv)
+   * @param[out] qout    The integrated configuration (size model.nq)
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename ReturnType>
+  void
+  integrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+            const Eigen::MatrixBase<ConfigVectorType> & q,
+            const Eigen::MatrixBase<TangentVectorType> & v,
+            const Eigen::MatrixBase<ReturnType> & qout)
+  {
+    integrate<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,ReturnType>(model, q.derived(), v.derived(), qout.derived());
+  }
+
+  /**
+   * @brief      Interpolate the model between two configurations
+   *
+   * @param[in]  model   Model to be interpolated
+   * @param[in]  q0      Initial configuration vector (size model.nq)
+   * @param[in]  q1      Final configuration vector (size model.nq)
+   * @param[in]  u       u in [0;1] position along the interpolation.
+   * @param[out] qout    The interpolated configuration (q0 if u = 0, q1 if u = 1)
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2, typename ReturnType>
+  void
+  interpolate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+              const Eigen::MatrixBase<ConfigVectorIn1> & q0,
+              const Eigen::MatrixBase<ConfigVectorIn2> & q1,
+              const Scalar & u,
+              const Eigen::MatrixBase<ReturnType> & qout);
+
+  /**
+   * @brief      Interpolate the model between two configurations
+   *
+   * @param[in]  model   Model to be interpolated
+   * @param[in]  q0      Initial configuration vector (size model.nq)
+   * @param[in]  q1      Final configuration vector (size model.nq)
+   * @param[in]  u       u in [0;1] position along the interpolation.
+   * @param[out] qout    The interpolated configuration (q0 if u = 0, q1 if u = 1)
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2, typename ReturnType>
+  void
+  interpolate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+              const Eigen::MatrixBase<ConfigVectorIn1> & q0,
+              const Eigen::MatrixBase<ConfigVectorIn2> & q1,
+              const Scalar & u,
+              const Eigen::MatrixBase<ReturnType> & qout)
+  {
+    interpolate<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2,ReturnType>(model, q0, q1, u, qout);
+  }
+
+  /**
+   * @brief      Compute the tangent vector that must be integrated during one unit time to go from q0 to q1
+   *
+   * @param[in]  model   Model to be differenced
+   * @param[in]  q0      Initial configuration (size model.nq)
+   * @param[in]  q1      Wished configuration (size model.nq)
+   * @param[out] dqout   The corresponding velocity (size model.nv)
+   */
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2, typename ReturnType>
+  void
+  difference(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+             const Eigen::MatrixBase<ConfigVectorIn1> & q0,
+             const Eigen::MatrixBase<ConfigVectorIn2> & q1,
+             const Eigen::MatrixBase<ReturnType> & dqout);
+
+  /**
+   * @brief      Compute the tangent vector that must be integrated during one unit time to go from q0 to q1
+   *
+   * @param[in]  model   Model to be differenced
+   * @param[in]  q0      Initial configuration (size model.nq)
+   * @param[in]  q1      Wished configuration (size model.nq)
+   * @param[out] dqout   The corresponding velocity (size model.nv)
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2, typename ReturnType>
+  void
+  difference(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+             const Eigen::MatrixBase<ConfigVectorIn1> & q0,
+             const Eigen::MatrixBase<ConfigVectorIn2> & q1,
+             const Eigen::MatrixBase<ReturnType> & dqout)
+  {
+    difference<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2,ReturnType>(model,q0.derived(),q1.derived(),dqout.derived());
+  }
+
+  /**
+   * @brief      Squared distance between two configuration vectors
+   *
+   * @param[in]  model      Model we want to compute the distance
+   * @param[in]  q0         Configuration 0 (size model.nq)
+   * @param[in]  q1         Configuration 1 (size model.nq)
+   * @param[out] out        The corresponding squared distances for each joint (size model.njoints-1 = number of joints)
+   */
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2, typename ReturnType>
+  void
+  squaredDistance(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                  const Eigen::MatrixBase<ConfigVectorIn1> & q0,
+                  const Eigen::MatrixBase<ConfigVectorIn2> & q1,
+                  const Eigen::MatrixBase<ReturnType> & out);
+
+  /**
+   * @brief      Squared distance between two configuration vectors
+   *
+   * @param[in]  model      Model we want to compute the distance
+   * @param[in]  q0         Configuration 0 (size model.nq)
+   * @param[in]  q1         Configuration 1 (size model.nq)
+   * @param[out] out        The corresponding squared distances for each joint (size model.njoints-1 = number of joints)
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2, typename ReturnType>
+  void
+  squaredDistance(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                  const Eigen::MatrixBase<ConfigVectorIn1> & q0,
+                  const Eigen::MatrixBase<ConfigVectorIn2> & q1,
+                  const Eigen::MatrixBase<ReturnType> & out)
+  {
+    squaredDistance<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2,ReturnType>(model,q0.derived(),q1.derived(),out.derived());
+  }
+
+  /**
+   * @brief      Generate a configuration vector uniformly sampled among provided limits.
+   *
+   * @remarks    Limits are not taken into account for rotational transformations (typically SO(2),SO(3)), because they are by definition unbounded.
+   *
+   * @warning     If limits are infinite, exceptions may be thrown in the joint implementation of uniformlySample
+   *
+   * @param[in]  model        Model for which we want to generate a configuration vector.
+   * @param[in]  lowerLimits  Joints lower limits
+   * @param[in]  upperLimits  Joints upper limits
+   * @param[out] qout         The resulted configuration vector (size model.nq)
+   */
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2, typename ReturnType>
+  void
+  randomConfiguration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                      const Eigen::MatrixBase<ConfigVectorIn1> & lowerLimits,
+                      const Eigen::MatrixBase<ConfigVectorIn2> & upperLimits,
+                      const Eigen::MatrixBase<ReturnType> & qout);
+
+ /**
+   * @brief      Generate a configuration vector uniformly sampled among provided limits.
+   *
+   * @remarks    Limits are not taken into account for rotational transformations (typically SO(2),SO(3)), because they are by definition unbounded.
+   *
+   * @warning     If limits are infinite, exceptions may be thrown in the joint implementation of uniformlySample
+   *
+   * @param[in]  model        Model for which we want to generate a configuration vector.
+   * @param[in]  lowerLimits  Joints lower limits
+   * @param[in]  upperLimits  Joints upper limits
+   * @param[out] qout         The resulted configuration vector (size model.nq)
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2, typename ReturnType>
+  void
+  randomConfiguration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                      const Eigen::MatrixBase<ConfigVectorIn1> & lowerLimits,
+                      const Eigen::MatrixBase<ConfigVectorIn2> & upperLimits,
+                      const Eigen::MatrixBase<ReturnType> & qout)
+  {
+    randomConfiguration<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2,ReturnType>(model, lowerLimits.derived(), upperLimits.derived(), qout.derived());
+  }
+
+  /**
+   * @brief         Return the neutral configuration element related to the model configuration space.
+   *
+   * @param[in]     model      Model
+   * @param[out]    qout        The neutral configuration element.
+   */
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ReturnType>
+  void
+  neutral(const ModelTpl<Scalar,Options,JointCollectionTpl> & model, const Eigen::MatrixBase<ReturnType> & qout);
+
+  /**
+   * @brief         Return the neutral configuration element related to the model configuration space.
+   *
+   * @param[in]     model      Model
+   * @param[out]    qout        The neutral configuration element.
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ReturnType>
+  void
+  neutral(const ModelTpl<Scalar,Options,JointCollectionTpl> & model, const Eigen::MatrixBase<ReturnType> & qout)
+  {
+    neutral<LieGroupMap,Scalar,Options,JointCollectionTpl,ReturnType>(model,qout.derived());
+  }
+
+  /**
    * @brief      Computes the Jacobian of a small variation of the configuration vector or the tangent vector into the tangent space at identity.
    *
    * @param[in]  model   Model that must be integrated
@@ -48,7 +248,7 @@ namespace pinocchio
                   const Eigen::MatrixBase<JacobianMatrixType> & J,
                   const ArgumentPosition arg)
   {
-    return dIntegrate<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), J.derived(),arg);
+    dIntegrate<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), J.derived(),arg);
   }
 
   /**
@@ -87,7 +287,7 @@ namespace pinocchio
   inline void normalize(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                         const Eigen::MatrixBase<ConfigVectorType> & qout)
   {
-    return normalize<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType>(model,qout.derived());
+    normalize<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType>(model,qout.derived());
   }
 
   /**
@@ -161,7 +361,7 @@ namespace pinocchio
                              const Eigen::MatrixBase<ConfigVector> & q,
                              const Eigen::MatrixBase<JacobianMatrix> & jacobian)
   {
-    return integrateCoeffWiseJacobian<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVector,JacobianMatrix>(model,q,jacobian);
+    integrateCoeffWiseJacobian<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVector,JacobianMatrix>(model,q,jacobian);
   }
 
   /// \}
@@ -391,6 +591,20 @@ namespace pinocchio
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
   inline Eigen::Matrix<Scalar,Eigen::Dynamic,1,Options>
   neutral(const ModelTpl<Scalar,Options,JointCollectionTpl> & model);
+
+  /**
+   * @brief         Return the neutral configuration element related to the model configuration space.
+   *
+   * @param[in]     model      Model
+   *
+   * @return        The neutral configuration element.
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  inline Eigen::Matrix<Scalar,Eigen::Dynamic,1,Options>
+  neutral(const ModelTpl<Scalar,Options,JointCollectionTpl> & model)
+  {
+    return neutral<LieGroupMap,Scalar,Options,JointCollectionTpl>(model);
+  }
 
   /// \}
 

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -252,6 +252,38 @@ namespace pinocchio
   }
 
   /**
+   * @brief      Overall squared distance between two configuration vectors
+   *
+   * @param[in]  model      Model we want to compute the distance
+   * @param[in]  q0         Configuration 0 (size model.nq)
+   * @param[in]  q1         Configuration 1 (size model.nq)
+   *
+   * @return     The squared distance between the two configurations
+   */
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
+  Scalar squaredDistanceSum(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                            const Eigen::MatrixBase<ConfigVectorIn1> & q0,
+                            const Eigen::MatrixBase<ConfigVectorIn2> & q1);
+
+  /**
+   * @brief      Overall squared distance between two configuration vectors
+   *
+   * @param[in]  model      Model we want to compute the distance
+   * @param[in]  q0         Configuration 0 (size model.nq)
+   * @param[in]  q1         Configuration 1 (size model.nq)
+   *
+   * @return     The squared distance between the two configurations
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
+  inline Scalar
+  squaredDistanceSum(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                     const Eigen::MatrixBase<ConfigVectorIn1> & q0,
+                     const Eigen::MatrixBase<ConfigVectorIn2> & q1)
+  {
+    return squaredDistanceSum<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2>(model, q0.derived(), q1.derived());
+  }
+
+  /**
    * @brief      Distance between two configuration vectors
    *
    * @param[in]  model      Model we want to compute the distance

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -26,10 +26,14 @@ namespace pinocchio
             const Eigen::MatrixBase<TangentVectorType> & v,
             const Eigen::MatrixBase<ReturnType> & qout)
   {
+    assert(q.size() == model.nq && "The configuration vector is not of the right size");
+    assert(v.size() == model.nv && "The joint velocity vector is not of the right size");
+    assert(qout.size() == model.nq && "The output argument is not of the right size");
+
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
     ReturnType & res = PINOCCHIO_EIGEN_CONST_CAST(ReturnType, qout);
-    
+
     typedef IntegrateStep<LieGroup_t,ConfigVectorType,TangentVectorType,ReturnType> Algo;
     typename Algo::ArgsType args(q.derived(),v.derived(),res);
     for(JointIndex i=1; i<(JointIndex)model.njoints; ++i)
@@ -46,6 +50,10 @@ namespace pinocchio
               const Scalar & u,
               const Eigen::MatrixBase<ReturnType> & qout)
   {
+    assert(q0.size() == model.nq && "The first configuration vector is not of the right size");
+    assert(q1.size() == model.nq && "The second configuration vector is not of the right size");
+    assert(qout.size() == model.nq && "The output argument is not of the right size");
+
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
     ReturnType & res = PINOCCHIO_EIGEN_CONST_CAST(ReturnType, qout);
@@ -63,11 +71,15 @@ namespace pinocchio
   difference(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
              const Eigen::MatrixBase<ConfigVectorIn1> & q0,
              const Eigen::MatrixBase<ConfigVectorIn2> & q1,
-             const Eigen::MatrixBase<ReturnType> & dqout)
+             const Eigen::MatrixBase<ReturnType> & dvout)
   {
+    assert(q0.size() == model.nq && "The first configuration vector is not of the right size");
+    assert(q1.size() == model.nq && "The second configuration vector is not of the right size");
+    assert(dvout.size() == model.nv && "The output argument is not of the right size");
+
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
-    ReturnType & res = PINOCCHIO_EIGEN_CONST_CAST(ReturnType, dqout);
+    ReturnType & res = PINOCCHIO_EIGEN_CONST_CAST(ReturnType, dvout);
 
     typedef DifferenceStep<LieGroup_t,ConfigVectorIn1,ConfigVectorIn2,ReturnType> Algo;
     typename Algo::ArgsType args(q0.derived(),q1.derived(),res);
@@ -84,6 +96,10 @@ namespace pinocchio
                   const Eigen::MatrixBase<ConfigVectorIn2> & q1,
                   const Eigen::MatrixBase<ReturnType> & out)
   {
+    assert(q0.size() == model.nq && "The first configuration vector is not of the right size");
+    assert(q1.size() == model.nq && "The second configuration vector is not of the right size");
+    assert(out.size() == (model.njoints-1) && "The output argument is not of the right size");
+
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
     ReturnType & distances = PINOCCHIO_EIGEN_CONST_CAST(ReturnType, out);
@@ -103,6 +119,10 @@ namespace pinocchio
                       const Eigen::MatrixBase<ConfigVectorIn2> & upperLimits,
                       const Eigen::MatrixBase<ReturnType> & qout)
   {
+    assert(lowerLimits.size() == model.nq && "The lower limits vector is not of the right size");
+    assert(upperLimits.size() == model.nq && "The upper limits vector is not of the right size");
+    assert(qout.size() == model.nq && "The output argument is not of the right size");
+
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
     ReturnType & q = PINOCCHIO_EIGEN_CONST_CAST(ReturnType, qout);
@@ -119,6 +139,8 @@ namespace pinocchio
   void
   neutral(const ModelTpl<Scalar,Options,JointCollectionTpl> & model, const Eigen::MatrixBase<ReturnType> & qout)
   {
+    assert(qout.size() == model.nq && "The output argument is not of the right size");
+
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
     ReturnType & neutral_elt = PINOCCHIO_EIGEN_CONST_CAST(ReturnType, qout);
@@ -137,6 +159,11 @@ namespace pinocchio
                   const Eigen::MatrixBase<JacobianMatrixType> & J,
                   const ArgumentPosition arg)
   {
+    assert(q.size() == model.nq && "The configuration vector is not of the right size");
+    assert(v.size() == model.nv && "The joint velocity vector is not of the right size");
+    assert(J.rows() == model.nv && "The output argument is not of the right size");
+    assert(J.cols() == model.nv && "The output argument is not of the right size");
+
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
     
@@ -154,6 +181,9 @@ namespace pinocchio
                      const Eigen::MatrixBase<ConfigVectorIn1> & q0,
                      const Eigen::MatrixBase<ConfigVectorIn2> & q1)
   {
+    assert(q0.size() == model.nq && "The first configuration vector is not of the right size");
+    assert(q1.size() == model.nq && "The second configuration vector is not of the right size");
+
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
     typename ConfigVectorIn1::Scalar squaredDistance = 0.0;
@@ -182,6 +212,8 @@ namespace pinocchio
   inline void normalize(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                         const Eigen::MatrixBase<ConfigVectorType> & qout)
   {
+    assert(qout.size() == model.nq && "The output argument is not of the right size");
+
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
     
@@ -200,6 +232,10 @@ namespace pinocchio
                       const Eigen::MatrixBase<ConfigVectorIn2> & q2,
                       const Scalar & prec)
   {
+    assert(q1.size() == model.nq && "The first configuration vector is not of the right size");
+    assert(q2.size() == model.nq && "The second configuration vector is not of the right size");
+    assert(prec >= 0 && "The precision is negative");
+
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
     
@@ -222,9 +258,10 @@ namespace pinocchio
                              const Eigen::MatrixBase<ConfigVector> & q,
                              const Eigen::MatrixBase<JacobianMatrix> & jacobian)
   {
+    assert(q.size() == model.nq && "The configuration vector is not of the right size");
     assert(jacobian.rows() == model.nq && jacobian.cols() == model.nv
            && "The jacobian does not have the right dimension");
-    
+
     typedef IntegrateCoeffWiseJacobianStep<LieGroup_t,ConfigVector,JacobianMatrix> Algo;
     typename Algo::ArgsType args(q.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrix,jacobian));
     for(JointIndex i=1; i<(JointIndex)model.njoints; ++i)

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -150,9 +150,9 @@ namespace pinocchio
 
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
   Scalar
-  distance(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-           const Eigen::MatrixBase<ConfigVectorIn1> & q0,
-           const Eigen::MatrixBase<ConfigVectorIn2> & q1)
+  squaredDistanceSum(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                     const Eigen::MatrixBase<ConfigVectorIn1> & q0,
+                     const Eigen::MatrixBase<ConfigVectorIn2> & q1)
   {
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
@@ -165,6 +165,16 @@ namespace pinocchio
       Algo::run(model.joints[i], args);
     }
     
+    return squaredDistance;
+  }
+
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
+  Scalar
+  distance(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+           const Eigen::MatrixBase<ConfigVectorIn1> & q0,
+           const Eigen::MatrixBase<ConfigVectorIn2> & q1)
+  {
+    const Scalar & squaredDistance = squaredDistanceSum<LieGroup_t,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2>(model, q0.derived(), q1.derived());
     return math::sqrt(squaredDistance);
   }
 

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -147,7 +147,27 @@ namespace pinocchio
       Algo::run(model.joints[i], args);
     }
   }
-  
+
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
+  Scalar
+  distance(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+           const Eigen::MatrixBase<ConfigVectorIn1> & q0,
+           const Eigen::MatrixBase<ConfigVectorIn2> & q1)
+  {
+    typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
+    typedef typename Model::JointIndex JointIndex;
+    typename ConfigVectorIn1::Scalar squaredDistance = 0.0;
+
+    typedef SquaredDistanceSumStep<LieGroup_t,ConfigVectorIn1,ConfigVectorIn2,Scalar> Algo;
+    for(JointIndex i=1; i<(JointIndex) model.njoints; ++i)
+    {
+      typename Algo::ArgsType args(q0.derived(),q1.derived(), squaredDistance);
+      Algo::run(model.joints[i], args);
+    }
+    
+    return math::sqrt(squaredDistance);
+  }
+
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
   inline void normalize(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                         const Eigen::MatrixBase<ConfigVectorType> & qout)
@@ -248,28 +268,10 @@ namespace pinocchio
                   const Eigen::MatrixBase<ConfigVectorIn1> & q0,
                   const Eigen::MatrixBase<ConfigVectorIn2> & q1)
   {
-    typedef typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorIn1) ReturnType; 
+    typedef typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorIn1) ReturnType;
     ReturnType distances(ReturnType::Zero(model.njoints-1));
     squaredDistance<LieGroup_t,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2,ReturnType>(model,q0.derived(),q1.derived(),distances);    
     return distances;
-  }
-
-  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
-  Scalar
-  distance(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-           const Eigen::MatrixBase<ConfigVectorIn1> & q0,
-           const Eigen::MatrixBase<ConfigVectorIn2> & q1)
-  {
-    return math::sqrt(squaredDistance<LieGroup_t,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2>(model, q0.derived(), q1.derived()).sum());
-  }
-
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
-  inline Scalar
-  distance(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-           const Eigen::MatrixBase<ConfigVectorIn1> & q0,
-           const Eigen::MatrixBase<ConfigVectorIn2> & q1)
-  {
-    return math::sqrt(squaredDistance<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2>(model, q0.derived(), q1.derived()).sum());
   }
 
   template<typename LieGroup_t,typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -9,7 +9,6 @@
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
 
-#include "pinocchio/multibody/liegroup/liegroup.hpp"
 #include "pinocchio/multibody/liegroup/liegroup-algo.hpp"
 
 #include <cmath>
@@ -17,14 +16,83 @@
 /* --- Details -------------------------------------------------------------------- */
 namespace pinocchio
 {
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType>
-  inline typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorType)
-  integrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-            const Eigen::MatrixBase<ConfigVectorType> & q,
-            const Eigen::MatrixBase<TangentVectorType> & v)
+
+  // --------------- API with return value as argument ---------------------- //
+
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
+  void dIntegrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                  const Eigen::MatrixBase<ConfigVectorType> & q,
+                  const Eigen::MatrixBase<TangentVectorType> & v,
+                  const Eigen::MatrixBase<JacobianMatrixType> & J,
+                  const ArgumentPosition arg)
   {
-    return integrate<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType>(model, q.derived(), v.derived());
+    typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
+    typedef typename Model::JointIndex JointIndex;
+    
+    typedef dIntegrateStep<LieGroup_t,ConfigVectorType,TangentVectorType,JacobianMatrixType> Algo;
+    typename Algo::ArgsType args(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
+    for(JointIndex i=1; i<(JointIndex)model.njoints; ++i)
+    {
+      Algo::run(model.joints[i], args);
+    }
   }
+  
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
+  inline void normalize(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                        const Eigen::MatrixBase<ConfigVectorType> & qout)
+  {
+    typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
+    typedef typename Model::JointIndex JointIndex;
+    
+    typedef NormalizeStep<LieGroup_t,ConfigVectorType> Algo;
+    for(JointIndex i=1; i<(JointIndex)model.njoints; ++i)
+    {
+      Algo::run(model.joints[i],
+                typename Algo::ArgsType(PINOCCHIO_EIGEN_CONST_CAST(ConfigVectorType,qout)));
+    }
+  }
+
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
+  inline bool
+  isSameConfiguration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                      const Eigen::MatrixBase<ConfigVectorIn1> & q1,
+                      const Eigen::MatrixBase<ConfigVectorIn2> & q2,
+                      const Scalar & prec)
+  {
+    typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
+    typedef typename Model::JointIndex JointIndex;
+    
+    bool result = true;
+    typedef IsSameConfigurationStep<LieGroup_t,ConfigVectorIn1,ConfigVectorIn2,Scalar> Algo;
+    typename Algo::ArgsType args(result,q1.derived(),q2.derived(),prec);
+    for(JointIndex i=1; i<(JointIndex) model.njoints; ++i)
+    {
+      Algo::run(model.joints[i], args);
+      if(!result)
+        return false;
+    }
+    
+    return true;
+  }
+
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVector, typename JacobianMatrix>
+  inline void
+  integrateCoeffWiseJacobian(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                             const Eigen::MatrixBase<ConfigVector> & q,
+                             const Eigen::MatrixBase<JacobianMatrix> & jacobian)
+  {
+    assert(jacobian.rows() == model.nq && jacobian.cols() == model.nv
+           && "The jacobian does not have the right dimension");
+    
+    typedef IntegrateCoeffWiseJacobianStep<LieGroup_t,ConfigVector,JacobianMatrix> Algo;
+    typename Algo::ArgsType args(q.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrix,jacobian));
+    for(JointIndex i=1; i<(JointIndex)model.njoints; ++i)
+    {
+      Algo::run(model.joints[i],args);
+    }
+  }
+
+  // ----------------- API that allocates memory ---------------------------- //
 
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType>
   inline typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorType)
@@ -44,44 +112,6 @@ namespace pinocchio
       Algo::run(model.joints[i], args);
     }
     return res;
-  }
-  
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
-  void dIntegrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                  const Eigen::MatrixBase<ConfigVectorType> & q,
-                  const Eigen::MatrixBase<TangentVectorType> & v,
-                  const Eigen::MatrixBase<JacobianMatrixType> & J,
-                  const ArgumentPosition arg)
-  {
-    return dIntegrate<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), J.derived(),arg);
-  }
-  
-  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
-  void dIntegrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                  const Eigen::MatrixBase<ConfigVectorType> & q,
-                  const Eigen::MatrixBase<TangentVectorType> & v,
-                  const Eigen::MatrixBase<JacobianMatrixType> & J,
-                  const ArgumentPosition arg)
-  {
-    typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
-    typedef typename Model::JointIndex JointIndex;
-    
-    typedef dIntegrateStep<LieGroup_t,ConfigVectorType,TangentVectorType,JacobianMatrixType> Algo;
-    typename Algo::ArgsType args(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
-    for(JointIndex i=1; i<(JointIndex)model.njoints; ++i)
-    {
-      Algo::run(model.joints[i], args);
-    }
-  }
-
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
-  inline typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorIn1)
-  interpolate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-              const Eigen::MatrixBase<ConfigVectorIn1> & q0,
-              const Eigen::MatrixBase<ConfigVectorIn2> & q1,
-              const Scalar & u)
-  {
-    return interpolate<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2>(model, q0, q1, u);
   }
 
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
@@ -128,15 +158,6 @@ namespace pinocchio
     return res;
   }
 
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
-  inline typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorIn1)
-  difference(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-             const Eigen::MatrixBase<ConfigVectorIn1> & q0,
-             const Eigen::MatrixBase<ConfigVectorIn2> & q1)
-  {
-    return difference<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2>(model,q0.derived(),q1.derived());
-  }
-
   template<typename LieGroup_t,typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
   inline typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorIn1)
   squaredDistance(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
@@ -156,15 +177,6 @@ namespace pinocchio
     }
     
     return distances;
-  }
-
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
-  inline typename PINOCCHIO_EIGEN_PLAIN_TYPE(ConfigVectorIn1)
-  squaredDistance(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                  const Eigen::MatrixBase<ConfigVectorIn1> & q0,
-                  const Eigen::MatrixBase<ConfigVectorIn2> & q1)
-  {
-    return squaredDistance<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2>(model,q0.derived(),q1.derived());
   }
   
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
@@ -206,15 +218,6 @@ namespace pinocchio
     return q;
   }
 
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
-  typename PINOCCHIO_EIGEN_PLAIN_TYPE((typename ModelTpl<Scalar,Options,JointCollectionTpl>::ConfigVectorType))
-  randomConfiguration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                      const Eigen::MatrixBase<ConfigVectorIn1> & lowerLimits,
-                      const Eigen::MatrixBase<ConfigVectorIn2> & upperLimits)
-  {
-    return randomConfiguration<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2>(model, lowerLimits.derived(), upperLimits.derived());
-  }
-
   template<typename LieGroup_t,typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
   typename PINOCCHIO_EIGEN_PLAIN_TYPE((typename ModelTpl<Scalar,Options,JointCollectionTpl>::ConfigVectorType))
   randomConfiguration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model)
@@ -222,68 +225,6 @@ namespace pinocchio
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::ConfigVectorType ConfigVectorType;
     return randomConfiguration<LieGroup_t,Scalar,Options,JointCollectionTpl,ConfigVectorType,ConfigVectorType>(model, model.lowerPositionLimit, model.upperPositionLimit);
-  }
-
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
-  typename PINOCCHIO_EIGEN_PLAIN_TYPE((typename ModelTpl<Scalar,Options,JointCollectionTpl>::ConfigVectorType))
-  randomConfiguration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model)
-  {
-    return randomConfiguration<LieGroupMap,Scalar,Options,JointCollectionTpl>(model);
-  }
-
-  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
-  inline void normalize(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                        const Eigen::MatrixBase<ConfigVectorType> & qout)
-  {
-    typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
-    typedef typename Model::JointIndex JointIndex;
-    
-    typedef NormalizeStep<LieGroup_t,ConfigVectorType> Algo;
-    for(JointIndex i=1; i<(JointIndex)model.njoints; ++i)
-    {
-      Algo::run(model.joints[i],
-                typename Algo::ArgsType(PINOCCHIO_EIGEN_CONST_CAST(ConfigVectorType,qout)));
-    }
-  }
-  
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
-  inline void normalize(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                        const Eigen::MatrixBase<ConfigVectorType> & qout)
-  {
-    return normalize<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType>(model,qout.derived());
-  }
-
-  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
-  inline bool
-  isSameConfiguration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                      const Eigen::MatrixBase<ConfigVectorIn1> & q1,
-                      const Eigen::MatrixBase<ConfigVectorIn2> & q2,
-                      const Scalar & prec)
-  {
-    typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
-    typedef typename Model::JointIndex JointIndex;
-    
-    bool result = true;
-    typedef IsSameConfigurationStep<LieGroup_t,ConfigVectorIn1,ConfigVectorIn2,Scalar> Algo;
-    typename Algo::ArgsType args(result,q1.derived(),q2.derived(),prec);
-    for(JointIndex i=1; i<(JointIndex) model.njoints; ++i)
-    {
-      Algo::run(model.joints[i], args);
-      if(!result)
-        return false;
-    }
-    
-    return true;
-  }
-
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorIn1, typename ConfigVectorIn2>
-  inline bool
-  isSameConfiguration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                      const Eigen::MatrixBase<ConfigVectorIn1> & q1,
-                      const Eigen::MatrixBase<ConfigVectorIn2> & q2,
-                      const Scalar & prec = Eigen::NumTraits<Scalar>::dummy_precision())
-  {
-    return isSameConfiguration<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorIn1,ConfigVectorIn2>(model, q1.derived(), q2.derived(), prec);
   }
   
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
@@ -311,33 +252,6 @@ namespace pinocchio
   {
     return neutral<LieGroupMap,Scalar,Options,JointCollectionTpl>(model);
   }
-  
-  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVector, typename JacobianMatrix>
-  inline void
-  integrateCoeffWiseJacobian(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                             const Eigen::MatrixBase<ConfigVector> & q,
-                             const Eigen::MatrixBase<JacobianMatrix> & jacobian)
-  {
-    assert(jacobian.rows() == model.nq && jacobian.cols() == model.nv
-           && "The jacobian does not have the right dimension");
-    
-    typedef IntegrateCoeffWiseJacobianStep<LieGroup_t,ConfigVector,JacobianMatrix> Algo;
-    typename Algo::ArgsType args(q.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrix,jacobian));
-    for(JointIndex i=1; i<(JointIndex)model.njoints; ++i)
-    {
-      Algo::run(model.joints[i],args);
-    }
-  }
-  
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVector, typename JacobianMatrix>
-  inline void
-  integrateCoeffWiseJacobian(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                             const Eigen::MatrixBase<ConfigVector> & q,
-                             const Eigen::MatrixBase<JacobianMatrix> & jacobian)
-  {
-    return integrateCoeffWiseJacobian<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVector,JacobianMatrix>(model,q,jacobian);
-  }
-
 
 } // namespace pinocchio
 

--- a/src/multibody/liegroup/liegroup-algo.hxx
+++ b/src/multibody/liegroup/liegroup-algo.hxx
@@ -276,6 +276,38 @@ namespace pinocchio
   };
   
   PINOCCHIO_DETAILS_DISPATCH_JOINT_COMPOSITE_4(SquaredDistanceStepAlgo);
+
+  template<typename Visitor, typename JointModel> struct SquaredDistanceSumStepAlgo;
+  
+  template<typename LieGroup_t, typename ConfigVectorIn1, typename ConfigVectorIn2, typename Scalar>
+  struct SquaredDistanceSumStep
+  : public fusion::JointVisitorBase<SquaredDistanceSumStep<LieGroup_t,ConfigVectorIn1,ConfigVectorIn2,Scalar> >
+  {
+    typedef boost::fusion::vector<const ConfigVectorIn1 &,
+                                  const ConfigVectorIn2 &,
+                                  Scalar &
+                                  > ArgsType;
+    
+    PINOCCHIO_DETAILS_VISITOR_METHOD_ALGO_3(SquaredDistanceSumStepAlgo, SquaredDistanceSumStep)
+  };
+  
+  template<typename Visitor, typename JointModel>
+  struct SquaredDistanceSumStepAlgo
+  {
+    template<typename ConfigVectorIn1, typename ConfigVectorIn2>
+    static void run(const JointModelBase<JointModel> & jmodel,
+                    const Eigen::MatrixBase<ConfigVectorIn1> & q0,
+                    const Eigen::MatrixBase<ConfigVectorIn2> & q1,
+                    typename ConfigVectorIn1::Scalar & squaredDistance)
+    {
+      typedef typename Visitor::LieGroupMap LieGroupMap;
+      typename LieGroupMap::template operation<JointModel>::type lgo;
+      squaredDistance += lgo.squaredDistance(jmodel.jointConfigSelector(q0.derived()),
+                                                 jmodel.jointConfigSelector(q1.derived()));
+    }
+  };
+  
+  PINOCCHIO_DETAILS_DISPATCH_JOINT_COMPOSITE_3(SquaredDistanceSumStepAlgo);
   
   template<typename Visitor, typename JointModel> struct RandomConfigurationStepAlgo;
   

--- a/src/multibody/liegroup/liegroup-algo.hxx
+++ b/src/multibody/liegroup/liegroup-algo.hxx
@@ -271,7 +271,7 @@ namespace pinocchio
       typename LieGroupMap::template operation<JointModel>::type lgo;
       DistanceVectorOut & distances_ = PINOCCHIO_EIGEN_CONST_CAST(DistanceVectorOut,distances);
       distances_[(Eigen::DenseIndex)i] += lgo.squaredDistance(jmodel.jointConfigSelector(q0.derived()),
-                                                 jmodel.jointConfigSelector(q1.derived()));
+                                                              jmodel.jointConfigSelector(q1.derived()));
     }
   };
   
@@ -303,7 +303,7 @@ namespace pinocchio
       typedef typename Visitor::LieGroupMap LieGroupMap;
       typename LieGroupMap::template operation<JointModel>::type lgo;
       squaredDistance += lgo.squaredDistance(jmodel.jointConfigSelector(q0.derived()),
-                                                 jmodel.jointConfigSelector(q1.derived()));
+                                             jmodel.jointConfigSelector(q1.derived()));
     }
   };
   


### PR DESCRIPTION
Fix #658.
Now all joint-configuration algorithms have two versions: one with return value as argument, and one which allocates memory.

Notice that most algorithms will probably give wrong results if the output is the same object as one of the inputs. This is true in particular for `integrate`. I might implement `integrateInPlace` in the future.

Additionally, I re-implemented `distance` so that it does not employ the auxiliary vector provided by `squaredDistance`.
Also, I am providing the square of the distance with method `squaredDistanceSum`, because `squaredDistance` was already taken. By the way, I think `squaredDistance` is pretty useless now that it is not employed by `distance`, should it be eliminated, and its name recycled for what I called `squaredDistanceSum`?
