### PR TITLE
add computation of dhg/dq inside computecentroidaldynamicsderivatives

### DIFF
--- a/bindings/python/algorithm/expose-centroidal-derivatives.cpp
+++ b/bindings/python/algorithm/expose-centroidal-derivatives.cpp
@@ -19,15 +19,15 @@ namespace pinocchio
                                                          const Eigen::VectorXd & a)
     {
       typedef Data::Matrix6x Matrix6x;
-      
+      Matrix6x partialh_dq(Matrix6x::Zero(6,model.nv));
       Matrix6x partial_dq(Matrix6x::Zero(6,model.nv));
       Matrix6x partial_dv(Matrix6x::Zero(6,model.nv));
       Matrix6x partial_da(Matrix6x::Zero(6,model.nv));
       
       computeCentroidalDynamicsDerivatives(model,data,q, v, a,
-                                           partial_dq, partial_dv, partial_da);
+                                           partialh_dq, partial_dq, partial_dv, partial_da);
       
-      return bp::make_tuple(partial_dq,partial_dv,partial_da);
+      return bp::make_tuple(partialh_dq, partial_dq,partial_dv,partial_da);
     }
     
     bp::tuple getCentroidalDynamicsDerivatives_proxy(const Model & model,

--- a/bindings/python/algorithm/expose-centroidal-derivatives.cpp
+++ b/bindings/python/algorithm/expose-centroidal-derivatives.cpp
@@ -35,12 +35,13 @@ namespace pinocchio
     {
       typedef Data::Matrix6x Matrix6x;
 
+      Matrix6x partialh_dq(Matrix6x::Zero(6,model.nv));
       Matrix6x partial_dq(Matrix6x::Zero(6,model.nv));
       Matrix6x partial_dv(Matrix6x::Zero(6,model.nv));
       Matrix6x partial_da(Matrix6x::Zero(6,model.nv));
 
-      getCentroidalDynamicsDerivatives(model,data, partial_dq, partial_dv, partial_da);
-      return bp::make_tuple(partial_dq,partial_dv,partial_da);
+      getCentroidalDynamicsDerivatives(model,data, partialh_dq, partial_dq, partial_dv, partial_da);
+      return bp::make_tuple(partialh_dq,partial_dq,partial_dv,partial_da);
     }
 
     void exposeCentroidalDerivatives()

--- a/bindings/python/multibody/geometry-data.hpp
+++ b/bindings/python/multibody/geometry-data.hpp
@@ -10,6 +10,7 @@
 
 #include "pinocchio/bindings/python/utils/eigen_container.hpp"
 #include "pinocchio/bindings/python/utils/printable.hpp"
+#include "pinocchio/bindings/python/utils/copyable.hpp"
 
 EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(pinocchio::GeometryData)
 
@@ -34,6 +35,7 @@ namespace pinocchio
         .def(bp::init<const GeomIndex &, const GeomIndex &>(bp::args("co1 (index)", "co2 (index)"),
                                                         "Initializer of collision pair."))
         .def(PrintableVisitor<CollisionPair>())
+        .def(CopyableVisitor<CollisionPair>())
         .def_readwrite("first",&CollisionPair::first)
         .def_readwrite("second",&CollisionPair::second);
         

--- a/src/algorithm/centroidal-derivatives.hpp
+++ b/src/algorithm/centroidal-derivatives.hpp
@@ -77,10 +77,11 @@ namespace pinocchio
   ///         For information, the centroidal momentum matrix is equivalent to dhdot_da.
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl,
-           typename Matrix6xLike1, typename Matrix6xLike2, typename Matrix6xLike3>
+           typename Matrix6xLike0,typename Matrix6xLike1, typename Matrix6xLike2, typename Matrix6xLike3>
   inline void
   getCentroidalDynamicsDerivatives(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                                    DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                                   const Eigen::MatrixBase<Matrix6xLike1> & dh_dq,
                                    const Eigen::MatrixBase<Matrix6xLike1> & dhdot_dq,
                                    const Eigen::MatrixBase<Matrix6xLike2> & dhdot_dv,
                                    const Eigen::MatrixBase<Matrix6xLike3> & dhdot_da);

--- a/src/algorithm/centroidal-derivatives.hpp
+++ b/src/algorithm/centroidal-derivatives.hpp
@@ -34,6 +34,7 @@ namespace pinocchio
   /// \param[in] q The joint configuration vector (dim model.nq).
   /// \param[in] v The joint velocity vector (dim model.nv).
   /// \param[in] a The joint acceleration vector (dim model.nv).
+  /// \param[out] dh_dq The partial derivative of the centroidal momentum with respect to the configuration vector (dim 6 x model.nv).
   /// \param[out] dhdot_dq The partial derivative of the centroidal dynamics with respect to the configuration vector (dim 6 x model.nv).
   /// \param[out] dhdot_dv The partial derivative of the centroidal dynamics with respect to the velocity vector (dim 6 x model.nv).
   /// \param[out] dhdot_da The partial derivative of the centroidal dynamics with respect to the acceleration vector (dim 6 x model.nv).
@@ -43,13 +44,14 @@ namespace pinocchio
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl,
            typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2,
-           typename Matrix6xLike1, typename Matrix6xLike2, typename Matrix6xLike3>
+           typename Matrix6xLike0, typename Matrix6xLike1, typename Matrix6xLike2, typename Matrix6xLike3>
   inline void
   computeCentroidalDynamicsDerivatives(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                                        DataTpl<Scalar,Options,JointCollectionTpl> & data,
                                        const Eigen::MatrixBase<ConfigVectorType> & q,
                                        const Eigen::MatrixBase<TangentVectorType1> & v,
                                        const Eigen::MatrixBase<TangentVectorType2> & a,
+                                       const Eigen::MatrixBase<Matrix6xLike0> & dh_dq,
                                        const Eigen::MatrixBase<Matrix6xLike1> & dhdot_dq,
                                        const Eigen::MatrixBase<Matrix6xLike2> & dhdot_dv,
                                        const Eigen::MatrixBase<Matrix6xLike3> & dhdot_da);

--- a/src/algorithm/centroidal-derivatives.hxx
+++ b/src/algorithm/centroidal-derivatives.hxx
@@ -142,6 +142,7 @@ namespace pinocchio
       ColsBlock dVdq_cols = jmodel.jointCols(data.dVdq);
       ColsBlock dAdq_cols = jmodel.jointCols(data.dAdq);
       ColsBlock dAdv_cols = jmodel.jointCols(data.dAdv);
+      ColsBlock dHdq_cols = jmodel.jointCols(data.dHdq);
       ColsBlock dFdq_cols = jmodel.jointCols(data.dFdq);
       ColsBlock dFdv_cols = jmodel.jointCols(data.dFdv);
       ColsBlock dFda_cols = jmodel.jointCols(data.dFda);
@@ -171,6 +172,9 @@ namespace pinocchio
       data.doYcrb[parent] += data.doYcrb[i];
       data.oh[parent] += data.oh[i];
       data.of[parent] += data.of[i];
+
+      forceSet::motionActions(J_cols, data.oh[i], dHdq_cols);
+      motionSet::inertiaAction<ADDTO>(data.oYcrb[i], dVdq_cols, dHdq_cols);
     }
     
     template<typename Min, typename Mout>
@@ -211,13 +215,14 @@ namespace pinocchio
   
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl,
   typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2,
-  typename Matrix6xLike1, typename Matrix6xLike2, typename Matrix6xLike3>
+  typename Matrix6xLike0, typename Matrix6xLike1, typename Matrix6xLike2, typename Matrix6xLike3>
   inline void
   computeCentroidalDynamicsDerivatives(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                                        DataTpl<Scalar,Options,JointCollectionTpl> & data,
                                        const Eigen::MatrixBase<ConfigVectorType> & q,
                                        const Eigen::MatrixBase<TangentVectorType1> & v,
                                        const Eigen::MatrixBase<TangentVectorType2> & a,
+                                       const Eigen::MatrixBase<Matrix6xLike0> & dh_dq,
                                        const Eigen::MatrixBase<Matrix6xLike1> & dhdot_dq,
                                        const Eigen::MatrixBase<Matrix6xLike2> & dhdot_dv,
                                        const Eigen::MatrixBase<Matrix6xLike3> & dhdot_da)
@@ -225,6 +230,8 @@ namespace pinocchio
     assert(q.size() == model.nq && "The joint configuration vector is not of right size");
     assert(v.size() == model.nv && "The joint velocity vector is not of right size");
     assert(a.size() == model.nv && "The joint acceleration vector is not of right size");
+    assert(dh_dq.cols() == model.nv);
+    assert(dh_dq.rows() == 6);
     assert(dhdot_dq.cols() == model.nv);
     assert(dhdot_dq.rows() == 6);
     assert(dhdot_dv.cols() == model.nv);
@@ -278,6 +285,7 @@ namespace pinocchio
     data.Ig.inertia() = Ytot.inertia();
     
     // Compute the partial derivatives
+    translateForceSet(data.dHdq,com,PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike0,dh_dq));
     translateForceSet(data.dFdq,com,PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike1,dhdot_dq));
     translateForceSet(data.dFdv,com,PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike2,dhdot_dv));
     translateForceSet(data.dFda,com,PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike3,dhdot_da));

--- a/src/algorithm/centroidal-derivatives.hxx
+++ b/src/algorithm/centroidal-derivatives.hxx
@@ -173,7 +173,7 @@ namespace pinocchio
       data.oh[parent] += data.oh[i];
       data.of[parent] += data.of[i];
 
-      forceSet::motionActions(J_cols, data.oh[i], dHdq_cols);
+      motionSet::act(J_cols, data.oh[i], dHdq_cols);
       motionSet::inertiaAction<ADDTO>(data.oYcrb[i], dVdq_cols, dHdq_cols);
     }
     
@@ -342,13 +342,13 @@ namespace pinocchio
         data.oYcrb[0] += data.oYcrb[i];
       }
 
-      forceSet::motionActions(J_cols, data.oh[i], dHdq_cols);
+      motionSet::act(J_cols, data.oh[i], dHdq_cols);
       motionSet::inertiaAction<ADDTO>(data.oYcrb[i], dVdq_cols, dHdq_cols);
     }
   }; // struct GetCentroidalDynDerivativesBackwardStep
   
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl,
-           typename Matrix6xLike0,typename Matrix6xLike1, typename Matrix6xLike2, typename Matrix6xLike3>
+           typename Matrix6xLike0, typename Matrix6xLike1, typename Matrix6xLike2, typename Matrix6xLike3>
   inline void
   getCentroidalDynamicsDerivatives(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                                    DataTpl<Scalar,Options,JointCollectionTpl> & data,

--- a/src/multibody/data.hpp
+++ b/src/multibody/data.hpp
@@ -143,6 +143,9 @@ namespace pinocchio
     
     /// \brief The Coriolis matrix (a square matrix of dim model.nv).
     MatrixXs C;
+
+    /// \brief Variation of the spatial momenta with respect to the joint configuration.
+    Matrix6x dHdq;
     
     /// \brief Variation of the forceset with respect to the joint configuration.
     Matrix6x dFdq;

--- a/src/multibody/data.hxx
+++ b/src/multibody/data.hxx
@@ -44,6 +44,7 @@ namespace pinocchio
   , M(model.nv,model.nv)
   , Minv(model.nv,model.nv)
   , C(model.nv,model.nv)
+  , dHdq(6,model.nv)
   , dFdq(6,model.nv)
   , dFdv(6,model.nv)
   , dFda(6,model.nv)

--- a/unittest/centroidal-derivatives.cpp
+++ b/unittest/centroidal-derivatives.cpp
@@ -194,14 +194,15 @@ BOOST_AUTO_TEST_CASE(test_retrieve_centroidal_derivatives)
   
   pinocchio::Data::Matrix6x
     dh_dq(6,model.nv), dhdot_dq(6,model.nv), dhdot_dv(6,model.nv), dhdot_da(6,model.nv);
-  pinocchio::Data::Matrix6x dhdot_dq_ref(6,model.nv), dhdot_dv_ref(6,model.nv), dhdot_da_ref(6,model.nv);
+  pinocchio::Data::Matrix6x
+    dh_dq_ref(6,model.nv), dhdot_dq_ref(6,model.nv), dhdot_dv_ref(6,model.nv), dhdot_da_ref(6,model.nv);
   
   pinocchio::computeCentroidalDynamicsDerivatives(model,data_ref,q,v,a,
-                                                  dh_dq, dhdot_dq_ref,dhdot_dv_ref,dhdot_da_ref);
+                                                  dh_dq_ref, dhdot_dq_ref,dhdot_dv_ref,dhdot_da_ref);
   
   pinocchio::computeRNEADerivatives(model,data,q,v,a);
   pinocchio::getCentroidalDynamicsDerivatives(model,data,
-                                        dhdot_dq,dhdot_dv,dhdot_da);
+                                              dh_dq, dhdot_dq,dhdot_dv,dhdot_da);
   
   BOOST_CHECK(data.J.isApprox(data_ref.J));
   
@@ -222,7 +223,7 @@ BOOST_AUTO_TEST_CASE(test_retrieve_centroidal_derivatives)
   BOOST_CHECK(data.Fcrb[0].isApprox(data_ref.dFdq));
   BOOST_CHECK(data.dFdv.isApprox(data_ref.dFdv));
   BOOST_CHECK(data.dFda.isApprox(data_ref.dFda));
-  
+  BOOST_CHECK(dh_dq.isApprox(dh_dq_ref));
   BOOST_CHECK(dhdot_dq.isApprox(dhdot_dq_ref));
   BOOST_CHECK(dhdot_dv.isApprox(dhdot_dv_ref));
   BOOST_CHECK(dhdot_da.isApprox(dhdot_da_ref));


### PR DESCRIPTION
I extend the forceSet::motionAction to include the case when multiple column vectors are being applied to a single force vector.

Except that, the implementation is easy to understand.