### PR TITLE
Add support for LOCAL_CARTESIAN_ORIENTED in jacobian computation

### DIFF
--- a/bindings/python/module.cpp
+++ b/bindings/python/module.cpp
@@ -44,6 +44,7 @@ BOOST_PYTHON_MODULE(libpinocchio_pywrap)
   bp::enum_< ::pinocchio::ReferenceFrame >("ReferenceFrame")
   .value("WORLD",::pinocchio::WORLD)
   .value("LOCAL",::pinocchio::LOCAL)
+  .value("LOCAL_CARTESIAN_ORIENTED",::pinocchio::LOCAL_CARTESIAN_ORIENTED)
   ;
 
   exposeModel();

--- a/bindings/python/module.cpp
+++ b/bindings/python/module.cpp
@@ -44,7 +44,7 @@ BOOST_PYTHON_MODULE(libpinocchio_pywrap)
   bp::enum_< ::pinocchio::ReferenceFrame >("ReferenceFrame")
   .value("WORLD",::pinocchio::WORLD)
   .value("LOCAL",::pinocchio::LOCAL)
-  .value("LOCAL_CARTESIAN_ORIENTED",::pinocchio::LOCAL_CARTESIAN_ORIENTED)
+  .value("LOCAL_WORLD_ALIGNED",::pinocchio::LOCAL_WORLD_ALIGNED)
   ;
 
   exposeModel();

--- a/src/algorithm/frames.hxx
+++ b/src/algorithm/frames.hxx
@@ -125,11 +125,7 @@ namespace pinocchio
     if(rf == WORLD)
     {
       getJointJacobian(model,data,joint_id,WORLD,PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike,J));
-      return;
-    }
-    
-    if(rf == LOCAL)
-    {
+    } else if(rf == LOCAL || rf == LOCAL_CARTESIAN_ORIENTED) {
       Matrix6xLike & J_ = PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike,J);
       const typename Data::SE3 & oMframe = data.oMf[frame_id];
       const int colRef = nv(model.joints[joint_id])+idx_v(model.joints[joint_id])-1;
@@ -138,7 +134,13 @@ namespace pinocchio
       {
         J_.col(j) = oMframe.actInv(Motion(data.J.col(j))).toVector(); // TODO: use MotionRef
       }
-      return;
+
+      if (rf == LOCAL_CARTESIAN_ORIENTED) {
+        Matrix6xLike J_tmp;
+        J_tmp.resize(6, model.nv);
+        J_tmp = SE3(data.oMf[frame_id].rotation(), Eigen::Vector3d::Zero()).toActionMatrix() * J;
+        J_ = J_tmp;
+      }
     }
   }
   

--- a/src/algorithm/frames.hxx
+++ b/src/algorithm/frames.hxx
@@ -126,6 +126,7 @@ namespace pinocchio
     if(rf == WORLD)
     {
       getJointJacobian(model,data,joint_id,WORLD,PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike,J));
+      return;
     } 
     else if(rf == LOCAL || rf == LOCAL_WORLD_ALIGNED) 
     {

--- a/src/algorithm/frames.hxx
+++ b/src/algorithm/frames.hxx
@@ -122,22 +122,28 @@ namespace pinocchio
     
     const Frame & frame = model.frames[frame_id];
     const JointIndex & joint_id = frame.parent;
+    
     if(rf == WORLD)
     {
       getJointJacobian(model,data,joint_id,WORLD,PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike,J));
-    } else if(rf == LOCAL || rf == LOCAL_WORLD_ALIGNED) {
+    } 
+    else if(rf == LOCAL || rf == LOCAL_WORLD_ALIGNED) 
+    {
       Matrix6xLike & J_ = PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike,J);
       const typename Data::SE3 & oMframe = data.oMf[frame_id];
       const int colRef = nv(model.joints[joint_id])+idx_v(model.joints[joint_id])-1;
       
       for(Eigen::DenseIndex j=colRef;j>=0;j=data.parents_fromRow[(size_t) j])
       {
-        if (rf == LOCAL) {
-        J_.col(j) = oMframe.actInv(Motion(data.J.col(j))).toVector(); // TODO: use MotionRef
-        } else {
+        if (rf == LOCAL) 
+        {
+          J_.col(j) = oMframe.actInv(Motion(data.J.col(j))).toVector(); // TODO: use MotionRef
+        } 
+        else 
+        {
           J_.col(j) = data.J.col(j);
           J_.col(j).template segment<3>(Motion::LINEAR) -= oMframe.translation().cross(J_.col(j).template segment<3>(Motion::ANGULAR));
-      }
+        }
       }
     }
   }

--- a/src/algorithm/frames.hxx
+++ b/src/algorithm/frames.hxx
@@ -125,21 +125,19 @@ namespace pinocchio
     if(rf == WORLD)
     {
       getJointJacobian(model,data,joint_id,WORLD,PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike,J));
-    } else if(rf == LOCAL || rf == LOCAL_CARTESIAN_ORIENTED) {
+    } else if(rf == LOCAL || rf == LOCAL_WORLD_ALIGNED) {
       Matrix6xLike & J_ = PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike,J);
       const typename Data::SE3 & oMframe = data.oMf[frame_id];
       const int colRef = nv(model.joints[joint_id])+idx_v(model.joints[joint_id])-1;
       
       for(Eigen::DenseIndex j=colRef;j>=0;j=data.parents_fromRow[(size_t) j])
       {
+        if (rf == LOCAL) {
         J_.col(j) = oMframe.actInv(Motion(data.J.col(j))).toVector(); // TODO: use MotionRef
+        } else {
+          J_.col(j) = data.J.col(j);
+          J_.col(j).template segment<3>(Motion::LINEAR) -= oMframe.translation().cross(J_.col(j).template segment<3>(Motion::ANGULAR));
       }
-
-      if (rf == LOCAL_CARTESIAN_ORIENTED) {
-        Matrix6xLike J_tmp;
-        J_tmp.resize(6, model.nv);
-        J_tmp = SE3(data.oMf[frame_id].rotation(), Eigen::Vector3d::Zero()).toActionMatrix() * J;
-        J_ = J_tmp;
       }
     }
   }

--- a/src/algorithm/jacobian.hxx
+++ b/src/algorithm/jacobian.hxx
@@ -141,6 +141,13 @@ namespace pinocchio
         J_.col(j) = oMjoint.actInv(mref).toVector();
       }
     }
+
+    if (rf == LOCAL_CARTESIAN_ORIENTED) {
+        Matrix6Like J_tmp;
+        J_tmp.resize(6, model.nv);
+        J_tmp = SE3(oMjoint.rotation(), Eigen::Vector3d::Zero()).toActionMatrix() * J;
+        J_ = J_tmp;
+      }
   }
   
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename Matrix6Like>

--- a/src/algorithm/jacobian.hxx
+++ b/src/algorithm/jacobian.hxx
@@ -134,20 +134,16 @@ namespace pinocchio
     int colRef = nv(model.joints[jointId])+idx_v(model.joints[jointId])-1;
     for(int j=colRef;j>=0;j=data.parents_fromRow[(Model::Index)j])
     {
-      if(rf == WORLD)   J_.col(j) = data.J.col(j);
-      else
-      {
+      if(rf == WORLD) {
+        J_.col(j) = data.J.col(j);
+      } else if (rf == LOCAL_WORLD_ALIGNED) {
+        J_.col(j) = data.J.col(j);
+        J_.col(j).template segment<3>(Motion::LINEAR) -= oMjoint.translation().cross(data.J.col(j).template segment<3>(Motion::ANGULAR));
+      } else {
         const MotionRef<M6xColXpr> mref(data.J.col(j).derived());
         J_.col(j) = oMjoint.actInv(mref).toVector();
       }
     }
-
-    if (rf == LOCAL_CARTESIAN_ORIENTED) {
-        Matrix6Like J_tmp;
-        J_tmp.resize(6, model.nv);
-        J_tmp = SE3(oMjoint.rotation(), Eigen::Vector3d::Zero()).toActionMatrix() * J;
-        J_ = J_tmp;
-      }
   }
   
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename Matrix6Like>

--- a/src/multibody/fwd.hpp
+++ b/src/multibody/fwd.hpp
@@ -42,7 +42,8 @@ namespace pinocchio
   enum ReferenceFrame
   {
     WORLD = 0,
-    LOCAL = 1
+    LOCAL = 1,
+    LOCAL_CARTESIAN_ORIENTED = 2
   };
 
   /**

--- a/src/multibody/fwd.hpp
+++ b/src/multibody/fwd.hpp
@@ -43,7 +43,7 @@ namespace pinocchio
   {
     WORLD = 0,
     LOCAL = 1,
-    LOCAL_CARTESIAN_ORIENTED = 2
+    LOCAL_WORLD_ALIGNED = 2
   };
 
   /**

--- a/unittest/frames.cpp
+++ b/unittest/frames.cpp
@@ -263,7 +263,7 @@ BOOST_AUTO_TEST_CASE ( test_frame_jacobian )
   BOOST_CHECK(Jf.isApprox(Jf_ref));  
 }
 
-BOOST_AUTO_TEST_CASE ( test_frame_jacobian_local_cartesian_oriented )
+BOOST_AUTO_TEST_CASE ( test_frame_jacobian_local_world_oriented )
 {
   using namespace Eigen;
   using namespace pinocchio;
@@ -277,7 +277,6 @@ BOOST_AUTO_TEST_CASE ( test_frame_jacobian_local_cartesian_oriented )
   BOOST_CHECK(model.existFrame(frame_name));
 
   pinocchio::Data data(model);
-  pinocchio::Data data_ref(model);
 
   model.lowerPositionLimit.head<7>().fill(-1.);
   model.upperPositionLimit.head<7>().fill( 1.);
@@ -285,22 +284,16 @@ BOOST_AUTO_TEST_CASE ( test_frame_jacobian_local_cartesian_oriented )
   VectorXd v = VectorXd::Ones(model.nv);
 
   Model::Index idx = model.getFrameId(frame_name);
-  const SE3 & oMframe = data.oMf[idx];
-  const Frame & frame = model.frames[idx];
-  BOOST_CHECK(frame.placement.isApprox_impl(framePlacement));
   Data::Matrix6x Jf(6,model.nv); Jf.fill(0);
   Data::Matrix6x Jf_ref(6,model.nv); Jf_ref.fill(0);
 
-  computeJointJacobians(model, data_ref, q);
-  updateFramePlacement(model,  data_ref, idx);
-  getFrameJacobian(model,      data_ref, idx, LOCAL, Jf_ref);
+  computeJointJacobians(model, data, q);
+  updateFramePlacement(model,  data, idx);
+  getFrameJacobian(model,      data, idx, LOCAL, Jf_ref);
 
-  // Compute the frame
-  Jf_ref = SE3(oMframe.rotation(), Eigen::Vector3d::Zero()).toActionMatrix() * Jf_ref;
-  getFrameJacobian(model,      data_ref, idx, LOCAL_WORLD_ALIGNED, Jf);
-
-  std::cout << Jf_ref - Jf << std::endl;
-//   std::cout <<  << std::endl;
+  // Compute the jacobians.
+  Jf_ref = SE3(data.oMf[idx].rotation(), Eigen::Vector3d::Zero()).toActionMatrix() * Jf_ref;
+  getFrameJacobian(model,      data, idx, LOCAL_WORLD_ALIGNED, Jf);
 
   BOOST_CHECK(Jf.isApprox(Jf_ref));
 }


### PR DESCRIPTION
This is to fix #773. 

This is NOT done yet but there are a few points I thought it's better to get feedback on earlier then later.

I haven't tested the code yet. The code compute the frame orientation I've copied from some other internal code we have, but I don't know if the jointJacobian code is working as expected.

A few things:
- Does the name `LOCAL_CARTESIAN_ORIENTED` make sense?
- I have to use a temporary `J_tmp` to avoid allocations (this was a problem we ran into with tsid). Though I am not 100% sure yet if using a local `J_tmp` and resizing works around the memory allocation problem. Does someone has an idea how to write the SE3 rotation of the jacobian without doing the `toActionMatrix() * J` matrix product - e.g. in a form where no new resulting matrix must be allocated and the results can be directly stored in J.