### PR TITLE
[computeSubtreeMasses] Fix bug for data.mass[0]

### DIFF
--- a/src/algorithm/center-of-mass.hxx
+++ b/src/algorithm/center-of-mass.hxx
@@ -36,6 +36,8 @@ namespace pinocchio
   inline void computeSubtreeMasses(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                                    DataTpl<Scalar,Options,JointCollectionTpl> & data)
   {
+    data.mass[0] = Scalar(0);
+
     // Forward Step
     for(JointIndex i=1; i<(JointIndex)(model.njoints); ++i)
     {


### PR DESCRIPTION
Correcting a bug introduced in #736