### PR TITLE
Fix python3 compatability for version number

### DIFF
--- a/bindings/python/pinocchio/__init__.py
+++ b/bindings/python/pinocchio/__init__.py
@@ -3,7 +3,7 @@
 #
 
 import numpy as np
-from pinocchio.robot_wrapper import RobotWrapper
+from .robot_wrapper import RobotWrapper
 from libpinocchio_pywrap import __version__
 
 from . import libpinocchio_pywrap as pin


### PR DESCRIPTION
This fixes  #716 for python3 following the spirit of 8586c58a2362d56.