### PR TITLE
[com] computeSubtreeMasses + CoM bindings

### DIFF
--- a/bindings/python/algorithm/expose-com.cpp
+++ b/bindings/python/algorithm/expose-com.cpp
@@ -15,22 +15,24 @@ namespace pinocchio
     BOOST_PYTHON_FUNCTION_OVERLOADS(jacobianCenterOfMassUpdate_overload,jacobianCenterOfMass,3,4)
 
     BOOST_PYTHON_FUNCTION_OVERLOADS(jacobianCenterOfMassNoUpdate_overload,jacobianCenterOfMass,2,3)
-    
+
     static SE3::Vector3
     com_0_proxy(const Model& model,
                 Data & data,
-                const Eigen::VectorXd & q)
+                const Eigen::VectorXd & q,
+                bool computeSubtreeComs = true)
     {
-      return centerOfMass(model,data,q,true);
+      return centerOfMass(model,data,q,computeSubtreeComs);
     }
     
     static SE3::Vector3
     com_1_proxy(const Model& model,
                 Data & data,
                 const Eigen::VectorXd & q,
-                const Eigen::VectorXd & v)
+                const Eigen::VectorXd & v,
+                bool computeSubtreeComs = true)
     {
-      return centerOfMass(model,data,q,v,true);
+      return centerOfMass(model,data,q,v,computeSubtreeComs);
     }
     
     static SE3::Vector3
@@ -38,10 +40,38 @@ namespace pinocchio
                 Data & data,
                 const Eigen::VectorXd & q,
                 const Eigen::VectorXd & v,
-                const Eigen::VectorXd & a)
+                const Eigen::VectorXd & a,
+                bool computeSubtreeComs = true)
     {
-      return centerOfMass(model,data,q,v,a,true);
+      return centerOfMass(model,data,q,v,a,computeSubtreeComs);
     }
+
+    static void
+    com_level_proxy(const Model & model,
+                    Data & data,
+                    int LEVEL,
+                    bool computeSubtreeComs = true)
+    {
+      centerOfMass(model,data,LEVEL,computeSubtreeComs);
+    }
+
+    static void
+    com_default_proxy(const Model & model,
+                Data & data,
+                bool computeSubtreeComs = true)
+    {
+      centerOfMass(model,data,computeSubtreeComs);
+    }
+
+    BOOST_PYTHON_FUNCTION_OVERLOADS(com_0_overload, com_0_proxy, 3, 4)
+
+    BOOST_PYTHON_FUNCTION_OVERLOADS(com_1_overload, com_1_proxy, 4, 5)
+
+    BOOST_PYTHON_FUNCTION_OVERLOADS(com_2_overload, com_2_proxy, 5, 6)
+
+    BOOST_PYTHON_FUNCTION_OVERLOADS(com_level_overload, com_level_proxy, 3, 4)
+
+    BOOST_PYTHON_FUNCTION_OVERLOADS(com_default_overload, com_default_proxy, 2, 3)
     
     void exposeCOM()
     {
@@ -62,26 +92,63 @@ namespace pinocchio
               bp::args("Model", "Data"),
               "Compute the mass of each kinematic subtree and store it in data.mass.");
 
-      bp::def("centerOfMass",com_0_proxy,
-              bp::args("Model","Data",
-                       "Joint configuration q (size Model::nq)"),
-              "Compute the center of mass, putting the result in Data and return it.");
-      
-      bp::def("centerOfMass",com_1_proxy,
-              bp::args("Model","Data",
-                       "Joint configuration q (size Model::nq)",
-                       "Joint velocity v (size Model::nv)"),
-              "Computes the center of mass position and velocuty by storing the result in Data"
-              "and returns the center of mass position of the full model expressed in the world frame.");
-      
-      bp::def("centerOfMass",com_2_proxy,
-              bp::args("Model","Data",
-                       "Joint configuration q (size Model::nq)",
-                       "Joint velocity v (size Model::nv)",
-                       "Joint acceleration a (size Model::nv)"),
-              "Computes the center of mass position, velocity and acceleration by storing the result in Data"
-              "and returns the center of mass position of the full model expressed in the world frame.");
-      
+      bp::def("centerOfMass",
+              com_0_proxy,
+              com_0_overload(
+                  bp::args("Model","Data",
+                           "Joint configuration q (size Model::nq)",
+                           "computeSubtreeComs If true, the algorithm computes also the center of mass of the subtrees"
+                  ),
+                  "Compute the center of mass, putting the result in Data and return it."
+              )[bp::return_value_policy<bp::return_by_value>()]
+      );
+
+      bp::def("centerOfMass",
+              com_1_proxy,
+              com_1_overload(
+                  bp::args("Model","Data",
+                           "Joint configuration q (size Model::nq)",
+                           "Joint velocity v (size Model::nv)",
+                           "computeSubtreeComs If true, the algorithm computes also the center of mass of the subtrees"
+                  ),
+                  "Computes the center of mass position and velocity by storing the result in Data."
+              )[bp::return_value_policy<bp::return_by_value>()]
+      );
+
+      bp::def("centerOfMass",
+              com_2_proxy,
+              com_2_overload(
+                  bp::args("Model","Data",
+                           "Joint configuration q (size Model::nq)",
+                           "Joint velocity v (size Model::nv)",
+                           "Joint acceleration a (size Model::nv)",
+                           "computeSubtreeComs If true, the algorithm computes also the center of mass of the subtrees"
+                  ),
+                  "Computes the center of mass position, velocity and acceleration by storing the result in Data."
+              )[bp::return_value_policy<bp::return_by_value>()]
+      );
+
+      bp::def("centerOfMass",
+              com_level_proxy,
+              com_level_overload(
+                  bp::args("Model","Data",
+                           "level if = 0, computes CoM position, if = 1, also computes CoM velocity and if = 2, also computes CoM acceleration",
+                           "computeSubtreeComs If true, the algorithm computes also the center of mass of the subtrees"
+                  ),
+                  "Computes the center of mass position, velocity and acceleration of a given model according to the current kinematic values contained in data and the requested level."
+              )[bp::return_value_policy<bp::return_by_value>()]
+      );
+
+      bp::def("centerOfMass",
+              com_default_proxy,
+              com_default_overload(
+                  bp::args("Model","Data",
+                           "computeSubtreeComs If true, the algorithm computes also the center of mass of the subtrees"
+                  ),
+                  "Computes the center of mass position, velocity and acceleration of a given model according to the current kinematic values contained in data."
+              )[bp::return_value_policy<bp::return_by_value>()]
+      );
+
       bp::def("jacobianCenterOfMass",
               (const Data::Matrix3x & (*)(const Model &, Data &, const Eigen::MatrixBase<Eigen::VectorXd> &, bool))&jacobianCenterOfMass<double,0,JointCollectionDefaultTpl,VectorXd>,
               jacobianCenterOfMassUpdate_overload(bp::args("Model","Data",
@@ -89,8 +156,8 @@ namespace pinocchio
                        "computeSubtreeComs If true, the algorithm computes also the center of mass of the subtrees"),
               "Computes the jacobian of the center of mass, puts the result in Data and return it.")[
               bp::return_value_policy<bp::return_by_value>()]);
-      
-            bp::def("jacobianCenterOfMass",
+
+      bp::def("jacobianCenterOfMass",
               (const Data::Matrix3x & (*)(const Model &, Data &, bool))&jacobianCenterOfMass<double,0,JointCollectionDefaultTpl>,
               jacobianCenterOfMassNoUpdate_overload(bp::args("Model","Data",
                        "computeSubtreeComs If true, the algorithm computes also the center of mass of the subtrees"),

--- a/bindings/python/algorithm/expose-com.cpp
+++ b/bindings/python/algorithm/expose-com.cpp
@@ -57,6 +57,11 @@ namespace pinocchio
               bp::args("Model", "Data"),
               "Compute the total mass of the model, put it in data.mass[0] and return it.");
 
+      bp::def("computeSubtreeMasses",
+              (void (*)(const Model &, Data &))&computeSubtreeMasses<double,0,JointCollectionDefaultTpl>,
+              bp::args("Model", "Data"),
+              "Compute the mass of each kinematic subtree and store it in data.mass.");
+
       bp::def("centerOfMass",com_0_proxy,
               bp::args("Model","Data",
                        "Joint configuration q (size Model::nq)"),

--- a/src/algorithm/center-of-mass.hpp
+++ b/src/algorithm/center-of-mass.hpp
@@ -25,11 +25,22 @@ namespace pinocchio
   /// \param[in] data The data structure of the rigid body system.
   ///
   /// \warning This method does not fill the whole data.mass vector. Only data.mass[0] is updated.
+  /// If you need the whole data.mass vector to be computed, use computeSubtreeMasses
   ///
   /// \return Total mass of the model.
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
   inline Scalar computeTotalMass(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                                  DataTpl<Scalar,Options,JointCollectionTpl> & data);
+
+  /// \brief Compute the mass of each kinematic subtree and store it in data.mass. The element mass[0] corresponds to the total mass of the model.
+  ///
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  ///
+  /// \note If you are only interested in knowing the total mass of the model, computeTotalMass will probably be slightly faster.
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  inline void computeSubtreeMasses(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                                   DataTpl<Scalar,Options,JointCollectionTpl> & data);
 
   ///
   /// \brief Computes the center of mass position of a given model according to a particular joint configuration.

--- a/src/algorithm/center-of-mass.hpp
+++ b/src/algorithm/center-of-mass.hpp
@@ -117,7 +117,7 @@ namespace pinocchio
                const bool computeSubtreeComs = true);
   
   ///
-  /// \brief Computes the center of mass position, velocity and acceleration of a given model according to the current kinematic values contained in data and the template value parameters.
+  /// \brief Computes the center of mass position, velocity and acceleration of a given model according to the current kinematic values contained in data and the requested level.
   ///        The result is accessible through data.com[0], data.vcom[0] and data.acom[0] for the full body com position and velocity.
   ///        And data.com[i] and data.vcom[i] for the subtree supported by joint i (expressed in the joint i frame).
   ///
@@ -125,7 +125,7 @@ namespace pinocchio
   ///
   /// \param[in] model The model structure of the rigid body system.
   /// \param[in] data The data structure of the rigid body system.
-  /// \param[in] LEVEL if =0, compytes CoM position, if =1, also computes CoM velocity and if =2, also computes CoM acceleration.
+  /// \param[in] LEVEL if = 0, computes CoM position, if = 1, also computes CoM velocity and if = 2, also computes CoM acceleration.
   /// \param[in] computeSubtreeComs If true, the algorithm computes also the center of mass of the subtrees.
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
@@ -148,7 +148,7 @@ namespace pinocchio
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
   inline void centerOfMass(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                            DataTpl<Scalar,Options,JointCollectionTpl> & data,
-                           const bool computeSubtreeComs)
+                           const bool computeSubtreeComs = true)
   { centerOfMass(model,data,2,computeSubtreeComs); }
   
   ///

--- a/src/algorithm/center-of-mass.hxx
+++ b/src/algorithm/center-of-mass.hxx
@@ -32,6 +32,24 @@ namespace pinocchio
     return data.mass[0];
   }
 
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  inline void computeSubtreeMasses(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                                   DataTpl<Scalar,Options,JointCollectionTpl> & data)
+  {
+    // Forward Step
+    for(JointIndex i=1; i<(JointIndex)(model.njoints); ++i)
+    {
+      data.mass[i] = model.inertias[i].mass();
+    }
+
+    // Backward Step
+    for(JointIndex i=(JointIndex)(model.njoints-1); i>0; --i)
+    {
+      const JointIndex & parent = model.parents[i];
+      data.mass[parent] += data.mass[i];
+    }
+  }
+
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
   inline const typename DataTpl<Scalar,Options,JointCollectionTpl>::Vector3 &
   centerOfMass(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,

--- a/src/multibody/data.hpp
+++ b/src/multibody/data.hpp
@@ -280,7 +280,7 @@ namespace pinocchio
     /// \brief Vector of subtree center of mass linear accelerations expressed in the root joint of the subtree. In other words, acom[j] is the CoM linear acceleration of the subtree supported by joint \f$ j \f$ and expressed in the joint frame \f$ j \f$. The element acom[0] corresponds to the acceleration of the CoM of the whole model expressed in the global frame.
     container::aligned_vector<Vector3> acom;
     
-    /// \brief Vector of subtree mass. In other words, mass[j] is the mass of the subtree supported by joint \f$ j \f$. The element mass[0] corrresponds to the total mass of the model.
+    /// \brief Vector of subtree mass. In other words, mass[j] is the mass of the subtree supported by joint \f$ j \f$. The element mass[0] corresponds to the total mass of the model.
     std::vector<Scalar> mass;
     
     /// \brief Jacobien of center of mass.

--- a/unittest/com.cpp
+++ b/unittest/com.cpp
@@ -110,6 +110,29 @@ BOOST_AUTO_TEST_CASE ( test_mass )
   BOOST_CHECK_CLOSE(data2.mass[0], mass, 1e-12);
 }
 
+BOOST_AUTO_TEST_CASE ( test_subtree_masses )
+{
+  using namespace Eigen;
+  using namespace pinocchio;
+
+  pinocchio::Model model;
+  pinocchio::buildModels::humanoidRandom(model);
+
+  pinocchio::Data data1(model);
+
+  computeSubtreeMasses(model,data1);
+
+  pinocchio::Data data2(model);
+  VectorXd q = VectorXd::Ones(model.nq);
+  q.middleRows<4> (3).normalize();
+  centerOfMass(model,data2,q);
+
+  for(size_t i=0; i<(size_t)(model.njoints);++i)
+  {
+    BOOST_CHECK_CLOSE(data1.mass[i], data2.mass[i], 1e-12);
+  }
+}
+
 //BOOST_AUTO_TEST_CASE ( test_timings )
 //{
 //  using namespace Eigen;

--- a/unittest/com.cpp
+++ b/unittest/com.cpp
@@ -39,16 +39,16 @@ BOOST_AUTO_TEST_CASE ( test_com )
   Vector3d com = centerOfMass(model,data,q);
   BOOST_CHECK(data.com[0].isApprox(getComFromCrba(model,data), 1e-12));
 
-	/* Test COM against Jcom (both use different way of compute the COM. */
+	/* Test COM against Jcom (both use different way to compute the COM). */
   com = centerOfMass(model,data,q);
   jacobianCenterOfMass(model,data,q);
   BOOST_CHECK(com.isApprox(data.com[0], 1e-12));
 
-	/* Test COM against Jcom (both use different way of compute the COM. */
+	/* Test COM against Jcom (both use different way to compute the COM). */
   centerOfMass(model,data,q,v,a);
   BOOST_CHECK(com.isApprox(data.com[0], 1e-12));
 
-  /* Test vCoM againt nle algorithm without gravity field */
+  /* Test vCoM against nle algorithm without gravity field */
   a.setZero();
   model.gravity.setZero();
   centerOfMass(model,data,q,v,a);
@@ -61,12 +61,12 @@ BOOST_AUTO_TEST_CASE ( test_com )
   Eigen::MatrixXd Jcom = jacobianCenterOfMass(model,data,q);
   BOOST_CHECK(data.Jcom.isApprox(getJacobianComFromCrba(model,data), 1e-12));
 
-  /* Test CoM vecolity againt jacobianCenterOfMass */
+  /* Test CoM velocity againt jacobianCenterOfMass */
   BOOST_CHECK((Jcom * v).isApprox(data.vcom[0], 1e-12));
   
   
   centerOfMass(model,data,q,v);
-  /* Test CoM vecolity againt jacobianCenterOfMass */
+  /* Test CoM velocity againt jacobianCenterOfMass */
   BOOST_CHECK((Jcom * v).isApprox(data.vcom[0], 1e-12));
 
 

--- a/unittest/python/bindings_com.py
+++ b/unittest/python/bindings_com.py
@@ -45,6 +45,70 @@ class TestComBindings(TestCase):
         for i in range(self.model.njoints):
             self.assertApprox(self.data.mass[i],data2.mass[i])
 
+    def test_com_0(self):
+        c0 = pin.centerOfMass(self.model,self.data,self.q)
+
+        data2 = self.model.createData()
+        pin.forwardKinematics(self.model,data2,self.q)
+        pin.centerOfMass(self.model,data2,0)
+
+        self.assertApprox(c0,data2.com[0])
+        self.assertApprox(self.data.com[0],data2.com[0])
+
+    def test_com_1(self):
+        v = rand(self.model.nv)
+        pin.centerOfMass(self.model,self.data,self.q,v)
+
+        data2 = self.model.createData()
+        pin.forwardKinematics(self.model,data2,self.q,v)
+        pin.centerOfMass(self.model,data2,1)
+
+        data3 = self.model.createData()
+        pin.centerOfMass(self.model,data3,self.q)
+
+        self.assertApprox(self.data.com[0],data2.com[0])
+        self.assertApprox(self.data.vcom[0],data2.vcom[0])
+
+        self.assertApprox(self.data.com[0],data3.com[0])
+
+    def test_com_2(self):
+        v = rand(self.model.nv)
+        a = rand(self.model.nv)
+        pin.centerOfMass(self.model,self.data,self.q,v,a)
+
+        data2 = self.model.createData()
+        pin.forwardKinematics(self.model,data2,self.q,v,a)
+        pin.centerOfMass(self.model,data2,2)
+
+        data3 = self.model.createData()
+        pin.centerOfMass(self.model,data3,self.q)
+
+        data4 = self.model.createData()
+        pin.centerOfMass(self.model,data4,self.q,v)
+
+        self.assertApprox(self.data.com[0],data2.com[0])
+        self.assertApprox(self.data.vcom[0],data2.vcom[0])
+        self.assertApprox(self.data.acom[0],data2.acom[0])
+
+        self.assertApprox(self.data.com[0],data3.com[0])
+
+        self.assertApprox(self.data.com[0],data4.com[0])
+        self.assertApprox(self.data.vcom[0],data4.vcom[0])
+
+    def test_com_default(self):
+        v = rand(self.model.nv)
+        a = rand(self.model.nv)
+        pin.centerOfMass(self.model,self.data,self.q,v,a)
+
+        data2 = self.model.createData()
+        pin.forwardKinematics(self.model,data2,self.q,v,a)
+        pin.centerOfMass(self.model,data2)
+
+        for i in range(self.model.njoints):
+            self.assertApprox(self.data.com[i],data2.com[i])
+            self.assertApprox(self.data.vcom[i],data2.vcom[i])
+            self.assertApprox(self.data.acom[i],data2.acom[i])
+
     def test_Jcom_update3(self):
         Jcom = pin.jacobianCenterOfMass(self.model,self.data,self.q)
         self.assertFalse(np.isnan(Jcom).any())

--- a/unittest/python/bindings_com.py
+++ b/unittest/python/bindings_com.py
@@ -36,6 +36,15 @@ class TestComBindings(TestCase):
         pin.centerOfMass(self.model,data2,self.q)
         self.assertApprox(mass,data2.mass[0])
 
+    def test_subtree_masses(self):
+        pin.computeSubtreeMasses(self.model,self.data)
+
+        data2 = self.model.createData()
+        pin.centerOfMass(self.model,data2,self.q)
+
+        for i in range(self.model.njoints):
+            self.assertApprox(self.data.mass[i],data2.mass[i])
+
     def test_Jcom_update3(self):
         Jcom = pin.jacobianCenterOfMass(self.model,self.data,self.q)
         self.assertFalse(np.isnan(Jcom).any())


### PR DESCRIPTION
Related to #724.
This PR adds an algorithm called `computeSubtreeMasses` which fills the whole `data.mass` vector.
An alternative implementation would be providing an optional boolean to `computeTotalMass(model,data)`, but I find the current interface is neater and clearer.

Also, I've exposed all missing overloads of `centerOfMass`.