### PR TITLE
[bindings][loadReferenceConfig] fix bug when deprecated function is called

### DIFF
--- a/bindings/python/scripts/deprecated.py
+++ b/bindings/python/scripts/deprecated.py
@@ -75,11 +75,13 @@ def differentiate(model,q0,q1):
 @deprecated("This function has been renamed loadReferenceConfigurations and will be removed in future releases of Pinocchio. Please change for new loadReferenceConfigurations function.")
 def getNeutralConfigurationFromSrdf(model, filename, verbose):
   pin.loadReferenceConfigurations(model,filename,verbose)
+  model.neutralConfiguration = model.referenceConfigurations["half_sitting"]
   return model.referenceConfigurations["half_sitting"]
 
 @deprecated("This function has been renamed loadReferenceConfigurations and will be removed in future releases of Pinocchio. Please change for new loadReferenceConfigurations function.")
 def getNeutralConfiguration(model, filename, verbose):
   pin.loadReferenceConfigurations(model,filename,verbose)
+  model.neutralConfiguration = model.referenceConfigurations["half_sitting"]
   return model.referenceConfigurations["half_sitting"]
 
 @deprecated("This function has been renamed difference and will be removed in future releases of Pinocchio. Please change for new loadRotorParameters function.")


### PR DESCRIPTION
Earlier, model.neutralConfiguration is set when getNeutralConfiguration was called from python.
With #666, I introduced a bug where calling getNeutralConfiguration does not set model.neutralConfiguration.
This PR is to fix that bug.