### PR TITLE
[Doc] fix gepetto-viewer package name

### DIFF
--- a/doc/d-practical-exercises/1-directgeom.md
+++ b/doc/d-practical-exercises/1-directgeom.md
@@ -21,7 +21,7 @@ For this tutorial, you will need [Pinocchio](http://stack-of-tasks.github.io/pin
 
 For this, the easiest way is to add [robotpkg apt repository](http://robotpkg.openrobots.org/debian.html) and launch:
 ```
-sudo apt install robotpkg-py27-pinocchio robotpkg-ur5-description robotpkg-gepetto-viewer-corba robotpkg-osg-dae
+sudo apt install robotpkg-py27-pinocchio robotpkg-ur5-description robotpkg-py27-qt4-gepetto-viewer-corba robotpkg-osg-dae
 ```
 
 ### Python


### PR DESCRIPTION
as gepetto-viewer{,-corba} can now be installed for different Python / Qt versions.