### PR TITLE
Introduce joint torque regressor

### DIFF
--- a/bindings/python/algorithm/expose-regressor.cpp
+++ b/bindings/python/algorithm/expose-regressor.cpp
@@ -30,7 +30,7 @@ namespace pinocchio
       using namespace Eigen;
 
       bp::def("computeStaticRegressor",
-              &regressor::computeStaticRegressor<double,0,JointCollectionDefaultTpl,VectorXd>,
+              &computeStaticRegressor<double,0,JointCollectionDefaultTpl,VectorXd>,
               bp::args("Model","Data",
                        "Configuration q (size Model::nq)"),
               "Compute the static regressor that links the inertia parameters of the system to its center of mass position,\n"

--- a/bindings/python/algorithm/expose-regressor.cpp
+++ b/bindings/python/algorithm/expose-regressor.cpp
@@ -20,6 +20,11 @@ namespace pinocchio
       return jointBodyRegressor(model,data,jointId);
     }
 
+    Eigen::MatrixXd frameBodyRegressor_proxy(const Model & model, Data & data, const FrameIndex frameId)
+    {
+      return frameBodyRegressor(model,data,frameId);
+    }
+
     void exposeRegressor()
     {
       using namespace Eigen;
@@ -44,6 +49,13 @@ namespace pinocchio
               bp::args("Model","Data",
                        "jointId (int)"),
               "Compute the regressor for the dynamic parameters of a rigid body attached to a given joint.\n"
+              "This algorithm assumes RNEA has been run to compute the acceleration and gravitational effects.");
+
+      bp::def("frameBodyRegressor",
+              &frameBodyRegressor_proxy,
+              bp::args("Model","Data",
+                       "frameId (int)"),
+              "Computes the regressor for the dynamic parameters of a rigid body attached to a given frame.\n"
               "This algorithm assumes RNEA has been run to compute the acceleration and gravitational effects.");
     }
     

--- a/bindings/python/algorithm/expose-regressor.cpp
+++ b/bindings/python/algorithm/expose-regressor.cpp
@@ -15,6 +15,11 @@ namespace pinocchio
       return bodyRegressor(v,a);
     }
 
+    Eigen::MatrixXd jointBodyRegressor_proxy(const Model & model, Data & data, const JointIndex jointId)
+    {
+      return jointBodyRegressor(model,data,jointId);
+    }
+
     void exposeRegressor()
     {
       using namespace Eigen;
@@ -23,8 +28,8 @@ namespace pinocchio
               &regressor::computeStaticRegressor<double,0,JointCollectionDefaultTpl,VectorXd>,
               bp::args("Model","Data",
                        "Configuration q (size Model::nq)"),
-              "Compute the static regressor that links the inertia parameters of the system to its center of mass position\n"
-              ",put the result in Data and return it.",
+              "Compute the static regressor that links the inertia parameters of the system to its center of mass position,\n"
+              "put the result in Data and return it.",
               bp::return_value_policy<bp::return_by_value>());
 
       bp::def("bodyRegressor",
@@ -33,6 +38,13 @@ namespace pinocchio
               "Computes the regressor for the dynamic parameters of a single rigid body.\n"
               "The result is such that "
               "Ia + v x Iv = bodyRegressor(v,a) * I.toDynamicParameters()");
+
+      bp::def("jointBodyRegressor",
+              &jointBodyRegressor_proxy,
+              bp::args("Model","Data",
+                       "jointId (int)"),
+              "Compute the regressor for the dynamic parameters of a rigid body attached to a given joint.\n"
+              "This algorithm assumes RNEA has been run to compute the acceleration and gravitational effects.");
     }
     
   } // namespace python

--- a/bindings/python/algorithm/expose-regressor.cpp
+++ b/bindings/python/algorithm/expose-regressor.cpp
@@ -9,7 +9,12 @@ namespace pinocchio
 {
   namespace python
   {
-    
+
+    Eigen::MatrixXd bodyRegressor_proxy(const Motion & v, const Motion & a)
+    {
+      return bodyRegressor(v,a);
+    }
+
     void exposeRegressor()
     {
       using namespace Eigen;
@@ -21,7 +26,13 @@ namespace pinocchio
               "Compute the static regressor that links the inertia parameters of the system to its center of mass position\n"
               ",put the result in Data and return it.",
               bp::return_value_policy<bp::return_by_value>());
-      
+
+      bp::def("bodyRegressor",
+              &bodyRegressor_proxy,
+              bp::args("velocity","acceleration"),
+              "Computes the regressor for the dynamic parameters of a single rigid body.\n"
+              "The result is such that "
+              "Ia + v x Iv = bodyRegressor(v,a) * I.toDynamicParameters()");
     }
     
   } // namespace python

--- a/bindings/python/algorithm/expose-regressor.cpp
+++ b/bindings/python/algorithm/expose-regressor.cpp
@@ -57,6 +57,17 @@ namespace pinocchio
                        "frameId (int)"),
               "Computes the regressor for the dynamic parameters of a rigid body attached to a given frame.\n"
               "This algorithm assumes RNEA has been run to compute the acceleration and gravitational effects.");
+
+      bp::def("computeJointTorqueRegressor",
+              &computeJointTorqueRegressor<double,0,JointCollectionDefaultTpl,VectorXd,VectorXd,VectorXd>,
+              bp::args("Model","Data",
+                       "Configuration q (size Model::nq)",
+                       "Velocity v (size Model::nv)"
+                       "Acceleration a (size Model::nv)"),
+              "Compute the joint torque regressor that links the joint torque "
+              "to the dynamic parameters of each link according to the current the robot motion,\n"
+              "put the result in Data and return it.",
+              bp::return_value_policy<bp::return_by_value>());
     }
     
   } // namespace python

--- a/bindings/python/multibody/data.hpp
+++ b/bindings/python/multibody/data.hpp
@@ -117,6 +117,7 @@ namespace pinocchio
         
         .ADD_DATA_PROPERTY_READONLY_BYVALUE(Eigen::VectorXd,dq_after,"Generalized velocity after the impact.")
         .ADD_DATA_PROPERTY_READONLY_BYVALUE(Matrix3x,staticRegressor,"Static regressor.")
+        .ADD_DATA_PROPERTY_READONLY_BYVALUE(Eigen::MatrixXd,jointTorqueRegressor,"Joint Torque Regressor.")
         ;
       }
 

--- a/bindings/python/multibody/data.hpp
+++ b/bindings/python/multibody/data.hpp
@@ -116,6 +116,7 @@ namespace pinocchio
         .ADD_DATA_PROPERTY_READONLY_BYVALUE(Eigen::VectorXd,impulse_c,"Lagrange Multipliers linked to contact impulses")
         
         .ADD_DATA_PROPERTY_READONLY_BYVALUE(Eigen::VectorXd,dq_after,"Generalized velocity after the impact.")
+        .ADD_DATA_PROPERTY_READONLY_BYVALUE(Matrix3x,staticRegressor,"Static regressor.")
         ;
       }
 

--- a/bindings/python/multibody/model.hpp
+++ b/bindings/python/multibody/model.hpp
@@ -172,7 +172,7 @@ namespace pinocchio
         .def("addJointFrame", &Model::addJointFrame, bp::args("jointIndex", "frameIndex"), "add the joint at index jointIndex as a frame to the frame tree")
         .def("appendBodyToJoint",&Model::appendBodyToJoint,bp::args("joint_id","body_inertia","body_placement"),"Appends a body to the joint given by its index. The body is defined by its inertia, its relative placement regarding to the joint and its name.")
         
-        .def("addBodyFrame", &Model::addBodyFrame, bp::args("body_name", "parentJoint", "body_plaement", "previous_frame(parent frame)"), "add a body to the frame tree")
+        .def("addBodyFrame", &Model::addBodyFrame, bp::args("body_name", "parentJoint", "body_placement", "previous_frame(parent frame)"), "add a body to the frame tree")
         .def("getBodyId",&Model::getBodyId, bp::args("name"), "Return the index of a frame of type BODY given by its name")
         .def("existBodyName", &Model::existBodyName, bp::args("name"), "Check if a frame of type BODY exists, given its name")
         .def("getJointId",&Model::getJointId, bp::args("name"), "Return the index of a joint given by its name")

--- a/bindings/python/spatial/inertia.hpp
+++ b/bindings/python/spatial/inertia.hpp
@@ -91,6 +91,19 @@ namespace pinocchio
         .def("Random",&Inertia::Random,"Returns a random Inertia.")
         .staticmethod("Random")
         
+        .def("toDynamicParameters",&InertiaPythonVisitor::toDynamicParameters_proxy,
+             "Returns the representation of the matrix as a vector of dynamic parameters."
+              "\nThe parameters are given as v = [m, mc_x, mc_y, mc_z, I_{xx}, I_{xy}, I_{yy}, I_{xz}, I_{yz}, I_{zz}]^T "
+              "where I = I_C + mS^T(c)S(c) and I_C has its origin at the barycenter"
+        )
+        .def("FromDynamicParameters",&Inertia::template FromDynamicParameters<Eigen::VectorXd>,
+              bp::args("Dynamic parameters (size 10)"),
+              "Builds and inertia matrix from a vector of dynamic parameters."
+              "\nThe parameters are given as v = [m, mc_x, mc_y, mc_z, I_{xx}, I_{xy}, I_{yy}, I_{xz}, I_{yz}, I_{zz}]^T "
+              "where I = I_C + mS^T(c)S(c) and I_C has its origin at the barycenter"
+        )
+        .staticmethod("FromDynamicParameters")
+
         .def("FromEllipsoid", &Inertia::FromEllipsoid,
              bp::args("mass","length_x","length_y","length_z"),
              "Returns an Inertia of an ellipsoid shape with a mass and of dimension the semi axis of length_{x,y,z}.")
@@ -127,6 +140,8 @@ namespace pinocchio
         symmetric_inertia(1,2),
         symmetric_inertia(2,2);
       }
+
+      static Eigen::VectorXd toDynamicParameters_proxy( const Inertia & self ) { return self.toDynamicParameters(); }
 
       static Inertia* makeFromMCI(const double & mass,
                                   const Vector3 & lever,

--- a/doc/treeview.dox
+++ b/doc/treeview.dox
@@ -128,9 +128,6 @@ namespace pinocchio {
   /// \namespace pinocchio::quaternion
   /// \brief Quaternion operations
 
-  /// \namespace pinocchio::regressor
-  /// \brief Regressor computation
-
   /// \namespace pinocchio::urdf
   /// \brief URDF parsing
 

--- a/src/algorithm/regressor.hpp
+++ b/src/algorithm/regressor.hpp
@@ -47,8 +47,8 @@ namespace pinocchio
   /// \return The regressor of the body.
   ///
   template<typename MotionVelocity, typename MotionAcceleration>
-  inline Eigen::Matrix<typename MotionVelocity::Scalar,6,10,MotionVelocity::Options>
-  bodyRegressor(const MotionBase<MotionVelocity> & v, const MotionBase<MotionAcceleration> & a);
+  inline Eigen::Matrix<typename MotionVelocity::Scalar,6,10,PINOCCHIO_EIGEN_PLAIN_TYPE(typename MotionVelocity::Vector3)::Options>
+  bodyRegressor(const MotionDense<MotionVelocity> & v, const MotionDense<MotionAcceleration> & a);
 
   ///
   /// \brief Computes the regressor for the dynamic parameters of a rigid body attached to a given joint.

--- a/src/algorithm/regressor.hpp
+++ b/src/algorithm/regressor.hpp
@@ -34,6 +34,21 @@ namespace pinocchio
                            DataTpl<Scalar,Options,JointCollectionTpl> & data,
                            const Eigen::MatrixBase<ConfigVectorType> & q);
   }
+
+  ///
+  /// \brief Computes the regressor for the dynamic parameters of a single rigid body.
+  ///
+  /// The result is such that
+  /// \f$ I a + v \times I v = bodyRegressor(v,a) * I.toDynamicParameters() \f$
+  ///
+  /// \param[in] v Velocity of the rigid body
+  /// \param[in] a Acceleration of the rigid body
+  ///
+  /// \return The regressor of the body.
+  ///
+  template<typename MotionVelocity, typename MotionAcceleration>
+  inline Eigen::Matrix<typename MotionVelocity::Scalar,6,10,MotionVelocity::Options>
+  bodyRegressor(const MotionBase<MotionVelocity> & v, const MotionBase<MotionAcceleration> & a);
   
 } // namespace pinocchio
 

--- a/src/algorithm/regressor.hpp
+++ b/src/algorithm/regressor.hpp
@@ -15,6 +15,11 @@ namespace pinocchio
   /// \brief Computes the static regressor that links the center of mass positions of all the links
   ///        to the center of mass of the complete model according to the current configuration of the robot.
   ///
+  /// The result is stored in `data.staticRegressor` and it corresponds to a matrix \f$ Y \f$ such that
+  /// \f$ c = Y(q,\dot{q},\ddot{q})\tilde{\pi} \f$
+  /// where \f$ \tilde{\pi} = (\tilde{\pi}_1^T\ \dots\ \tilde{\pi}_n^T)^T \f$ and
+  /// \f$ \tilde{\pi}_i = \text{model.inertias[i].toDynamicParameters().head<4>()} \f$
+  ///
   /// \tparam JointCollection Collection of Joint types.
   /// \tparam ConfigVectorType Type of the joint configuration vector.
   ///
@@ -79,7 +84,7 @@ namespace pinocchio
   /// This algorithm assumes RNEA has been run to compute the acceleration and gravitational effects.
   ///
   /// The result is such that
-  /// \f$ f = jointBodyRegressor(model,data,jointId) * I.toDynamicParameters() \f$
+  /// \f$ f = \text{jointBodyRegressor(model,data,jointId) * I.toDynamicParameters()} \f$
   /// where \f$ f \f$ is the net force acting on the body, including gravity
   ///
   /// \param[in] model The model structure of the rigid body system.
@@ -100,7 +105,7 @@ namespace pinocchio
   /// This algorithm assumes RNEA has been run to compute the acceleration and gravitational effects.
   ///
   /// The result is such that
-  /// \f$ f = frameBodyRegressor(model,data,frameId) * I.toDynamicParameters() \f$
+  /// \f$ f = \text{frameBodyRegressor(model,data,frameId) * I.toDynamicParameters()} \f$
   /// where \f$ f \f$ is the net force acting on the body, including gravity
   ///
   /// \param[in] model The model structure of the rigid body system.
@@ -115,31 +120,35 @@ namespace pinocchio
                      DataTpl<Scalar,Options,JointCollectionTpl> & data,
                      FrameIndex frameId);
 
-    ///
-    /// \brief Computes the joint torque regressor that links the joint torque
-    ///        to the dynamic parameters of each link according to the current the robot motion.
-    ///
-    /// \tparam JointCollection Collection of Joint types.
-    /// \tparam ConfigVectorType Type of the joint configuration vector.
-    /// \tparam TangentVectorType1 Type of the joint velocity vector.
-    /// \tparam TangentVectorType2 Type of the joint acceleration vector.
-    ///
-    /// \param[in] model The model structure of the rigid body system.
-    /// \param[in] data The data structure of the rigid body system.
-    /// \param[in] q The joint configuration vector (dim model.nq).
-    /// \param[in] v The joint velocity vector (dim model.nv).
-    /// \param[in] a The joint acceleration vector (dim model.nv).
-    ///
-    /// \return The joint torque regressor of the system.
-    ///
-    template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2>
-    inline typename DataTpl<Scalar,Options,JointCollectionTpl>::MatrixXs &
-    computeJointTorqueRegressor(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                                DataTpl<Scalar,Options,JointCollectionTpl> & data,
-                                const Eigen::MatrixBase<ConfigVectorType> & q,
-                                const Eigen::MatrixBase<TangentVectorType1> & v,
-                                const Eigen::MatrixBase<TangentVectorType2> & a);
-  
+  ///
+  /// \brief Computes the joint torque regressor that links the joint torque
+  ///        to the dynamic parameters of each link according to the current the robot motion.
+  ///
+  /// The result is stored in `data.jointTorqueRegressor` and it corresponds to a matrix \f$ Y \f$ such that
+  /// \f$ \tau = Y(q,\dot{q},\ddot{q})\pi \f$
+  /// where \f$ \pi = (\pi_1^T\ \dots\ \pi_n^T)^T \f$ and \f$ \pi_i = \text{model.inertias[i].toDynamicParameters()} \f$
+  ///
+  /// \tparam JointCollection Collection of Joint types.
+  /// \tparam ConfigVectorType Type of the joint configuration vector.
+  /// \tparam TangentVectorType1 Type of the joint velocity vector.
+  /// \tparam TangentVectorType2 Type of the joint acceleration vector.
+  ///
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  /// \param[in] q The joint configuration vector (dim model.nq).
+  /// \param[in] v The joint velocity vector (dim model.nv).
+  /// \param[in] a The joint acceleration vector (dim model.nv).
+  ///
+  /// \return The joint torque regressor of the system.
+  ///
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2>
+  inline typename DataTpl<Scalar,Options,JointCollectionTpl>::MatrixXs &
+  computeJointTorqueRegressor(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                              DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                              const Eigen::MatrixBase<ConfigVectorType> & q,
+                              const Eigen::MatrixBase<TangentVectorType1> & v,
+                              const Eigen::MatrixBase<TangentVectorType2> & a);
+
 } // namespace pinocchio
 
 /* --- Details -------------------------------------------------------------------- */

--- a/src/algorithm/regressor.hpp
+++ b/src/algorithm/regressor.hpp
@@ -91,6 +91,31 @@ namespace pinocchio
   frameBodyRegressor(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                      DataTpl<Scalar,Options,JointCollectionTpl> & data,
                      FrameIndex frameId);
+
+    ///
+    /// \brief Computes the joint torque regressor that links the joint torque
+    ///        to the dynamic parameters of each link according to the current the robot motion.
+    ///
+    /// \tparam JointCollection Collection of Joint types.
+    /// \tparam ConfigVectorType Type of the joint configuration vector.
+    /// \tparam TangentVectorType1 Type of the joint velocity vector.
+    /// \tparam TangentVectorType2 Type of the joint acceleration vector.
+    ///
+    /// \param[in] model The model structure of the rigid body system.
+    /// \param[in] data The data structure of the rigid body system.
+    /// \param[in] q The joint configuration vector (dim model.nq).
+    /// \param[in] v The joint velocity vector (dim model.nv).
+    /// \param[in] a The joint acceleration vector (dim model.nv).
+    ///
+    /// \return The joint torque regressor of the system.
+    ///
+    template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2>
+    inline typename DataTpl<Scalar,Options,JointCollectionTpl>::MatrixXs &
+    computeJointTorqueRegressor(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                                DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                                const Eigen::MatrixBase<ConfigVectorType> & q,
+                                const Eigen::MatrixBase<TangentVectorType1> & v,
+                                const Eigen::MatrixBase<TangentVectorType2> & a);
   
 } // namespace pinocchio
 

--- a/src/algorithm/regressor.hpp
+++ b/src/algorithm/regressor.hpp
@@ -70,6 +70,27 @@ namespace pinocchio
   jointBodyRegressor(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                      DataTpl<Scalar,Options,JointCollectionTpl> & data,
                      JointIndex jointId);
+
+  ///
+  /// \brief Computes the regressor for the dynamic parameters of a rigid body attached to a given frame.
+  ///
+  /// This algorithm assumes RNEA has been run to compute the acceleration and gravitational effects.
+  ///
+  /// The result is such that
+  /// \f$ f = frameBodyRegressor(model,data,frameId) * I.toDynamicParameters() \f$
+  /// where \f$ f \f$ is the net force acting on the body, including gravity
+  ///
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  /// \param[in] frameId The id of the frame.
+  ///
+  /// \return The regressor of the body.
+  ///
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  inline Eigen::Matrix<Scalar,6,10,Options>
+  frameBodyRegressor(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                     DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                     FrameIndex frameId);
   
 } // namespace pinocchio
 

--- a/src/algorithm/regressor.hpp
+++ b/src/algorithm/regressor.hpp
@@ -71,6 +71,20 @@ namespace pinocchio
   ///
   /// \param[in] v Velocity of the rigid body
   /// \param[in] a Acceleration of the rigid body
+  /// \param[out] regressor The resulting regressor of the body.
+  ///
+  template<typename MotionVelocity, typename MotionAcceleration, typename OutputType>
+  inline void
+  bodyRegressor(const MotionDense<MotionVelocity> & v, const MotionDense<MotionAcceleration> & a, const Eigen::MatrixBase<OutputType> & regressor);
+
+  ///
+  /// \brief Computes the regressor for the dynamic parameters of a single rigid body.
+  ///
+  /// The result is such that
+  /// \f$ I a + v \times I v = bodyRegressor(v,a) * I.toDynamicParameters() \f$
+  ///
+  /// \param[in] v Velocity of the rigid body
+  /// \param[in] a Acceleration of the rigid body
   ///
   /// \return The regressor of the body.
   ///
@@ -79,7 +93,8 @@ namespace pinocchio
   bodyRegressor(const MotionDense<MotionVelocity> & v, const MotionDense<MotionAcceleration> & a);
 
   ///
-  /// \brief Computes the regressor for the dynamic parameters of a rigid body attached to a given joint.
+  /// \brief Computes the regressor for the dynamic parameters of a rigid body attached to a given joint,
+  ///        puts the result in data.bodyRegressor and returns it.
   ///
   /// This algorithm assumes RNEA has been run to compute the acceleration and gravitational effects.
   ///
@@ -94,13 +109,14 @@ namespace pinocchio
   /// \return The regressor of the body.
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
-  inline Eigen::Matrix<Scalar,6,10,Options>
+  inline typename DataTpl<Scalar,Options,JointCollectionTpl>::BodyRegressorType &
   jointBodyRegressor(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                      DataTpl<Scalar,Options,JointCollectionTpl> & data,
                      JointIndex jointId);
 
   ///
-  /// \brief Computes the regressor for the dynamic parameters of a rigid body attached to a given frame.
+  /// \brief Computes the regressor for the dynamic parameters of a rigid body attached to a given frame,
+  ///        puts the result in data.bodyRegressor and returns it.
   ///
   /// This algorithm assumes RNEA has been run to compute the acceleration and gravitational effects.
   ///
@@ -115,7 +131,7 @@ namespace pinocchio
   /// \return The regressor of the body.
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
-  inline Eigen::Matrix<Scalar,6,10,Options>
+  inline typename DataTpl<Scalar,Options,JointCollectionTpl>::BodyRegressorType &
   frameBodyRegressor(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                      DataTpl<Scalar,Options,JointCollectionTpl> & data,
                      FrameIndex frameId);
@@ -140,6 +156,8 @@ namespace pinocchio
   /// \param[in] a The joint acceleration vector (dim model.nv).
   ///
   /// \return The joint torque regressor of the system.
+  ///
+  /// \warning This function writes temporary information in data.bodyRegressor. This means if you have valuable data in it it will be overwritten.
   ///
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2>
   inline typename DataTpl<Scalar,Options,JointCollectionTpl>::MatrixXs &

--- a/src/algorithm/regressor.hpp
+++ b/src/algorithm/regressor.hpp
@@ -49,6 +49,27 @@ namespace pinocchio
   template<typename MotionVelocity, typename MotionAcceleration>
   inline Eigen::Matrix<typename MotionVelocity::Scalar,6,10,MotionVelocity::Options>
   bodyRegressor(const MotionBase<MotionVelocity> & v, const MotionBase<MotionAcceleration> & a);
+
+  ///
+  /// \brief Computes the regressor for the dynamic parameters of a rigid body attached to a given joint.
+  ///
+  /// This algorithm assumes RNEA has been run to compute the acceleration and gravitational effects.
+  ///
+  /// The result is such that
+  /// \f$ f = jointBodyRegressor(model,data,jointId) * I.toDynamicParameters() \f$
+  /// where \f$ f \f$ is the net force acting on the body, including gravity
+  ///
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  /// \param[in] jointId The id of the joint.
+  ///
+  /// \return The regressor of the body.
+  ///
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  inline Eigen::Matrix<Scalar,6,10,Options>
+  jointBodyRegressor(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                     DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                     JointIndex jointId);
   
 } // namespace pinocchio
 

--- a/src/algorithm/regressor.hpp
+++ b/src/algorithm/regressor.hpp
@@ -10,10 +10,28 @@
 
 namespace pinocchio
 {
-  
+    
+  ///
+  /// \brief Computes the static regressor that links the center of mass positions of all the links
+  ///        to the center of mass of the complete model according to the current configuration of the robot.
+  ///
+  /// \tparam JointCollection Collection of Joint types.
+  /// \tparam ConfigVectorType Type of the joint configuration vector.
+  ///
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  /// \param[in] q The joint configuration vector (dim model.nq).
+  ///
+  /// \return The static regressor of the system.
+  ///
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
+  inline typename DataTpl<Scalar,Options,JointCollectionTpl>::Matrix3x &
+  computeStaticRegressor(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                         DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                         const Eigen::MatrixBase<ConfigVectorType> & q);
+
   namespace regressor
   {
-    
     
     ///
     /// \brief Computes the static regressor that links the center of mass positions of all the links
@@ -28,11 +46,16 @@ namespace pinocchio
     ///
     /// \return The static regressor of the system.
     ///
+    /// \deprecated This function is now in the main pinocchio namespace
+    ///
     template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
-    inline typename DataTpl<Scalar,Options,JointCollectionTpl>::Matrix3x &
+    inline PINOCCHIO_DEPRECATED typename DataTpl<Scalar,Options,JointCollectionTpl>::Matrix3x &
     computeStaticRegressor(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                            DataTpl<Scalar,Options,JointCollectionTpl> & data,
-                           const Eigen::MatrixBase<ConfigVectorType> & q);
+                           const Eigen::MatrixBase<ConfigVectorType> & q)
+    {
+        return ::pinocchio::computeStaticRegressor(model,data,q);
+    }
   }
 
   ///

--- a/src/algorithm/regressor.hxx
+++ b/src/algorithm/regressor.hxx
@@ -58,11 +58,12 @@ namespace pinocchio
   namespace details {
     // auxiliary function for bodyRegressor: bigL(omega)*I.toDynamicParameters().tail<6>() = I.inertia() * omega
     template<typename Vector3Like>
-    inline Eigen::Matrix<typename Vector3Like::Scalar,3,6>
+    inline Eigen::Matrix<typename Vector3Like::Scalar,3,6,PINOCCHIO_EIGEN_PLAIN_TYPE(Vector3Like)::Options>
     bigL(const Eigen::MatrixBase<Vector3Like> & omega)
     {
       typedef typename Vector3Like::Scalar Scalar;
-      typedef Eigen::Matrix<typename Vector3Like::Scalar,3,6> ReturnType;
+      enum { Options = PINOCCHIO_EIGEN_PLAIN_TYPE(Vector3Like)::Options };
+      typedef Eigen::Matrix<Scalar,3,6,Options> ReturnType;
 
       ReturnType L;
       L <<  omega[0],  omega[1], Scalar(0),  omega[2], Scalar(0), Scalar(0),
@@ -73,16 +74,18 @@ namespace pinocchio
   }
 
   template<typename MotionVelocity, typename MotionAcceleration>
-  inline Eigen::Matrix<typename MotionVelocity::Scalar,6,10,MotionVelocity::Options>
-  bodyRegressor(const MotionBase<MotionVelocity> & v, const MotionBase<MotionAcceleration> & a)
+  inline Eigen::Matrix<typename MotionVelocity::Scalar,6,10,PINOCCHIO_EIGEN_PLAIN_TYPE(typename MotionVelocity::Vector3)::Options>
+  bodyRegressor(const MotionDense<MotionVelocity> & v, const MotionDense<MotionAcceleration> & a)
   {
     typedef typename MotionVelocity::Scalar Scalar;
-    typedef Symmetric3Tpl<typename MotionVelocity::Scalar,MotionVelocity::Options> Symmetric3;
-    typedef typename Symmetric3Tpl<typename MotionVelocity::Scalar,MotionVelocity::Options>::SkewSquare SkewSquare;
-    typedef Eigen::Matrix<typename MotionVelocity::Scalar,6,10,MotionVelocity::Options> ReturnType;
+    enum { Options = PINOCCHIO_EIGEN_PLAIN_TYPE(typename MotionVelocity::Vector3)::Options };
+
+    typedef Symmetric3Tpl<Scalar,Options> Symmetric3;
+    typedef typename Symmetric3::SkewSquare SkewSquare;
+    typedef Eigen::Matrix<Scalar,6,10,Options> ReturnType;
     using ::pinocchio::details::bigL;
 
-    Eigen::Matrix<Scalar, 3, 1, MotionVelocity::Options> acc = a.linear() + v.angular().cross(v.linear());
+    Eigen::Matrix<Scalar, 3, 1, Options> acc = a.linear() + v.angular().cross(v.linear());
 
     ReturnType res;
 

--- a/src/algorithm/regressor.hxx
+++ b/src/algorithm/regressor.hxx
@@ -7,6 +7,8 @@
 
 #include "pinocchio/algorithm/check.hpp"
 #include "pinocchio/algorithm/kinematics.hpp"
+#include "pinocchio/spatial/skew.hpp"
+#include "pinocchio/spatial/symmetric3.hpp"
 
 namespace pinocchio
 {
@@ -51,7 +53,52 @@ namespace pinocchio
       return data.staticRegressor;
     }
   }
-  
+
+
+  namespace details {
+    // auxiliary function for bodyRegressor: bigL(omega)*I.toDynamicParameters().tail<6>() = I.inertia() * omega
+    template<typename Vector3Like>
+    inline Eigen::Matrix<typename Vector3Like::Scalar,3,6>
+    bigL(const Eigen::MatrixBase<Vector3Like> & omega)
+    {
+      typedef typename Vector3Like::Scalar Scalar;
+      typedef Eigen::Matrix<typename Vector3Like::Scalar,3,6> ReturnType;
+
+      ReturnType L;
+      L <<  omega[0],  omega[1], Scalar(0),  omega[2], Scalar(0), Scalar(0),
+           Scalar(0),  omega[0],  omega[1], Scalar(0),  omega[2], Scalar(0),
+           Scalar(0), Scalar(0), Scalar(0),  omega[0],  omega[1],  omega[2];
+      return L;
+    }
+  }
+
+  template<typename MotionVelocity, typename MotionAcceleration>
+  inline Eigen::Matrix<typename MotionVelocity::Scalar,6,10,MotionVelocity::Options>
+  bodyRegressor(const MotionBase<MotionVelocity> & v, const MotionBase<MotionAcceleration> & a)
+  {
+    typedef typename MotionVelocity::Scalar Scalar;
+    typedef Symmetric3Tpl<typename MotionVelocity::Scalar,MotionVelocity::Options> Symmetric3;
+    typedef typename Symmetric3Tpl<typename MotionVelocity::Scalar,MotionVelocity::Options>::SkewSquare SkewSquare;
+    typedef Eigen::Matrix<typename MotionVelocity::Scalar,6,10,MotionVelocity::Options> ReturnType;
+    using ::pinocchio::details::bigL;
+
+    Eigen::Matrix<Scalar, 3, 1, MotionVelocity::Options> acc = a.linear() + v.angular().cross(v.linear());
+
+    ReturnType res;
+
+    res.template block<3,1>(MotionVelocity::LINEAR,0) = acc;
+    res.template block<3,3>(MotionVelocity::LINEAR,1) = Symmetric3(SkewSquare(v.angular())).matrix();
+    addSkew(a.angular(), res.template block<3,3>(MotionVelocity::LINEAR,1));
+
+    res.template block<3,6>(MotionVelocity::LINEAR,4).setZero();
+
+    res.template block<3,1>(MotionVelocity::ANGULAR,0).setZero();
+    skew(-acc, res.template block<3,3>(MotionVelocity::ANGULAR,1));
+    res.template block<3,6>(MotionVelocity::ANGULAR,4) = bigL(a.angular()) + cross(v.angular(), bigL(v.angular()));
+
+    return res;
+  }
+
 } // namespace pinocchio
 
 #endif // ifndef __pinocchio_regressor_hxx__

--- a/src/algorithm/regressor.hxx
+++ b/src/algorithm/regressor.hxx
@@ -14,47 +14,42 @@
 namespace pinocchio
 {
   
-  namespace regressor
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
+  inline typename DataTpl<Scalar,Options,JointCollectionTpl>::Matrix3x &
+  computeStaticRegressor(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                         DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                         const Eigen::MatrixBase<ConfigVectorType> & q)
   {
+    assert(model.check(data) && "data is not consistent with model.");
+    assert(q.size() == model.nq);
     
-    template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
-    inline typename DataTpl<Scalar,Options,JointCollectionTpl>::Matrix3x &
-    computeStaticRegressor(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                           DataTpl<Scalar,Options,JointCollectionTpl> & data,
-                           const Eigen::MatrixBase<ConfigVectorType> & q)
+    typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
+    typedef DataTpl<Scalar,Options,JointCollectionTpl> Data;
+    typedef typename Model::JointIndex JointIndex;
+    typedef typename Data::SE3 SE3;
+
+    typedef typename Data::Matrix3x Matrix3x;
+    typedef typename SizeDepType<4>::ColsReturn<Matrix3x>::Type ColsBlock;
+    
+    forwardKinematics(model,data,q.derived());
+    
+    // Computes the total mass of the system
+    Scalar mass = Scalar(0);
+    for(JointIndex i = 1; i < (JointIndex)model.njoints; ++i)
+      mass += model.inertias[(JointIndex)i].mass();
+    
+    const Scalar mass_inv = Scalar(1)/mass;
+    for(JointIndex i = 1; i < (JointIndex)model.njoints; ++i)
     {
-      assert(model.check(data) && "data is not consistent with model.");
-      assert(q.size() == model.nq);
-      
-      typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
-      typedef DataTpl<Scalar,Options,JointCollectionTpl> Data;
-      typedef typename Model::JointIndex JointIndex;
-      typedef typename Data::SE3 SE3;
-
-      typedef typename Data::Matrix3x Matrix3x;
-      typedef typename SizeDepType<4>::ColsReturn<Matrix3x>::Type ColsBlock;
-      
-      forwardKinematics(model,data,q.derived());
-      
-      // Computes the total mass of the system
-      Scalar mass = Scalar(0);
-      for(JointIndex i = 1; i < (JointIndex)model.njoints; ++i)
-        mass += model.inertias[(JointIndex)i].mass();
-      
-      const Scalar mass_inv = Scalar(1)/mass;
-      for(JointIndex i = 1; i < (JointIndex)model.njoints; ++i)
-      {
-        const SE3 & oMi = data.oMi[i];
-        ColsBlock sr_cols = data.staticRegressor.template middleCols<4>((Eigen::DenseIndex)(i-1)*4);
-        sr_cols.col(0) = oMi.translation();
-        sr_cols.template rightCols<3>() = oMi.rotation();
-        sr_cols *= mass_inv;
-      }
-      
-      return data.staticRegressor;
+      const SE3 & oMi = data.oMi[i];
+      ColsBlock sr_cols = data.staticRegressor.template middleCols<4>((Eigen::DenseIndex)(i-1)*4);
+      sr_cols.col(0) = oMi.translation();
+      sr_cols.template rightCols<3>() = oMi.rotation();
+      sr_cols *= mass_inv;
     }
+    
+    return data.staticRegressor;
   }
-
 
   namespace details {
     // auxiliary function for bodyRegressor: bigL(omega)*I.toDynamicParameters().tail<6>() = I.inertia() * omega

--- a/src/algorithm/regressor.hxx
+++ b/src/algorithm/regressor.hxx
@@ -115,6 +115,30 @@ namespace pinocchio
     return bodyRegressor(data.v[jointId], data.a_gf[jointId]);
   }
 
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  inline Eigen::Matrix<Scalar,6,10,Options>
+  frameBodyRegressor(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                     DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                     FrameIndex frameId)
+  {
+    assert(model.check(data) && "data is not consistent with model.");
+
+    typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
+    typedef typename Model::Frame Frame;
+    typedef typename Model::JointIndex JointIndex;
+    typedef typename Model::SE3 SE3;
+    typedef typename Model::Motion Motion;
+
+    const Frame & frame = model.frames[frameId];
+    const JointIndex & parent = frame.parent;
+    const SE3 & placement = frame.placement;
+
+    const Motion v  = placement.actInv(data.v[parent]);
+    const Motion a  = placement.actInv(data.a_gf[parent]);
+
+    return bodyRegressor(v, a);
+  }
+
 } // namespace pinocchio
 
 #endif // ifndef __pinocchio_regressor_hxx__

--- a/src/algorithm/regressor.hxx
+++ b/src/algorithm/regressor.hxx
@@ -99,6 +99,19 @@ namespace pinocchio
     return res;
   }
 
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  inline Eigen::Matrix<Scalar,6,10,Options>
+  jointBodyRegressor(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                     DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                     JointIndex jointId)
+  {
+    assert(model.check(data) && "data is not consistent with model.");
+
+    PINOCCHIO_UNUSED_VARIABLE(model);
+
+    return bodyRegressor(data.v[jointId], data.a_gf[jointId]);
+  }
+
 } // namespace pinocchio
 
 #endif // ifndef __pinocchio_regressor_hxx__

--- a/src/algorithm/regressor.hxx
+++ b/src/algorithm/regressor.hxx
@@ -81,11 +81,10 @@ namespace pinocchio
     typedef Eigen::Matrix<Scalar,6,10,Options> ReturnType;
     using ::pinocchio::details::bigL;
 
-    Eigen::Matrix<Scalar, 3, 1, Options> acc = a.linear() + v.angular().cross(v.linear());
-
     ReturnType res;
 
-    res.template block<3,1>(MotionVelocity::LINEAR,0) = acc;
+    res.template block<3,1>(MotionVelocity::LINEAR,0) = a.linear() + v.angular().cross(v.linear());
+    const Eigen::Matrix<Scalar, 3, 1, Options> & acc = res.template block<3,1>(MotionVelocity::LINEAR,0);
     res.template block<3,3>(MotionVelocity::LINEAR,1) = Symmetric3(SkewSquare(v.angular())).matrix();
     addSkew(a.angular(), res.template block<3,3>(MotionVelocity::LINEAR,1));
 

--- a/src/multibody/data.hpp
+++ b/src/multibody/data.hpp
@@ -325,8 +325,11 @@ namespace pinocchio
     /// \brief Lagrange Multipliers corresponding to the contact impulses in pinocchio::impulseDynamics.
     VectorXs impulse_c;
     
-    // data related to regressor
+    // data related to static regressor
     Matrix3x staticRegressor;
+
+    // data related to joint torque regressor
+    MatrixXs jointTorqueRegressor;
     
     ///
     /// \brief Default constructor of pinocchio::Data from a pinocchio::Model.

--- a/src/multibody/data.hpp
+++ b/src/multibody/data.hpp
@@ -70,7 +70,10 @@ namespace pinocchio
     typedef Eigen::Matrix<Scalar,6,6,Options> Matrix6;
     typedef Eigen::Matrix<Scalar,6,6,Eigen::RowMajor | Options> RowMatrix6;
     typedef Eigen::Matrix<Scalar,Eigen::Dynamic,Eigen::Dynamic,Eigen::RowMajor | Options> RowMatrixXs;
-    
+
+    /// \brief The type of the body regressor
+    typedef Eigen::Matrix<Scalar,6,10,Options> BodyRegressorType;
+
     /// \brief Vector of pinocchio::JointData associated to the pinocchio::JointModel stored in model, 
     /// encapsulated in JointDataAccessor.
     JointDataVector joints;
@@ -327,6 +330,9 @@ namespace pinocchio
     
     // data related to static regressor
     Matrix3x staticRegressor;
+
+    /// body regressor
+    BodyRegressorType bodyRegressor;
 
     // data related to joint torque regressor
     MatrixXs jointTorqueRegressor;

--- a/src/multibody/data.hxx
+++ b/src/multibody/data.hxx
@@ -92,6 +92,7 @@ namespace pinocchio
   , dq_after(model.nv)
   , impulse_c()
   , staticRegressor(3,4*(model.njoints-1))
+  , jointTorqueRegressor(model.nv,10*(model.njoints-1))
   {
     typedef typename Model::JointIndex JointIndex;
     

--- a/src/spatial/inertia.hpp
+++ b/src/spatial/inertia.hpp
@@ -271,7 +271,8 @@ namespace pinocchio
     /** Returns the representation of the matrix as a vector of dynamic parameters.
     * The parameters are given as
     * \f$ v = [m, mc_x, mc_y, mc_z, I_{xx}, I_{xy}, I_{yy}, I_{xz}, I_{yz}, I_{zz}]^T \f$
-    * where \f$ I = I_C + mS^T(c)S(c) \f$ and \f$ I_C \f$ has its origin at the barycenter.
+    * where \f$ c \f$ is the center of mass, \f$ I = I_C + mS^T(c)S(c) \f$ and \f$ I_C \f$ has its origin at the barycenter
+    * and \f$ S(c) \f$ is the the skew matrix representation of the cross product operator.
     */
     Vector10 toDynamicParameters() const
     {

--- a/unittest/python/CMakeLists.txt
+++ b/unittest/python/CMakeLists.txt
@@ -3,6 +3,7 @@ SET(${PROJECT_NAME}_PYTHON_TESTS
   bindings_data
   bindings_com
   bindings_com_velocity_derivatives
+  bindings_regressor
   bindings_dynamics
   bindings_force
   bindings_frame

--- a/unittest/python/bindings_regressor.py
+++ b/unittest/python/bindings_regressor.py
@@ -6,6 +6,29 @@ import numpy as np
 
 class TestRegressorBindings(TestCase):
 
+    def test_staticRegressor(self):
+        model = pin. buildSampleModelHumanoidRandom()
+
+        data = model.createData()
+        data_ref = model.createData()
+
+        model.lowerPositionLimit[:7] = -1.
+        model.upperPositionLimit[:7] = 1.
+  
+        q = pin.randomConfiguration(model)
+        staticRegressor = pin.computeStaticRegressor(model,data,q)
+
+        phi = zero(4*(model.njoints-1))
+        for k in range(1,model.njoints):
+            Y = model.inertias[k]
+            phi[4*(k-1)] = Y.mass
+            phi[4*k-3:4*k] = Y.mass * Y.lever
+
+        static_com_ref = pin.centerOfMass(model,data_ref,q)
+        static_com = staticRegressor * phi
+
+        self.assertApprox(static_com, static_com_ref)
+
     def test_bodyRegressor(self):
         I = pin.Inertia.Random()
         v = pin.Motion.Random()

--- a/unittest/python/bindings_regressor.py
+++ b/unittest/python/bindings_regressor.py
@@ -17,5 +17,23 @@ class TestRegressorBindings(TestCase):
         
         self.assertApprox(f_regressor, f.vector)
 
+    def test_jointBodyRegressor(self):
+        model = pin.buildSampleModelManipulator()
+        data = model.createData()
+
+        JOINT_ID = model.njoints - 1
+
+        q = pin.randomConfiguration(model)
+        v = pin.utils.rand(model.nv)
+        a = pin.utils.rand(model.nv)
+
+        pin.rnea(model,data,q,v,a)
+
+        f = data.f[JOINT_ID]
+
+        f_regressor = pin.jointBodyRegressor(model,data,JOINT_ID) * model.inertias[JOINT_ID].toDynamicParameters()
+
+        self.assertApprox(f_regressor, f.vector)
+
 if __name__ == '__main__':
     unittest.main()

--- a/unittest/python/bindings_regressor.py
+++ b/unittest/python/bindings_regressor.py
@@ -1,0 +1,21 @@
+import unittest
+from test_case import TestCase
+import pinocchio as pin
+from pinocchio.utils import rand, zero
+import numpy as np
+
+class TestRegressorBindings(TestCase):
+
+    def test_bodyRegressor(self):
+        I = pin.Inertia.Random()
+        v = pin.Motion.Random()
+        a = pin.Motion.Random()
+
+        f = I*a + I.vxiv(v)
+
+        f_regressor = pin.bodyRegressor(v,a) * I.toDynamicParameters()
+        
+        self.assertApprox(f_regressor, f.vector)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unittest/python/bindings_regressor.py
+++ b/unittest/python/bindings_regressor.py
@@ -35,5 +35,28 @@ class TestRegressorBindings(TestCase):
 
         self.assertApprox(f_regressor, f.vector)
 
+    def test_frameBodyRegressor(self):
+        model = pin.buildSampleModelManipulator()
+
+        JOINT_ID = model.njoints - 1
+
+        framePlacement = pin.SE3.Random()
+        FRAME_ID = model.addBodyFrame ("test_body", JOINT_ID, framePlacement, -1)
+
+        data = model.createData()
+
+        q = pin.randomConfiguration(model)
+        v = pin.utils.rand(model.nv)
+        a = pin.utils.rand(model.nv)
+
+        pin.rnea(model,data,q,v,a)
+
+        f = framePlacement.actInv(data.f[JOINT_ID])
+        I = framePlacement.actInv(model.inertias[JOINT_ID])
+
+        f_regressor = pin.frameBodyRegressor(model,data,FRAME_ID) * I.toDynamicParameters()
+
+        self.assertApprox(f_regressor, f.vector)
+
 if __name__ == '__main__':
     unittest.main()

--- a/unittest/python/bindings_regressor.py
+++ b/unittest/python/bindings_regressor.py
@@ -14,9 +14,9 @@ class TestRegressorBindings(TestCase):
 
         model.lowerPositionLimit[:7] = -1.
         model.upperPositionLimit[:7] = 1.
-  
+
         q = pin.randomConfiguration(model)
-        staticRegressor = pin.computeStaticRegressor(model,data,q)
+        pin.computeStaticRegressor(model,data,q)
 
         phi = zero(4*(model.njoints-1))
         for k in range(1,model.njoints):
@@ -25,7 +25,7 @@ class TestRegressorBindings(TestCase):
             phi[4*k-3:4*k] = Y.mass * Y.lever
 
         static_com_ref = pin.centerOfMass(model,data_ref,q)
-        static_com = staticRegressor * phi
+        static_com = data.staticRegressor * phi
 
         self.assertApprox(static_com, static_com_ref)
 

--- a/unittest/python/bindings_regressor.py
+++ b/unittest/python/bindings_regressor.py
@@ -81,5 +81,29 @@ class TestRegressorBindings(TestCase):
 
         self.assertApprox(f_regressor, f.vector)
 
+    def test_joint_torque_regressor(self):
+        model = pin.buildSampleModelHumanoidRandom()
+        model.lowerPositionLimit[:7] = -1.
+        model.upperPositionLimit[:7] = 1.
+
+        data = model.createData()
+        data_ref = model.createData()
+
+        q = pin.randomConfiguration(model)
+        v = pin.utils.rand(model.nv)
+        a = pin.utils.rand(model.nv)
+
+        pin.rnea(model,data_ref,q,v,a)
+
+        params = zero(10*(model.njoints-1))
+        for i in range(1, model.njoints):
+            params[(i-1)*10:i*10] = model.inertias[i].toDynamicParameters()
+
+        pin.computeJointTorqueRegressor(model,data,q,v,a)
+
+        tau_regressor = data.jointTorqueRegressor * params
+
+        self.assertApprox(tau_regressor, data_ref.tau)
+
 if __name__ == '__main__':
     unittest.main()

--- a/unittest/regressor.cpp
+++ b/unittest/regressor.cpp
@@ -47,4 +47,20 @@ BOOST_AUTO_TEST_CASE(test_static_regressor)
   BOOST_CHECK(static_com.isApprox(static_com_ref)); 
 }
 
+BOOST_AUTO_TEST_CASE(test_body_regressor)
+{
+  using namespace Eigen;
+  using namespace pinocchio;
+
+  Inertia I(Inertia::Random());
+  Motion v(Motion::Random());
+  Motion a(Motion::Random());
+
+  Force f = I*a + I.vxiv(v);
+
+  Inertia::Vector6 f_regressor = bodyRegressor(v,a) * I.toDynamicParameters();
+
+  BOOST_CHECK(f_regressor.isApprox(f.toVector()));
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/regressor.cpp
+++ b/unittest/regressor.cpp
@@ -30,7 +30,7 @@ BOOST_AUTO_TEST_CASE(test_static_regressor)
   model.upperPositionLimit.head<7>().fill(1.);
   
   VectorXd q = randomConfiguration(model);
-  regressor::computeStaticRegressor(model,data,q);
+  computeStaticRegressor(model,data,q);
   
   VectorXd phi(4*(model.njoints-1));
   for(int k = 1; k < model.njoints; ++k)

--- a/unittest/regressor.cpp
+++ b/unittest/regressor.cpp
@@ -4,6 +4,7 @@
 
 #include "pinocchio/spatial/fwd.hpp"
 #include "pinocchio/algorithm/regressor.hpp"
+#include "pinocchio/algorithm/rnea.hpp"
 #include "pinocchio/algorithm/joint-configuration.hpp"
 #include "pinocchio/algorithm/center-of-mass.hpp"
 #include "pinocchio/parsers/sample-models.hpp"
@@ -59,6 +60,30 @@ BOOST_AUTO_TEST_CASE(test_body_regressor)
   Force f = I*a + I.vxiv(v);
 
   Inertia::Vector6 f_regressor = bodyRegressor(v,a) * I.toDynamicParameters();
+
+  BOOST_CHECK(f_regressor.isApprox(f.toVector()));
+}
+
+BOOST_AUTO_TEST_CASE(test_joint_body_regressor)
+{
+  using namespace Eigen;
+  using namespace pinocchio;
+
+  pinocchio::Model model;
+  buildModels::manipulator(model);
+  pinocchio::Data data(model);
+
+  JointIndex JOINT_ID = JointIndex(model.njoints) - 1;
+
+  VectorXd q = randomConfiguration(model);
+  VectorXd v = Eigen::VectorXd::Random(model.nv);
+  VectorXd a = Eigen::VectorXd::Random(model.nv);
+
+  rnea(model,data,q,v,a);
+
+  Force f = data.f[JOINT_ID];
+
+  Inertia::Vector6 f_regressor = jointBodyRegressor(model,data,JOINT_ID) * model.inertias[JOINT_ID].toDynamicParameters();
 
   BOOST_CHECK(f_regressor.isApprox(f.toVector()));
 }

--- a/unittest/tspatial.cpp
+++ b/unittest/tspatial.cpp
@@ -541,7 +541,7 @@ BOOST_AUTO_TEST_CASE ( test_Inertia )
     BOOST_CHECK(I.ivx(v).isApprox(M_ref));
   }
   
-  // Text variation against vxI - Ivx operator
+  // Test variation against vxI - Ivx operator
   {
     typedef Inertia::Matrix6 Matrix6;
     Inertia I(Inertia::Random());
@@ -555,7 +555,30 @@ BOOST_AUTO_TEST_CASE ( test_Inertia )
     
     BOOST_CHECK(M3.isApprox(Ivariation));
   }
-  
+
+  // Test dynamic parameters
+  {
+    Inertia I(Inertia::Random());
+
+    Inertia::Vector10 v = I.toDynamicParameters();
+
+    BOOST_CHECK_CLOSE(v[0], I.mass(), 1e-12);
+
+    BOOST_CHECK(v.segment<3>(1).isApprox(I.mass()*I.lever()));
+
+    Eigen::Matrix3d I_o = I.inertia() + I.mass()*skew(I.lever()).transpose()*skew(I.lever());
+    Eigen::Matrix3d I_ov;
+    I_ov << v[4], v[5], v[7],
+            v[5], v[6], v[8],
+            v[7], v[8], v[9];
+
+    BOOST_CHECK(I_o.isApprox(I_ov));
+
+    Inertia I2 = Inertia::FromDynamicParameters(v);
+    BOOST_CHECK(I2.isApprox(I));
+
+  }
+
 }
 
 BOOST_AUTO_TEST_CASE(cast_inertia)


### PR DESCRIPTION
Summary:
this PR introduces a joint torque regressor, such that

<a href="https://www.codecogs.com/eqnedit.php?latex=\tau&space;=&space;Y(q,\dot{q},\ddot{q})\pi" target="_blank"><img src="https://latex.codecogs.com/gif.latex?\tau&space;=&space;Y(q,\dot{q},\ddot{q})\pi" title="\tau = Y(q,\dot{q},\ddot{q})\pi" /></a>

where

<a href="https://www.codecogs.com/eqnedit.php?latex=\pi&space;=&space;(\pi_1^T\&space;\dots\&space;\pi_n^T)^T" target="_blank"><img src="https://latex.codecogs.com/gif.latex?\pi&space;=&space;(\pi_1^T\&space;\dots\&space;\pi_n^T)^T" title="\pi = (\pi_1^T\ \dots\ \pi_n^T)^T" /></a>

<a href="https://www.codecogs.com/eqnedit.php?latex=\pi_i&space;=&space;(m,&space;mc_x,&space;mc_y,&space;mc_z,&space;I_{xx},&space;I_{xy},&space;I_{yy},&space;I_{xz},&space;I_{yz},&space;I_{zz})^T" target="_blank"><img src="https://latex.codecogs.com/gif.latex?\pi_i&space;=&space;(m,&space;mc_x,&space;mc_y,&space;mc_z,&space;I_{xx},&space;I_{xy},&space;I_{yy},&space;I_{xz},&space;I_{yz},&space;I_{zz})^T" title="\pi_i = (m, mc_x, mc_y, mc_z, I_{xx}, I_{xy}, I_{yy}, I_{xz}, I_{yz}, I_{zz})^T" /></a>

<a href="https://www.codecogs.com/eqnedit.php?latex=I&space;=&space;I_C&space;&plus;&space;mS^T(c)S(c)" target="_blank"><img src="https://latex.codecogs.com/gif.latex?I&space;=&space;I_C&space;&plus;&space;mS^T(c)S(c)" title="I = I_C + mS^T(c)S(c)" /></a>

and <a href="https://www.codecogs.com/eqnedit.php?latex=I_C" target="_blank"><img src="https://latex.codecogs.com/gif.latex?I_C" title="I_C" /></a> has its origin at the barycenter.

Also, it introduces several methods which, other than being employed by the function, might be useful *per se*, and a couple of minor additions and modifications.

This may be useful for calibration, but also for the computation of partial derivatives w.r.t. the dynamic parameters.

In detail:
- introduce methods `inertia.toDynamicParameters()` and `Inertia.FromDynamicParameters(Vector10)` to convert between a Pinocchio `Inertia` and its corresponding <a href="https://www.codecogs.com/eqnedit.php?latex=\pi_i" target="_blank"><img src="https://latex.codecogs.com/gif.latex?\pi_i" title="\pi_i" /></a>
- introduce algorithm `bodyRegressor`, computing the regressor for the dynamic parameters of a single rigid body, of which the velocity and acceleration are given
- introduce algorithm `jointBodyRegressor`, computing the regressor for the dynamic parameters of a rigid body attached to a given joint, assuming RNEA has been called
- introduce algorithm `frameBodyRegressor`, computing the regressor for the dynamic parameters of a rigid body attached to a given frame, assuming RNEA has been called
- introduce algorithm `computeJointTorqueRegressor`, computing the joint torque regressor described above, which is written in `data.jointTorqueRegressor`
- expose `data.staticRegressor` in Python
- move `computeStaticRegressor` to main `pinocchio` namespace. Deprecating the version in `regressor` namespace. I did this because the existence of this namespace has always seemed incoherent with the style of the rest of Pinocchio, which is having all algorithms in the main Pinocchio namespace

NOTE 1: notice that, as forward step of the algorithm, I am using `RneaForwardStep`. I did it to go quickly, and also to avoid the need of compiling another step. I now realize calling `RneaForwardStep` will modify `data.f`, leaving it in an inconsistent state. This should be fixed. Therefore, I will either create a custom forward step or find another way to fix the problem which does not require creating a new step type (I can think of at least two,both of which would slightly increase execution time).

NOTE 2: because the matrices are small enough, I used fixed-size matrices: `Matrix<Scalar,10, 1>` and `Matrix<Scalar,6,10>`. As for `Matrix<Scalar,10, 1>`, I typedefed it to `Vector10` inside `InertiaTpl`. `Matrix<Scalar,6,10>`, I do not know where to put a convenient typedef. Also, neither of them is exposed in eigenpy. Should we think about it, especially for `Vector10`?