### PR TITLE
Add support for pickling std vector, std aligned vector and std map

### DIFF
--- a/bindings/python/multibody/data.hpp
+++ b/bindings/python/multibody/data.hpp
@@ -117,6 +117,7 @@ namespace pinocchio
                          bp::no_init)
         .def(DataPythonVisitor());
         StdAlignedVectorPythonVisitor<Vector3, true>::expose("StdVec_vec3d");
+        StdAlignedVectorPythonVisitor<Matrix6x, true>::expose("StdMat_Matrix6x");
         StdVectorPythonVisitor<int>::expose("StdVec_int");
         
         eigenpy::enableEigenPySpecific<Data::RowMatrixXs>();

--- a/bindings/python/multibody/data.hpp
+++ b/bindings/python/multibody/data.hpp
@@ -9,7 +9,8 @@
 
 #include <eigenpy/memory.hpp>
 #include <eigenpy/eigenpy.hpp>
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
+#include "pinocchio/bindings/python/utils/std-vector.hpp"
+#include "pinocchio/bindings/python/utils/std-aligned-vector.hpp"
 
 EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(pinocchio::Data)
 
@@ -115,11 +116,8 @@ namespace pinocchio
                          "It contains all the data that can be modified by the algorithms.",
                          bp::no_init)
         .def(DataPythonVisitor());
-        
-        bp::class_< container::aligned_vector<Vector3> >("StdVec_vec3d")
-        .def(bp::vector_indexing_suite< container::aligned_vector<Vector3>, true >());
-        bp::class_< std::vector<int> >("StdVec_int")
-        .def(bp::vector_indexing_suite< std::vector<int> >());
+        StdAlignedVectorPythonVisitor<Vector3, true>::expose("StdVec_vec3d");
+        StdVectorPythonVisitor<int>::expose("StdVec_int");
         
         eigenpy::enableEigenPySpecific<Data::RowMatrixXs>();
       }

--- a/bindings/python/multibody/model.hpp
+++ b/bindings/python/multibody/model.hpp
@@ -6,7 +6,6 @@
 #ifndef __pinocchio_python_model_hpp__
 #define __pinocchio_python_model_hpp__
 
-#include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
 #include <boost/python/overloads.hpp>
 #include <eigenpy/memory.hpp>
@@ -18,6 +17,7 @@
 #include "pinocchio/bindings/python/utils/printable.hpp"
 #include "pinocchio/bindings/python/utils/copyable.hpp"
 #include "pinocchio/bindings/python/utils/pickle-map.hpp"
+#include "pinocchio/bindings/python/utils/std-vector.hpp"
 
 EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(pinocchio::Model)
 
@@ -188,17 +188,11 @@ namespace pinocchio
       /* --- Expose --------------------------------------------------------- */
       static void expose()
       {
-        bp::class_< std::vector<Index> >("StdVec_Index")
-          .def(bp::vector_indexing_suite< std::vector<Index> >());
-        bp::class_< std::vector<Model::IndexVector> >("StdVec_IndexVector")
-        .def(bp::vector_indexing_suite< std::vector<Model::IndexVector> >());
-        bp::class_< std::vector<std::string> >("StdVec_StdString")
-          .def(bp::vector_indexing_suite< std::vector<std::string> >())
-          .def("index", &ModelPythonVisitor::index<std::string>);
-        bp::class_< std::vector<bool> >("StdVec_Bool")
-          .def(bp::vector_indexing_suite< std::vector<bool> >());
-        bp::class_< std::vector<double> >("StdVec_double")
-          .def(bp::vector_indexing_suite< std::vector<double> >());
+        StdVectorPythonVisitor<Index>::expose("StdVec_Index");
+        StdVectorPythonVisitor<Model::IndexVector>::expose("StdVec_IndexVector");
+        StdVectorPythonVisitor<std::string>::expose("StdVec_StdString");
+        StdVectorPythonVisitor<bool>::expose("StdVec_Bool");
+        StdVectorPythonVisitor<double>::expose("StdVec_double");
         bp::class_< std::map<std::string, Eigen::VectorXd> >("StdMap_String_EigenVectorXd")
           .def(bp::map_indexing_suite< std::map<std::string, Eigen::VectorXd>, true >())
           .def_pickle(PickleMap<std::map<std::string, Eigen::VectorXd> >());

--- a/bindings/python/multibody/model.hpp
+++ b/bindings/python/multibody/model.hpp
@@ -12,12 +12,12 @@
 #include <eigenpy/memory.hpp>
 
 #include "pinocchio/multibody/model.hpp"
-#include "pinocchio/multibody/model.hpp"
 #include "pinocchio/algorithm/check.hpp"
 #include "pinocchio/parsers/sample-models.hpp"
 #include "pinocchio/bindings/python/utils/eigen_container.hpp"
 #include "pinocchio/bindings/python/utils/printable.hpp"
 #include "pinocchio/bindings/python/utils/copyable.hpp"
+#include "pinocchio/bindings/python/utils/pickle-map.hpp"
 
 EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(pinocchio::Model)
 
@@ -200,7 +200,8 @@ namespace pinocchio
         bp::class_< std::vector<double> >("StdVec_double")
           .def(bp::vector_indexing_suite< std::vector<double> >());
         bp::class_< std::map<std::string, Eigen::VectorXd> >("StdMap_String_EigenVectorXd")
-          .def(bp::map_indexing_suite< std::map<std::string, Eigen::VectorXd>, true >());
+          .def(bp::map_indexing_suite< std::map<std::string, Eigen::VectorXd>, true >())
+          .def_pickle(PickleMap<std::map<std::string, Eigen::VectorXd> >());
 
         bp::class_<Model>("Model",
                           "Articulated rigid body model (const)",

--- a/bindings/python/utils/pickle-map.hpp
+++ b/bindings/python/utils/pickle-map.hpp
@@ -5,8 +5,7 @@
 #ifndef __pinocchio_python_utils_pickle_map_hpp__
 #define __pinocchio_python_utils_pickle_map_hpp__
 
-#include <boost/python.hpp>
-#include <boost/python/tuple.hpp>
+#include "pinocchio/bindings/python/utils/pickle-vector.hpp"
 
 namespace pinocchio
 {
@@ -21,11 +20,8 @@ namespace pinocchio
     /// \sa Pickle
     ///
     template<typename VecType>
-    struct PickleMap : bp::pickle_suite
+    struct PickleMap : public PickleVector<VecType>
     { 
-      static bp::tuple getinitargs(const VecType&) {    return bp::make_tuple();      }
-      static bp::tuple getstate(bp::object op)
-      { return bp::make_tuple(bp::list(bp::extract<const VecType&>(op)()));           }
       static void setstate(bp::object op, bp::tuple tup)
       {
         VecType& o = bp::extract<VecType&>(op)(); 

--- a/bindings/python/utils/pickle-map.hpp
+++ b/bindings/python/utils/pickle-map.hpp
@@ -1,0 +1,39 @@
+//
+// Copyright (c) 2019 CNRS
+//
+
+#ifndef __pinocchio_python_utils_pickle_map_hpp__
+#define __pinocchio_python_utils_pickle_map_hpp__
+
+#include <boost/python.hpp>
+#include <boost/python/tuple.hpp>
+
+namespace pinocchio
+{
+  namespace python
+  {
+    namespace bp = boost::python;
+    ///
+    /// \brief Create a pickle interface for the std::map and aligned map
+    ///
+    /// \tparam VecType Map Type to pickle
+    ///
+    /// \sa Pickle
+    ///
+    template<typename VecType>
+    struct PickleMap : bp::pickle_suite
+    { 
+      static bp::tuple getinitargs(const VecType&) {    return bp::make_tuple();      }
+      static bp::tuple getstate(bp::object op)
+      { return bp::make_tuple(bp::list(bp::extract<const VecType&>(op)()));           }
+      static void setstate(bp::object op, bp::tuple tup)
+      {
+        VecType& o = bp::extract<VecType&>(op)(); 
+        bp::stl_input_iterator<typename VecType::value_type> begin(tup[0]), end;
+        o.insert(begin,end);
+      }
+    };
+  }
+}
+
+#endif // ifndef __pinocchio_python_utils_pickle_map_hpp__

--- a/bindings/python/utils/pickle-vector.hpp
+++ b/bindings/python/utils/pickle-vector.hpp
@@ -7,6 +7,7 @@
 
 #include <boost/python.hpp>
 #include <boost/python/tuple.hpp>
+#include <boost/python/stl_iterator.hpp>
 
 namespace pinocchio
 {

--- a/bindings/python/utils/pickle-vector.hpp
+++ b/bindings/python/utils/pickle-vector.hpp
@@ -1,0 +1,39 @@
+//
+// Copyright (c) 2019 CNRS
+//
+
+#ifndef __pinocchio_python_utils_pickle_vector_hpp__
+#define __pinocchio_python_utils_pickle_vector_hpp__
+
+#include <boost/python.hpp>
+#include <boost/python/tuple.hpp>
+
+namespace pinocchio
+{
+  namespace python
+  {
+    namespace bp = boost::python;
+    ///
+    /// \brief Create a pickle interface for the std::vector and aligned vector
+    ///
+    /// \tparam VecType Vector Type to pickle
+    ///
+    /// \sa Pickle
+    ///
+    template<typename VecType>
+    struct PickleVector : bp::pickle_suite
+    { 
+      static bp::tuple getinitargs(const VecType&) {    return bp::make_tuple();      }
+      static bp::tuple getstate(bp::object op)
+      { return bp::make_tuple(bp::list(bp::extract<const VecType&>(op)()));           }
+      static void setstate(bp::object op, bp::tuple tup)
+      {
+        VecType& o = bp::extract<VecType&>(op)(); 
+        bp::stl_input_iterator<typename VecType::value_type> begin(tup[0]), end;
+        o.insert(o.begin(),begin,end);
+      }
+    };
+  }
+}
+
+#endif // ifndef __pinocchio_python_utils_pickle_vector_hpp__

--- a/bindings/python/utils/std-aligned-vector.hpp
+++ b/bindings/python/utils/std-aligned-vector.hpp
@@ -9,6 +9,7 @@
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <string>
 #include "pinocchio/container/aligned-vector.hpp"
+#include "pinocchio/bindings/python/utils/pickle-vector.hpp"
 
 namespace pinocchio
 {
@@ -33,7 +34,8 @@ namespace pinocchio
                          const std::string & doc_string = "")
       {
         bp::class_< typename container::aligned_vector<T> >(class_name.c_str(),doc_string.c_str())
-        .def(StdAlignedVectorPythonVisitor());
+        .def(StdAlignedVectorPythonVisitor())
+        .def_pickle(PickleVector<typename container::aligned_vector<T> >());
       }
     };
   } // namespace python

--- a/bindings/python/utils/std-vector.hpp
+++ b/bindings/python/utils/std-vector.hpp
@@ -9,6 +9,7 @@
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <string>
 #include <vector>
+#include "pinocchio/bindings/python/utils/pickle-vector.hpp"
 
 namespace pinocchio
 {
@@ -33,7 +34,8 @@ namespace pinocchio
                          const std::string & doc_string = "")
       {
         bp::class_< std::vector<T> >(class_name.c_str(),doc_string.c_str())
-        .def(StdVectorPythonVisitor());
+        .def(StdVectorPythonVisitor())
+        .def_pickle(PickleVector<typename std::vector<T> >());        
       }
     };
   } // namespace python


### PR DESCRIPTION
With this I believe all elements of model and data classes are now picklable.