### PR TITLE
Fix bug in computation of dVdq and dAdq

### DIFF
--- a/src/algorithm/centroidal-derivatives.hxx
+++ b/src/algorithm/centroidal-derivatives.hxx
@@ -85,17 +85,16 @@ namespace pinocchio
       J_cols = data.oMi[i].act(jdata.S());
       motionSet::motionAction(ov,J_cols,dJ_cols);
       motionSet::motionAction(data.oa[parent],J_cols,dAdq_cols);
-      
+      dAdv_cols = dJ_cols;      
       if(parent > 0)
       {
-        motionSet::motionAction<ADDTO>(data.ov[parent],dJ_cols,dAdq_cols);
-        dVdq_cols = dJ_cols;
-        dAdv_cols.noalias() = (Scalar)2*dJ_cols;
+        motionSet::motionAction(data.ov[parent],J_cols,dVdq_cols);
+        motionSet::motionAction<ADDTO>(data.ov[parent],dVdq_cols,dAdq_cols);
+        dAdv_cols.noalias() += dVdq_cols;
       }
       else
       {
         dVdq_cols.setZero();
-        dAdv_cols = dJ_cols;
       }
       
       // computes variation of inertias

--- a/src/algorithm/rnea-derivatives.hxx
+++ b/src/algorithm/rnea-derivatives.hxx
@@ -223,17 +223,16 @@ namespace pinocchio
       J_cols = data.oMi[i].act(jdata.S());
       motionSet::motionAction(ov,J_cols,dJ_cols);
       motionSet::motionAction(data.oa_gf[parent],J_cols,dAdq_cols);
-
+      dAdv_cols = dJ_cols;
       if(parent > 0)
       {
-        motionSet::motionAction<ADDTO>(data.ov[parent],dJ_cols,dAdq_cols);
-        dVdq_cols = dJ_cols;
-        dAdv_cols.noalias() = (Scalar)2*dJ_cols;
+        motionSet::motionAction(data.ov[parent],J_cols,dVdq_cols);
+        motionSet::motionAction<ADDTO>(data.ov[parent],dVdq_cols,dAdq_cols);
+        dAdv_cols.noalias() += dVdq_cols;
       }
       else
       {
         dVdq_cols.setZero();
-        dAdv_cols = dJ_cols;
       }
 
       // computes variation of inertias

--- a/unittest/centroidal-derivatives.cpp
+++ b/unittest/centroidal-derivatives.cpp
@@ -4,6 +4,7 @@
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
+#include "pinocchio/multibody/joint/joint-spherical.hpp"
 #include "pinocchio/algorithm/crba.hpp"
 #include "pinocchio/algorithm/centroidal.hpp"
 #include "pinocchio/algorithm/centroidal-derivatives.hpp"
@@ -50,7 +51,7 @@ static void addJointAndBody(pinocchio::Model & model,
       
       model.appendBodyToJoint(idx,Inertia::Random(),SE3::Identity());
       model.addBodyFrame(name + "_body", idx);
-      }
+}
 
 BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
   
@@ -58,6 +59,10 @@ BOOST_AUTO_TEST_CASE(test_centroidal_derivatives)
 {
   pinocchio::Model model;
   pinocchio::buildModels::humanoidRandom(model);
+  const std::string parent_name = model.names[model.njoints-1];
+  const std::string joint_name = "ee_spherical_joint";
+  addJointAndBody(model, pinocchio::JointModelSpherical(), parent_name , joint_name);
+  
   pinocchio::Data data(model), data_ref(model);
   
   model.lowerPositionLimit.head<7>().fill(-1.);


### PR DESCRIPTION
There is a small bug in the computation of dVdq and dAdq.

To explain using dVdq as the example, the computation of dVdq for the ith joint is given by ov[parent].cross(Ji), where Ji is the jacobian of the ith joint.

The current implementation of dVdq is done using dJ, which is ov[i].cross(Ji).

Normally, in most cases, the two are equal. The difference between the two is given by an S x S term, which is zero for all one DoF joint. And when we have a free flyer as the first joint, ov[parent] is zero, so we don't see the effect of S x S term again. This is why there are no problems with the unittest.

You can see the problem when you add a spherical joint ( or any joint in which SxS is not zero, such as freeflyer) at a position other than root joint. I added the spherical joint in centroidal-derivatives unittest, and the test does not pass anymore.

This PR takes care of this.

Surprisingly, the implementation in aba-derivatives is correct. The problem is only in the centroidal-derivatives and rnea-derivatives. So I have kept the same implementation for all three.