### PR TITLE
[bindings] Make GeometryModel.collisionPairs return-by-value, fix #764

### DIFF
--- a/bindings/python/algorithm/expose-aba-derivatives.cpp
+++ b/bindings/python/algorithm/expose-aba-derivatives.cpp
@@ -51,7 +51,7 @@ namespace pinocchio
               "put the result in data.ddq_dq, data.ddq_dv and data.Minv\n"
               "which correspond to the partial derivatives of the acceleration output with respect to the joint configuration,\n"
               "velocity and torque vectors.\n"
-              "The forces are of type StdVect_Force.");
+              "The forces are of type StdVec_Force.");
     }
   } // namespace python
 } // namespace pinocchio

--- a/bindings/python/multibody/data.hpp
+++ b/bindings/python/multibody/data.hpp
@@ -31,22 +31,22 @@ namespace pinocchio
 
     public:
 
-#define ADD_DATA_PROPERTY(TYPE,NAME,DOC)				 \
-      def_readwrite(#NAME,						 \
-      &Data::NAME,		 \
+#define ADD_DATA_PROPERTY(TYPE,NAME,DOC)    \
+      def_readwrite(#NAME,                  \
+      &Data::NAME,                          \
       DOC)
       
-#define ADD_DATA_PROPERTY_READONLY(TYPE,NAME,DOC)				 \
-      def_readonly(#NAME,						 \
-      &Data::NAME,		 \
+#define ADD_DATA_PROPERTY_READONLY(TYPE,NAME,DOC) \
+      def_readonly(#NAME,                         \
+      &Data::NAME,                                \
       DOC)
       
-#define ADD_DATA_PROPERTY_READONLY_BYVALUE(TYPE,NAME,DOC)				 \
-      add_property(#NAME,						 \
-      make_getter(&Data::NAME,bp::return_value_policy<bp::return_by_value>()), \
-      DOC)
-      
-	 
+#define ADD_DATA_PROPERTY_READONLY_BYVALUE(TYPE,NAME,DOC)                       \
+      add_property(#NAME,                                                       \
+      make_getter(&Data::NAME,bp::return_value_policy<bp::return_by_value>()),  \
+      DOC) 
+
+
       /* --- Exposing C++ API to python through the handler ----------------- */
       template<class PyClass>
       void visit(PyClass& cl) const 

--- a/bindings/python/multibody/expose-frame.cpp
+++ b/bindings/python/multibody/expose-frame.cpp
@@ -14,7 +14,7 @@ namespace pinocchio
     void exposeFrame()
     {
       FramePythonVisitor::expose();
-      StdAlignedVectorPythonVisitor<Frame>::expose("StdVect_Frame");
+      StdAlignedVectorPythonVisitor<Frame>::expose("StdVec_Frame");
     }
     
   } // namespace python

--- a/bindings/python/multibody/expose-geometry.cpp
+++ b/bindings/python/multibody/expose-geometry.cpp
@@ -16,7 +16,7 @@ namespace pinocchio
     void exposeGeometry()
     {
       GeometryObjectPythonVisitor::expose();
-      StdAlignedVectorPythonVisitor<GeometryObject>::expose("StdVect_GeometryObject");
+      StdAlignedVectorPythonVisitor<GeometryObject>::expose("StdVec_GeometryObject");
       
       CollisionPairPythonVisitor::expose();
       GeometryModelPythonVisitor::expose();

--- a/bindings/python/multibody/fcl/expose-fcl.cpp
+++ b/bindings/python/multibody/fcl/expose-fcl.cpp
@@ -19,13 +19,13 @@ namespace pinocchio
     {
       using namespace pinocchio::python::fcl;
       ContactPythonVisitor::expose();
-      StdVectorPythonVisitor<ContactPythonVisitor::Contact>::expose("StdVect_Contact");
+      StdVectorPythonVisitor<ContactPythonVisitor::Contact>::expose("StdVec_Contact");
       
       CollisionResultPythonVisitor::expose();
-      StdVectorPythonVisitor<CollisionResultPythonVisitor::CollisionResult>::expose("StdVect_CollisionResult");
+      StdVectorPythonVisitor<CollisionResultPythonVisitor::CollisionResult>::expose("StdVec_CollisionResult");
       
       DistanceResultPythonVisitor::expose();
-      StdVectorPythonVisitor<DistanceResultPythonVisitor::DistanceResult>::expose("StdVect_DistanceResult");
+      StdVectorPythonVisitor<DistanceResultPythonVisitor::DistanceResult>::expose("StdVec_DistanceResult");
       
       CollisionGeometryPythonVisitor::expose();
 

--- a/bindings/python/multibody/frame.hpp
+++ b/bindings/python/multibody/frame.hpp
@@ -47,8 +47,8 @@ namespace pinocchio
             ;
 
         bp::class_<Frame>("Frame",
-                           "A Plucker coordinate frame related to a parent joint inside a kinematic tree.\n\n",
-	                         bp::no_init
+                          "A Plucker coordinate frame related to a parent joint inside a kinematic tree.\n\n",
+                          bp::no_init
                          )
         .def(FramePythonVisitor())
         .def(CopyableVisitor<Frame>())

--- a/bindings/python/multibody/geometry-data.hpp
+++ b/bindings/python/multibody/geometry-data.hpp
@@ -42,17 +42,14 @@ namespace pinocchio
         .def_readwrite("second",&CollisionPair::second);
         
         bp::class_< std::vector<CollisionPair> >("StdVec_CollisionPair")
-        .def(bp::vector_indexing_suite< std::vector<CollisionPair> >());
+        .def(bp::vector_indexing_suite< std::vector<CollisionPair>, true >());
       }
-      
-      
+
     }; // struct CollisionPairPythonVisitor
 
     struct GeometryDataPythonVisitor
       : public boost::python::def_visitor< GeometryDataPythonVisitor >
     {
-      
-    
 
       /* --- Exposing C++ API to python through the handler ----------------- */
       template<class PyClass>

--- a/bindings/python/multibody/geometry-data.hpp
+++ b/bindings/python/multibody/geometry-data.hpp
@@ -36,6 +36,8 @@ namespace pinocchio
                                                         "Initializer of collision pair."))
         .def(PrintableVisitor<CollisionPair>())
         .def(CopyableVisitor<CollisionPair>())
+        .def(bp::self == bp::self)
+        .def(bp::self != bp::self)
         .def_readwrite("first",&CollisionPair::first)
         .def_readwrite("second",&CollisionPair::second);
         

--- a/bindings/python/multibody/geometry-model.hpp
+++ b/bindings/python/multibody/geometry-model.hpp
@@ -46,7 +46,8 @@ namespace pinocchio
 #ifdef PINOCCHIO_WITH_HPP_FCL
         .add_property("collisionPairs",
                       &GeometryModel::collisionPairs,
-                      "Vector of collision pairs.")
+                      "Vector of collision pairs."
+                      " Note: for technical reasons, when you read a collision pair from this vector it is automatically copied")
         .def("addCollisionPair",&GeometryModel::addCollisionPair,
              bp::args("co1 (index)","co2 (index)"),
              "Add a collision pair given by the index of the two collision objects."

--- a/bindings/python/pinocchio/deprecated.py
+++ b/bindings/python/pinocchio/deprecated.py
@@ -11,6 +11,17 @@ import warnings as _warnings
 from . import libpinocchio_pywrap as pin 
 from .deprecation import deprecated, DeprecatedWarning
 
+# deprecated StdVect_ (since: 19/04/2019)
+StdVect_Frame = deprecated("Please use StdVec_Frame")(pin.StdVec_Frame)
+StdVect_GeometryObject = deprecated("Please use StdVec_GeometryObject")(pin.StdVec_GeometryObject)
+if pin.WITH_FCL_SUPPORT():
+    StdVect_Contact = deprecated("Please use StdVec_Contact")(pin.StdVec_Contact)
+    StdVect_CollisionResult = deprecated("Please use StdVec_CollisionResult")(pin.StdVec_CollisionResult)
+    StdVect_DistanceResult = deprecated("Please use StdVec_DistanceResult")(pin.StdVec_DistanceResult)
+StdVect_SE3 = deprecated("Please use StdVec_SE3")(pin.StdVec_SE3)
+StdVect_Force = deprecated("Please use StdVec_Force")(pin.StdVec_Force)
+StdVect_Motion = deprecated("Please use StdVec_Motion")(pin.StdVec_Motion)
+
 @deprecated("This function has been renamed to impulseDynamics for consistency with the C++ interface. Please change for impulseDynamics.")
 def impactDynamics(model, data, q, v_before, J, r_coeff=0.0, update_kinematics=True):
   return pin.impulseDynamics(model, data, q, v_before, J, r_coeff, update_kinematics)

--- a/bindings/python/spatial/expose-SE3.cpp
+++ b/bindings/python/spatial/expose-SE3.cpp
@@ -14,7 +14,7 @@ namespace pinocchio
     void exposeSE3()
     {
       SE3PythonVisitor<SE3>::expose();
-      StdAlignedVectorPythonVisitor<SE3>::expose("StdVect_SE3");
+      StdAlignedVectorPythonVisitor<SE3>::expose("StdVec_SE3");
     }
     
   } // namespace python

--- a/bindings/python/spatial/expose-force.cpp
+++ b/bindings/python/spatial/expose-force.cpp
@@ -14,7 +14,7 @@ namespace pinocchio
     void exposeForce()
     {
       ForcePythonVisitor<Force>::expose();
-      StdAlignedVectorPythonVisitor<Force>::expose("StdVect_Force");
+      StdAlignedVectorPythonVisitor<Force>::expose("StdVec_Force");
     }
     
   } // namespace python

--- a/bindings/python/spatial/expose-motion.cpp
+++ b/bindings/python/spatial/expose-motion.cpp
@@ -14,7 +14,7 @@ namespace pinocchio
     void exposeMotion()
     {
       MotionPythonVisitor<Motion>::expose();
-      StdAlignedVectorPythonVisitor<Motion>::expose("StdVect_Motion");
+      StdAlignedVectorPythonVisitor<Motion>::expose("StdVec_Motion");
     }
     
   } // namespace python

--- a/bindings/python/utils/eigen_container.hpp
+++ b/bindings/python/utils/eigen_container.hpp
@@ -31,40 +31,44 @@ namespace pinocchio
       template<class PyClass>
       void visit(PyClass& cl) const 
       {
-	cl
-	  .def("__getitem__", &PyWraperForAlignedStdVector::getItem)
-	  .def("__setitem__", &PyWraperForAlignedStdVector::setItem)
-	  .def("__len__",     &PyWraperForAlignedStdVector::length)
-	  ;
+        cl
+        .def("__getitem__", &PyWraperForAlignedStdVector::getItem)
+        .def("__setitem__", &PyWraperForAlignedStdVector::setItem)
+        .def("__len__",     &PyWraperForAlignedStdVector::length)
+        ;
       }
 
       static EigenObject getItem( const stdVectorAligned & Ys,int i)
       {
-	assert( Ys.size()<INT_MAX );
-	if( i<0 ) i = int(Ys.size())+i;
-	assert( (i>=0) && (i<int(Ys.size())) );
-	return Ys[(std::size_t)i]; 
+        assert( Ys.size()<INT_MAX );
+        if(i<0)
+          i = int(Ys.size())+i;
+          assert( (i>=0) && (i<int(Ys.size())) );
+          return Ys[(std::size_t)i];
       }
 
       static void setItem( stdVectorAligned & Ys,
-			   int i,const EigenObject & Y)
+                           int i,const EigenObject & Y)
       { 
-	assert( Ys.size()<INT_MAX );
-	if( i<0 ) i = int(Ys.size())+i;
-	assert( (i>=0) && (i<int(Ys.size())) );
-	Ys[(std::size_t)i] = Y; 
+        assert( Ys.size()<INT_MAX );
+        if(i<0)
+          i = int(Ys.size())+i;
+        assert( (i>=0) && (i<int(Ys.size())) );
+        Ys[(std::size_t)i] = Y;
       }
       static typename stdVectorAligned::size_type length( const stdVectorAligned & Ys )
-      { return Ys.size(); }
+      {
+        return Ys.size();
+      }
 
       static void expose(const std::string & className)
       {
-	bp::class_<stdVectorAligned>(className.c_str())
-	  .def(PyWraperForAlignedStdVector());
+        bp::class_<stdVectorAligned>(className.c_str())
+        .def(PyWraperForAlignedStdVector());
       }
     };
-
-  }} // namespace pinocchio::python
+  }
+} // namespace pinocchio::python
 
 #endif // ifndef __pinocchio_python_eigen_container_hpp__
 

--- a/bindings/python/utils/handler.hpp
+++ b/bindings/python/utils/handler.hpp
@@ -51,15 +51,22 @@ namespace pinocchio
       bool smart;
 
       Handler(CppObject * cppobj,bool transmitOwnership=false)
-	: smptr( transmitOwnership ? cppobj : NULL )
-	, rawptr( cppobj )
-	, smart( transmitOwnership ) {}
-      Handler( SmartPtr_t cppobj )
-	: smptr(cppobj), rawptr(NULL), smart(true) {}
+      : smptr(transmitOwnership ? cppobj : NULL)
+      , rawptr(cppobj)
+      , smart(transmitOwnership)
+      {}
+        
+      Handler(SmartPtr_t cppobj)
+      : smptr(cppobj),
+      rawptr(NULL),
+      smart(true)
+      {}
+
       ~Handler()
       {    
-	//std::cout << "Destroy cppobj handler " << std::endl;
-	if( (!smart) && (rawptr!=NULL) ) delete rawptr;
+        //std::cout << "Destroy cppobj handler " << std::endl;
+        if( (!smart) && (rawptr!=NULL) )
+          delete rawptr;
       }
 
       CppObject *       ptr()              { return smart ?  smptr.get() :  rawptr; }

--- a/unittest/python/CMakeLists.txt
+++ b/unittest/python/CMakeLists.txt
@@ -10,6 +10,7 @@ SET(${PROJECT_NAME}_PYTHON_TESTS
   bindings_joint_composite
   bindings_motion
   bindings_SE3
+  bindings_geometry_model
   explog
   model
   rpy

--- a/unittest/python/bindings_geometry_model.py
+++ b/unittest/python/bindings_geometry_model.py
@@ -1,6 +1,10 @@
+from __future__ import print_function
+
+import sys
 import unittest
+import logging
+
 import pinocchio as pin
-import numpy as np
 
 class TestGeometryModelBindings(unittest.TestCase):
 
@@ -16,7 +20,7 @@ class TestGeometryModelBindings(unittest.TestCase):
         self.assertNotEqual(c1,c3)
         self.assertTrue(c1!=c3)
         self.assertFalse(c1==c3)
-    
+
     def test_pair_copy(self):
         c1 = pin.CollisionPair(1,2)
         c2 = c1.copy()
@@ -26,5 +30,71 @@ class TestGeometryModelBindings(unittest.TestCase):
         c2.second = 3
         self.assertNotEqual(c1,c2)
 
+    @unittest.skipUnless(pin.WITH_FCL_SUPPORT(),"Needs FCL")
+    def test_collision_pairs(self):
+        log = logging.getLogger("log."+self.id())
+        log.debug('\n')
+
+        c0 = pin.CollisionPair(1,0)
+        c1 = pin.CollisionPair(2,0)
+        c2 = pin.CollisionPair(3,0)
+
+        c0c = c0.copy()
+        c1c = c1.copy()
+        c2c = c2.copy()
+
+        gmodel = pin.GeometryModel()
+        gmodel.addCollisionPair(c0)
+        gmodel.addCollisionPair(c1)
+        gmodel.addCollisionPair(c2)
+
+        self.assertEqual(len(gmodel.collisionPairs),3)
+        log.debug(gmodel.collisionPairs[0]) # (1,0)
+        self.assertEqual(gmodel.collisionPairs[0],c0c)
+        log.debug(gmodel.collisionPairs[1]) # (2,0)
+        self.assertEqual(gmodel.collisionPairs[1],c1c)
+        log.debug(gmodel.collisionPairs[2]) # (3,0)
+        self.assertEqual(gmodel.collisionPairs[2],c2c)
+
+        p = gmodel.collisionPairs[1]
+        log.debug(p) # (2,0)
+        self.assertEqual(p,c1c)
+
+        gmodel.removeCollisionPair(gmodel.collisionPairs[0])
+        log.debug(p) # still (2,0)
+        self.assertEqual(p,c1c)
+
+        for c in gmodel.collisionPairs:
+            self.assertNotEqual(c,c0)
+
+        self.assertEqual(len(gmodel.collisionPairs),2)
+        log.debug(gmodel.collisionPairs[0]) # (2,0)
+        self.assertEqual(gmodel.collisionPairs[0],c1c)
+        log.debug(gmodel.collisionPairs[1]) # (3,0)
+        self.assertEqual(gmodel.collisionPairs[1],c2c)
+
+        c3 = pin.CollisionPair(4,0)
+        c3c = c3.copy()
+
+        gmodel.addCollisionPair(c3)
+
+        self.assertEqual(len(gmodel.collisionPairs),3)
+        log.debug(gmodel.collisionPairs[0]) # (2,0)
+        self.assertEqual(gmodel.collisionPairs[0],c1c)
+        log.debug(gmodel.collisionPairs[1]) # (3,0)
+        self.assertEqual(gmodel.collisionPairs[1],c2c)
+        log.debug(gmodel.collisionPairs[2]) # (4,0)
+        self.assertEqual(gmodel.collisionPairs[2],c3c)
+
+        c4 = pin.CollisionPair(5,0)
+        c4c = c4.copy()
+
+        gmodel.collisionPairs[2] = c4
+        log.debug(gmodel.collisionPairs[2]) # (5,0)
+        self.assertEqual(gmodel.collisionPairs[2],c4c)
+        self.assertEqual(c3,c3c)
+
 if __name__ == '__main__':
+    if ('-v' in sys.argv) or ('--verbose' in sys.argv):
+        logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
     unittest.main()

--- a/unittest/python/bindings_geometry_model.py
+++ b/unittest/python/bindings_geometry_model.py
@@ -1,0 +1,30 @@
+import unittest
+import pinocchio as pin
+import numpy as np
+
+class TestGeometryModelBindings(unittest.TestCase):
+
+    def test_pair_equals(self):
+        c1 = pin.CollisionPair(1,2)
+        c2 = pin.CollisionPair(1,2)
+        c3 = pin.CollisionPair(3,4)
+
+        self.assertEqual(c1,c2)
+        self.assertTrue(c1==c2)
+        self.assertFalse(c1!=c2)
+
+        self.assertNotEqual(c1,c3)
+        self.assertTrue(c1!=c3)
+        self.assertFalse(c1==c3)
+    
+    def test_pair_copy(self):
+        c1 = pin.CollisionPair(1,2)
+        c2 = c1.copy()
+
+        self.assertEqual(c1,c2)
+
+        c2.second = 3
+        self.assertNotEqual(c1,c2)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The return policy of `GeometryModel.collisionPairs` is now return-by-value. In other words, `gmodel.collisionPairs[i]` returns a copy of the element at `i`, instead of a reference. However, it is still possible to assign the vector elements by doing `gmodel.collisionPairs[i] = c`. This fixes #764.

In fact, boost-python allows to choose very easily between the two policies - just setting a boolean parameter!
I found that boost-python vector wrappers handle removals and insertions quite well. However, the problem with `gmodel.collisionPairs` is that it was directly manipulated by C++ code, so the wrapper could not see it. That is why I only made this change to vectors of `CollisionPair` elements -- the others are untouched.

As a bonus, I made the naming of `std::vector` bindings uniform.
Before, as noticed in #555 and #626, some were named beginning with `StdVec` while others are with `StdVect`. Now they are all called `StdVec`. I retained the old `StdVect` as deprecated for back-compatibility.