### PR TITLE
[URDF][Experimental] Enable convex representation of meshes for collision detection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ git:
   depth: false
 compiler:
   - gcc
+cache:
+  ccache: true
 env:
   global:
     - secure: "SnIBG/xLIHX3CSvUbqqsX8xTVqIqQ7fFS6HWO6KZQVBsT6yugTwYHbyhNiU531JejYJ/I3ZrDhXfYH3qFZiYxnH1sifvwV+fnTtMXpPN7qPZwIymkjcmm6gJF51e0C7VOfUbvKFv0ngwj+ul21rgZSMuoEvxPK0WxtE3/ZSfn9c="

--- a/models/simple_humanoid.urdf
+++ b/models/simple_humanoid.urdf
@@ -17,10 +17,16 @@
         <cylinder radius="1" length="1"/>
       </geometry>
     </collision>
+    <collision name="box">
+      <geometry>
+        <mesh filename="package://simple_humanoid_description/box.stl" />
+      </geometry>
+    </collision>
     <collision_checking>
       <!--- This tells to pinocchio to replace the cylinder called "test"
            by a capsule with the same radius and length -->
       <capsule name="test"/>
+      <convex name="box"/>
     </collision_checking>
   </link>
 

--- a/models/simple_humanoid_description/box.stl
+++ b/models/simple_humanoid_description/box.stl
@@ -1,0 +1,86 @@
+solid Exported from Blender-2.78 (sub 0)
+facet normal -1.000000 0.000000 0.000000
+outer loop
+vertex -0.500000 -0.500000 -0.500000
+vertex -0.500000 -0.500000 0.500000
+vertex -0.500000 0.500000 0.500000
+endloop
+endfacet
+facet normal -1.000000 0.000000 0.000000
+outer loop
+vertex -0.500000 0.500000 0.500000
+vertex -0.500000 0.500000 -0.500000
+vertex -0.500000 -0.500000 -0.500000
+endloop
+endfacet
+facet normal 0.000000 1.000000 0.000000
+outer loop
+vertex -0.500000 0.500000 -0.500000
+vertex -0.500000 0.500000 0.500000
+vertex 0.500000 0.500000 0.500000
+endloop
+endfacet
+facet normal 0.000000 1.000000 0.000000
+outer loop
+vertex 0.500000 0.500000 0.500000
+vertex 0.500000 0.500000 -0.500000
+vertex -0.500000 0.500000 -0.500000
+endloop
+endfacet
+facet normal 1.000000 0.000000 0.000000
+outer loop
+vertex 0.500000 0.500000 -0.500000
+vertex 0.500000 0.500000 0.500000
+vertex 0.500000 -0.500000 0.500000
+endloop
+endfacet
+facet normal 1.000000 0.000000 0.000000
+outer loop
+vertex 0.500000 -0.500000 0.500000
+vertex 0.500000 -0.500000 -0.500000
+vertex 0.500000 0.500000 -0.500000
+endloop
+endfacet
+facet normal 0.000000 -1.000000 0.000000
+outer loop
+vertex -0.500000 -0.500000 0.500000
+vertex -0.500000 -0.500000 -0.500000
+vertex 0.500000 -0.500000 -0.500000
+endloop
+endfacet
+facet normal 0.000000 -1.000000 0.000000
+outer loop
+vertex 0.500000 -0.500000 -0.500000
+vertex 0.500000 -0.500000 0.500000
+vertex -0.500000 -0.500000 0.500000
+endloop
+endfacet
+facet normal 0.000000 0.000000 -1.000000
+outer loop
+vertex 0.500000 -0.500000 -0.500000
+vertex -0.500000 -0.500000 -0.500000
+vertex -0.500000 0.500000 -0.500000
+endloop
+endfacet
+facet normal 0.000000 0.000000 -1.000000
+outer loop
+vertex -0.500000 0.500000 -0.500000
+vertex 0.500000 0.500000 -0.500000
+vertex 0.500000 -0.500000 -0.500000
+endloop
+endfacet
+facet normal 0.000000 0.000000 1.000000
+outer loop
+vertex 0.500000 0.500000 0.500000
+vertex -0.500000 0.500000 0.500000
+vertex -0.500000 -0.500000 0.500000
+endloop
+endfacet
+facet normal 0.000000 0.000000 1.000000
+outer loop
+vertex -0.500000 -0.500000 0.500000
+vertex 0.500000 -0.500000 0.500000
+vertex 0.500000 0.500000 0.500000
+endloop
+endfacet
+endsolid Exported from Blender-2.78 (sub 0)

--- a/src/parsers/urdf/geometry.hxx
+++ b/src/parsers/urdf/geometry.hxx
@@ -56,8 +56,8 @@ namespace pinocchio
           } // BOOST_FOREACH
         }
         
-        bool replaceCylinderByCapsule (const std::string & linkName,
-                                       const std::string & geomName) const
+        bool isCapsule (const std::string & linkName,
+                        const std::string & geomName) const
         {
           LinkMap_t::const_iterator _link = links_.find(linkName);
           assert (_link != links_.end());
@@ -189,7 +189,7 @@ namespace pinocchio
         // Use FCL capsules for cylinders
         else if (urdf_geometry->type == ::urdf::Geometry::CYLINDER)
         {
-          bool capsule = tree.replaceCylinderByCapsule(linkName, geomName);
+          bool capsule = tree.isCapsule(linkName, geomName);
           meshScale << 1,1,1;
           const ::urdf::CylinderSharedPtr collisionGeometry = ::urdf::dynamic_pointer_cast< ::urdf::Cylinder> (urdf_geometry);
           

--- a/src/parsers/urdf/geometry.hxx
+++ b/src/parsers/urdf/geometry.hxx
@@ -66,8 +66,13 @@ namespace pinocchio
             return false;
           BOOST_FOREACH(const ptree::value_type & cc, link.get_child("collision_checking")) {
             if (cc.first == "capsule") {
+#ifdef PINOCCHIO_URDFDOM_COLLISION_WITH_GROUP_NAME
+              std::cerr << "Warning: support for tag link/collision_checking/capsule"
+                " is not available for URDFDOM < 0.3.0" << std::endl;
+#else
               std::string name = cc.second.get<std::string>("<xmlattr>.name");
               if (geomName == name) return true;
+#endif
             }
           } // BOOST_FOREACH
           
@@ -84,8 +89,13 @@ namespace pinocchio
             return false;
           BOOST_FOREACH(const ptree::value_type & cc, link.get_child("collision_checking")) {
             if (cc.first == "convex") {
+#ifdef PINOCCHIO_URDFDOM_COLLISION_WITH_GROUP_NAME
+              std::cerr << "Warning: support for tag link/collision_checking/convex"
+                " is not available for URDFDOM < 0.3.0" << std::endl;
+#else
               std::string name = cc.second.get<std::string>("<xmlattr>.name");
               if (geomName == name) return true;
+#endif
             }
           } // BOOST_FOREACH
           

--- a/unittest/urdf.cpp
+++ b/unittest/urdf.cpp
@@ -47,19 +47,27 @@ BOOST_AUTO_TEST_CASE ( build_model_simple_humanoid )
   pinocchio::GeometryModel geomModel;
   pinocchio::urdf::buildGeom(model, filename, pinocchio::COLLISION, geomModel, dir);
   BOOST_CHECK_EQUAL(geomModel.ngeoms, 2);
+
 #ifdef PINOCCHIO_WITH_HPP_FCL
-# if ( HPP_FCL_MAJOR_VERSION>1 || ( HPP_FCL_MAJOR_VERSION==1 && \
+  // Check that cylinder is converted into capsule.
+#ifdef PINOCCHIO_URDFDOM_COLLISION_WITH_GROUP_NAME
+  BOOST_CHECK_EQUAL(geomModel.geometryObjects[0].fcl->getNodeType(), hpp::fcl::GEOM_CYLINDER);
+#else // PINOCCHIO_URDFDOM_COLLISION_WITH_GROUP_NAME
+  BOOST_CHECK_EQUAL(geomModel.geometryObjects[0].fcl->getNodeType(), hpp::fcl::GEOM_CAPSULE);
+#endif
+
+#if ( HPP_FCL_MAJOR_VERSION>1 || ( HPP_FCL_MAJOR_VERSION==1 && \
       ( HPP_FCL_MINOR_VERSION>1 || ( HPP_FCL_MINOR_VERSION==1 && \
                                      HPP_FCL_PATCH_VERSION>3))))
 #  define PINOCCHIO_HPP_FCL_SUPERIOR_TO_1_1_3
 #endif
-  BOOST_CHECK_EQUAL(geomModel.geometryObjects[0].fcl->getNodeType(), hpp::fcl::GEOM_CAPSULE);
-#ifdef PINOCCHIO_HPP_FCL_SUPERIOR_TO_1_1_3
+
+#if defined(PINOCCHIO_HPP_FCL_SUPERIOR_TO_1_1_3) && !defined(PINOCCHIO_URDFDOM_COLLISION_WITH_GROUP_NAME)
   BOOST_CHECK_EQUAL(geomModel.geometryObjects[1].fcl->getNodeType(), hpp::fcl::GEOM_CONVEX);
 #undef PINOCCHIO_HPP_FCL_SUPERIOR_TO_1_1_3
-#else
+#else // PINOCCHIO_HPP_FCL_SUPERIOR_TO_1_1_3 && !PINOCCHIO_URDFDOM_COLLISION_WITH_GROUP_NAME
   BOOST_CHECK_EQUAL(geomModel.geometryObjects[1].fcl->getObjectType(), hpp::fcl::OT_BVH);
-#endif // PINOCCHIO_HPP_FCL_SUPERIOR_TO_1_1_3
+#endif // PINOCCHIO_HPP_FCL_SUPERIOR_TO_1_1_3 && !PINOCCHIO_URDFDOM_COLLISION_WITH_GROUP_NAME
 #endif // PINOCCHIO_WITH_HPP_FCL
   
   pinocchio::Model model_ff;


### PR DESCRIPTION
This is an experimental features so I prefer not to document it.

It is experimental for the following reasons:
- it isn't tested a lot,
- it isn't benchmarked, i.e. for a collision pair (BVH with convex representation, Other), I don't know in which case the convex representation is preferable wrt the BVH representation.
- the API is not perfect yet and will likely change in the future.