### PR TITLE
[Model] Total mass

### DIFF
--- a/bindings/python/algorithm/expose-com.cpp
+++ b/bindings/python/algorithm/expose-com.cpp
@@ -47,6 +47,16 @@ namespace pinocchio
     {
       using namespace Eigen;
       
+      bp::def("computeTotalMass",
+              (double (*)(const Model &))&computeTotalMass<double,0,JointCollectionDefaultTpl>,
+              bp::args("Model"),
+              "Compute the total mass of the model and return it.");
+
+      bp::def("computeTotalMass",
+              (double (*)(const Model &, Data &))&computeTotalMass<double,0,JointCollectionDefaultTpl>,
+              bp::args("Model", "Data"),
+              "Compute the total mass of the model, put it in data.mass[0] and return it.");
+
       bp::def("centerOfMass",com_0_proxy,
               bp::args("Model","Data",
                        "Joint configuration q (size Model::nq)"),

--- a/src/algorithm/center-of-mass.hpp
+++ b/src/algorithm/center-of-mass.hpp
@@ -11,6 +11,26 @@
 namespace pinocchio
 {
   
+  /// \brief Compute the total mass of the model and return it.
+  ///
+  /// \param[in] model The model structure of the rigid body system.
+  ///
+  /// \return Total mass of the model.
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  inline Scalar computeTotalMass(const ModelTpl<Scalar,Options,JointCollectionTpl> & model);
+
+  /// \brief Compute the total mass of the model, put it in data.mass[0] and return it.
+  ///
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  ///
+  /// \warning This method does not fill the whole data.mass vector. Only data.mass[0] is updated.
+  ///
+  /// \return Total mass of the model.
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  inline Scalar computeTotalMass(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                                 DataTpl<Scalar,Options,JointCollectionTpl> & data);
+
   ///
   /// \brief Computes the center of mass position of a given model according to a particular joint configuration.
   ///        The result is accessible through data.com[0] for the full body com and data.com[i] for the subtree supported by joint i (expressed in the joint i frame).

--- a/src/algorithm/center-of-mass.hxx
+++ b/src/algorithm/center-of-mass.hxx
@@ -13,6 +13,25 @@
 
 namespace pinocchio
 {
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  inline Scalar computeTotalMass(const ModelTpl<Scalar,Options,JointCollectionTpl> & model)
+  {
+    Scalar m = Scalar(0);
+    for(JointIndex i=1; i<(JointIndex)(model.njoints); ++i)
+    {
+      m += model.inertias[i].mass();
+    }
+    return m;
+  }
+
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  inline Scalar computeTotalMass(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                                 DataTpl<Scalar,Options,JointCollectionTpl> & data)
+  {
+    data.mass[0] = computeTotalMass(model);
+    return data.mass[0];
+  }
+
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
   inline const typename DataTpl<Scalar,Options,JointCollectionTpl>::Vector3 &
   centerOfMass(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,

--- a/unittest/com.cpp
+++ b/unittest/com.cpp
@@ -76,6 +76,39 @@ BOOST_AUTO_TEST_CASE ( test_com )
 //  std::cout << "M3 = [ " << data.M.topRows<3>() << " ];" << std::endl;
 }
 
+BOOST_AUTO_TEST_CASE ( test_mass )
+{
+  using namespace Eigen;
+  using namespace pinocchio;
+
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model);
+
+  double mass = computeTotalMass(model);
+
+  BOOST_CHECK(mass == mass); // checking it is not NaN
+
+  double mass_check = 0.0;
+  for(size_t i=1; i<(size_t)(model.njoints);++i)
+    mass_check += model.inertias[i].mass();
+
+  BOOST_CHECK_CLOSE(mass, mass_check, 1e-12);
+
+  pinocchio::Data data1(model);
+
+  double mass_data = computeTotalMass(model,data1);
+
+  BOOST_CHECK(mass_data == mass_data); // checking it is not NaN
+  BOOST_CHECK_CLOSE(mass, mass_data, 1e-12);
+  BOOST_CHECK_CLOSE(data1.mass[0], mass_data, 1e-12);
+
+  pinocchio::Data data2(model);
+  VectorXd q = VectorXd::Ones(model.nq);
+  q.middleRows<4> (3).normalize();
+  centerOfMass(model,data2,q);
+
+  BOOST_CHECK_CLOSE(data2.mass[0], mass, 1e-12);
+}
 
 //BOOST_AUTO_TEST_CASE ( test_timings )
 //{

--- a/unittest/python/bindings_com.py
+++ b/unittest/python/bindings_com.py
@@ -20,6 +20,22 @@ class TestComBindings(TestCase):
         qmax = np.matrix(np.full((self.model.nq,1),np.pi))
         self.q = pin.randomConfiguration(self.model,-qmax,qmax)
 
+    def test_mass(self):
+        mass = pin.computeTotalMass(self.model)
+        self.assertIsNot(mass, np.nan)
+
+        mass_check = sum([inertia.mass for inertia in self.model.inertias[1:] ])
+        self.assertApprox(mass,mass_check)
+
+        mass_data = pin.computeTotalMass(self.model,self.data)
+        self.assertIsNot(mass_data, np.nan)
+        self.assertApprox(mass,mass_data)
+        self.assertApprox(mass_data,self.data.mass[0])
+
+        data2 = self.model.createData()
+        pin.centerOfMass(self.model,data2,self.q)
+        self.assertApprox(mass,data2.mass[0])
+
     def test_Jcom_update3(self):
         Jcom = pin.jacobianCenterOfMass(self.model,self.data,self.q)
         self.assertFalse(np.isnan(Jcom).any())


### PR DESCRIPTION
Quite often, I find myself in need of just getting the total mass of the robot.
However, there is no simple one-shot algorithm to get it in Pinocchio.
The standard today is to check `data.mass[0]`. However, the only way of having the correct value is to first call an unrelated method which fills it as a side-effect, such as `centerOfMass`, possibly with meaningless arguments. This is annoying, and somewhat error-prone.

With this PR, I add an instance method `Model.getTotalMass()`.
I implemented it as an instance method inside the `Model` class because it is very simple, I did not know in which existing header to put it, and it seemed like an overkill to create a new one just for this.

I am returning the value, instead of putting it in `data.mass[0]`. This is partly due to the choice of developing this algorithm as an instance method, and partly because, as I am not filling the other values, it seemed inconsistent to just fill the zeroth element.