### PR TITLE
Add package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -20,7 +20,9 @@
   <depend>eigen</depend>
   <depend>boost</depend>
   <depend>eigenpy</depend>
-  <depend>hpp-fcl</depend>
+  <!-- The ROS-released HPP-FCL is not yet ready for use with Pinocchio out of the box (old version).
+  Additionally, as BUILD_WITH_COLLISION_SUPPORT is default OFF, the ROS buildfarm would not configure it proper either way. -->
+  <!-- <depend>hpp-fcl</depend> -->
 
   <buildtool_depend>cmake</buildtool_depend>
   <export>

--- a/package.xml
+++ b/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>pinocchio</name>
+  <version>2.1.9</version>
+  <description>A fast and flexible implementation of Rigid Body Dynamics algorithms and their analytical derivatives.</description>
+  <!-- The maintainer listed here is for the ROS release to receive emails for the buildfarm. 
+  Please check the repository URL for full list of authors and maintainers. -->
+  <maintainer email="justin.carpentier@inria.fr">Justin Carpentier</maintainer>
+  <maintainer email="wolfgang.merkt@ed.ac.uk">Wolfgang Merkt</maintainer>
+  <license>BSD</license>
+
+  <url type="website">https://github.com/stack-of-tasks/pinocchio</url>
+
+  <build_depend>git</build_depend>
+  <build_depend>doxygen</build_depend>
+  <doc_depend>doxygen</doc_depend>
+  <depend>python</depend>
+  <depend>python-numpy</depend>
+  <depend>liburdfdom-dev</depend>
+  <depend>eigen</depend>
+  <depend>boost</depend>
+  <depend>eigenpy</depend>
+  <depend>hpp-fcl</depend>
+
+  <buildtool_depend>cmake</buildtool_depend>
+  <export>
+    <build_type>cmake</build_type>
+  </export>
+</package>

--- a/src/multibody/data.hpp
+++ b/src/multibody/data.hpp
@@ -310,7 +310,7 @@ namespace pinocchio
     /// \brief Vector of subtree mass. In other words, mass[j] is the mass of the subtree supported by joint \f$ j \f$. The element mass[0] corresponds to the total mass of the model.
     std::vector<Scalar> mass;
     
-    /// \brief Jacobien of center of mass.
+    /// \brief Jacobian of center of mass.
     /// \note This Jacobian maps the joint velocity vector to the velocity of the center of mass, expressed in the inertial frame. In other words, \f$ v_{\text{CoM}} = J_{\text{CoM}} \dot{q}\f$.
     Matrix3x Jcom;
 


### PR DESCRIPTION
Allows to build Pinocchio inside a catkin workspace by cloning directly into it. This is intended to be used for the upcoming third-party library ROS-release deprecating the current catkinised wrapper [1].

[1] The catkinised wrapper was necessary as the Python installation directory was incorrect - since this has been fixed, we can replace the previous work-around wrapper simplifying maintenance and release.