### PR TITLE
Revert "[CI] work with hpp-fcl v1, which is not yet in the binary repository"

### DIFF
--- a/.ci-deps
+++ b/.ci-deps
@@ -1,1 +1,0 @@
-path/hpp-fcl

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,6 @@ cache:
     - git pull
     - cd pinocchio
     - make checkout MASTER_REPOSITORY="git ${CI_PROJECT_DIR}/.git"
-    - /ci_deps.sh
     - make install
     - cd $(make show-var VARNAME=WRKSRC)
     - make test
@@ -66,7 +65,6 @@ robotpkg-pinocchio-18.04-debug:
     - cd ..
     - cd py-pinocchio
     - make checkout MASTER_REPOSITORY="git ${CI_PROJECT_DIR}/.git"
-    - /ci_deps.sh
     - make install
     - cd $(make show-var VARNAME=WRKSRC)
     - make test
@@ -144,7 +142,6 @@ doc-coverage:
     - echo -e 'CXXFLAGS+= --coverage\nLDFLAGS+= --coverage\nPKG_DEFAULT_OPTIONS= debug' >> /opt/openrobots/etc/robotpkg.conf
   after_script:
     - cd /root/robotpkg/math/py-pinocchio
-    - /ci_deps.sh
     - cd $(make show-var VARNAME=WRKSRC)
     - make doc
     - mv doc/doxygen-html ${CI_PROJECT_DIR}


### PR DESCRIPTION
This reverts commit eb73311af732c6efbbbeec4eade59f37cdc03ad9, because hpp-fcl v1 is in the binary respository now.