### PR TITLE
[Doc] Add a cheat sheet

### DIFF
--- a/doc/Doxyfile.extra.in
+++ b/doc/Doxyfile.extra.in
@@ -675,3 +675,9 @@ MATHJAX_RELPATH        = MathJax/
 # the tag USE_MATHJAX is set to YES.
 
 MATHJAX_FORMAT         = SVG
+
+#---------------------------------------------------------------------------
+# Aliases
+#---------------------------------------------------------------------------
+
+ALIASES += "cheatsheet=\xrefitem cheatsheet \"Remarkable identity\" \"Cheat sheet\""

--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -439,6 +439,7 @@ namespace pinocchio
                * SE3(p1.matrix(), q1.derived().template head<3>())).toVector();
     }
 
+    /// \cheatsheet \f$ \frac{\partial\ominus}{\partial q_1} {}^1X_0 = - \frac{\partial\ominus}{\partial q_0} \f$
     template <ArgumentPosition arg, class ConfigL_t, class ConfigR_t, class JacobianOut_t>
     void dDifference_impl (const Eigen::MatrixBase<ConfigL_t> & q0,
                            const Eigen::MatrixBase<ConfigR_t> & q1,

--- a/src/spatial/se3-base.hpp
+++ b/src/spatial/se3-base.hpp
@@ -10,15 +10,17 @@ namespace pinocchio
 {
   /** The rigid transform aMb can be seen in two ways:
    *
-   * - given a point p expressed in frame B by its coordinate vector Bp, aMb
-   * computes its coordinates in frame A by Ap = aMb Bp.
-   * - aMb displaces a solid S centered at frame A into the solid centered in
-   * B. In particular, the origin of A is displaced at the origin of B: $^aM_b
-   * ^aA = ^aB$.
+   * - given a point p expressed in frame B by its coordinate vector \f$ ^bp \f$, \f$ ^aM_b \f$
+   * computes its coordinates in frame A by \f$ ^ap = {}^aM_b {}^bp \f$.
+   * - \f$ ^aM_b \f$ displaces a solid S centered at frame A into the solid centered in
+   * B. In particular, the origin of A is displaced at the origin of B:
+   * \f$^aM_b {}^aA = {}^aB \f$.
    
    * The rigid displacement is stored as a rotation matrix and translation vector by:
-   * aMb (x) =  aRb*x + aAB
-   * where aAB is the vector from origin A to origin B expressed in coordinates A.
+   * \f$ ^aM_b x = {}^aR_b x + {}^aAB \f$
+   * where \f$^aAB\f$ is the vector from origin A to origin B expressed in coordinates A.
+   *
+   * \cheatsheet \f$ {}^aM_c = {}^aM_b {}^bM_c \f$
    */
   template<class Derived>
   struct SE3Base
@@ -41,12 +43,21 @@ namespace pinocchio
     }
     operator HomogeneousMatrixType() const { return toHomogeneousMatrix(); }
     
+    /**
+     * @brief The action matrix \f$ {}^aX_b \f$ of \f$ {}^aM_b \f$.
+     *
+     * \cheatsheet \f$ {}^a\nu_c = {}^aX_b {}^b\nu_c \f$
+     */
     ActionMatrixType toActionMatrix() const
     {
       return derived().toActionMatrix_impl();
     }
     operator ActionMatrixType() const { return toActionMatrix(); }
     
+    /**
+     * @brief The action matrix \f$ {}^bX_a \f$ of \f$ {}^aM_b \f$.
+     * \sa toActionMatrix()
+     */
     ActionMatrixType toActionMatrixInverse() const
     {
       return derived().toActionMatrixInverse_impl();


### PR DESCRIPTION
I propose to add a cheat sheet of notations used in Pinocchio. This is achieved by adding a doxygen command cheatsheet. Each function having a *remarkable identity* calls this command. This produces two things:
- in the menu on the left, there is a new page called *Cheat sheet*, containing something like:
![image](https://user-images.githubusercontent.com/2388209/65585196-5ff2c900-df82-11e9-9b95-c207585691b2.png)

- in function that have a *Remarkable identity*:
![image](https://user-images.githubusercontent.com/2388209/65585171-536e7080-df82-11e9-85f1-5ea574924f87.png)

At the moment, I do not know how to somehow sort the elements of the cheat sheet.