### PR TITLE
[doc] Doxygen and macros

### DIFF
--- a/doc/Doxyfile.extra.in
+++ b/doc/Doxyfile.extra.in
@@ -599,8 +599,22 @@ EXPAND_ONLY_PREDEF     = YES
 # undefined via #undef or recursively expanded use the := operator
 # instead of the = operator.
 
-PREDEFINED             += WITH_HPP_FCL \
-                          EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+PREDEFINED             += EIGEN_MAKE_ALIGNED_OPERATOR_NEW \
+                          EIGEN_STRONG_INLINE=inline \
+                          PINOCCHIO_WITH_HPP_FCL \
+                          PINOCCHIO_WITH_URDFDOM \
+                          PINOCCHIO_WITH_CPPAD_SUPPORT \
+                          PINOCCHIO_WITH_CPPADCG_SUPPORT \
+                          PINOCCHIO_WITH_LUA5
+
+# The following macros would be better treated with EXPAND_AS_DEFINED.
+# However, it was not working properly
+PREDEFINED             += PINOCCHIO_EIGEN_PLAIN_TYPE(x)=x \
+                          "PINOCCHIO_EIGEN_REF_CONST_TYPE(x)=const x &" \
+                          "PINOCCHIO_EIGEN_DOT_PRODUCT_RETURN_TYPE(D1,D2)=Eigen::ScalarBinaryOpTraits< typename Eigen::internal::traits< D1 >::Scalar, typename Eigen::internal::traits< D2 >::Scalar >::ReturnType" \
+                          "PINOCCHIO_DEFINE_ALGO_CHECKER(NAME)=struct NAME##Checker : public AlgorithmCheckerBase<NAME##Checker>{}" \
+                          PINOCCHIO_JOINT_CAST_TYPE_SPECIALIZATION(JointModelTpl)=
+
 
 # If the MACRO_EXPANSION and EXPAND_ONLY_PREDEF tags are set to YES then
 # this tag can be used to specify a list of macro names that should be expanded.

--- a/src/algorithm/aba.hpp
+++ b/src/algorithm/aba.hpp
@@ -81,7 +81,7 @@ namespace pinocchio
                   const Eigen::MatrixBase<ConfigVectorType> & q);
 
 
-  DEFINE_ALGO_CHECKER(ABA);
+  PINOCCHIO_DEFINE_ALGO_CHECKER(ABA);
 
 } // namespace pinocchio
 

--- a/src/algorithm/check.hpp
+++ b/src/algorithm/check.hpp
@@ -32,7 +32,7 @@ namespace pinocchio
     { return derived().checkModel_impl(model); }
   };
 
-#define DEFINE_ALGO_CHECKER(NAME)                                           \
+#define PINOCCHIO_DEFINE_ALGO_CHECKER(NAME)                                           \
   struct NAME##Checker : public AlgorithmCheckerBase<NAME##Checker>         \
   {                                                                         \
     template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>                                      \
@@ -40,7 +40,7 @@ namespace pinocchio
   }
 
   /// Simple model checker, that assert that model.parents is indeed a tree.
-  DEFINE_ALGO_CHECKER(Parent);
+  PINOCCHIO_DEFINE_ALGO_CHECKER(Parent);
   
 #if !defined(BOOST_FUSION_HAS_VARIADIC_LIST)
   /// Checker having a list of Checker as input argument

--- a/src/algorithm/crba.hpp
+++ b/src/algorithm/crba.hpp
@@ -62,7 +62,7 @@ namespace pinocchio
               DataTpl<Scalar,Options,JointCollectionTpl> & data,
               const Eigen::MatrixBase<ConfigVectorType> & q);
 
-  DEFINE_ALGO_CHECKER(CRBA);
+  PINOCCHIO_DEFINE_ALGO_CHECKER(CRBA);
 
 } // namespace pinocchio 
 

--- a/src/multibody/joint/joint-base.hpp
+++ b/src/multibody/joint/joint-base.hpp
@@ -77,13 +77,13 @@ namespace pinocchio
   using Base::idx_q; \
   using Base::idx_v
 
-#define JOINT_CAST_TYPE_SPECIALIZATION(JointModelTpl) \
+#define PINOCCHIO_JOINT_CAST_TYPE_SPECIALIZATION(JointModelTpl) \
 template<typename Scalar, int Options, typename NewScalar> \
 struct CastType< NewScalar, JointModelTpl<Scalar,Options> > \
 { typedef JointModelTpl<NewScalar,Options> type; }
   
   
-#define JOINT_DATA_BASE_DEFAULT_ACCESSOR \
+#define PINOCCHIO_JOINT_DATA_BASE_DEFAULT_ACCESSOR \
   ConstraintTypeConstRef S_accessor() const { return S; } \
   TansformTypeConstRef M_accessor() const { return M; } \
   MotionTypeConstRef v_accessor() const { return v; } \
@@ -93,7 +93,7 @@ struct CastType< NewScalar, JointModelTpl<Scalar,Options> > \
   DTypeConstRef Dinv_accessor() const { return Dinv; } \
   UDTypeConstRef UDinv_accessor() const { return UDinv; }
   
-#define JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE \
+#define PINOCCHIO_JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE \
   typedef const Constraint_t & ConstraintTypeConstRef; \
   typedef const Transformation_t & TansformTypeConstRef; \
   typedef const Motion_t & MotionTypeConstRef; \

--- a/src/multibody/joint/joint-composite.hpp
+++ b/src/multibody/joint/joint-composite.hpp
@@ -42,7 +42,7 @@ namespace pinocchio
     typedef Eigen::Matrix<Scalar,Eigen::Dynamic,Eigen::Dynamic,Options> D_t;
     typedef Eigen::Matrix<Scalar,6,Eigen::Dynamic,Options> UD_t;
     
-    JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
+    PINOCCHIO_JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
 
     typedef Eigen::Matrix<Scalar,Eigen::Dynamic,1,Options> ConfigVector_t;
     typedef Eigen::Matrix<Scalar,Eigen::Dynamic,1,Options> TangentVector_t;
@@ -65,7 +65,7 @@ namespace pinocchio
     typedef JointDataBase<JointDataCompositeTpl> Base;
     typedef JointCompositeTpl<_Scalar,_Options,JointCollectionTpl> JointDerived;
     PINOCCHIO_JOINT_DATA_TYPEDEF_TEMPLATE;
-    JOINT_DATA_BASE_DEFAULT_ACCESSOR
+    PINOCCHIO_JOINT_DATA_BASE_DEFAULT_ACCESSOR
     
     typedef JointCollectionTpl<Scalar,Options> JointCollection;
     typedef JointDataTpl<Scalar,Options,JointCollectionTpl> JointDataVariant;

--- a/src/multibody/joint/joint-free-flyer.hpp
+++ b/src/multibody/joint/joint-free-flyer.hpp
@@ -166,7 +166,7 @@ namespace pinocchio
     typedef Eigen::Matrix<Scalar,NV,NV,Options> D_t;
     typedef Eigen::Matrix<Scalar,6,NV,Options> UD_t;
     
-    JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
+    PINOCCHIO_JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
 
     typedef Eigen::Matrix<Scalar,NQ,1,Options> ConfigVector_t;
     typedef Eigen::Matrix<Scalar,NV,1,Options> TangentVector_t;
@@ -186,7 +186,7 @@ namespace pinocchio
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     typedef JointFreeFlyerTpl<_Scalar,_Options> JointDerived;
     PINOCCHIO_JOINT_DATA_TYPEDEF_TEMPLATE;
-    JOINT_DATA_BASE_DEFAULT_ACCESSOR
+    PINOCCHIO_JOINT_DATA_BASE_DEFAULT_ACCESSOR
     
     Constraint_t S;
     Transformation_t M;
@@ -207,7 +207,7 @@ namespace pinocchio
     
   }; // struct JointDataFreeFlyerTpl
 
-  JOINT_CAST_TYPE_SPECIALIZATION(JointModelFreeFlyerTpl);
+  PINOCCHIO_JOINT_CAST_TYPE_SPECIALIZATION(JointModelFreeFlyerTpl);
   template<typename _Scalar, int _Options>
   struct JointModelFreeFlyerTpl
   : public JointModelBase< JointModelFreeFlyerTpl<_Scalar,_Options> >

--- a/src/multibody/joint/joint-planar.hpp
+++ b/src/multibody/joint/joint-planar.hpp
@@ -398,7 +398,7 @@ namespace pinocchio
     typedef Eigen::Matrix<Scalar,NV,NV,Options> D_t;
     typedef Eigen::Matrix<Scalar,6,NV,Options> UD_t;
     
-    JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
+    PINOCCHIO_JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
 
     typedef Eigen::Matrix<Scalar,NQ,1,Options> ConfigVector_t;
     typedef Eigen::Matrix<Scalar,NV,1,Options> TangentVector_t;
@@ -415,7 +415,7 @@ namespace pinocchio
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     typedef JointPlanarTpl<_Scalar,_Options> JointDerived;
     PINOCCHIO_JOINT_DATA_TYPEDEF_TEMPLATE;
-    JOINT_DATA_BASE_DEFAULT_ACCESSOR
+    PINOCCHIO_JOINT_DATA_BASE_DEFAULT_ACCESSOR
     
     Constraint_t S;
     Transformation_t M;
@@ -438,7 +438,7 @@ namespace pinocchio
     
   }; // struct JointDataPlanarTpl
 
-  JOINT_CAST_TYPE_SPECIALIZATION(JointModelPlanarTpl);
+  PINOCCHIO_JOINT_CAST_TYPE_SPECIALIZATION(JointModelPlanarTpl);
   template<typename _Scalar, int _Options>
   struct JointModelPlanarTpl
   : public JointModelBase< JointModelPlanarTpl<_Scalar,_Options> >

--- a/src/multibody/joint/joint-prismatic-unaligned.hpp
+++ b/src/multibody/joint/joint-prismatic-unaligned.hpp
@@ -375,7 +375,7 @@ namespace pinocchio
     typedef Eigen::Matrix<Scalar,NV,NV,Options> D_t;
     typedef Eigen::Matrix<Scalar,6,NV,Options> UD_t;
     
-    JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
+    PINOCCHIO_JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
     
     typedef Eigen::Matrix<Scalar,NQ,1,Options> ConfigVector_t;
     typedef Eigen::Matrix<Scalar,NV,1,Options> TangentVector_t;
@@ -392,7 +392,7 @@ namespace pinocchio
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     typedef JointPrismaticUnalignedTpl<_Scalar,_Options> JointDerived;
     PINOCCHIO_JOINT_DATA_TYPEDEF_TEMPLATE;
-    JOINT_DATA_BASE_DEFAULT_ACCESSOR
+    PINOCCHIO_JOINT_DATA_BASE_DEFAULT_ACCESSOR
     
     Transformation_t M;
     Constraint_t S;
@@ -425,7 +425,7 @@ namespace pinocchio
   struct traits< JointModelPrismaticUnalignedTpl<Scalar,Options> >
   { typedef JointPrismaticUnalignedTpl<Scalar,Options> JointDerived; };
 
-  JOINT_CAST_TYPE_SPECIALIZATION(JointModelPrismaticUnalignedTpl);
+  PINOCCHIO_JOINT_CAST_TYPE_SPECIALIZATION(JointModelPrismaticUnalignedTpl);
   template<typename _Scalar, int _Options>
   struct JointModelPrismaticUnalignedTpl
   : public JointModelBase< JointModelPrismaticUnalignedTpl<_Scalar,_Options> >

--- a/src/multibody/joint/joint-prismatic.hpp
+++ b/src/multibody/joint/joint-prismatic.hpp
@@ -449,7 +449,7 @@ namespace pinocchio
     typedef Eigen::Matrix<Scalar,NV,NV,Options> D_t;
     typedef Eigen::Matrix<Scalar,6,NV,Options> UD_t;
     
-    JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
+    PINOCCHIO_JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
 
     typedef Eigen::Matrix<Scalar,NQ,1,Options> ConfigVector_t;
     typedef Eigen::Matrix<Scalar,NV,1,Options> TangentVector_t;
@@ -469,7 +469,7 @@ namespace pinocchio
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     typedef JointPrismaticTpl<_Scalar,_Options,axis> JointDerived;
     PINOCCHIO_JOINT_DATA_TYPEDEF_TEMPLATE;
-    JOINT_DATA_BASE_DEFAULT_ACCESSOR
+    PINOCCHIO_JOINT_DATA_BASE_DEFAULT_ACCESSOR
 
     Constraint_t S;
     Transformation_t M;

--- a/src/multibody/joint/joint-revolute-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unaligned.hpp
@@ -391,7 +391,7 @@ namespace pinocchio
     typedef Eigen::Matrix<Scalar,NV,NV,Options> D_t;
     typedef Eigen::Matrix<Scalar,6,NV,Options> UD_t;
     
-    JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
+    PINOCCHIO_JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
     
     typedef Eigen::Matrix<Scalar,NQ,1,Options> ConfigVector_t;
     typedef Eigen::Matrix<Scalar,NV,1,Options> TangentVector_t;
@@ -413,7 +413,7 @@ namespace pinocchio
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     typedef JointRevoluteUnalignedTpl<_Scalar,_Options> JointDerived;
     PINOCCHIO_JOINT_DATA_TYPEDEF_TEMPLATE;
-    JOINT_DATA_BASE_DEFAULT_ACCESSOR
+    PINOCCHIO_JOINT_DATA_BASE_DEFAULT_ACCESSOR
 
     Transformation_t M;
     Constraint_t S;
@@ -442,7 +442,7 @@ namespace pinocchio
     
   }; // struct JointDataRevoluteUnalignedTpl
 
-  JOINT_CAST_TYPE_SPECIALIZATION(JointModelRevoluteUnalignedTpl);
+  PINOCCHIO_JOINT_CAST_TYPE_SPECIALIZATION(JointModelRevoluteUnalignedTpl);
   template<typename _Scalar, int _Options>
   struct JointModelRevoluteUnalignedTpl
   : public JointModelBase< JointModelRevoluteUnalignedTpl<_Scalar,_Options> >

--- a/src/multibody/joint/joint-revolute-unbounded.hpp
+++ b/src/multibody/joint/joint-revolute-unbounded.hpp
@@ -38,7 +38,7 @@ namespace pinocchio
     typedef Eigen::Matrix<Scalar,NV,NV,Options> D_t;
     typedef Eigen::Matrix<Scalar,6,NV,Options> UD_t;
     
-    JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
+    PINOCCHIO_JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
 
     typedef Eigen::Matrix<Scalar,NQ,1,Options> ConfigVector_t;
     typedef Eigen::Matrix<Scalar,NV,1,Options> TangentVector_t;
@@ -58,7 +58,7 @@ namespace pinocchio
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     typedef JointRevoluteUnboundedTpl<_Scalar,_Options,axis> JointDerived;
     PINOCCHIO_JOINT_DATA_TYPEDEF_TEMPLATE;
-    JOINT_DATA_BASE_DEFAULT_ACCESSOR
+    PINOCCHIO_JOINT_DATA_BASE_DEFAULT_ACCESSOR
 
     Constraint_t S;
     Transformation_t M;

--- a/src/multibody/joint/joint-revolute.hpp
+++ b/src/multibody/joint/joint-revolute.hpp
@@ -528,7 +528,7 @@ namespace pinocchio
     typedef Eigen::Matrix<Scalar,NV,NV,Options> D_t;
     typedef Eigen::Matrix<Scalar,6,NV,Options> UD_t;
     
-    JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
+    PINOCCHIO_JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
 
     typedef Eigen::Matrix<Scalar,NQ,1,Options> ConfigVector_t;
     typedef Eigen::Matrix<Scalar,NV,1,Options> TangentVector_t;
@@ -548,7 +548,7 @@ namespace pinocchio
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     typedef JointRevoluteTpl<_Scalar,_Options,axis> JointDerived;
     PINOCCHIO_JOINT_DATA_TYPEDEF_TEMPLATE;
-    JOINT_DATA_BASE_DEFAULT_ACCESSOR
+    PINOCCHIO_JOINT_DATA_BASE_DEFAULT_ACCESSOR
 
     Constraint_t S;
     Transformation_t M;

--- a/src/multibody/joint/joint-spherical-ZYX.hpp
+++ b/src/multibody/joint/joint-spherical-ZYX.hpp
@@ -256,7 +256,7 @@ namespace pinocchio
     typedef Eigen::Matrix<Scalar,NV,NV,Options> D_t;
     typedef Eigen::Matrix<Scalar,6,NV,Options> UD_t;
     
-    JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
+    PINOCCHIO_JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
 
     typedef Eigen::Matrix<Scalar,NQ,1,Options> ConfigVector_t;
     typedef Eigen::Matrix<Scalar,NV,1,Options> TangentVector_t;
@@ -276,7 +276,7 @@ namespace pinocchio
     EIGEN_MAKE_ALIGNED_OPERATOR_NEW
     typedef JointSphericalZYXTpl<_Scalar,_Options> JointDerived;
     PINOCCHIO_JOINT_DATA_TYPEDEF_TEMPLATE;
-    JOINT_DATA_BASE_DEFAULT_ACCESSOR
+    PINOCCHIO_JOINT_DATA_BASE_DEFAULT_ACCESSOR
     
     Constraint_t S;
     Transformation_t M;
@@ -298,7 +298,7 @@ namespace pinocchio
     
   }; // strcut JointDataSphericalZYXTpl
 
-  JOINT_CAST_TYPE_SPECIALIZATION(JointModelSphericalZYXTpl);
+  PINOCCHIO_JOINT_CAST_TYPE_SPECIALIZATION(JointModelSphericalZYXTpl);
   template<typename _Scalar, int _Options>
   struct JointModelSphericalZYXTpl
   : public JointModelBase< JointModelSphericalZYXTpl<_Scalar,_Options> >

--- a/src/multibody/joint/joint-spherical.hpp
+++ b/src/multibody/joint/joint-spherical.hpp
@@ -351,7 +351,7 @@ namespace pinocchio
     typedef Eigen::Matrix<Scalar,NV,NV,Options> D_t;
     typedef Eigen::Matrix<Scalar,6,NV,Options> UD_t;
     
-    JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
+    PINOCCHIO_JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
 
     typedef Eigen::Matrix<Scalar,NQ,1,Options> ConfigVector_t;
     typedef Eigen::Matrix<Scalar,NV,1,Options> TangentVector_t;
@@ -372,7 +372,7 @@ namespace pinocchio
     
     typedef JointSphericalTpl<_Scalar,_Options> JointDerived;
     PINOCCHIO_JOINT_DATA_TYPEDEF_TEMPLATE;
-    JOINT_DATA_BASE_DEFAULT_ACCESSOR
+    PINOCCHIO_JOINT_DATA_BASE_DEFAULT_ACCESSOR
 
     Constraint_t S;
     Transformation_t M;
@@ -393,7 +393,7 @@ namespace pinocchio
     
   }; // struct JointDataSphericalTpl
 
-  JOINT_CAST_TYPE_SPECIALIZATION(JointModelSphericalTpl);
+  PINOCCHIO_JOINT_CAST_TYPE_SPECIALIZATION(JointModelSphericalTpl);
   template<typename _Scalar, int _Options>
   struct JointModelSphericalTpl
   : public JointModelBase< JointModelSphericalTpl<_Scalar,_Options> >

--- a/src/multibody/joint/joint-translation.hpp
+++ b/src/multibody/joint/joint-translation.hpp
@@ -431,7 +431,7 @@ namespace pinocchio
     typedef Eigen::Matrix<Scalar,NV,NV,Options> D_t;
     typedef Eigen::Matrix<Scalar,6,NV,Options> UD_t;
     
-    JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
+    PINOCCHIO_JOINT_DATA_BASE_ACCESSOR_DEFAULT_RETURN_TYPE
 
     typedef Eigen::Matrix<Scalar,NQ,1,Options> ConfigVector_t;
     typedef Eigen::Matrix<Scalar,NV,1,Options> TangentVector_t;
@@ -453,7 +453,7 @@ namespace pinocchio
     
     typedef JointTranslationTpl<_Scalar,_Options> JointDerived;
     PINOCCHIO_JOINT_DATA_TYPEDEF_TEMPLATE;
-    JOINT_DATA_BASE_DEFAULT_ACCESSOR
+    PINOCCHIO_JOINT_DATA_BASE_DEFAULT_ACCESSOR
 
     Constraint_t S;
     Transformation_t M;
@@ -473,7 +473,7 @@ namespace pinocchio
     std::string shortname() const { return classname(); }
   }; // struct JointDataTranslationTpl
 
-  JOINT_CAST_TYPE_SPECIALIZATION(JointModelTranslationTpl);
+  PINOCCHIO_JOINT_CAST_TYPE_SPECIALIZATION(JointModelTranslationTpl);
   template<typename _Scalar, int _Options>
   struct JointModelTranslationTpl
   : public JointModelBase< JointModelTranslationTpl<_Scalar,_Options> >

--- a/src/parsers/lua.cpp
+++ b/src/parsers/lua.cpp
@@ -116,7 +116,7 @@ template<> pinocchio::Inertia LuaTableNode::getDefault<pinocchio::Inertia> (cons
   return result;
 }
 
-namespace se3
+namespace pinocchio
 {
   namespace lua
   {
@@ -330,4 +330,4 @@ namespace se3
 
   } // namespace lua
 
-} // namespace se3
+} // namespace pinocchio

--- a/src/utils/eigen-fix.hpp
+++ b/src/utils/eigen-fix.hpp
@@ -5,12 +5,12 @@
 #ifndef __pinocchio_utils_eigen_fix_hpp__
 #define __pinocchio_utils_eigen_fix_hpp__
 
-/// \brief Fix issue concerning 3.2.90 and more versions of Eigen that do not define size_of_xpr_at_compile_time structure.
 #if EIGEN_VERSION_AT_LEAST(3,2,90) && !EIGEN_VERSION_AT_LEAST(3,3,0)
 namespace pinocchio
 {
   namespace internal
   {
+    /// \brief Fix issue concerning 3.2.90 and more versions of Eigen that do not define size_of_xpr_at_compile_time structure.
     template<typename XprType> struct size_of_xpr_at_compile_time
     {
       enum { ret = Eigen::internal::size_at_compile_time<Eigen::internal::traits<XprType>::RowsAtCompileTime,Eigen::internal::traits<XprType>::ColsAtCompileTime>::ret };


### PR DESCRIPTION
This cleans the Doxygen output a bit by predefining a few macros during Doxygen parsing.
Also, I prefixed `PINOCCHIO_` to a few macros and changed the namespace `se3` to `pinocchio` in file [src/parsers/lua.cpp](https://github.com/stack-of-tasks/pinocchio/blob/devel/src/parsers/lua.cpp) (I don't know how ti was still `se3` in that file)