### PR TITLE
[python] Define buildModelsFromUrdf and createDatas function

### DIFF
--- a/bindings/python/multibody/geometry-model.hpp
+++ b/bindings/python/multibody/geometry-model.hpp
@@ -43,6 +43,7 @@ namespace pinocchio
                                                             "Add a GeometryObject to a GeometryModel and set its parent joint by reading its value in model")
         .def("getGeometryId",&GeometryModel::getGeometryId)
         .def("existGeometryName",&GeometryModel::existGeometryName)
+        .def("createData",&GeometryModelPythonVisitor::createData)
 #ifdef PINOCCHIO_WITH_HPP_FCL
         .add_property("collisionPairs",
                       &GeometryModel::collisionPairs,
@@ -71,7 +72,7 @@ namespace pinocchio
         ;
       }
       
-      
+      static GeometryData createData(const GeometryModel & geomModel) { return GeometryData(geomModel); }
 
       /* --- Expose --------------------------------------------------------- */
       static void expose()

--- a/bindings/python/parsers/parsers.hpp
+++ b/bindings/python/parsers/parsers.hpp
@@ -95,9 +95,8 @@ namespace pinocchio
                         const GeometryType type
                         )
       {
-        std::vector<std::string> hints;
         GeometryModel geometry_model;
-        pinocchio::urdf::buildGeom(model,filename,type,geometry_model,hints);
+        pinocchio::urdf::buildGeom(model,filename,type,geometry_model);
         
         return geometry_model;
       }
@@ -124,6 +123,19 @@ namespace pinocchio
       {
         std::vector<std::string> package_dirs_ = extractList<std::string>(package_dirs);
         return buildGeomFromUrdf(model,filename,package_dirs_,type);
+      }
+
+      static GeometryModel
+      buildGeomFromUrdf(const Model & model,
+                        const std::string & filename,
+                        const std::string & package_dir,
+                        const GeometryType type
+                        )
+      {
+        GeometryModel geometry_model;
+        pinocchio::urdf::buildGeom(model,filename,type,geometry_model,package_dir);
+
+        return geometry_model;
       }
 
 #ifdef PINOCCHIO_WITH_HPP_FCL
@@ -166,7 +178,21 @@ namespace pinocchio
         std::vector<std::string> package_dirs_ = extractList<std::string>(package_dirs);
         return buildGeomFromUrdf(model,filename,package_dirs_,type,meshLoader);
       }
-      
+
+      static GeometryModel
+      buildGeomFromUrdf(const Model & model,
+                        const std::string & filename,
+                        const std::string & package_dir,
+                        const GeometryType type,
+                        const fcl::MeshLoaderPtr& meshLoader
+                        )
+      {
+        GeometryModel geometry_model;
+        pinocchio::urdf::buildGeom(model,filename,type,geometry_model,package_dir,meshLoader);
+
+        return geometry_model;
+      }
+
       BOOST_PYTHON_FUNCTION_OVERLOADS(removeCollisionPairs_overload,
                                       srdf::removeCollisionPairs,
                                       3,4)
@@ -253,34 +279,44 @@ namespace pinocchio
       
       bp::def("buildGeomFromUrdf",
               static_cast <GeometryModel (*) (const Model &, const std::string &, const std::vector<std::string> &, const GeometryType)> (&ParsersPythonVisitor::buildGeomFromUrdf),
-              bp::args("Model to assosiate the Geometry","URDF filename (string)", "package_dirs (vector of strings)", "Geometry type (COLLISION or VISUAL)"),
+              bp::args("Model to associate the Geometry","URDF filename (string)", "package_dirs (vector of strings)", "Geometry type (COLLISION or VISUAL)"),
               "Parse the URDF file given in input looking for the geometry of the given Model and return a proper pinocchio geometry model ");
       
       bp::def("buildGeomFromUrdf",
               static_cast <GeometryModel (*) (const Model &, const std::string &, const bp::list &, const GeometryType)> (&ParsersPythonVisitor::buildGeomFromUrdf),
-              bp::args("Model to assosiate the Geometry","URDF filename (string)", "package_dirs (list of strings)", "Geometry type (COLLISION or VISUAL)"),
+              bp::args("Model to associate the Geometry","URDF filename (string)", "package_dirs (list of strings)", "Geometry type (COLLISION or VISUAL)"),
               "Parse the URDF file given in input looking for the geometry of the given Model and return a proper pinocchio geometry model ");
       
       bp::def("buildGeomFromUrdf",
               static_cast <GeometryModel (*) (const Model &, const std::string &, const GeometryType)> (&ParsersPythonVisitor::buildGeomFromUrdf),
-              bp::args("Model to assosiate the Geometry","URDF filename (string)","Geometry type (COLLISION or VISUAL)"),
+              bp::args("Model to associate the Geometry","URDF filename (string)","Geometry type (COLLISION or VISUAL)"),
+              "Parse the URDF file given in input looking for the geometry of the given Model and return a proper pinocchio  geometry model ");
+
+      bp::def("buildGeomFromUrdf",
+              static_cast <GeometryModel (*) (const Model &, const std::string &, const std::string &, const GeometryType)> (&ParsersPythonVisitor::buildGeomFromUrdf),
+              bp::args("Model to associate the Geometry","URDF filename (string)", "package_dir (string)","Geometry type (COLLISION or VISUAL)"),
               "Parse the URDF file given in input looking for the geometry of the given Model and return a proper pinocchio  geometry model ");
 
 #ifdef PINOCCHIO_WITH_HPP_FCL
 
       bp::def("buildGeomFromUrdf",
               static_cast <GeometryModel (*) (const Model &, const std::string &, const std::vector<std::string> &, const GeometryType, const fcl::MeshLoaderPtr&)> (&ParsersPythonVisitor::buildGeomFromUrdf),
-              bp::args("Model to assosiate the Geometry","URDF filename (string)", "package_dirs (vector of strings)","Geometry type (COLLISION or VISUAL)", "Mesh loader"),
+              bp::args("Model to associate the Geometry","URDF filename (string)", "package_dirs (vector of strings)","Geometry type (COLLISION or VISUAL)", "Mesh loader"),
               "Parse the URDF file given in input looking for the geometry of the given Model and return a proper pinocchio geometry model ");
       
       bp::def("buildGeomFromUrdf",
               static_cast <GeometryModel (*) (const Model &, const std::string &, const bp::list &, const GeometryType, const fcl::MeshLoaderPtr&)> (&ParsersPythonVisitor::buildGeomFromUrdf),
-              bp::args("Model to assosiate the Geometry","URDF filename (string)", "package_dirs (list of strings)","Geometry type (COLLISION or VISUAL)", "Mesh loader"),
+              bp::args("Model to associate the Geometry","URDF filename (string)", "package_dirs (list of strings)","Geometry type (COLLISION or VISUAL)", "Mesh loader"),
               "Parse the URDF file given in input looking for the geometry of the given Model and return a proper pinocchio geometry model ");
-      
+
+      bp::def("buildGeomFromUrdf",
+              static_cast <GeometryModel (*) (const Model &, const std::string &, const std::string &, const GeometryType, const fcl::MeshLoaderPtr&)> (&ParsersPythonVisitor::buildGeomFromUrdf),
+              bp::args("Model to associate the Geometry","URDF filename (string)", "package_dir (string)","Geometry type (COLLISION or VISUAL)", "Mesh loader"),
+              "Parse the URDF file given in input looking for the geometry of the given Model and return a proper pinocchio geometry model ");
+
       bp::def("buildGeomFromUrdf",
               static_cast <GeometryModel (*) (const Model &, const std::string &, const GeometryType, const fcl::MeshLoaderPtr&)> (&ParsersPythonVisitor::buildGeomFromUrdf),
-              bp::args("Model to assosiate the Geometry","URDF filename (string)","Geometry type (COLLISION or VISUAL)", "Mesh loader"),
+              bp::args("Model to associate the Geometry","URDF filename (string)","Geometry type (COLLISION or VISUAL)", "Mesh loader"),
               "Parse the URDF file given in input looking for the geometry of the given Model and return a proper pinocchio  geometry model ");
       
       bp::def("removeCollisionPairs",

--- a/bindings/python/pinocchio/robot_wrapper.py
+++ b/bindings/python/pinocchio/robot_wrapper.py
@@ -5,7 +5,7 @@
 from . import libpinocchio_pywrap as pin
 from . import utils
 from .deprecation import deprecated
-from .shortcuts import buildModelsFromUrdf
+from .shortcuts import buildModelsFromUrdf, createDatas
 
 import time
 import os
@@ -26,20 +26,10 @@ class RobotWrapper(object):
     def __init__(self, model = pin.Model(), collision_model = None, visual_model = None, verbose=False):
 
         self.model = model
-        self.data = self.model.createData()
-
         self.collision_model = collision_model
         self.visual_model = visual_model
 
-        if self.collision_model is None:
-            self.collision_data = None
-        else:
-            self.collision_data = pin.GeometryData(self.collision_model)
-
-        if self.visual_model is None:
-            self.visual_data = None
-        else:
-            self.visual_data = pin.GeometryData(self.visual_model)
+        self.data, self.collision_data, self.visual_data = createDatas(model,collision_model,visual_model)
 
         self.v0 = utils.zero(self.nv)
         self.q0 = pin.neutral(self.model)

--- a/bindings/python/pinocchio/robot_wrapper.py
+++ b/bindings/python/pinocchio/robot_wrapper.py
@@ -51,10 +51,8 @@ class RobotWrapper(object):
                 if not all(isinstance(item, str) for item in package_dirs):
                     raise Exception('The list of package directories is wrong. At least one is not a string')
                 else:
-                    collision_model = _buildGeomFromUrdf(model, filename, pin.GeometryType.COLLISION, meshLoader,
-                                                            dirs = utils.fromListToVectorOfString(package_dirs))
-                    visual_model = _buildGeomFromUrdf(model, filename, pin.GeometryType.VISUAL, meshLoader,
-                                                         dirs = utils.fromListToVectorOfString(package_dirs))
+                    collision_model = _buildGeomFromUrdf(model, filename, pin.GeometryType.COLLISION, meshLoader, package_dirs)
+                    visual_model = _buildGeomFromUrdf(model, filename, pin.GeometryType.VISUAL, meshLoader, package_dirs)
 
 
         RobotWrapper.__init__(self,model=model,collision_model=collision_model,visual_model=visual_model)

--- a/bindings/python/pinocchio/robot_wrapper.py
+++ b/bindings/python/pinocchio/robot_wrapper.py
@@ -31,21 +31,15 @@ class RobotWrapper(object):
         self.collision_model = collision_model
         self.visual_model = visual_model
 
-        if "buildGeomFromUrdf" not in dir(pin):
+        if self.collision_model is None:
             self.collision_data = None
-            self.visual_data = None
-            if verbose:
-                print('Info: the Geometry Module has not been compiled with Pinocchio. No geometry model and data have been built.')
         else:
-            if self.collision_model is None:
-                self.collision_data = None
-            else:
-                self.collision_data = pin.GeometryData(self.collision_model)
+            self.collision_data = pin.GeometryData(self.collision_model)
 
-            if self.visual_model is None:
-                self.visual_data = None
-            else:
-                self.visual_data = pin.GeometryData(self.visual_model)
+        if self.visual_model is None:
+            self.visual_data = None
+        else:
+            self.visual_data = pin.GeometryData(self.visual_model)
 
         self.v0 = utils.zero(self.nv)
         self.q0 = pin.neutral(self.model)

--- a/bindings/python/pinocchio/robot_wrapper.py
+++ b/bindings/python/pinocchio/robot_wrapper.py
@@ -5,6 +5,7 @@
 from . import libpinocchio_pywrap as pin
 from . import utils
 from .deprecation import deprecated
+from .shortcuts import buildModelsFromUrdf
 
 import time
 import os
@@ -13,50 +14,14 @@ import numpy as np
 class RobotWrapper(object):
 
     @staticmethod
-    def BuildFromURDF(filename, package_dirs=None, root_joint=None, verbose=False):
+    def BuildFromURDF(filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None):
         robot = RobotWrapper()
-        robot.initFromURDF(filename, package_dirs, root_joint, verbose)
+        robot.initFromURDF(filename, package_dirs, root_joint, verbose, meshLoader)
         return robot
 
     def initFromURDF(self,filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None):
-        if root_joint is None:
-            model = pin.buildModelFromUrdf(filename)
-        else:
-            model = pin.buildModelFromUrdf(filename, root_joint)
-
-        if "buildGeomFromUrdf" not in dir(pin):
-            collision_model = None
-            visual_model = None
-            if verbose:
-                print('Info: the Geometry Module has not been compiled with Pinocchio. No geometry model and data have been built.')
-        else:
-            if verbose and "removeCollisionPairs" not in dir(pin) and meshLoader is not None:
-                print('Info: Pinocchio was compiled without hpp-fcl. meshLoader is ignored.')
-            def _buildGeomFromUrdf (model, filename, geometryType, meshLoader, dirs=None):
-                if "removeCollisionPairs" not in dir(pin):
-                    if dirs:
-                        return pin.buildGeomFromUrdf(model, filename, dirs, geometryType)
-                    else:
-                        return pin.buildGeomFromUrdf(model, filename, geometryType)
-                else:
-                    if dirs:
-                        return pin.buildGeomFromUrdf(model, filename, dirs, geometryType, meshLoader)
-                    else:
-                        return pin.buildGeomFromUrdf(model, filename, geometryType, meshLoader)
-
-            if package_dirs is None:
-                self.collision_model = _buildGeomFromUrdf(self.model, filename, pin.GeometryType.COLLISION,meshLoader)
-                self.visual_model = _buildGeomFromUrdf(self.model, filename, pin.GeometryType.VISUAL, meshLoader)
-            else:
-                if not all(isinstance(item, str) for item in package_dirs):
-                    raise Exception('The list of package directories is wrong. At least one is not a string')
-                else:
-                    collision_model = _buildGeomFromUrdf(model, filename, pin.GeometryType.COLLISION, meshLoader, package_dirs)
-                    visual_model = _buildGeomFromUrdf(model, filename, pin.GeometryType.VISUAL, meshLoader, package_dirs)
-
-
+        model, collision_model, visual_model = buildModelsFromUrdf(filename, package_dirs, root_joint, verbose, meshLoader)
         RobotWrapper.__init__(self,model=model,collision_model=collision_model,visual_model=visual_model)
-
 
     def __init__(self, model = pin.Model(), collision_model = None, visual_model = None, verbose=False):
 

--- a/bindings/python/pinocchio/shortcuts.py
+++ b/bindings/python/pinocchio/shortcuts.py
@@ -48,3 +48,9 @@ def buildModelsFromUrdf(filename, package_dirs=None, root_joint=None, verbose=Fa
     else:
         geom_model = _buildGeomFromUrdf(model, filename, package_dirs, geometry_type, meshLoader)
         return model, geom_model
+
+def createDatas(*models):
+    """Call createData() on each Model or GeometryModel in input and return the results in a tuple.
+    If one of the models is None, the corresponding data object in the result is also None.
+    """
+    return tuple([None if model is None else model.createData() for model in models])

--- a/bindings/python/pinocchio/shortcuts.py
+++ b/bindings/python/pinocchio/shortcuts.py
@@ -8,18 +8,12 @@ from . import libpinocchio_pywrap as pin
 
 nle = pin.nonLinearEffects
 
-def _buildGeomFromUrdf (model, filename, geometryType, meshLoader, dirs=None):
+def _buildGeomFromUrdf (model, filename, dirs, geometryType, meshLoader):
     """Helper function. It ignores meshLoader if Pinocchio was compiled without hpp-fcl."""
     if meshLoader is None or not pin.WITH_FCL_SUPPORT():
-        if dirs:
-            return pin.buildGeomFromUrdf(model, filename, dirs, geometryType)
-        else:
-            return pin.buildGeomFromUrdf(model, filename, geometryType)
+        return pin.buildGeomFromUrdf(model, filename, dirs, geometryType)
     else:
-        if dirs:
-            return pin.buildGeomFromUrdf(model, filename, dirs, geometryType, meshLoader)
-        else:
-            return pin.buildGeomFromUrdf(model, filename, geometryType, meshLoader)
+        return pin.buildGeomFromUrdf(model, filename, dirs, geometryType, meshLoader)
 
 def buildModelsFromUrdf(filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None):
     """Parse the URDF file given in input and return model, collision model, and visual model (in this order)"""
@@ -28,23 +22,12 @@ def buildModelsFromUrdf(filename, package_dirs=None, root_joint=None, verbose=Fa
     else:
         model = pin.buildModelFromUrdf(filename, root_joint)
 
-    if "buildGeomFromUrdf" not in dir(pin):
-        collision_model = None
-        visual_model = None
-        if verbose:
-            print('Info: the Geometry Module has not been compiled with Pinocchio. No geometry model and data have been built.')
-    else:
-        if verbose and "removeCollisionPairs" not in dir(pin) and meshLoader is not None:
-            print('Info: Pinocchio was compiled without hpp-fcl. meshLoader is ignored.')
+    if verbose and not pin.WITH_FCL_SUPPORT() and meshLoader is not None:
+        print('Info: Pinocchio was compiled without hpp-fcl. meshLoader is ignored.')
+    if package_dirs is None:
+        package_dirs = []
 
-        if package_dirs is None:
-            collision_model = _buildGeomFromUrdf(model, filename, pin.GeometryType.COLLISION,meshLoader)
-            visual_model = _buildGeomFromUrdf(model, filename, pin.GeometryType.VISUAL, meshLoader)
-        else:
-            if not all(isinstance(item, str) for item in package_dirs):
-                raise Exception('The list of package directories is wrong. At least one is not a string')
-            else:
-                collision_model = _buildGeomFromUrdf(model, filename, pin.GeometryType.COLLISION, meshLoader, package_dirs)
-                visual_model = _buildGeomFromUrdf(model, filename, pin.GeometryType.VISUAL, meshLoader, package_dirs)
+    collision_model = _buildGeomFromUrdf(model, filename, package_dirs, pin.GeometryType.COLLISION, meshLoader)
+    visual_model = _buildGeomFromUrdf(model, filename, package_dirs, pin.GeometryType.VISUAL, meshLoader)
 
     return model, collision_model, visual_model

--- a/bindings/python/pinocchio/shortcuts.py
+++ b/bindings/python/pinocchio/shortcuts.py
@@ -8,27 +8,18 @@ from . import libpinocchio_pywrap as pin
 
 nle = pin.nonLinearEffects
 
-def _buildGeomFromUrdf (model, filename, dirs, geometryType, meshLoader):
-    """Helper function. It ignores meshLoader if Pinocchio was compiled without hpp-fcl."""
-    if meshLoader is None or not pin.WITH_FCL_SUPPORT():
-        return pin.buildGeomFromUrdf(model, filename, dirs, geometryType)
-    else:
-        return pin.buildGeomFromUrdf(model, filename, dirs, geometryType, meshLoader)
-
-def buildModelsFromUrdf(filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None, geometry_type=None):
-    """Parse the URDF file given in input and return a Pinocchio Model and appropriate GeometryModel(s).
-    You can use this function in two ways.
-    
-    The first one is by specifying the geometry type, as in
-        model, collision_model = buildModelsFromUrdf(filename[, ...], geometry_type=pin.GeometryType.COLLISION)
-        model, visual_model    = buildModelsFromUrdf(filename[, ...], geometry_type=pin.GeometryType.VISUAL)
-    
-    In this case, the function will return a Pinocchio Model and a GeometryModel of the specified type.
-    
-    The second one is by leaving the geometry type unspecified (i.e. None), for instance as in
-        model, collision_model, visual_model = buildModelsFromUrdf(filename)
-    
-    In this case, the function will return a Pinocchio Model, a collision model, and visual model (in this order)
+def buildModelsFromUrdf(filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None, geometry_types=[pin.GeometryType.COLLISION,pin.GeometryType.VISUAL]):
+    """Parse the URDF file given in input and return a Pinocchio Model followed by corresponding GeometryModels of types specified by geometry_types, in the same order as listed.
+    Examples of usage:
+        # load model, collision model, and visual model, in this order (default)
+        model, collision_model, visual_model = buildModelsFromUrdf(filename[, ...], geometry_types=[pin.GeometryType.COLLISION,pin.GeometryType.VISUAL])
+        model, collision_model, visual_model = buildModelsFromUrdf(filename[, ...]) # same as above
+        
+        model, collision_model = buildModelsFromUrdf(filename[, ...], geometry_types=[pin.GeometryType.COLLISION]) # only load the model and the collision model
+        model, collision_model = buildModelsFromUrdf(filename[, ...], geometry_types=pin.GeometryType.COLLISION)   # same as above
+        model, visual_model    = buildModelsFromUrdf(filename[, ...], geometry_types=pin.GeometryType.VISUAL)      # only load the model and the visual model
+        
+        model = buildModelsFromUrdf(filename[, ...], geometry_types=[])  # equivalent to buildModelFromUrdf(filename[, root_joint])
     """
 
     if root_joint is None:
@@ -41,13 +32,19 @@ def buildModelsFromUrdf(filename, package_dirs=None, root_joint=None, verbose=Fa
     if package_dirs is None:
         package_dirs = []
 
-    if geometry_type is None:
-        collision_model = _buildGeomFromUrdf(model, filename, package_dirs, pin.GeometryType.COLLISION, meshLoader)
-        visual_model = _buildGeomFromUrdf(model, filename, package_dirs, pin.GeometryType.VISUAL, meshLoader)
-        return model, collision_model, visual_model
-    else:
-        geom_model = _buildGeomFromUrdf(model, filename, package_dirs, geometry_type, meshLoader)
-        return model, geom_model
+    lst = [model]
+
+    if not hasattr(geometry_types, '__iter__'):
+        geometry_types = [geometry_types]
+
+    for geometry_type in geometry_types:
+        if meshLoader is None or not pin.WITH_FCL_SUPPORT():
+            geom_model = pin.buildGeomFromUrdf(model, filename, package_dirs, geometry_type)
+        else:
+            geom_model = pin.buildGeomFromUrdf(model, filename, package_dirs, geometry_type, meshLoader)
+        lst.append(geom_model)
+
+    return tuple(lst)
 
 def createDatas(*models):
     """Call createData() on each Model or GeometryModel in input and return the results in a tuple.

--- a/bindings/python/pinocchio/shortcuts.py
+++ b/bindings/python/pinocchio/shortcuts.py
@@ -15,8 +15,22 @@ def _buildGeomFromUrdf (model, filename, dirs, geometryType, meshLoader):
     else:
         return pin.buildGeomFromUrdf(model, filename, dirs, geometryType, meshLoader)
 
-def buildModelsFromUrdf(filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None):
-    """Parse the URDF file given in input and return model, collision model, and visual model (in this order)"""
+def buildModelsFromUrdf(filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None, geometry_type=None):
+    """Parse the URDF file given in input and return a Pinocchio Model and appropriate GeometryModel(s).
+    You can use this function in two ways.
+    
+    The first one is by specifying the geometry type, as in
+        model, collision_model = buildModelsFromUrdf(filename[, ...], geometry_type=pin.GeometryType.COLLISION)
+        model, visual_model    = buildModelsFromUrdf(filename[, ...], geometry_type=pin.GeometryType.VISUAL)
+    
+    In this case, the function will return a Pinocchio Model and a GeometryModel of the specified type.
+    
+    The second one is by leaving the geometry type unspecified (i.e. None), for instance as in
+        model, collision_model, visual_model = buildModelsFromUrdf(filename)
+    
+    In this case, the function will return a Pinocchio Model, a collision model, and visual model (in this order)
+    """
+
     if root_joint is None:
         model = pin.buildModelFromUrdf(filename)
     else:
@@ -27,7 +41,10 @@ def buildModelsFromUrdf(filename, package_dirs=None, root_joint=None, verbose=Fa
     if package_dirs is None:
         package_dirs = []
 
-    collision_model = _buildGeomFromUrdf(model, filename, package_dirs, pin.GeometryType.COLLISION, meshLoader)
-    visual_model = _buildGeomFromUrdf(model, filename, package_dirs, pin.GeometryType.VISUAL, meshLoader)
-
-    return model, collision_model, visual_model
+    if geometry_type is None:
+        collision_model = _buildGeomFromUrdf(model, filename, package_dirs, pin.GeometryType.COLLISION, meshLoader)
+        visual_model = _buildGeomFromUrdf(model, filename, package_dirs, pin.GeometryType.VISUAL, meshLoader)
+        return model, collision_model, visual_model
+    else:
+        geom_model = _buildGeomFromUrdf(model, filename, package_dirs, geometry_type, meshLoader)
+        return model, geom_model

--- a/bindings/python/pinocchio/shortcuts.py
+++ b/bindings/python/pinocchio/shortcuts.py
@@ -7,3 +7,44 @@
 from . import libpinocchio_pywrap as pin
 
 nle = pin.nonLinearEffects
+
+def _buildGeomFromUrdf (model, filename, geometryType, meshLoader, dirs=None):
+    """Helper function. It ignores meshLoader if Pinocchio was compiled without hpp-fcl."""
+    if meshLoader is None or not pin.WITH_FCL_SUPPORT():
+        if dirs:
+            return pin.buildGeomFromUrdf(model, filename, dirs, geometryType)
+        else:
+            return pin.buildGeomFromUrdf(model, filename, geometryType)
+    else:
+        if dirs:
+            return pin.buildGeomFromUrdf(model, filename, dirs, geometryType, meshLoader)
+        else:
+            return pin.buildGeomFromUrdf(model, filename, geometryType, meshLoader)
+
+def buildModelsFromUrdf(filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None):
+    """Parse the URDF file given in input and return model, collision model, and visual model (in this order)"""
+    if root_joint is None:
+        model = pin.buildModelFromUrdf(filename)
+    else:
+        model = pin.buildModelFromUrdf(filename, root_joint)
+
+    if "buildGeomFromUrdf" not in dir(pin):
+        collision_model = None
+        visual_model = None
+        if verbose:
+            print('Info: the Geometry Module has not been compiled with Pinocchio. No geometry model and data have been built.')
+    else:
+        if verbose and "removeCollisionPairs" not in dir(pin) and meshLoader is not None:
+            print('Info: Pinocchio was compiled without hpp-fcl. meshLoader is ignored.')
+
+        if package_dirs is None:
+            collision_model = _buildGeomFromUrdf(model, filename, pin.GeometryType.COLLISION,meshLoader)
+            visual_model = _buildGeomFromUrdf(model, filename, pin.GeometryType.VISUAL, meshLoader)
+        else:
+            if not all(isinstance(item, str) for item in package_dirs):
+                raise Exception('The list of package directories is wrong. At least one is not a string')
+            else:
+                collision_model = _buildGeomFromUrdf(model, filename, pin.GeometryType.COLLISION, meshLoader, package_dirs)
+                visual_model = _buildGeomFromUrdf(model, filename, pin.GeometryType.VISUAL, meshLoader, package_dirs)
+
+    return model, collision_model, visual_model

--- a/examples/python/collision-detection.py
+++ b/examples/python/collision-detection.py
@@ -14,7 +14,7 @@ urdf_model_path = model_path + "/romeo_description/urdf/" + urdf_filename
 model = pin.buildModelFromUrdf(urdf_model_path,pin.JointModelFreeFlyer())
 
 # Load collision geometries
-geom_model = pin.buildGeomFromUrdf(model,urdf_model_path,[model_path],pin.GeometryType.COLLISION)
+geom_model = pin.buildGeomFromUrdf(model,urdf_model_path,model_path,pin.GeometryType.COLLISION)
 
 # Add collisition pairs
 geom_model.addAllCollisionPairs()

--- a/unittest/python/bindings_geometry_object.py
+++ b/unittest/python/bindings_geometry_object.py
@@ -33,5 +33,9 @@ class TestGeometryObjectBindings(unittest.TestCase):
         col = self.collision_model.geometryObjects[0]
         self.assertTrue(col.meshPath == "")
 
+    def test_create_data(self):
+        collision_data = self.collision_model.createData()
+        self.assertEqual(len(collision_data.oMg), self.collision_model.ngeoms)
+
 if __name__ == '__main__':
     unittest.main()

--- a/unittest/python/bindings_geometry_object.py
+++ b/unittest/python/bindings_geometry_object.py
@@ -6,8 +6,8 @@ import numpy as np
 class TestGeometryObjectBindings(unittest.TestCase):
 
     def setUp(self):
-        model = pin.buildSampleModelHumanoid()
-        self.collision_model = pin.buildSampleGeometryModelHumanoid(model)
+        self.model = pin.buildSampleModelHumanoid()
+        self.collision_model = pin.buildSampleGeometryModelHumanoid(self.model)
 
     def test_name_get_set(self):
         col = self.collision_model.geometryObjects[0]
@@ -36,6 +36,15 @@ class TestGeometryObjectBindings(unittest.TestCase):
     def test_create_data(self):
         collision_data = self.collision_model.createData()
         self.assertEqual(len(collision_data.oMg), self.collision_model.ngeoms)
+
+    def test_create_datas(self):
+        collision_data = self.collision_model.createData()
+
+        self.assertEqual(len(collision_data.oMg), self.collision_model.ngeoms)
+
+        data_2, collision_data_2 = pin.createDatas(self.model, self.collision_model)
+        self.assertTrue(self.model.check(data_2))
+        self.assertEqual(len(collision_data_2.oMg), self.collision_model.ngeoms)
 
 if __name__ == '__main__':
     unittest.main()

--- a/unittest/python/bindings_geometry_object_urdf.py
+++ b/unittest/python/bindings_geometry_object_urdf.py
@@ -26,22 +26,38 @@ class TestGeometryObjectUrdfBindings(unittest.TestCase):
         expected_visual_path = os.path.join(self.model_dir,'romeo_description/meshes/V1/visual/LHipPitch.dae')
 
         model = pin.buildModelFromUrdf(self.model_path, pin.JointModelFreeFlyer())
+
         collision_model = pin.buildGeomFromUrdf(model, self.model_path, hint_list, pin.GeometryType.COLLISION)
+        col = collision_model.geometryObjects[1]
+        self.assertEqual(col.meshPath, expected_collision_path)
+
         visual_model = pin.buildGeomFromUrdf(model, self.model_path, hint_list, pin.GeometryType.VISUAL)
+        vis = visual_model.geometryObjects[1]
+        self.assertEqual(vis.meshPath, expected_visual_path)
 
         model_2, collision_model_2, visual_model_2 = pin.buildModelsFromUrdf(self.model_path, hint_list, pin.JointModelFreeFlyer())
 
         self.assertEqual(model,model_2)
 
-        col = collision_model.geometryObjects[1]
         col_2 = collision_model_2.geometryObjects[1]
-        self.assertEqual(col.meshPath, expected_collision_path)
         self.assertEqual(col_2.meshPath, expected_collision_path)
 
-        vis = visual_model.geometryObjects[1]
         vis_2 = visual_model_2.geometryObjects[1]
-        self.assertEqual(vis.meshPath, expected_visual_path)
         self.assertEqual(vis_2.meshPath, expected_visual_path)
+
+        model_c, collision_model_c = pin.buildModelsFromUrdf(self.model_path, hint_list, pin.JointModelFreeFlyer(), geometry_type=pin.GeometryType.COLLISION)
+
+        self.assertEqual(model,model_c)
+
+        col_c = collision_model_c.geometryObjects[1]
+        self.assertEqual(col_c.meshPath, expected_collision_path)
+
+        model_v, visual_model_v = pin.buildModelsFromUrdf(self.model_path, hint_list, pin.JointModelFreeFlyer(), geometry_type=pin.GeometryType.VISUAL)
+
+        self.assertEqual(model,model_v)
+
+        vis_v = visual_model_v.geometryObjects[1]
+        self.assertEqual(vis_v.meshPath, expected_visual_path)
 
 if __name__ == '__main__':
     unittest.main()

--- a/unittest/python/bindings_geometry_object_urdf.py
+++ b/unittest/python/bindings_geometry_object_urdf.py
@@ -45,14 +45,14 @@ class TestGeometryObjectUrdfBindings(unittest.TestCase):
         vis_2 = visual_model_2.geometryObjects[1]
         self.assertEqual(vis_2.meshPath, expected_visual_path)
 
-        model_c, collision_model_c = pin.buildModelsFromUrdf(self.model_path, hint_list, pin.JointModelFreeFlyer(), geometry_type=pin.GeometryType.COLLISION)
+        model_c, collision_model_c = pin.buildModelsFromUrdf(self.model_path, hint_list, pin.JointModelFreeFlyer(), geometry_types=pin.GeometryType.COLLISION)
 
         self.assertEqual(model,model_c)
 
         col_c = collision_model_c.geometryObjects[1]
         self.assertEqual(col_c.meshPath, expected_collision_path)
 
-        model_v, visual_model_v = pin.buildModelsFromUrdf(self.model_path, hint_list, pin.JointModelFreeFlyer(), geometry_type=pin.GeometryType.VISUAL)
+        model_v, visual_model_v = pin.buildModelsFromUrdf(self.model_path, hint_list, pin.JointModelFreeFlyer(), geometry_types=pin.GeometryType.VISUAL)
 
         self.assertEqual(model,model_v)
 

--- a/unittest/python/bindings_geometry_object_urdf.py
+++ b/unittest/python/bindings_geometry_object_urdf.py
@@ -5,18 +5,43 @@ import os
 @unittest.skipUnless(pin.WITH_URDFDOM_SUPPORT(),"Needs URDFDOM")
 class TestGeometryObjectUrdfBindings(unittest.TestCase):
 
-    def test_load(self):
-        current_file =  os.path.dirname(os.path.abspath(__file__))
-        model_dir = os.path.abspath(os.path.join(current_file, '../../models/romeo'))
-        model_path = os.path.abspath(os.path.join(model_dir, 'romeo_description/urdf/romeo.urdf'))
-        expected_mesh_path = os.path.join(model_dir,'romeo_description/meshes/V1/collision/LHipPitch.dae')
+    def setUp(self):
+        self.current_file =  os.path.dirname(os.path.abspath(__file__))
+        self.model_dir = os.path.abspath(os.path.join(self.current_file, '../../models/romeo'))
+        self.model_path = os.path.abspath(os.path.join(self.model_dir, 'romeo_description/urdf/romeo.urdf'))
 
-        hint_list = [model_dir, "wrong/hint"]
-        model = pin.buildModelFromUrdf(model_path, pin.JointModelFreeFlyer())
-        collision_model = pin.buildGeomFromUrdf(model, model_path, hint_list, pin.GeometryType.COLLISION)
+    def test_load(self):
+        hint_list = [self.model_dir, "wrong/hint"]
+        expected_mesh_path = os.path.join(self.model_dir,'romeo_description/meshes/V1/collision/LHipPitch.dae')
+
+        model = pin.buildModelFromUrdf(self.model_path, pin.JointModelFreeFlyer())
+        collision_model = pin.buildGeomFromUrdf(model, self.model_path, hint_list, pin.GeometryType.COLLISION)
 
         col = collision_model.geometryObjects[1]
-        self.assertTrue(col.meshPath == expected_mesh_path)
+        self.assertEqual(col.meshPath, expected_mesh_path)
+
+    def test_multi_load(self):
+        hint_list = [self.model_dir, "wrong/hint"]
+        expected_collision_path = os.path.join(self.model_dir,'romeo_description/meshes/V1/collision/LHipPitch.dae')
+        expected_visual_path = os.path.join(self.model_dir,'romeo_description/meshes/V1/visual/LHipPitch.dae')
+
+        model = pin.buildModelFromUrdf(self.model_path, pin.JointModelFreeFlyer())
+        collision_model = pin.buildGeomFromUrdf(model, self.model_path, hint_list, pin.GeometryType.COLLISION)
+        visual_model = pin.buildGeomFromUrdf(model, self.model_path, hint_list, pin.GeometryType.VISUAL)
+
+        model_2, collision_model_2, visual_model_2 = pin.buildModelsFromUrdf(self.model_path, hint_list, pin.JointModelFreeFlyer())
+
+        self.assertEqual(model,model_2)
+
+        col = collision_model.geometryObjects[1]
+        col_2 = collision_model_2.geometryObjects[1]
+        self.assertEqual(col.meshPath, expected_collision_path)
+        self.assertEqual(col_2.meshPath, expected_collision_path)
+
+        vis = visual_model.geometryObjects[1]
+        vis_2 = visual_model_2.geometryObjects[1]
+        self.assertEqual(vis.meshPath, expected_visual_path)
+        self.assertEqual(vis_2.meshPath, expected_visual_path)
 
 if __name__ == '__main__':
     unittest.main()

--- a/unittest/python/bindings_geometry_object_urdf.py
+++ b/unittest/python/bindings_geometry_object_urdf.py
@@ -13,7 +13,7 @@ class TestGeometryObjectUrdfBindings(unittest.TestCase):
 
         hint_list = [model_dir, "wrong/hint"]
         model = pin.buildModelFromUrdf(model_path, pin.JointModelFreeFlyer())
-        collision_model = pin.buildGeomFromUrdf(model, model_path, pin.utils.fromListToVectorOfString(hint_list), pin.GeometryType.COLLISION)
+        collision_model = pin.buildGeomFromUrdf(model, model_path, hint_list, pin.GeometryType.COLLISION)
 
         col = collision_model.geometryObjects[1]
         self.assertTrue(col.meshPath == expected_mesh_path)


### PR DESCRIPTION
This PR partially addresses #663 by providing convenience Python methods for creating models and geometry models in a single call, and analogously for the data objects.

This PR is autonomous, so if it is agreed upon it might be safely accepted. I thought it might be better to split the changes in two separate PRs so that this part may be more easily reviewed.

In summary:
- expose `buildGeomFromUrdf` accepting a single string for the package_directory, so we don't always have to put it inside a list
- define a function called `buildModelsFromUrdf` which parses an URDF and returns a Pinocchio Model plus one or two GeometryModel(s), depending on the inputs (see docstring for more details)
- define a Python method called `createData()` for `GeometryModel`, in analogy to `Model`
- define a function called `createDatas(*models)`, taking any number of `Model` or `GeometryModel` objects and returning corresponding data objects (see docstring for more details)
- use `buildModelsFromUrdf` and `createDatas` inside `RobotWrapper`

Thus, the recommended Python workflow is now the following:
```
model, collision_model, visual_model = pin.buildModelsFromUrdf(model_path, hint_list, root_joint)
data, collision_data, visual_data = pin.createDatas(model,collision_model,visual_model)
```
saving a lot of typing in cases when `RobotWrapper` is not used (two lines instead of six).

A few notes:
- As an exception to the general rule of implementing things in C++ and exposing them in Python, I implemented the new methods purely in Python. They are in [shortcuts.py](https://github.com/gabrielebndn/pinocchio/blob/c7e39ca8da3971e31914b6f247f006ead79c4664/bindings/python/pinocchio/shortcuts.py). This for two reasons:
  - These are basically shortcuts thought for rapid prototyping and for reducing the dependency on `RobotWrapper`. As such, they are not really needed in C++
  - I figured it would be much easier to write and to maintain: implementing it in C++ would have meant creating at least 2 or 3 C++ overloads and and exposing 7 or 8 signatures depending whether the package directory is a string, a list, a vector, or not provided, and wether the mesh loader is provided or not. This way it is much more compact.
- I greatly simplified the implementation of `buildModelsFromUrdf` with respect to the original code in `RobotWrapper`. This because it seemed to me that `RobotWrapper` was making a lot of redundant safety checks, such as `if "buildGeomFromUrdf" not in dir(pin)` (true if and only if the URDF module is not provided) or wether the elements in `package_dirs` are indeed all strings (let boost-python handle that). If you want to check, you may put extra care in reviewing commit 
8ae5cf4 (and possibly c7e39ca)

Hope this helps!