### PR TITLE
[serialization] [python] Fix compilation bug in Python on (old) Mac OS and FreeBSD

### DIFF
--- a/src/serialization/archive.hpp
+++ b/src/serialization/archive.hpp
@@ -18,6 +18,17 @@
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 
+/* undo some macro defs in pyport.h */
+#if defined(_PY_PORT_CTYPE_UTF8_ISSUE)
+#undef isalnum
+#undef isalpha
+#undef islower
+#undef isspace
+#undef isupper
+#undef tolower
+#undef toupper
+#endif
+
 // Handle NAN inside TXT or XML archives
 #include <boost/math/special_functions/nonfinite_num_facets.hpp>
 


### PR DESCRIPTION
I had a hard time solving this.

I'm on Mac OSX 10.11 (El Capitan).
I found this fix was necessary for the serialization bindings to compile.

It originates from a known [bug](https://bugs.python.org/issue10910) in file pyport.h. My solution was inspired from [here](https://gitlab.kitware.com/vtk/vtk/commit/a4fa4480994822c957d624762c55f29a41634f21#42ca2d64cee3c4b8f3adde83c1959ecd974599cc).

However, my Mac version is pretty old and the bug is marked as "resolved". So I think it should not be a problem on newer versions.

@jcarpent, I know you often work on Mac. Which version are you on? Do you need the fix?

If the fix is needed on the latest Mac versions, then it should definitely be added.

If it is not needed on the latest Mac versions, it may still be added as a way of providing support for old versions, up to you to decide.