### PR TITLE
[bindings] copyable data

### DIFF
--- a/bindings/python/multibody/data.hpp
+++ b/bindings/python/multibody/data.hpp
@@ -12,6 +12,8 @@
 #include "pinocchio/bindings/python/utils/std-vector.hpp"
 #include "pinocchio/bindings/python/utils/std-aligned-vector.hpp"
 
+#include "pinocchio/bindings/python/utils/copyable.hpp"
+
 EIGENPY_DEFINE_STRUCT_ALLOCATOR_SPECIALIZATION(pinocchio::Data)
 
 namespace pinocchio
@@ -124,7 +126,8 @@ namespace pinocchio
                          "Articulated rigid body data.\n"
                          "It contains all the data that can be modified by the algorithms.",
                          bp::no_init)
-        .def(DataPythonVisitor());
+        .def(DataPythonVisitor())
+        .def(CopyableVisitor<Data>());
         StdAlignedVectorPythonVisitor<Vector3, true>::expose("StdVec_vec3d");
         StdAlignedVectorPythonVisitor<Matrix6x, true>::expose("StdVec_Matrix6x");
         StdVectorPythonVisitor<int>::expose("StdVec_int");

--- a/unittest/python/CMakeLists.txt
+++ b/unittest/python/CMakeLists.txt
@@ -1,5 +1,6 @@
 SET(${PROJECT_NAME}_PYTHON_TESTS
   bindings
+  bindings_data
   bindings_com
   bindings_com_velocity_derivatives
   bindings_dynamics

--- a/unittest/python/bindings_data.py
+++ b/unittest/python/bindings_data.py
@@ -1,0 +1,22 @@
+import unittest
+import pinocchio as pin
+
+from test_case import TestCase
+
+class TestData(TestCase):
+    def setUp(self):
+        self.model = pin.buildSampleModelHumanoidRandom()
+        self.data = self.model.createData()
+
+    def test_copy(self):
+        data2 = self.data.copy()
+        q = pin.neutral(self.model)
+        pin.forwardKinematics(self.model,data2,q)
+        jointId = self.model.njoints-1
+        self.assertNotEqual(self.data.oMi[jointId], data2.oMi[jointId])
+
+        data3 = data2.copy()
+        self.assertEqual(data2.oMi[jointId], data3.oMi[jointId])
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Allows to copy a `Data` object in Python by doing `data.copy()`.