### PR TITLE
algo/derivatives: use const references

### DIFF
--- a/src/algorithm/aba-derivatives.hpp
+++ b/src/algorithm/aba-derivatives.hpp
@@ -76,7 +76,7 @@ namespace pinocchio
                                     const Eigen::MatrixBase<ConfigVectorType> & q,
                                     const Eigen::MatrixBase<TangentVectorType1> & v,
                                     const Eigen::MatrixBase<TangentVectorType2> & tau,
-                                    const container::aligned_vector< ForceTpl<Scalar,Options> > fext,
+                                    const container::aligned_vector< ForceTpl<Scalar,Options> > & fext,
                                     const Eigen::MatrixBase<MatrixType1> & aba_partial_dq,
                                     const Eigen::MatrixBase<MatrixType2> & aba_partial_dv,
                                     const Eigen::MatrixBase<MatrixType3> & aba_partial_dtau);
@@ -139,7 +139,7 @@ namespace pinocchio
                                     const Eigen::MatrixBase<ConfigVectorType> & q,
                                     const Eigen::MatrixBase<TangentVectorType1> & v,
                                     const Eigen::MatrixBase<TangentVectorType2> & tau,
-                                    const container::aligned_vector< ForceTpl<Scalar,Options> > fext)
+                                    const container::aligned_vector< ForceTpl<Scalar,Options> > & fext)
   {
     computeABADerivatives(model,data,q,v,tau,fext,
                           data.ddq_dq,data.ddq_dv,data.Minv);

--- a/src/algorithm/aba-derivatives.hxx
+++ b/src/algorithm/aba-derivatives.hxx
@@ -403,7 +403,7 @@ namespace pinocchio
                                     const Eigen::MatrixBase<ConfigVectorType> & q,
                                     const Eigen::MatrixBase<TangentVectorType1> & v,
                                     const Eigen::MatrixBase<TangentVectorType2> & tau,
-                                    const container::aligned_vector< ForceTpl<Scalar,Options> > fext,
+                                    const container::aligned_vector< ForceTpl<Scalar,Options> > & fext,
                                     const Eigen::MatrixBase<MatrixType1> & aba_partial_dq,
                                     const Eigen::MatrixBase<MatrixType2> & aba_partial_dv,
                                     const Eigen::MatrixBase<MatrixType3> & aba_partial_dtau)

--- a/src/algorithm/rnea-derivatives.hpp
+++ b/src/algorithm/rnea-derivatives.hpp
@@ -110,7 +110,7 @@ namespace pinocchio
                          const Eigen::MatrixBase<ConfigVectorType> & q,
                          const Eigen::MatrixBase<TangentVectorType1> & v,
                          const Eigen::MatrixBase<TangentVectorType2> & a,
-                         const container::aligned_vector< ForceTpl<Scalar,Options> > fext,
+                         const container::aligned_vector< ForceTpl<Scalar,Options> > & fext,
                          const Eigen::MatrixBase<MatrixType1> & rnea_partial_dq,
                          const Eigen::MatrixBase<MatrixType2> & rnea_partial_dv,
                          const Eigen::MatrixBase<MatrixType3> & rnea_partial_da);
@@ -177,7 +177,7 @@ namespace pinocchio
                          const Eigen::MatrixBase<ConfigVectorType> & q,
                          const Eigen::MatrixBase<TangentVectorType1> & v,
                          const Eigen::MatrixBase<TangentVectorType2> & a,
-                         const container::aligned_vector< ForceTpl<Scalar,Options> > fext)
+                         const container::aligned_vector< ForceTpl<Scalar,Options> > & fext)
   {
     computeRNEADerivatives(model,data,q.derived(),v.derived(),a.derived(),fext,
                            data.dtau_dq, data.dtau_dv, data.M);

--- a/src/algorithm/rnea-derivatives.hxx
+++ b/src/algorithm/rnea-derivatives.hxx
@@ -424,7 +424,7 @@ namespace pinocchio
                          const Eigen::MatrixBase<ConfigVectorType> & q,
                          const Eigen::MatrixBase<TangentVectorType1> & v,
                          const Eigen::MatrixBase<TangentVectorType2> & a,
-                         const container::aligned_vector< ForceTpl<Scalar,Options> > fext,
+                         const container::aligned_vector< ForceTpl<Scalar,Options> > & fext,
                          const Eigen::MatrixBase<MatrixType1> & rnea_partial_dq,
                          const Eigen::MatrixBase<MatrixType2> & rnea_partial_dv,
                          const Eigen::MatrixBase<MatrixType3> & rnea_partial_da)


### PR DESCRIPTION
Avoid useless memory allocation.
Related to #859 and #879.