### PR TITLE
[CI] workaround the temporary lack of binary release of hpp-fcl

### DIFF
--- a/.ci-deps
+++ b/.ci-deps
@@ -1,0 +1,1 @@
+path/hpp-fcl

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,10 +1,10 @@
-# Please don't edit this file, and use the version generated at
 # http://rainboard.laas.fr/project/pinocchio/.gitlab-ci.yml
 
 variables:
   GIT_SUBMODULE_STRATEGY: "recursive"
   CCACHE_BASEDIR: "${CI_PROJECT_DIR}"
   CCACHE_DIR: "${CI_PROJECT_DIR}/ccache"
+  CTEST_PARALLEL_LEVEL: 4
 
 cache:
   paths:
@@ -27,13 +27,31 @@ robotpkg-pinocchio-14.04-release:
   <<: *robotpkg-pinocchio
   image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/pinocchio:14.04
 
+robotpkg-pinocchio-14.04-debug:
+  <<: *robotpkg-pinocchio
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/pinocchio:14.04
+  before_script:
+    - echo PKG_OPTIONS.pinocchio=debug >> /opt/openrobots/etc/robotpkg.conf
+
 robotpkg-pinocchio-16.04-release:
   <<: *robotpkg-pinocchio
   image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/pinocchio:16.04
 
+robotpkg-pinocchio-16.04-debug:
+  <<: *robotpkg-pinocchio
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/pinocchio:16.04
+  before_script:
+    - echo PKG_OPTIONS.pinocchio=debug >> /opt/openrobots/etc/robotpkg.conf
+
 robotpkg-pinocchio-18.04-release:
   <<: *robotpkg-pinocchio
   image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/pinocchio:18.04
+
+robotpkg-pinocchio-18.04-debug:
+  <<: *robotpkg-pinocchio
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/pinocchio:18.04
+  before_script:
+    - echo PKG_OPTIONS.pinocchio=debug >> /opt/openrobots/etc/robotpkg.conf
 
 .robotpkg-py-pinocchio: &robotpkg-py-pinocchio
   except:
@@ -60,6 +78,19 @@ robotpkg-py-pinocchio-py3-14.04-release:
   image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:14.04
   allow_failure: true
 
+robotpkg-py-pinocchio-14.04-debug:
+  <<: *robotpkg-py-pinocchio
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio:14.04
+  before_script:
+    - echo PKG_OPTIONS.py-pinocchio=debug >> /opt/openrobots/etc/robotpkg.conf
+
+robotpkg-py-pinocchio-py3-14.04-debug:
+  <<: *robotpkg-py-pinocchio
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:14.04
+  allow_failure: true
+  before_script:
+    - echo PKG_OPTIONS.py-pinocchio=debug >> /opt/openrobots/etc/robotpkg.conf
+
 robotpkg-py-pinocchio-16.04-release:
   <<: *robotpkg-py-pinocchio
   image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio:16.04
@@ -69,14 +100,38 @@ robotpkg-py-pinocchio-py3-16.04-release:
   image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:16.04
   allow_failure: true
 
-robotpkg-py-pinocchio-18.04-release:
+robotpkg-py-pinocchio-16.04-debug:
   <<: *robotpkg-py-pinocchio
-  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio:18.04
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio:16.04
+  before_script:
+    - echo PKG_OPTIONS.py-pinocchio=debug >> /opt/openrobots/etc/robotpkg.conf
+
+robotpkg-py-pinocchio-py3-16.04-debug:
+  <<: *robotpkg-py-pinocchio
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:16.04
+  allow_failure: true
+  before_script:
+    - echo PKG_OPTIONS.py-pinocchio=debug >> /opt/openrobots/etc/robotpkg.conf
 
 robotpkg-py-pinocchio-py3-18.04-release:
   <<: *robotpkg-py-pinocchio
   image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:18.04
-  allow_failure: true
+
+robotpkg-py-pinocchio-18.04-release:
+  <<: *robotpkg-py-pinocchio
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio:18.04
+
+robotpkg-py-pinocchio-18.04-debug:
+  <<: *robotpkg-py-pinocchio
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio:18.04
+  before_script:
+    - echo PKG_OPTIONS.py-pinocchio=debug >> /opt/openrobots/etc/robotpkg.conf
+
+robotpkg-py-pinocchio-py3-18.04-debug:
+  <<: *robotpkg-py-pinocchio
+  image: eur0c.laas.fr:5000/stack-of-tasks/pinocchio/py-pinocchio-py3:18.04
+  before_script:
+    - echo PKG_OPTIONS.py-pinocchio=debug >> /opt/openrobots/etc/robotpkg.conf
 
 doc-coverage:
   <<: *robotpkg-py-pinocchio

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,6 +19,7 @@ cache:
     - git pull
     - cd pinocchio
     - make checkout MASTER_REPOSITORY="git ${CI_PROJECT_DIR}/.git"
+    - /ci_deps.sh
     - make install
     - cd $(make show-var VARNAME=WRKSRC)
     - make test
@@ -65,6 +66,7 @@ robotpkg-pinocchio-18.04-debug:
     - cd ..
     - cd py-pinocchio
     - make checkout MASTER_REPOSITORY="git ${CI_PROJECT_DIR}/.git"
+    - /ci_deps.sh
     - make install
     - cd $(make show-var VARNAME=WRKSRC)
     - make test
@@ -140,6 +142,7 @@ doc-coverage:
     - echo -e 'CXXFLAGS+= --coverage\nLDFLAGS+= --coverage\nPKG_DEFAULT_OPTIONS= debug' >> /opt/openrobots/etc/robotpkg.conf
   after_script:
     - cd /root/robotpkg/math/py-pinocchio
+    - /ci_deps.sh
     - cd $(make show-var VARNAME=WRKSRC)
     - make doc
     - mv doc/doxygen-html ${CI_PROJECT_DIR}


### PR DESCRIPTION
Hi,

This PR updates gitlab-CI with a few things:
- run all tests in Debug and Release modes
- use [a special branch of robotpkg](https://gepgitlab.laas.fr/gepetto/robotpkg/tree/ci/pinocchio) in the docker image generation, that allows us to use hpp-fcl from source, and fix an issue in the main repo that prevented us to run the tests of the python bindings, for any version >= 1.3.4
- adds a (temporary) `.ci-deps` file, instructing the buildfarm to build the robotpkg package `path/hpp-fcl` (which has been updated in v1.0.1 in the branch for the previous point). We will remove this line from this file (and this file as it will be empty) when hpp-fcl v1.0.1 will be available in the binary repository
- take this file in account in the CI jobs
- set `CTEST_PARALLEL_LEVEL=4` to speed up tests a bit (honestly, this is neglegible on pinocchio, but on other packages it can save tens of minutes)

And this works: https://gepgitlab.laas.fr/gsaurel/pinocchio/pipelines/2950/builds

But this is far from perfect yet, because with tests in 14.04-16.04-18.04 / Debug-Release / no python-python2-python3, plus one to generate code coverage & documentation, it takes 19 jobs and 2h to complete, and all of them are building hpp-fcl first.

I think we can use it to make the next source release of pinocchio, and use the same mechanism to make the source release of the SoT, HPP & RBPRM, and then make a binary release of all those source releases.