### PR TITLE
Fix memory errors in unit tests

### DIFF
--- a/unittest/aba-derivatives.cpp
+++ b/unittest/aba-derivatives.cpp
@@ -283,7 +283,6 @@ BOOST_AUTO_TEST_CASE(test_multiple_calls)
   
   BOOST_CHECK(data1.dFdq.isApprox(data2.dFdq));
   BOOST_CHECK(data1.dFdv.isApprox(data2.dFdv));
-  BOOST_CHECK(data1.dFda.isApprox(data2.dFda));
   
   BOOST_CHECK(data1.dtau_dq.isApprox(data2.dtau_dq));
   BOOST_CHECK(data1.dtau_dv.isApprox(data2.dtau_dv));

--- a/unittest/contact-dynamics.cpp
+++ b/unittest/contact-dynamics.cpp
@@ -292,8 +292,10 @@ BOOST_AUTO_TEST_CASE (timings_fd_llt)
   const std::string LF = "lleg6_joint";
   
   Data::Matrix6x J_RF (6, model.nv);
+  J_RF.setZero();
   getJointJacobian(model, data, model.getJointId(RF), LOCAL, J_RF);
   Data::Matrix6x J_LF (6, model.nv);
+  J_LF.setZero();
   getJointJacobian(model, data, model.getJointId(LF), LOCAL, J_LF);
   
   Eigen::MatrixXd J (12, model.nv);

--- a/unittest/frames.cpp
+++ b/unittest/frames.cpp
@@ -43,7 +43,7 @@ BOOST_AUTO_TEST_CASE(frame_basic)
   }
   
   std::ostringstream os;
-  os << Frame() << std::endl;
+  os << Frame("toto",0,0,SE3::Random(),OP_FRAME) << std::endl;
   BOOST_CHECK(!os.str().empty());
 }
 


### PR DESCRIPTION
A few unit test contained some memory errors, as they where using uninitialized values.
These errors would not make the tests fail, but they caused valgrind to complain.

I fixed the errors. Now the tests are cleaner: in one case the input matrices where not set to zero and in another one a test was performed which did not make sense (the third error being negligible).

I would like to point out that valgrind complains a lot about python-parser-test too... However, since there is Python in the middle, it is much more difficult to analyze.