### PR TITLE
Create python objects for JointData classes

### DIFF
--- a/bindings/python/multibody/joint/expose-joints.cpp
+++ b/bindings/python/multibody/joint/expose-joints.cpp
@@ -16,11 +16,11 @@ namespace pinocchio
     
     static void exposeVariants()
     {
-      boost::mpl::for_each<JointModelVariant::types>(model_exposer());
+      boost::mpl::for_each<JointModelVariant::types>(ModelExposer());
       bp::to_python_converter<pinocchio::JointModelVariant,
                               JointVariantVisitor<pinocchio::JointModelVariant > >();
 
-      boost::mpl::for_each<JointDataVariant::types>(data_exposer());
+      boost::mpl::for_each<JointDataVariant::types>(DataExposer());
       bp::to_python_converter<pinocchio::JointDataVariant,
                               JointVariantVisitor<pinocchio::JointDataVariant > >();
     }

--- a/bindings/python/multibody/joint/expose-joints.cpp
+++ b/bindings/python/multibody/joint/expose-joints.cpp
@@ -16,8 +16,13 @@ namespace pinocchio
     
     static void exposeVariants()
     {
-      boost::mpl::for_each<JointModelVariant::types>(exposer());
-      bp::to_python_converter<pinocchio::JointModelVariant, jointModelVariantVisitor>();
+      boost::mpl::for_each<JointModelVariant::types>(model_exposer());
+      bp::to_python_converter<pinocchio::JointModelVariant,
+                              JointVariantVisitor<pinocchio::JointModelVariant > >();
+
+      boost::mpl::for_each<JointDataVariant::types>(data_exposer());
+      bp::to_python_converter<pinocchio::JointDataVariant,
+                              JointVariantVisitor<pinocchio::JointDataVariant > >();
     }
     
     void exposeJoints()

--- a/bindings/python/multibody/joint/joint-derived.hpp
+++ b/bindings/python/multibody/joint/joint-derived.hpp
@@ -61,24 +61,33 @@ namespace pinocchio
       void visit(PyClass& cl) const 
       {
         cl
-        // All are add_properties cause ReadOnly
-          //.add_property("id",&JointDataDerivedPythonVisitor::getId)
-          //.add_property("idx_q",&JointDataDerivedPythonVisitor::getIdx_q)
-          //.add_property("idx_v",&JointDataDerivedPythonVisitor::getIdx_v)
-          //.add_property("nq",&JointDataDerivedPythonVisitor::getNq)
-          //.add_property("nv",&JointDataDerivedPythonVisitor::getNv)
-          //.def("setIndexes",&JointDataDerived::setIndexes)
+          // All are add_properties cause ReadOnly
+          .add_property("S",&JointDataDerivedPythonVisitor::getS)
+          .add_property("M",&JointDataDerivedPythonVisitor::getM)
+          .add_property("v",&JointDataDerivedPythonVisitor::getv)
+          .add_property("c",&JointDataDerivedPythonVisitor::getc)
+          .add_property("U",&JointDataDerivedPythonVisitor::getU)
+          .add_property("Dinv",&JointDataDerivedPythonVisitor::getDinv)
+          .add_property("UDinv",&JointDataDerivedPythonVisitor::getUDinv)
           .def("shortname",&JointDataDerived::shortname)
         ;
       }
 
-      //static JointIndex getId( const JointDataDerived & self ) { return self.id(); }
-      //static int getIdx_q(const JointDataDerived & self) {return self.idx_q();}
-      //static int getIdx_v(const JointDataDerived & self) {return self.idx_v();}
-      //static int getNq(const JointDataDerived & self) {return self.nq();}
-      //static int getNv(const JointDataDerived & self) {return self.nv();}
-
-
+      static typename JointDataDerived::Constraint_t getS(const JointDataDerived & self )
+      { return self.S_accessor(); }
+      static typename JointDataDerived::Transformation_t getM(const JointDataDerived & self )
+      { return self.M_accessor(); }
+      static typename JointDataDerived::Motion_t getv(const JointDataDerived & self )
+      { return self.v_accessor(); }
+      static typename JointDataDerived::Bias_t getc(const JointDataDerived & self )
+      { return self.c_accessor(); }
+      static typename JointDataDerived::U_t getU(const JointDataDerived & self )
+      { return self.U_accessor(); }
+      static typename JointDataDerived::D_t getDinv(const JointDataDerived & self )
+      { return self.Dinv_accessor(); }
+      static typename JointDataDerived::UD_t getUDinv(const JointDataDerived & self )
+      { return self.UDinv_accessor(); }
+      
       static void expose()
       {
 

--- a/bindings/python/multibody/joint/joint-derived.hpp
+++ b/bindings/python/multibody/joint/joint-derived.hpp
@@ -17,8 +17,8 @@ namespace pinocchio
     namespace bp = boost::python;
     
     template<class JointModelDerived>
-    struct JointPythonVisitor
-      : public boost::python::def_visitor< JointPythonVisitor<JointModelDerived> >
+    struct JointModelDerivedPythonVisitor
+      : public boost::python::def_visitor< JointModelDerivedPythonVisitor<JointModelDerived> >
     {
     public:
 
@@ -27,11 +27,11 @@ namespace pinocchio
       {
         cl
         // All are add_properties cause ReadOnly
-        .add_property("id",&JointPythonVisitor::getId)
-        .add_property("idx_q",&JointPythonVisitor::getIdx_q)
-        .add_property("idx_v",&JointPythonVisitor::getIdx_v)
-        .add_property("nq",&JointPythonVisitor::getNq)
-        .add_property("nv",&JointPythonVisitor::getNv)
+        .add_property("id",&JointModelDerivedPythonVisitor::getId)
+        .add_property("idx_q",&JointModelDerivedPythonVisitor::getIdx_q)
+        .add_property("idx_v",&JointModelDerivedPythonVisitor::getIdx_v)
+        .add_property("nq",&JointModelDerivedPythonVisitor::getNq)
+        .add_property("nv",&JointModelDerivedPythonVisitor::getNv)
         .def("setIndexes",&JointModelDerived::setIndexes)
         .def("shortname",&JointModelDerived::shortname)
         ;
@@ -42,6 +42,41 @@ namespace pinocchio
       static int getIdx_v(const JointModelDerived & self) {return self.idx_v();}
       static int getNq(const JointModelDerived & self) {return self.nq();}
       static int getNv(const JointModelDerived & self) {return self.nv();}
+
+
+      static void expose()
+      {
+
+      }
+
+    };
+
+    template<class JointDataDerived>
+    struct JointDataDerivedPythonVisitor
+      : public boost::python::def_visitor< JointDataDerivedPythonVisitor<JointDataDerived> >
+    {
+    public:
+
+      template<class PyClass>
+      void visit(PyClass& cl) const 
+      {
+        cl
+        // All are add_properties cause ReadOnly
+          //.add_property("id",&JointDataDerivedPythonVisitor::getId)
+          //.add_property("idx_q",&JointDataDerivedPythonVisitor::getIdx_q)
+          //.add_property("idx_v",&JointDataDerivedPythonVisitor::getIdx_v)
+          //.add_property("nq",&JointDataDerivedPythonVisitor::getNq)
+          //.add_property("nv",&JointDataDerivedPythonVisitor::getNv)
+          //.def("setIndexes",&JointDataDerived::setIndexes)
+          .def("shortname",&JointDataDerived::shortname)
+        ;
+      }
+
+      //static JointIndex getId( const JointDataDerived & self ) { return self.id(); }
+      //static int getIdx_q(const JointDataDerived & self) {return self.idx_q();}
+      //static int getIdx_v(const JointDataDerived & self) {return self.idx_v();}
+      //static int getNq(const JointDataDerived & self) {return self.nq();}
+      //static int getNv(const JointDataDerived & self) {return self.nv();}
 
 
       static void expose()

--- a/bindings/python/multibody/joint/joints-datas.hpp
+++ b/bindings/python/multibody/joint/joints-datas.hpp
@@ -5,8 +5,7 @@
 #ifndef __pinocchio_python_joints_datas_hpp__
 #define __pinocchio_python_joints_datas_hpp__
 
-#include <eigenpy/exception.hpp>
-#include <eigenpy/eigenpy.hpp>
+#include<boost/python.hpp>
 
 namespace pinocchio
 {

--- a/bindings/python/multibody/joint/joints-datas.hpp
+++ b/bindings/python/multibody/joint/joints-datas.hpp
@@ -7,8 +7,6 @@
 
 #include <eigenpy/exception.hpp>
 #include <eigenpy/eigenpy.hpp>
-//#include "pinocchio/multibody/joint/joint-collection.hpp"
-//#include "pinocchio/multibody/joint/joint-composite.hpp"
 
 namespace pinocchio
 {
@@ -24,6 +22,41 @@ namespace pinocchio
       return cl;
     }
 
+    // specialization for JointDataRevoluteUnaligned
+    template<>
+    inline bp::class_<JointDataRevoluteUnaligned>& expose_joint_data<JointDataRevoluteUnaligned> (bp::class_<JointDataRevoluteUnaligned> & cl)
+    {
+      return cl
+        .def(bp::init<Eigen::Vector3d> (bp::args("axis"), "Init JointDataRevoluteUnaligned from an axis with x-y-z components"))
+        ;
+    }
+
+    // specialization for JointDataPrismaticUnaligned
+    template<>
+    inline bp::class_<JointDataPrismaticUnaligned>& expose_joint_data<JointDataPrismaticUnaligned> (bp::class_<JointDataPrismaticUnaligned> & cl)
+    {
+      return cl
+        .def(bp::init<Eigen::Vector3d> (bp::args("axis"), "Init JointDataPrismaticUnaligned from an axis with x-y-z components"))
+               ;
+    }
+
+    template<>
+    inline bp::class_<JointDataPlanar>& expose_joint_data<JointDataPlanar> (bp::class_<JointDataPlanar> & cl)
+    {
+      return cl
+        .add_property("StU",&JointDataPlanar::StU)
+        ;
+    }
+
+
+    template<>
+    inline bp::class_<JointDataSphericalZYX>& expose_joint_data<JointDataSphericalZYX> (bp::class_<JointDataSphericalZYX> & cl)
+    {
+      return cl
+        .add_property("StU",&JointDataSphericalZYX::StU)
+        ;
+    }
+    
     template<>
     inline bp::class_<JointDataComposite>& expose_joint_data<JointDataComposite> (bp::class_<JointDataComposite> & cl)
     {
@@ -31,6 +64,10 @@ namespace pinocchio
         .def(bp::init<const typename JointDataComposite::JointDataVector&, const int, const int>
            (bp::args("Vector of joints", "nq", "nv"),
             "Init JointDataComposite with a defined size"))
+        .add_property("joints",&JointDataComposite::joints)
+        .add_property("iMlast",&JointDataComposite::iMlast)
+        .add_property("pjMi",&JointDataComposite::pjMi)
+        .add_property("StU",&JointDataComposite::StU)
         ;
     }
     

--- a/bindings/python/multibody/joint/joints-datas.hpp
+++ b/bindings/python/multibody/joint/joints-datas.hpp
@@ -1,0 +1,40 @@
+//
+// Copyright (c) 2019 CNRS
+//
+
+#ifndef __pinocchio_python_joints_datas_hpp__
+#define __pinocchio_python_joints_datas_hpp__
+
+#include <eigenpy/exception.hpp>
+#include <eigenpy/eigenpy.hpp>
+//#include "pinocchio/multibody/joint/joint-collection.hpp"
+//#include "pinocchio/multibody/joint/joint-composite.hpp"
+
+namespace pinocchio
+{
+  namespace python
+  {
+    namespace bp = boost::python;
+
+
+    // generic expose_joint_data : do nothing special
+    template <class T>
+    inline bp::class_<T>& expose_joint_data(bp::class_<T>& cl)
+    {
+      return cl;
+    }
+
+    template<>
+    inline bp::class_<JointDataComposite>& expose_joint_data<JointDataComposite> (bp::class_<JointDataComposite> & cl)
+    {
+      return cl
+        .def(bp::init<const typename JointDataComposite::JointDataVector&, const int, const int>
+           (bp::args("Vector of joints", "nq", "nv"),
+            "Init JointDataComposite with a defined size"))
+        ;
+    }
+    
+  } // namespace python
+} // namespace pinocchio
+
+#endif // ifndef __pinocchio_python_joint_datas_hpp__

--- a/bindings/python/multibody/joint/joints-variant.hpp
+++ b/bindings/python/multibody/joint/joints-variant.hpp
@@ -43,7 +43,7 @@ namespace pinocchio
                           T::classname().c_str(),
                           bp::init<>())
             .def(JointDataDerivedPythonVisitor<T>())
-            //.def(PrintableVisitor<T>())
+            .def(PrintableVisitor<T>())
         );
         bp::implicitly_convertible<T,pinocchio::JointDataVariant>();
       }

--- a/bindings/python/multibody/joint/joints-variant.hpp
+++ b/bindings/python/multibody/joint/joints-variant.hpp
@@ -33,7 +33,7 @@ namespace pinocchio
       }
     };
 
-    struct data_exposer
+    struct DataExposer
     {
       template<class T>
       void operator()(T)
@@ -49,7 +49,7 @@ namespace pinocchio
       }
     };
 
-    struct model_exposer
+    struct ModelExposer
     {
       template<class T>
       void operator()(T)

--- a/src/multibody/joint/joint-base.hpp
+++ b/src/multibody/joint/joint-base.hpp
@@ -124,6 +124,9 @@ struct CastType< NewScalar, JointModelTpl<Scalar,Options> > \
     UTypeRef U()           { return derived().U_accessor(); }
     DTypeConstRef Dinv() const  { return derived().Dinv_accessor(); }
     UDTypeConstRef UDinv() const { return derived().UDinv_accessor(); }
+
+    std::string shortname() const { return derived().shortname(); }
+    static std::string classname() { return Derived::classname(); }    
     
   protected:
     

--- a/src/multibody/joint/joint-base.hpp
+++ b/src/multibody/joint/joint-base.hpp
@@ -126,7 +126,19 @@ struct CastType< NewScalar, JointModelTpl<Scalar,Options> > \
     UDTypeConstRef UDinv() const { return derived().UDinv_accessor(); }
 
     std::string shortname() const { return derived().shortname(); }
-    static std::string classname() { return Derived::classname(); }    
+    static std::string classname() { return Derived::classname(); }
+
+    void disp(std::ostream & os) const
+    {
+      using namespace std;
+      os << shortname() << endl;
+    }
+    
+    friend std::ostream & operator << (std::ostream & os, const JointDataBase<Derived> & joint)
+    {
+      joint.disp(os);
+      return os;
+    }
     
   protected:
     

--- a/src/multibody/joint/joint-basic-visitors.hxx
+++ b/src/multibody/joint/joint-basic-visitors.hxx
@@ -283,9 +283,9 @@ namespace pinocchio
 
 
   /**
-   * @brief      JointShortnameVisitor visitor
+   * @brief      JointModelShortnameVisitor visitor
    */
-  struct JointShortnameVisitor
+  struct JointModelShortnameVisitor
   : boost::static_visitor<std::string>
   {
     template<typename JointModelDerived>
@@ -294,12 +294,12 @@ namespace pinocchio
     
     template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
     static std::string run(const JointModelTpl<Scalar,Options,JointCollectionTpl> & jmodel)
-    { return boost::apply_visitor(JointShortnameVisitor(),jmodel); }
+    { return boost::apply_visitor(JointModelShortnameVisitor(),jmodel); }
   };
   
   template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
   inline std::string shortname(const JointModelTpl<Scalar,Options,JointCollectionTpl> & jmodel)
-  { return JointShortnameVisitor::run(jmodel);}
+  { return JointModelShortnameVisitor::run(jmodel);}
   
   template<typename NewScalar, typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
   struct JointCastVisitor
@@ -523,6 +523,26 @@ namespace pinocchio
   {
     return JointUDInvInertiaVisitor<Scalar,Options,JointCollectionTpl>::run(jdata);
   }
+
+  /**
+   * @brief      JointDataShortnameVisitor visitor
+   */
+  struct JointDataShortnameVisitor
+  : boost::static_visitor<std::string>
+  {
+    template<typename JointDataDerived>
+    std::string operator()(const JointDataBase<JointDataDerived> & jdata) const
+    { return jdata.shortname(); }
+    
+    template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
+    static std::string run(const JointDataTpl<Scalar,Options,JointCollectionTpl> & jdata)
+    { return boost::apply_visitor(JointDataShortnameVisitor(),jdata); }
+  };
+  
+  template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
+  inline std::string shortname(const JointDataTpl<Scalar,Options,JointCollectionTpl> & jdata)
+  { return JointDataShortnameVisitor::run(jdata);}
+  
 
   /// @endcond
 

--- a/src/multibody/joint/joint-composite.hpp
+++ b/src/multibody/joint/joint-composite.hpp
@@ -117,6 +117,19 @@ namespace pinocchio
     std::string shortname() const { return classname(); }
     
   };
+
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  inline std::ostream & operator <<(std::ostream & os, const JointDataCompositeTpl<Scalar,Options,JointCollectionTpl> & jdata)
+  {
+    typedef typename JointDataCompositeTpl<Scalar,Options,JointCollectionTpl>::JointDataVector JointDataVector;
+    
+    os << "JointDataComposite containing following models:\n" ;
+    for (typename JointDataVector::const_iterator it = jdata.joints.begin();
+         it != jdata.joints.end(); ++it)
+      os << "  " << shortname(*it) << std::endl;
+    return os;
+  }
+  
  
   template<typename NewScalar, typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
   struct CastType< NewScalar, JointModelCompositeTpl<Scalar,Options,JointCollectionTpl> >

--- a/src/multibody/joint/joint-composite.hpp
+++ b/src/multibody/joint/joint-composite.hpp
@@ -73,6 +73,16 @@ namespace pinocchio
     typedef container::aligned_vector<JointDataVariant> JointDataVector;
     
     // JointDataComposite()  {} // can become necessary if we want a vector of JointDataComposite ?
+
+    JointDataCompositeTpl()
+    : joints()
+    , iMlast(0), pjMi(0)
+    , S(0)
+    , M(),v(),c()
+    , U(0,0), Dinv(0,0), UDinv(0,0)
+    , StU(0,0)
+    {}
+
     
     JointDataCompositeTpl(const JointDataVector & joint_data, const int /*nq*/, const int nv)
     : joints(joint_data), iMlast(joint_data.size()), pjMi(joint_data.size())
@@ -103,6 +113,9 @@ namespace pinocchio
     
     D_t StU;
 
+    static std::string classname() { return std::string("JointDataComposite"); }
+    std::string shortname() const { return classname(); }
+    
   };
  
   template<typename NewScalar, typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>

--- a/src/multibody/joint/joint-composite.hpp
+++ b/src/multibody/joint/joint-composite.hpp
@@ -79,7 +79,7 @@ namespace pinocchio
     , iMlast(0), pjMi(0)
     , S(0)
     , M(),v(),c()
-    , U(0,0), Dinv(0,0), UDinv(0,0)
+    , U(6,0), Dinv(0,0), UDinv(6,0)
     , StU(0,0)
     {}
 

--- a/src/multibody/joint/joint-free-flyer.hpp
+++ b/src/multibody/joint/joint-free-flyer.hpp
@@ -202,6 +202,9 @@ namespace pinocchio
     
     JointDataFreeFlyerTpl() : M(1), U(), Dinv(), UDinv(UD_t::Identity()) {}
 
+    static std::string classname() { return std::string("JointDataFreeFlyer"); }
+    std::string shortname() const { return classname(); }
+    
   }; // struct JointDataFreeFlyerTpl
 
   JOINT_CAST_TYPE_SPECIALIZATION(JointModelFreeFlyerTpl);

--- a/src/multibody/joint/joint-generic.hpp
+++ b/src/multibody/joint/joint-generic.hpp
@@ -115,6 +115,9 @@ namespace pinocchio
     D_t Dinv_accessor() const { return Dinv(); }
     UD_t UDinv_accessor() const { return UDinv(); }
 
+    static std::string classname() { return "JointData"; }
+    std::string shortname() const { return ::pinocchio::shortname(*this); }
+
   };
   
   template<typename NewScalar, typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>

--- a/src/multibody/joint/joint-planar.hpp
+++ b/src/multibody/joint/joint-planar.hpp
@@ -433,6 +433,9 @@ namespace pinocchio
 
     JointDataPlanarTpl () : M(1), U(), Dinv(), UDinv() {}
 
+    static std::string classname() { return std::string("JointDataPlanar"); }
+    std::string shortname() const { return classname(); }
+    
   }; // struct JointDataPlanarTpl
 
   JOINT_CAST_TYPE_SPECIALIZATION(JointModelPlanarTpl);

--- a/src/multibody/joint/joint-prismatic-unaligned.hpp
+++ b/src/multibody/joint/joint-prismatic-unaligned.hpp
@@ -416,6 +416,9 @@ namespace pinocchio
     , U(), Dinv(), UDinv()
     {}
 
+    static std::string classname() { return std::string("JointDataPrismaticUnaligned"); }
+    std::string shortname() const { return classname(); }
+    
   }; // struct JointDataPrismaticUnalignedTpl
   
   template<typename Scalar, int Options>

--- a/src/multibody/joint/joint-prismatic.hpp
+++ b/src/multibody/joint/joint-prismatic.hpp
@@ -485,6 +485,9 @@ namespace pinocchio
 
     JointDataPrismaticTpl() {}
 
+    static std::string classname() { return std::string("JointDataPrismatic"); }
+    std::string shortname() const { return classname(); }
+
   }; // struct JointDataPrismaticTpl
   
   template<typename NewScalar, typename Scalar, int Options, int axis>

--- a/src/multibody/joint/joint-revolute-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unaligned.hpp
@@ -437,6 +437,9 @@ namespace pinocchio
     , U(), Dinv(), UDinv()
     {}
 
+    static std::string classname() { return std::string("JointDataRevoluteUnaligned"); }
+    std::string shortname() const { return classname(); }
+    
   }; // struct JointDataRevoluteUnalignedTpl
 
   JOINT_CAST_TYPE_SPECIALIZATION(JointModelRevoluteUnalignedTpl);

--- a/src/multibody/joint/joint-revolute-unbounded.hpp
+++ b/src/multibody/joint/joint-revolute-unbounded.hpp
@@ -73,6 +73,9 @@ namespace pinocchio
 
     JointDataRevoluteUnboundedTpl() {}
 
+    static std::string classname() { return std::string("JointDataRevoluteUnbounded"); }
+    std::string shortname() const { return classname(); }
+    
   }; // struct JointDataRevoluteUnbounded
   
   template<typename NewScalar, typename Scalar, int Options, int axis>

--- a/src/multibody/joint/joint-revolute.hpp
+++ b/src/multibody/joint/joint-revolute.hpp
@@ -563,6 +563,9 @@ namespace pinocchio
 
     JointDataRevoluteTpl() {}
 
+    static std::string classname() { return std::string("JointDataRevolute"); }
+    std::string shortname() const { return classname(); }
+    
   }; // struct JointDataRevoluteTpl
   
   template<typename NewScalar, typename Scalar, int Options, int axis>

--- a/src/multibody/joint/joint-spherical-ZYX.hpp
+++ b/src/multibody/joint/joint-spherical-ZYX.hpp
@@ -292,6 +292,9 @@ namespace pinocchio
     D_t StU;
 
     JointDataSphericalZYXTpl () : M(1), U(), Dinv(), UDinv() {}
+
+    static std::string classname() { return std::string("JointDataSphericalZYX"); }
+    std::string shortname() const { return classname(); }
     
   }; // strcut JointDataSphericalZYXTpl
 

--- a/src/multibody/joint/joint-spherical.hpp
+++ b/src/multibody/joint/joint-spherical.hpp
@@ -388,6 +388,9 @@ namespace pinocchio
 
     JointDataSphericalTpl () : M(1), U(), Dinv(), UDinv() {}
 
+    static std::string classname() { return std::string("JointDataSpherical"); }
+    std::string shortname() const { return classname(); }
+    
   }; // struct JointDataSphericalTpl
 
   JOINT_CAST_TYPE_SPECIALIZATION(JointModelSphericalTpl);

--- a/src/multibody/joint/joint-translation.hpp
+++ b/src/multibody/joint/joint-translation.hpp
@@ -469,6 +469,8 @@ namespace pinocchio
 
     JointDataTranslationTpl() {}
 
+    static std::string classname() { return std::string("JointDataTranslation"); }
+    std::string shortname() const { return classname(); }
   }; // struct JointDataTranslationTpl
 
   JOINT_CAST_TYPE_SPECIALIZATION(JointModelTranslationTpl);


### PR DESCRIPTION
This PR primarily creates the python bindings for the joint data classes.

In order to achive that, there are the following changes inside the JointData structs:
1) adding a shortname/classname visitor and function
2) adding a default constructor for JointDataComposite
3) create an ostream operator for making the classes printable

The rest of the PR deals with the python bindings of the JointData variants.
I don't expose JointData::F, since I didn't really understand why it is there. I'll add it if #683 is resolved that way.