### PR TITLE
Deprecate neutralConfiguration in Python

### DIFF
--- a/bindings/python/multibody/model.hpp
+++ b/bindings/python/multibody/model.hpp
@@ -88,7 +88,7 @@ namespace pinocchio
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
         cl
-        .add_property("neutralConfiguration",
+        .add_property("_neutralConfiguration",
                       make_getter(&Model::neutralConfiguration, bp::return_value_policy<bp::return_by_value>()),
                       make_setter(&Model::neutralConfiguration, bp::return_value_policy<bp::return_by_value>()),
                       "Joint's neutral configurations.");

--- a/bindings/python/pinocchio/__init__.py
+++ b/bindings/python/pinocchio/__init__.py
@@ -11,6 +11,3 @@ from .explog import exp, log
 from .libpinocchio_pywrap import *
 from .deprecated import *
 from .shortcuts import *
-
-pin.AngleAxis.__repr__ = lambda s: 'AngleAxis(%s)' % s.vector()
-

--- a/bindings/python/pinocchio/deprecated.py
+++ b/bindings/python/pinocchio/deprecated.py
@@ -6,6 +6,8 @@
 
 from __future__ import print_function
 
+import warnings as _warnings
+
 from . import libpinocchio_pywrap as pin 
 from .deprecation import deprecated, DeprecatedWarning
 
@@ -95,14 +97,8 @@ def removeCollisionPairsFromSrdf(model, geomModel, filename, verbose):
 # This function is only deprecated when using a specific signature. Therefore, it needs special care
 def jacobianCenterOfMass(model, data, *args):
   if len(args)==3:
-    import warnings
-    import inspect
     message = "This function signature has been deprecated and will be removed in future releases of Pinocchio. Please change for one of the new signatures of the jacobianCenterOfMass function."
-    frame = inspect.currentframe().f_back
-    warnings.warn_explicit(message,
-                           category=DeprecatedWarning,
-                           filename=inspect.getfile(frame.f_code),
-                           lineno=frame.f_lineno)
+    _warnings.warn(message, category=DeprecatedWarning, stacklevel=2)
     q = args[0]
     computeSubtreeComs = args[1]
     updateKinematics = args[2]

--- a/bindings/python/pinocchio/deprecated.py
+++ b/bindings/python/pinocchio/deprecated.py
@@ -31,6 +31,21 @@ def _Model__BuildEmptyModel():
 
 pin.Model.BuildEmptyModel = staticmethod(_Model__BuildEmptyModel)
 
+# deprecate Model.neutralConfiguration. Since: 19 feb 2019
+def _Model__neutralConfiguration(self):
+    message = "Using deprecated instance variable Model.neutralConfiguration. Please use Model.referenceConfigurations instead."
+    _warnings.warn(message, DeprecatedWarning, stacklevel=2)
+    return self._neutralConfiguration
+
+pin.Model.neutralConfiguration = property(_Model__neutralConfiguration)
+
+def _Model__set_neutralConfiguration(self,q):
+    message = "Using deprecated instance variable Model.neutralConfiguration. Please use Model.referenceConfigurations instead."
+    _warnings.warn(message, DeprecatedWarning, stacklevel=2)
+    self._neutralConfiguration = q
+
+pin.Model.neutralConfiguration = pin.Model.neutralConfiguration.setter(_Model__set_neutralConfiguration)
+
 @deprecated("This function has been renamed updateFramePlacements when taking two arguments, and framesForwardKinematics when taking three. Please change your code to the appropriate method.")
 def framesKinematics(model,data,q=None):
   if q is None:

--- a/bindings/python/pinocchio/deprecation.py
+++ b/bindings/python/pinocchio/deprecation.py
@@ -1,5 +1,4 @@
 import functools
-import inspect
 import warnings
 
 class DeprecatedWarning(UserWarning):
@@ -21,17 +20,15 @@ def deprecated(instructions):
                 func.__name__,
                 instructions)
 
-            frame = inspect.currentframe().f_back
-
-            warnings.warn_explicit(message,
-                                   category=DeprecatedWarning,
-                                   filename=inspect.getfile(frame.f_code),
-                                   lineno=frame.f_lineno)
+            warnings.warn(message, category=DeprecatedWarning, stacklevel=2)
 
             return func(*args, **kwargs)
 
+        instructions_doc = 'Deprecated: ' + instructions
         if wrapper.__doc__ is None:
-            wrapper.__doc__ = instructions
+            wrapper.__doc__ = instructions_doc
+        else:
+            wrapper.__doc__ = wrapper.__doc__.rstrip() + '\n\n' + instructions_doc
         return wrapper
 
     return decorator


### PR DESCRIPTION
`neutralConfiguration` is now deprecated in Python too. To achieve this, I exposed it as `_neutralConfiguration` and then I created a `neutralConfiguration` property raising the warning.