### PR TITLE
Locally disable deprecation warnings inside model.hpp arising from manipulation of neutralConfiguration

### DIFF
--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -21,6 +21,11 @@
 #include <iostream>
 #include <map>
 
+// disable warnings arising from internal manipulation of deprecated instance variables
+// originally inserted for neutralConfiguration
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 namespace pinocchio
 {
   
@@ -491,6 +496,8 @@ namespace pinocchio
   };
 
 } // namespace pinocchio
+
+#pragma GCC diagnostic pop
 
 /* --- Details -------------------------------------------------------------- */
 /* --- Details -------------------------------------------------------------- */

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -15,6 +15,11 @@
 
 /// @cond DEV
 
+// disable warnings arising from internal manipulation of deprecated instance variables
+// originally inserted for neutralConfiguration
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+
 namespace pinocchio
 {
   namespace details
@@ -267,6 +272,8 @@ namespace pinocchio
   }
 
 } // namespace pinocchio
+
+#pragma GCC diagnostic pop
 
 /// @endcond
 


### PR DESCRIPTION
With #666, `model.neutralConfiguration` was deprecated.

However, inside the `Model` class, `neutralConfiguration` is still directly manipulated, to do things like testing for equality, casting, and updating it in `addJoint`. This is good and it is the only way to go if we want to maintain backward compatibility before finally removing this instance variable.

However, it was also causing a lot of warnings. These warnings are completely meaningless to the user, as there is nothing that can be done about them. As the `Model` class is used and compiled everywhere, this is basically making illegible the make print output, potentially hiding more important warnings.

With this PR, I disable deprecation warnings originating inside `model.hpp` and `model.hxx`.

***Important:*** the assertions are disabled only when *originating inside model.hpp or model.hxx*. An external file including `model.hpp` and using `neutralConfiguration` will *still* get the warning, which is what we want.

I haven't touched the bindings file [bindings/python/multibody/model.hpp](https://github.com/stack-of-tasks/pinocchio/blob/devel/bindings/python/multibody/model.hpp). As a consequence, 2 warnings are generated when compiling the Python library, which is manageable.

I used `#pragma`. It works both on GCC and Clang. I cannot say reliably the minimum compiler version, but I found this in a [post on stackoverflow from 2012](https://stackoverflow.com/a/13492589), somebody commenting it works for GCC >= 4.6. Compilers which *do not* support this (don't know which ones) should not have problems and simply keep issuing warnings as they are doing now.
