### PR TITLE
Align Python Jacobian to C++, fix #545

### DIFF
--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -75,3 +75,7 @@ ADD_BENCH(timings-eigen)
 IF(URDFDOM_FOUND AND HPP_FCL_FOUND)
   ADD_BENCH(timings-geometry TRUE)
 ENDIF(URDFDOM_FOUND AND HPP_FCL_FOUND)
+
+# timings-jacobian
+#
+ADD_BENCH(timings-jacobian TRUE)

--- a/benchmark/timings-cg.cpp
+++ b/benchmark/timings-cg.cpp
@@ -2,6 +2,7 @@
 // Copyright (c) 2018 CNRS
 //
 
+#include "pinocchio/algorithm/joint-configuration.hpp"
 #include "pinocchio/algorithm/crba.hpp"
 #include "pinocchio/algorithm/centroidal.hpp"
 #include "pinocchio/algorithm/aba.hpp"
@@ -60,6 +61,7 @@ int main(int argc, const char ** argv)
   std::cout << "--" << std::endl;
 
   pinocchio::Data data(model);
+  VectorXd qmax = Eigen::VectorXd::Ones(model.nq);
   
   CodeGenRNEA<double> rnea_code_gen(model);
   rnea_code_gen.initLib();
@@ -92,8 +94,7 @@ int main(int argc, const char ** argv)
   
   for(size_t i=0;i<NBT;++i)
   {
-    qs[i]     = Eigen::VectorXd::Random(model.nq);
-    qs[i].segment<4>(3) /= qs[i].segment<4>(3).norm();
+    qs[i]     = randomConfiguration(model,-qmax,qmax);
     qdots[i]  = Eigen::VectorXd::Random(model.nv);
     qddots[i] = Eigen::VectorXd::Random(model.nv);
     taus[i] = Eigen::VectorXd::Random(model.nv);

--- a/benchmark/timings-cholesky.cpp
+++ b/benchmark/timings-cholesky.cpp
@@ -7,6 +7,7 @@
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
+#include "pinocchio/algorithm/joint-configuration.hpp"
 #include "pinocchio/algorithm/crba.hpp"
 #include "pinocchio/algorithm/aba.hpp"
 #include "pinocchio/algorithm/cholesky.hpp"
@@ -46,9 +47,7 @@ int main(int argc, const char ** argv)
   std::cout << "nq = " << model.nq << std::endl;
 
   pinocchio::Data data(model);
-  VectorXd q = VectorXd::Random(model.nq);
-  VectorXd qdot = VectorXd::Random(model.nv);
-  VectorXd qddot = VectorXd::Random(model.nv);
+  VectorXd qmax = Eigen::VectorXd::Ones(model.nq);
   
   MatrixXd A(model.nv,model.nv), B(model.nv,model.nv);
   A.setZero(); B.setRandom();
@@ -58,7 +57,7 @@ int main(int argc, const char ** argv)
   std::vector<VectorXd> rhs (NBT);
   for(size_t i=0;i<NBT;++i)
   {
-    qs[i] = Eigen::VectorXd::Random(model.nq);
+    qs[i] = randomConfiguration(model,-qmax,qmax);
     lhs[i] = Eigen::VectorXd::Zero(model.nv);
     rhs[i] = Eigen::VectorXd::Random(model.nv);
   }
@@ -145,7 +144,7 @@ int main(int argc, const char ** argv)
   {
     computeMinverse(model,data,qs[_smooth]);
   }
-  std::cout << "M.inverse() = \t\t"; timer.toc(std::cout,NBT);
+  std::cout << "computeMinverse = \t\t"; timer.toc(std::cout,NBT);
   
   return 0;
 }

--- a/benchmark/timings-derivatives.cpp
+++ b/benchmark/timings-derivatives.cpp
@@ -149,9 +149,7 @@ int main(int argc, const char ** argv)
   std::cout << "nv = " << model.nv << std::endl;
 
   Data data(model);
-  VectorXd q = VectorXd::Random(model.nq);
-  VectorXd qdot = VectorXd::Random(model.nv);
-  VectorXd qddot = VectorXd::Random(model.nv);
+  VectorXd qmax = Eigen::VectorXd::Ones(model.nq);
 
   container::aligned_vector<VectorXd> qs     (NBT);
   container::aligned_vector<VectorXd> qdots  (NBT);
@@ -160,8 +158,7 @@ int main(int argc, const char ** argv)
   
   for(size_t i=0;i<NBT;++i)
   {
-    qs[i]     = Eigen::VectorXd::Random(model.nq);
-    qs[i].segment<4>(3) /= qs[i].segment<4>(3).norm();
+    qs[i]     = randomConfiguration(model,-qmax,qmax);
     qdots[i]  = Eigen::VectorXd::Random(model.nv);
     qddots[i] = Eigen::VectorXd::Random(model.nv);
     taus[i] = Eigen::VectorXd::Random(model.nv);

--- a/benchmark/timings-geometry.cpp
+++ b/benchmark/timings-geometry.cpp
@@ -7,6 +7,7 @@
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
+#include "pinocchio/algorithm/joint-configuration.hpp"
 #include "pinocchio/algorithm/crba.hpp"
 #include "pinocchio/algorithm/rnea.hpp"
 #include "pinocchio/algorithm/cholesky.hpp"
@@ -42,7 +43,7 @@ int main()
   
   std::string romeo_filename = PINOCCHIO_SOURCE_DIR"/models/romeo/romeo_description/urdf/romeo.urdf";
   std::vector < std::string > package_dirs;
-  std::string romeo_meshDir  = PINOCCHIO_SOURCE_DIR"/models/";
+  std::string romeo_meshDir  = PINOCCHIO_SOURCE_DIR"/models/romeo";
   package_dirs.push_back(romeo_meshDir);
 
   pinocchio::Model model;
@@ -54,6 +55,7 @@ int main()
    
   Data data(model);
   GeometryData geom_data(geom_model);
+  VectorXd qmax = Eigen::VectorXd::Ones(model.nq);
 
 
   std::vector<VectorXd> qs_romeo     (NBT);
@@ -61,8 +63,7 @@ int main()
   std::vector<VectorXd> qddots_romeo (NBT);
   for(size_t i=0;i<NBT;++i)
   {
-    qs_romeo[i]     = Eigen::VectorXd::Random(model.nq);
-    qs_romeo[i].segment<4>(3) /= qs_romeo[i].segment<4>(3).norm();
+    qs_romeo[i]     = randomConfiguration(model,-qmax,qmax);
     qdots_romeo[i]  = Eigen::VectorXd::Random(model.nv);
     qddots_romeo[i] = Eigen::VectorXd::Random(model.nv);
   }

--- a/benchmark/timings-jacobian.cpp
+++ b/benchmark/timings-jacobian.cpp
@@ -1,0 +1,113 @@
+//
+// Copyright (c) 2015-2018 CNRS
+//
+
+#include "pinocchio/multibody/model.hpp"
+#include "pinocchio/multibody/data.hpp"
+#include "pinocchio/algorithm/joint-configuration.hpp"
+#include "pinocchio/algorithm/kinematics.hpp"
+#include "pinocchio/algorithm/jacobian.hpp"
+#include "pinocchio/parsers/urdf.hpp"
+#include "pinocchio/parsers/sample-models.hpp"
+
+#include <iostream>
+
+#include "pinocchio/utils/timer.hpp"
+
+#include <Eigen/StdVector>
+EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(Eigen::VectorXd)
+
+int main(int argc, const char ** argv)
+{
+  using namespace Eigen;
+  using namespace pinocchio;
+
+  PinocchioTicToc timer(PinocchioTicToc::US);
+  #ifdef NDEBUG
+  const int NBT = 1000*100;
+  #else
+    const int NBT = 1;
+    std::cout << "(the time score in debug mode is not relevant) " << std::endl;
+  #endif
+
+  pinocchio::Model model;
+
+  std::string filename = PINOCCHIO_SOURCE_DIR"/models/simple_humanoid.urdf";
+  if(argc>1) filename = argv[1];
+
+  bool with_ff = true;
+  if(argc>2)
+  {
+    const std::string ff_option = argv[2];
+    if(ff_option == "-no-ff")
+      with_ff = false;
+  }
+
+  if( filename == "HS")
+    pinocchio::buildModels::humanoidRandom(model,true);
+  else
+    if(with_ff)
+      pinocchio::urdf::buildModel(filename,JointModelFreeFlyer(),model);
+    else
+      pinocchio::urdf::buildModel(filename,model);
+  std::cout << "nq = " << model.nq << std::endl;
+
+  pinocchio::Data data(model);
+  VectorXd qmax = Eigen::VectorXd::Ones(model.nq);
+  //VectorXd q = randomConfiguration(model);
+
+  pinocchio::Data::Matrix6x J(6,model.nv);
+  J.setZero();
+  pinocchio::Model::JointIndex JOINT_ID = (Model::JointIndex)(model.njoints-1);
+
+  std::vector<VectorXd> qs(NBT);
+  for(size_t i=0;i<NBT;++i)
+  {
+    qs[i] = randomConfiguration(model,-qmax,qmax);
+  }
+
+  timer.tic();
+  SMOOTH(NBT)
+  {
+    forwardKinematics(model,data,qs[_smooth]);
+  }
+  std::cout << "Zero Order Kinematics = \t"; timer.toc(std::cout,NBT);
+
+  timer.tic();
+  SMOOTH(NBT)
+  {
+    jointJacobian(model,data,qs[_smooth],JOINT_ID,J);
+  }
+  std::cout << "jointJacobian = \t\t"; timer.toc(std::cout,NBT);
+
+  timer.tic();
+  SMOOTH(NBT)
+  {
+    computeJointJacobians(model,data,qs[_smooth]);
+  }
+  std::cout << "computeJointJacobians(q) = \t"; timer.toc(std::cout,NBT);
+
+  timer.tic();
+  SMOOTH(NBT)
+  {
+    computeJointJacobians(model,data);
+  }
+  std::cout << "computeJointJacobians() = \t"; timer.toc(std::cout,NBT);
+
+  timer.tic();
+  SMOOTH(NBT)
+  {
+    getJointJacobian(model,data,JOINT_ID,LOCAL,J);
+  }
+  std::cout << "getJointJacobian(LOCAL) = \t"; timer.toc(std::cout,NBT);
+
+  timer.tic();
+  SMOOTH(NBT)
+  {
+    getJointJacobian(model,data,JOINT_ID,WORLD,J);
+  }
+  std::cout << "getJointJacobian(WORLD) = \t"; timer.toc(std::cout,NBT);
+
+  std::cout << "--" << std::endl;
+  return 0;
+}

--- a/benchmark/timings.cpp
+++ b/benchmark/timings.cpp
@@ -7,6 +7,7 @@
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
+#include "pinocchio/algorithm/joint-configuration.hpp"
 #include "pinocchio/algorithm/crba.hpp"
 #include "pinocchio/algorithm/centroidal.hpp"
 #include "pinocchio/algorithm/aba.hpp"
@@ -64,17 +65,14 @@ int main(int argc, const char ** argv)
   
 
   pinocchio::Data data(model);
-  VectorXd q = VectorXd::Random(model.nq);
-  VectorXd qdot = VectorXd::Random(model.nv);
-  VectorXd qddot = VectorXd::Random(model.nv);
+  VectorXd qmax = Eigen::VectorXd::Ones(model.nq);
 
   std::vector<VectorXd> qs     (NBT);
   std::vector<VectorXd> qdots  (NBT);
   std::vector<VectorXd> qddots (NBT);
   for(size_t i=0;i<NBT;++i)
     {
-      qs[i]     = Eigen::VectorXd::Random(model.nq);
-      qs[i].segment<4>(3) /= qs[i].segment<4>(3).norm();
+      qs[i]     = randomConfiguration(model,-qmax,qmax);
       qdots[i]  = Eigen::VectorXd::Random(model.nv);
       qddots[i] = Eigen::VectorXd::Random(model.nv);
     }

--- a/bindings/python/algorithm/expose-frames.cpp
+++ b/bindings/python/algorithm/expose-frames.cpp
@@ -58,26 +58,6 @@ namespace pinocchio
       updateFramePlacements(model,data);
   
       return get_frame_jacobian_time_variation_proxy(model, data, frame_id, rf);
-    }        
-
-    static Motion get_frame_velocity_proxy(const Model & model,
-                                           Data & data,
-                                           const Model::FrameIndex frame_id
-                                           )
-    {
-      Motion v;
-      getFrameVelocity(model,data,frame_id,v);
-      return v;
-    }
-
-    static Motion get_frame_acceleration_proxy(const Model & model,
-                                               Data & data,
-                                               const Model::FrameIndex frame_id
-                                               )
-    {
-      Motion a;
-      getFrameAcceleration(model,data,frame_id,a);
-      return a;
     }
     
     void exposeFramesAlgo()
@@ -97,13 +77,13 @@ namespace pinocchio
               bp::return_value_policy<bp::return_by_value>());
 
       bp::def("getFrameVelocity",
-              (Motion (*)(const Model &, Data &, const Model::FrameIndex))&get_frame_velocity_proxy,
+              &getFrameVelocity<double,0,JointCollectionDefaultTpl>,
               bp::args("Model","Data","Operational frame ID (int)"),
               "Returns the spatial velocity of the frame expressed in the LOCAL frame coordinate system."
               "Fist or second order forwardKinematics should be called first.");
 
       bp::def("getFrameAcceleration",
-              (Motion (*)(const Model &, Data &, const Model::FrameIndex))&get_frame_acceleration_proxy,
+              &getFrameAcceleration<double,0,JointCollectionDefaultTpl>,
               bp::args("Model","Data","Operational frame ID (int)"),
               "Returns the spatial velocity of the frame expressed in the LOCAL frame coordinate system."
               "Second order forwardKinematics should be called first.");

--- a/bindings/python/algorithm/expose-frames.cpp
+++ b/bindings/python/algorithm/expose-frames.cpp
@@ -24,14 +24,13 @@ namespace pinocchio
     static Data::Matrix6x frame_jacobian_proxy(const Model & model,
                                                Data & data,
                                                const Eigen::VectorXd & q,
-                                               const Model::FrameIndex frame_id,
-                                               ReferenceFrame rf
+                                               const Model::FrameIndex frame_id
                                                )
     {
-      computeJointJacobians(model,data,q);
-      updateFramePlacements(model,data);
+      Data::Matrix6x J(6,model.nv); J.setZero();
+      frameJacobian(model, data, q, frame_id, J);
   
-      return get_frame_jacobian_proxy(model, data, frame_id, rf);
+      return J;
     }
 
 
@@ -121,9 +120,8 @@ namespace pinocchio
               &frame_jacobian_proxy,
               bp::args("Model","Data",
                        "Configuration q (size Model::nq)",
-                       "Operational frame ID (int)",
-                       "Reference frame rf (either ReferenceFrame.LOCAL or ReferenceFrame.WORLD)"),
-              "Computes the Jacobian of the frame given by its ID either in the local or the world frames."
+                       "Operational frame ID (int)"),
+              "Computes the Jacobian of the frame given by its ID."
               "The columns of the Jacobian are expressed in the frame coordinates.\n"
               "In other words, the velocity of the frame vF expressed in the local coordinate is given by J*v,"
               "where v is the time derivative of the configuration q.");

--- a/bindings/python/algorithm/expose-jacobian.cpp
+++ b/bindings/python/algorithm/expose-jacobian.cpp
@@ -14,16 +14,10 @@ namespace pinocchio
     jacobian_proxy(const Model & model,
                    Data & data,
                    const Eigen::VectorXd & q,
-                   Model::JointIndex jointId,
-                   ReferenceFrame rf,
-                   bool update_kinematics)
+                   Model::JointIndex jointId)
     {
       Data::Matrix6x J(6,model.nv); J.setZero();
-      
-      if (update_kinematics)
-        computeJointJacobians(model,data,q);
-      
-      getJointJacobian(model,data,jointId,rf,J);
+      jointJacobian(model,data,q,jointId,J);
       
       return J;
     }
@@ -75,11 +69,8 @@ namespace pinocchio
               bp::args("Model, the model of the kinematic tree",
                        "Data, the data associated to the model where the results are stored",
                        "Joint configuration q (size Model::nq)",
-                       "Joint ID, the index of the joint.",
-                       "Reference frame rf (either ReferenceFrame.LOCAL or ReferenceFrame.WORLD)",
-                       "update_kinematics (true = update the value of the total jacobian)"),
-              "Computes the jacobian of a given given joint according to the given input configuration."
-              "If rf is set to LOCAL, it returns the jacobian associated to the joint frame. Otherwise, it returns the jacobian of the frame coinciding with the world frame.");
+                       "Joint ID, the index of the joint"),
+              "Computes the Jacobian of a specific joint frame expressed in the local frame of the joint according to the given input configuration.");
 
       bp::def("getJointJacobian",get_jacobian_proxy,
               bp::args("Model, the model of the kinematic tree",

--- a/bindings/python/pinocchio/deprecated.py
+++ b/bindings/python/pinocchio/deprecated.py
@@ -80,6 +80,25 @@ jointJacobian.__doc__ =  (
   + '\n    This function signature has been deprecated and will be removed in future releases of Pinocchio.'
 )
 
+# This function is only deprecated when using a specific signature. Therefore, it needs special care
+# Marked as deprecated on 19 Feb 2019
+def frameJacobian(model, data, q, jointId, *args):
+  if len(args)==1:
+    message = ("This function signature has been deprecated and will be removed in future releases of Pinocchio. "
+               "Please change for the new signature of frameJacobian or use computeJointJacobian + updateFramePlacements + getFrameJacobian.")
+    _warnings.warn(message, category=DeprecatedWarning, stacklevel=2)
+    rf = args[0]
+    pin.computeJointJacobians(model,data,q)
+    pin.updateFramePlacements(model,data)
+    return pin.getFrameJacobian(model, data, frameId, rf);
+  else:
+    return pin.frameJacobian(model,data,q,frameId)
+frameJacobian.__doc__ =  (
+  pin.frameJacobian.__doc__
+  + '\n\nframeJacobian( (Model)Model, (Data)Data, (object)Joint configuration q (size Model::nq), (Index)frameId, ReferenceFrame rf) -> object :'
+  + '\n    This function signature has been deprecated and will be removed in future releases of Pinocchio.'
+)
+
 @deprecated("This function has been renamed jointJacobian and will be removed in future releases of Pinocchio. Please change for new jointJacobian function.")
 def jacobian(model,data,q,jointId,local,update_kinematics):
   rf = pin.ReferenceFrame.LOCAL if local else pin.ReferenceFrame.WORLD

--- a/bindings/python/pinocchio/deprecated.py
+++ b/bindings/python/pinocchio/deprecated.py
@@ -60,12 +60,32 @@ def computeJacobians(model,data,q=None):
   else:
     return pin.computeJointJacobians(model,data,q)
 
+# This function is only deprecated when using a specific signature. Therefore, it needs special care
+# Marked as deprecated on 19 Feb 2019
+def jointJacobian(model, data, q, jointId, *args):
+  if len(args)==2:
+    message = ("This function signature has been deprecated and will be removed in future releases of Pinocchio. "
+               "Please change for the new signature of jointJacobian or use computeJointJacobian + getJointJacobian.")
+    _warnings.warn(message, category=DeprecatedWarning, stacklevel=2)
+    rf = args[0]
+    update_kinematics = args[1]
+    if update_kinematics:
+        pin.computeJointJacobians(model,data,q)
+    return pin.getJointJacobian(model,data,jointId,rf)
+  else:
+    return pin.jointJacobian(model,data,q,jointId)
+jointJacobian.__doc__ =  (
+  pin.jointJacobian.__doc__
+  + '\n\njointJacobian( (Model)Model, (Data)Data, (object)Joint configuration q (size Model::nq), (Index)jointId, ReferenceFrame rf, (bool)updateKinematics) -> object :'
+  + '\n    This function signature has been deprecated and will be removed in future releases of Pinocchio.'
+)
+
 @deprecated("This function has been renamed jointJacobian and will be removed in future releases of Pinocchio. Please change for new jointJacobian function.")
 def jacobian(model,data,q,jointId,local,update_kinematics):
-  if local:
-    return pin.jointJacobian(model,data,q,jointId,pin.ReferenceFrame.LOCAL,update_kinematics)
-  else:
-    return pin.jointJacobian(model,data,q,jointId,pin.ReferenceFrame.WORLD,update_kinematics)
+  rf = pin.ReferenceFrame.LOCAL if local else pin.ReferenceFrame.WORLD
+  if update_kinematics:
+      computeJointJacobians(model,data,q)
+  return pin.getJointJacobian(model,data,jointId,rf)
 
 @deprecated("This function has been renamed getJointJacobian and will be removed in future releases of Pinocchio. Please change for new getJointJacobian function.")
 def getJacobian(model,data,jointId,local):

--- a/bindings/python/pinocchio/robot_wrapper.py
+++ b/bindings/python/pinocchio/robot_wrapper.py
@@ -188,8 +188,13 @@ class RobotWrapper(object):
         else:
             return pin.jointJacobian(self.model, self.data, q, index, pin.ReferenceFrame.WORLD, update_kinematics)
 
-    def jointJacobian(self, q, index, rf_frame=pin.ReferenceFrame.LOCAL, update_kinematics=True):
-        return pin.jointJacobian(self.model, self.data, q, index, rf_frame, update_kinematics)
+    def jointJacobian(self, q, index, *args):
+        if len(args)==0:
+            return pin.jointJacobian(self.model, self.data, q, index)
+        else: # use deprecated signature (19 Feb 2019)
+            update_kinematics = True if len(args)==1 else args[1]
+            rf = args[0]
+            return pin.jointJacobian(self.model, self.data, q, index, rf_frame, update_kinematics)
 
     def getJointJacobian(self, index, rf_frame=pin.ReferenceFrame.LOCAL):
         return pin.getFrameJacobian(self.model, self.data, index, rf_frame)
@@ -229,11 +234,14 @@ class RobotWrapper(object):
         return pin.getFrameJacobian(self.model, self.data, frame_id, rf_frame)
 
     '''
-        Similar to getFrameJacobian but it also calls before pin.computeJointJacobians and
+        Similar to getFrameJacobian but does not need pin.computeJointJacobians and
         pin.updateFramePlacements to update internal value of self.data related to frames.
     '''
-    def frameJacobian(self, q, frame_id, rf_frame=pin.ReferenceFrame.LOCAL):
-        return pin.frameJacobian(self.model, self.data, q, frame_id, rf_frame)
+    def frameJacobian(self, q, frame_id, rf_frame=None):
+        if rf_frame: # use deprecated signature (19 Feb 2019)
+            return pin.frameJacobian(self.model, self.data, q, frame_id, rf_frame)
+        else: # use normal signature
+            return pin.frameJacobian(self.model, self.data, q, frame_id)
 
 
     # --- ACCESS TO NAMES ----

--- a/src/algorithm/frames.hpp
+++ b/src/algorithm/frames.hpp
@@ -67,15 +67,78 @@ namespace pinocchio
    * @param[in]  model       The kinematic model
    * @param[in]  data        Data associated to model
    * @param[in]  frame_id    Id of the operational Frame
+   *
+   * @return     The spatial velocity of the Frame expressed in the coordinates Frame.
+   *
+   * @warning    Fist or second order forwardKinematics should have been called first
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  inline MotionTpl<Scalar, Options>
+  getFrameVelocity(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                   const DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                   const typename ModelTpl<Scalar,Options,JointCollectionTpl>::FrameIndex frame_id);
+
+  /**
+   * @brief      Returns the spatial velocity of the frame expressed in the LOCAL frame coordinate system.
+   *             You must first call pinocchio::forwardKinematics to update placement and velocity values in data structure.
+   *
+   * @param[in]  model       The kinematic model
+   * @param[in]  data        Data associated to model
+   * @param[in]  frame_id    Id of the operational Frame
    * @param[out] frame_v     The spatial velocity of the Frame expressed in the coordinates Frame.
+   *
+   * @deprecated This function is now deprecated. Use the return-value version instead (since: 19 feb 2019)
    *
    * @warning    Fist or second order forwardKinematics should have been called first
    */
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename MotionLike>
-  void getFrameVelocity(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                        const DataTpl<Scalar,Options,JointCollectionTpl> & data,
-                        const typename ModelTpl<Scalar,Options,JointCollectionTpl>::FrameIndex frame_id,
-                        const MotionDense<MotionLike> & frame_v);
+  PINOCCHIO_DEPRECATED
+  inline void getFrameVelocity(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                               const DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                               const typename ModelTpl<Scalar,Options,JointCollectionTpl>::FrameIndex frame_id,
+                               const MotionDense<MotionLike> & frame_v)
+  {
+    frame_v.derived() = getFrameVelocity(model, data, frame_id);
+  }
+
+  /**
+   * @brief      Returns the spatial acceleration of the frame expressed in the LOCAL frame coordinate system.
+   *             You must first call pinocchio::forwardKinematics to update placement values in data structure.
+   *
+   * @param[in]  model       The kinematic model
+   * @param[in]  data        Data associated to model
+   * @param[in]  frame_id    Id of the operational Frame
+   *
+   * @return The spatial acceleration of the Frame expressed in the coordinates Frame.
+   *
+   * @warning    Second order forwardKinematics should have been called first
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  inline MotionTpl<Scalar, Options>
+  getFrameAcceleration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                       const DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                       const typename ModelTpl<Scalar,Options,JointCollectionTpl>::FrameIndex frame_id);
+
+  /**
+   * @brief      Returns the spatial acceleration of the frame expressed in the LOCAL frame coordinate system.
+   *             You must first call pinocchio::forwardKinematics to update placement values in data structure.
+   *
+   * @param[in]  model       The kinematic model
+   * @param[in]  data        Data associated to model
+   * @param[in]  frame_id    Id of the operational Frame
+   * @param[out] frame_a     The spatial acceleration of the Frame expressed in the coordinates Frame.
+   *
+   * @deprecated This function is now deprecated. Use the return-value version instead (since: 19 feb 2019)
+   *
+   * @warning    Second order forwardKinematics should have been called first
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename MotionLike>
+  PINOCCHIO_DEPRECATED
+  inline void getFrameAcceleration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                                   const DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                                   const typename ModelTpl<Scalar,Options,JointCollectionTpl>::FrameIndex frame_id,
+                                   const MotionDense<MotionLike> & frame_a)
+  { frame_a.derived() = getFrameAcceleration(model, data, frame_id); }
 
   /**
    * @brief      Returns the jacobian of the frame expressed either expressed in the LOCAL frame coordinate system or in the WORLD coordinate system,
@@ -131,23 +194,6 @@ namespace pinocchio
                             const FrameIndex frameId,
                             const Eigen::MatrixBase<Matrix6Like> & J);
 
-   /**
-   * @brief      Returns the spatial acceleration of the frame expressed in the LOCAL frame coordinate system.
-   *             You must first call pinocchio::forwardKinematics to update placement values in data structure.
-   *
-   * @param[in]  model       The kinematic model
-   * @param[in]  data        Data associated to model
-   * @param[in]  frame_id    Id of the operational Frame
-   * @param[out] frame_a     The spatial acceleration of the Frame expressed in the coordinates Frame.
-   *
-   * @warning    Second order forwardKinematics should have been called first
-   */
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename MotionLike>
-  void getFrameAcceleration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                            const DataTpl<Scalar,Options,JointCollectionTpl> & data,
-                            const typename ModelTpl<Scalar,Options,JointCollectionTpl>::FrameIndex frame_id,
-                            const MotionDense<MotionLike> & frame_a);
-
   /**
    * @brief      Returns the jacobian of the frame expresssed either expressed in the LOCAL frame coordinate system or in the WORLD coordinate system,
    *             depending on the value of rf.
@@ -155,7 +201,7 @@ namespace pinocchio
    *
    * @tparam     rf Reference frame in which the columns of the Jacobian are expressed.
    * @deprecated This function is now deprecated. Please call pinocchio::getFrameJacobian for same functionality.
-   
+   *
    * @remark     Similarly to pinocchio::getJointJacobian with LOCAL or WORLD parameters, if rf == LOCAL, this function returns the Jacobian of the frame expressed
    *             in the local coordinates of the frame, or if rl == WORDL, it returns the Jacobian expressed of the point coincident with the origin
    *             and expressed in a coordinate system aligned with the WORLD.

--- a/src/algorithm/frames.hpp
+++ b/src/algorithm/frames.hpp
@@ -78,7 +78,7 @@ namespace pinocchio
                         const MotionDense<MotionLike> & frame_v);
 
   /**
-   * @brief      Returns the jacobian of the frame expresssed either expressed in the LOCAL frame coordinate system or in the WORLD coordinate system,
+   * @brief      Returns the jacobian of the frame expressed either expressed in the LOCAL frame coordinate system or in the WORLD coordinate system,
    *             depending on the value of rf.
    *             You must first call pinocchio::computeJointJacobians followed by pinocchio::framesForwardKinematics to update placement values in data structure.
    *
@@ -104,6 +104,32 @@ namespace pinocchio
                                const ReferenceFrame rf,
                                const Eigen::MatrixBase<Matrix6xLike> & J);
   
+  ///
+  /// \brief Computes the Jacobian of a specific Frame expressed in the LOCAL frame coordinate system.
+  ///
+  /// \tparam JointCollection Collection of Joint types.
+  /// \tparam ConfigVectorType Type of the joint configuration vector.
+  /// \tparam Matrix6xLike Type of the matrix containing the joint Jacobian.
+  ///
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  /// \param[in] q The joint configuration vector (dim model.nq).
+  /// \param[in] frameId The id of the Frame refering to model.frames[frameId].
+  /// \param[out] J A reference on the Jacobian matrix where the results will be stored in (dim 6 x model.nv). You must fill J with zero elements, e.g. J.setZero().
+  ///
+  /// \return The Jacobian of the specific Frame expressed in the LOCAL frame coordinate system (matrix 6 x model.nv).
+  ///
+  /// \remark The result of this function is equivalent to call first computeJointJacobians(model,data,q), then updateFramePlacements(model,data) and then call getJointJacobian(model,data,jointId,LOCAL,J),
+  ///         but forwardKinematics and updateFramePlacements are not fully computed.
+  ///         It is worth to call jacobian if you only need a single Jacobian for a specific joint. Otherwise, for several Jacobians, it is better
+  ///         to call computeJacobians(model,data,q) followed by getJointJacobian(model,data,jointId,LOCAL,J) for each Jacobian.
+  ///
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename Matrix6Like>
+  inline void frameJacobian(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                            DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                            const Eigen::MatrixBase<ConfigVectorType> & q,
+                            const FrameIndex frameId,
+                            const Eigen::MatrixBase<Matrix6Like> & J);
 
    /**
    * @brief      Returns the spatial acceleration of the frame expressed in the LOCAL frame coordinate system.

--- a/src/algorithm/frames.hxx
+++ b/src/algorithm/frames.hxx
@@ -74,11 +74,11 @@ namespace pinocchio
     updateFramePlacements(model, data);
   }
 
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename MotionLike>
-  void getFrameVelocity(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                        const DataTpl<Scalar,Options,JointCollectionTpl> & data,
-                        const typename ModelTpl<Scalar,Options,JointCollectionTpl>::FrameIndex frame_id,
-                        const MotionDense<MotionLike> & frame_v)
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  inline MotionTpl<Scalar, Options>
+  getFrameVelocity(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                   const DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                   const typename ModelTpl<Scalar,Options,JointCollectionTpl>::FrameIndex frame_id)
   {
     assert(model.check(data) && "data is not consistent with model.");
     
@@ -86,14 +86,14 @@ namespace pinocchio
 
     const typename Model::Frame & frame = model.frames[frame_id];
     const typename Model::JointIndex & parent = frame.parent;
-    const_cast<MotionLike &>(frame_v.derived()) = frame.placement.actInv(data.v[parent]);
-  }
+    return frame.placement.actInv(data.v[parent]);
+  }  
 
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename MotionLike>
-  void getFrameAcceleration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                            const DataTpl<Scalar,Options,JointCollectionTpl> & data,
-                            const typename ModelTpl<Scalar,Options,JointCollectionTpl>::FrameIndex frame_id,
-                            const MotionDense<MotionLike> & frame_a)
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  inline MotionTpl<Scalar, Options>
+  getFrameAcceleration(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                       const DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                       const typename ModelTpl<Scalar,Options,JointCollectionTpl>::FrameIndex frame_id)
   {
     assert(model.check(data) && "data is not consistent with model.");
 
@@ -101,7 +101,7 @@ namespace pinocchio
     
     const typename Model::Frame & frame = model.frames[frame_id];
     const typename Model::JointIndex & parent = frame.parent;
-    const_cast<MotionLike &>(frame_a.derived()) = frame.placement.actInv(data.a[parent]);
+    return frame.placement.actInv(data.a[parent]);
   }
   
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename Matrix6xLike>

--- a/src/algorithm/jacobian.hpp
+++ b/src/algorithm/jacobian.hpp
@@ -132,7 +132,7 @@ namespace pinocchio
   
   ///
   /// \brief Computes the Jacobian of a specific joint frame expressed either in the world (rf = WORLD) frame or in the local frame (rf = LOCAL) of the joint.
-  /// \note This jacobian is extracted from data.J. You have to run pinocchio::computeJacobians before calling it.
+  /// \note This jacobian is extracted from data.J. You have to run pinocchio::computeJointJacobians before calling it.
   ///
   /// \deprecated This function is now deprecated. Please refer now to pinocchio::getJointJacobian for similar function with updated name.
   ///
@@ -167,9 +167,10 @@ namespace pinocchio
   ///
   /// \return The Jacobian of the specific joint frame expressed in the local frame of the joint (matrix 6 x model.nv).
   ///
-  /// \remark This function is equivalent to call first computeJacobians(model,data,q) and then call getJointJacobian(model,data,jointId,LOCAL,J).
+  /// \remark The result of this function is equivalent to call first computeJointJacobians(model,data,q) and then call getJointJacobian(model,data,jointId,LOCAL,J),
+  ///         but forwardKinematics is not fully computed.
   ///         It is worth to call jacobian if you only need a single Jacobian for a specific joint. Otherwise, for several Jacobians, it is better
-  ///         to call computeJacobians(model,data,q) followed by getJointJacobian(model,data,jointId,LOCAL,J) for each Jacobian.
+  ///         to call computeJointJacobians(model,data,q) followed by getJointJacobian(model,data,jointId,LOCAL,J) for each Jacobian.
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename Matrix6Like>
   inline void jointJacobian(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
@@ -191,9 +192,10 @@ namespace pinocchio
   ///
   /// \return The Jacobian of the specific joint frame expressed in the local frame of the joint (matrix 6 x model.nv).
   ///
-  /// \remark This function is equivalent to call first computeJacobians(model,data,q) and then call getJointJacobian<LOCAL>(model,data,jointId,J).
+  /// \remark The result of this function is equivalent to call first computeJointJacobians(model,data,q) and then call getJointJacobian<LOCAL>(model,data,jointId,J),
+  ///         but forwardKinematics is not fully computed.
   ///         It is worth to call jacobian if you only need a single Jacobian for a specific joint. Otherwise, for several Jacobians, it is better
-  ///         to call computeJacobians(model,data,q) followed by getJointJacobian<LOCAL>(model,data,jointId,J) for each Jacobian.
+  ///         to call computeJointJacobians(model,data,q) followed by getJointJacobian<LOCAL>(model,data,jointId,J) for each Jacobian.
   ///
   PINOCCHIO_DEPRECATED
   inline void jacobian(const Model & model,
@@ -271,7 +273,7 @@ namespace pinocchio
   
   ///
   /// \brief Computes the Jacobian time variation of a specific joint frame expressed either in the world frame (rf = WORLD) or in the local frame (rf = LOCAL) of the joint.
-  /// \note This jacobian is extracted from data.dJ. You have to run pinocchio::computeJacobiansTimeVariation before calling it.
+  /// \note This jacobian is extracted from data.dJ. You have to run pinocchio::computeJointJacobiansTimeVariation before calling it.
   ///
   /// \tparam JointCollection Collection of Joint types.
   /// \tparam Matrix6xLike Type of the matrix containing the joint Jacobian.
@@ -291,7 +293,7 @@ namespace pinocchio
   
   ///
   /// \brief Computes the Jacobian time variation of a specific joint frame expressed either in the world frame (rf = WORLD) or in the local frame (rf = LOCAL) of the joint.
-  /// \note This jacobian is extracted from data.dJ. You have to run pinocchio::computeJacobiansTimeVariation before calling it.
+  /// \note This jacobian is extracted from data.dJ. You have to run pinocchio::computeJointJacobiansTimeVariation before calling it.
   ///
   /// \deprecated This function is now deprecated. Please refer now to pinocchio::getJointJacobianTimeVariation for similar function with updated name.
   ///

--- a/unittest/frames.cpp
+++ b/unittest/frames.cpp
@@ -148,8 +148,7 @@ BOOST_AUTO_TEST_CASE ( test_velocity )
   VectorXd v = VectorXd::Ones(model.nv);
   forwardKinematics(model, data, q, v);
 
-  Motion vf;
-  getFrameVelocity(model, data, frame_idx, vf);
+  Motion vf = getFrameVelocity(model, data, frame_idx);
 
   BOOST_CHECK(vf.isApprox(framePlacement.actInv(data.v[parent_idx])));
 }
@@ -174,8 +173,7 @@ BOOST_AUTO_TEST_CASE ( test_acceleration )
   VectorXd a = VectorXd::Ones(model.nv);
   forwardKinematics(model, data, q, v, a);
 
-  Motion af;
-  getFrameAcceleration(model, data, frame_idx, af);
+  Motion af = getFrameAcceleration(model, data, frame_idx);
 
   BOOST_CHECK(af.isApprox(framePlacement.actInv(data.a[parent_idx])));
 }

--- a/unittest/frames.cpp
+++ b/unittest/frames.cpp
@@ -180,7 +180,7 @@ BOOST_AUTO_TEST_CASE ( test_acceleration )
   BOOST_CHECK(af.isApprox(framePlacement.actInv(data.a[parent_idx])));
 }
 
-BOOST_AUTO_TEST_CASE ( test_jacobian )
+BOOST_AUTO_TEST_CASE ( test_get_frame_jacobian )
 {
   using namespace Eigen;
   using namespace pinocchio;
@@ -227,6 +227,42 @@ BOOST_AUTO_TEST_CASE ( test_jacobian )
   getFrameJacobian(model,data,idx,WORLD,Jff);
   getJointJacobian(model, data_ref, parent_idx,WORLD, Jjj);
   BOOST_CHECK(Jff.isApprox(Jjj));
+}
+
+BOOST_AUTO_TEST_CASE ( test_frame_jacobian )
+{
+  using namespace Eigen;
+  using namespace pinocchio;
+
+  Model model;
+  buildModels::humanoidRandom(model);
+  Model::Index parent_idx = model.existJointName("rarm2_joint")?model.getJointId("rarm2_joint"):(Model::Index)(model.njoints-1);
+  const std::string & frame_name = std::string( model.names[parent_idx]+ "_frame");
+  const SE3 & framePlacement = SE3::Random();
+  model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
+  BOOST_CHECK(model.existFrame(frame_name));
+
+  pinocchio::Data data(model);
+  pinocchio::Data data_ref(model);
+
+  model.lowerPositionLimit.head<7>().fill(-1.);
+  model.upperPositionLimit.head<7>().fill( 1.);
+  VectorXd q = randomConfiguration(model);
+  VectorXd v = VectorXd::Ones(model.nv);
+
+  Model::Index idx = model.getFrameId(frame_name);
+  const Frame & frame = model.frames[idx];
+  BOOST_CHECK(frame.placement.isApprox_impl(framePlacement));
+  Data::Matrix6x Jf(6,model.nv); Jf.fill(0);
+  Data::Matrix6x Jf_ref(6,model.nv); Jf_ref.fill(0);
+
+  frameJacobian(model, data_ref, q, idx, Jf);
+
+  computeJointJacobians(model, data_ref, q);
+  updateFramePlacement(model,  data_ref, idx);
+  getFrameJacobian(model,      data_ref, idx, LOCAL, Jf_ref);
+
+  BOOST_CHECK(Jf.isApprox(Jf_ref));  
 }
 
 BOOST_AUTO_TEST_CASE ( test_frame_jacobian_time_variation )

--- a/unittest/python/bindings_dynamics.py
+++ b/unittest/python/bindings_dynamics.py
@@ -27,7 +27,7 @@ class TestDynamicsBindings(TestCase):
         self.tolerance = 1e-9
 
         # we compute J on a different self.data
-        self.J = pin.jointJacobian(self.model,self.model.createData(),self.q,self.model.getJointId('lleg6_joint'),pin.ReferenceFrame.LOCAL,True)
+        self.J = pin.jointJacobian(self.model,self.model.createData(),self.q,self.model.getJointId('lleg6_joint'))
         self.gamma = zero(6)
 
     def test_forwardDynamics7(self):


### PR DESCRIPTION
Mostly four things:
- Add a benchmark called `timings-jacobian` to compare between `getJointJacobian`, `computeJointJacobians` and related algorithms.
- Use the corresponding C++ function for the Python bindings of `jointJacobian`. Now, the signature and side-effects of `jointJacobian` in Python are completely aligned to C++. The old signature is now deprecated. This fixes #545
- Implemented missing `frameJacobian` function in C++, and use the newly-created function for the Python bindings of `frameJacobian`. The old signature is now deprecated. This also fixes #545
- Change the C++ return policy `getFrameVelocity` and `getFrameAcceleration`. Now, the value is returned instead of being written in a reference
