### PR TITLE
[visualize] Add geometric primitives

### DIFF
--- a/bindings/python/pinocchio/visualize/gepetto_visualizer.py
+++ b/bindings/python/pinocchio/visualize/gepetto_visualizer.py
@@ -69,6 +69,8 @@ class GepettoVisualizer(BaseVisualizer):
             return gui.addBox(meshName, w, h, d, npToTuple(meshColor))
         elif isinstance(geom, hppfcl.Sphere):
             return gui.addSphere(meshName, geom.radius, npToTuple(meshColor))
+        elif isinstance(geom, hppfcl.Cone):
+            return gui.addCone(meshName, geom.radius, 2. * geom.halfLength, npToTuple(meshColor))
         else:
             msg = "Unsupported geometry type for %s (%s)" % (geometry_object.name, type(geom) )
             warnings.warn(msg, category=UserWarning, stacklevel=2)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -41,6 +41,7 @@ IF(BUILD_PYTHON_INTERFACE)
     id-derivatives
     gepetto-viewer
     meshcat-viewer
+    meshcat-viewer-dae
     robot-wrapper-viewer
     geometry-models
     )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -49,6 +49,7 @@ IF(BUILD_PYTHON_INTERFACE)
   IF(HPP_FCL_FOUND)
     LIST(APPEND ${PROJECT_NAME}_PYTHON_EXAMPLES 
       collisions
+      sample-model-viewer
       )
   ENDIF(HPP_FCL_FOUND)
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -50,6 +50,7 @@ IF(BUILD_PYTHON_INTERFACE)
     LIST(APPEND ${PROJECT_NAME}_PYTHON_EXAMPLES 
       collisions
       sample-model-viewer
+      display_shapes
       )
   ENDIF(HPP_FCL_FOUND)
 

--- a/examples/display_shapes.py
+++ b/examples/display_shapes.py
@@ -1,0 +1,32 @@
+import numpy as np
+import pinocchio as pin
+import hppfcl
+from pinocchio.visualize import GepettoVisualizer
+
+pin.switchToNumpyArray()
+
+model = pin.Model()
+
+geom_model = pin.GeometryModel()
+geometries = [
+    hppfcl.Capsule(0.1, 0.8),
+    hppfcl.Sphere(0.5),
+    hppfcl.Box(1, 1, 1),
+    hppfcl.Cylinder(0.1, 1.0),
+    hppfcl.Cone(0.5, 1.0),
+]
+for i, geom in enumerate(geometries):
+    placement = pin.SE3(np.eye(3), np.array([i, 0, 0]))
+    geom_obj = pin.GeometryObject("obj{}".format(i), 0, 0, geom, placement)
+    color = np.random.uniform(0, 1, 4)
+    color[3] = 1
+    geom_obj.meshColor = color
+    geom_model.addGeometryObject(geom_obj)
+
+viz = GepettoVisualizer(
+    model=model, collision_model=geom_model, visual_model=geom_model,
+)
+
+viz.initViewer()
+viz.loadViewerModel("{}".format(np.random.randint(5)))
+viz.display(np.zeros(0))

--- a/examples/display_shapes.py
+++ b/examples/display_shapes.py
@@ -28,5 +28,5 @@ viz = GepettoVisualizer(
 )
 
 viz.initViewer()
-viz.loadViewerModel("{}".format(np.random.randint(5)))
+viz.loadViewerModel("shapes")
 viz.display(np.zeros(0))

--- a/examples/display_shapes.py
+++ b/examples/display_shapes.py
@@ -1,6 +1,11 @@
+import sys
 import numpy as np
 import pinocchio as pin
-import hppfcl
+try:
+    import hppfcl
+except ImportError:
+    print("This example requires hppfcl")
+    sys.exit(0)
 from pinocchio.visualize import GepettoVisualizer
 
 pin.switchToNumpyArray()
@@ -27,6 +32,19 @@ viz = GepettoVisualizer(
     model=model, collision_model=geom_model, visual_model=geom_model,
 )
 
-viz.initViewer()
-viz.loadViewerModel("shapes")
+# Initialize the viewer.
+try:
+    viz.initViewer()
+except ImportError:
+    print("Error while initializing the viewer. It seems you should install gepetto-viewer")
+    print(err)
+    sys.exit(0)
+
+try:
+    viz.loadViewerModel("shapes")
+except AttributeError:
+    print("Error while loading the viewer model. It seems you should start gepetto-viewer")
+    print(err)
+    sys.exit(0)
+
 viz.display(np.zeros(0))

--- a/examples/gepetto-viewer.py
+++ b/examples/gepetto-viewer.py
@@ -1,5 +1,4 @@
 # NOTE: this example needs gepetto-gui to be installed
-# Also, as romeo employs DAE files, you need the DAE plugin
 # usage: launch gepetto-gui and then run this test
 
 import pinocchio as pin
@@ -17,8 +16,8 @@ pinocchio_model_dir = join(dirname(dirname(str(abspath(__file__)))),"models")
 
 model_path = join(pinocchio_model_dir,"others/robots")
 mesh_dir = model_path
-urdf_filename = "romeo_small.urdf"
-urdf_model_path = join(join(model_path,"romeo_description/urdf"),urdf_filename)
+urdf_filename = "talos_reduced.urdf"
+urdf_model_path = join(join(model_path,"talos_data/urdf"),urdf_filename)
 
 model, collision_model, visual_model = pin.buildModelsFromUrdf(urdf_model_path, mesh_dir, pin.JointModelFreeFlyer())
 viz = GepettoVisualizer(model, collision_model, visual_model)
@@ -39,15 +38,7 @@ except AttributeError as err:
     sys.exit(0)
 
 # Display a robot configuration.
-q0 = np.matrix([
-    0, 0, 0.840252, 0, 0, 0, 1,  # Free flyer
-    0, 0, -0.3490658, 0.6981317, -0.3490658, 0,  # left leg
-    0, 0, -0.3490658, 0.6981317, -0.3490658, 0,  # right leg
-    0,  # chest
-    1.5, 0.6, -0.5, -1.05, -0.4, -0.3, -0.2,  # left arm
-    0, 0, 0, 0,  # head
-    1.5, -0.6, 0.5, 1.05, -0.4, -0.3, -0.2,  # right arm
-]).T
+q0 = pin.neutral(model)
 viz.display(q0)
 
 # Display another robot.

--- a/examples/meshcat-viewer-dae.py
+++ b/examples/meshcat-viewer-dae.py
@@ -1,0 +1,70 @@
+# This examples shows how to load and move a robot in meshcat.
+# Note: this feature requires Meshcat to be installed, this can be done using
+# pip install --user meshcat
+
+import pinocchio as pin
+pin.switchToNumpyMatrix()
+import numpy as np
+import sys
+import os
+from os.path import dirname, join, abspath
+
+from pinocchio.visualize import MeshcatVisualizer
+
+# Load the URDF model.
+# Conversion with str seems to be necessary when executing this file with ipython
+pinocchio_model_dir = join(dirname(dirname(str(abspath(__file__)))),"models")
+
+model_path = join(pinocchio_model_dir,"others/robots")
+mesh_dir = model_path
+urdf_filename = "romeo_small.urdf"
+urdf_model_path = join(join(model_path,"romeo_description/urdf"),urdf_filename)
+
+model, collision_model, visual_model = pin.buildModelsFromUrdf(urdf_model_path, mesh_dir, pin.JointModelFreeFlyer())
+
+# Currently, MeshCat is not able to retrieve the scaling from DAE files. Set it manually.
+for geom in visual_model.geometryObjects:
+  s = geom.meshScale 
+  s *= 0.01
+  geom.meshScale = s
+
+viz = MeshcatVisualizer(model, collision_model, visual_model)
+
+# Start a new MeshCat server and client.
+# Note: the server can also be started separately using the "meshcat-server" command in a terminal:
+# this enables the server to remain active after the current script ends.
+#
+# Option open=True pens the visualizer.
+# Note: the visualizer can also be opened seperately by visiting the provided URL.
+try:
+    viz.initViewer(open=True)
+except ImportError as err:
+    print("Error while initializing the viewer. It seems you should install Python meshcat")
+    print(err)
+    sys.exit(0)
+
+# Load the robot in the viewer.
+# Color is needed here because the Romeo URDF doesn't contain any color, so the default color results in an
+# invisible robot (alpha value set to 0).
+viz.loadViewerModel(color = [0.0, 0.0, 0.0, 1.0])
+
+# Display a robot configuration.
+q0 = np.matrix([
+    0, 0, 0.840252, 0, 0, 0, 1,  # Free flyer
+    0, 0, -0.3490658, 0.6981317, -0.3490658, 0,  # left leg
+    0, 0, -0.3490658, 0.6981317, -0.3490658, 0,  # right leg
+    0,  # chest
+    1.5, 0.6, -0.5, -1.05, -0.4, -0.3, -0.2,  # left arm
+    0, 0, 0, 0,  # head
+    1.5, -0.6, 0.5, 1.05, -0.4, -0.3, -0.2,  # right arm
+]).T
+viz.display(q0)
+
+# Display another robot.
+red_robot_viz = MeshcatVisualizer(model, collision_model, visual_model)
+red_robot_viz.initViewer(viz.viewer)
+red_robot_viz.loadViewerModel(rootNodeName = "red_robot", color = [1.0, 0.0, 0.0, 0.5])
+q = q0.copy()
+q[1] = 1.0
+red_robot_viz.display(q)
+

--- a/examples/meshcat-viewer.py
+++ b/examples/meshcat-viewer.py
@@ -17,16 +17,10 @@ pinocchio_model_dir = join(dirname(dirname(str(abspath(__file__)))),"models")
 
 model_path = join(pinocchio_model_dir,"others/robots")
 mesh_dir = model_path
-urdf_filename = "romeo_small.urdf"
-urdf_model_path = join(join(model_path,"romeo_description/urdf"),urdf_filename)
+urdf_filename = "talos_reduced.urdf"
+urdf_model_path = join(join(model_path,"talos_data/urdf"),urdf_filename)
 
 model, collision_model, visual_model = pin.buildModelsFromUrdf(urdf_model_path, mesh_dir, pin.JointModelFreeFlyer())
-
-# Currently, MeshCat is not able to retrieve the scaling from DAE files. Set it manually.
-for geom in visual_model.geometryObjects:
-  s = geom.meshScale 
-  s *= 0.01
-  geom.meshScale = s
 
 viz = MeshcatVisualizer(model, collision_model, visual_model)
 
@@ -44,27 +38,17 @@ except ImportError as err:
     sys.exit(0)
 
 # Load the robot in the viewer.
-# Color is needed here because the Romeo URDF doesn't contain any color, so the default color results in an
-# invisible robot (alpha value set to 0).
-viz.loadViewerModel(color = [0.0, 0.0, 0.0, 1.0])
+viz.loadViewerModel()
 
 # Display a robot configuration.
-q0 = np.matrix([
-    0, 0, 0.840252, 0, 0, 0, 1,  # Free flyer
-    0, 0, -0.3490658, 0.6981317, -0.3490658, 0,  # left leg
-    0, 0, -0.3490658, 0.6981317, -0.3490658, 0,  # right leg
-    0,  # chest
-    1.5, 0.6, -0.5, -1.05, -0.4, -0.3, -0.2,  # left arm
-    0, 0, 0, 0,  # head
-    1.5, -0.6, 0.5, 1.05, -0.4, -0.3, -0.2,  # right arm
-]).T
+q0 = pin.neutral(model)
 viz.display(q0)
 
 # Display another robot.
-red_robot_viz = MeshcatVisualizer(model, collision_model, visual_model)
-red_robot_viz.initViewer(viz.viewer)
-red_robot_viz.loadViewerModel(rootNodeName = "red_robot", color = [1.0, 0.0, 0.0, 0.5])
+viz2 = MeshcatVisualizer(model, collision_model, visual_model)
+viz2.initViewer(viz.viewer)
+viz2.loadViewerModel(rootNodeName = "pinocchio2")
 q = q0.copy()
 q[1] = 1.0
-red_robot_viz.display(q)
+viz2.display(q)
 

--- a/examples/robot-wrapper-viewer.py
+++ b/examples/robot-wrapper-viewer.py
@@ -32,8 +32,8 @@ pinocchio_model_dir = join(dirname(dirname(str(abspath(__file__)))),"models")
 
 model_path = join(pinocchio_model_dir,"others/robots")
 mesh_dir = model_path
-urdf_filename = "romeo_small.urdf"
-urdf_model_path = join(join(model_path,"romeo_description/urdf"),urdf_filename)
+urdf_filename = "talos_reduced.urdf"
+urdf_model_path = join(join(model_path,"talos_data/urdf"),urdf_filename)
 
 robot = RobotWrapper.BuildFromURDF(urdf_model_path, mesh_dir, pin.JointModelFreeFlyer())
 
@@ -52,9 +52,5 @@ com2 = pin.centerOfMass(model,data,q0)
 if VISUALIZER:
     robot.setVisualizer(VISUALIZER())
     robot.initViewer()
-    if VISUALIZER == MeshcatVisualizer:
-        robot.loadViewerModel("pinocchio", color=[0., 0., 0., 1.])
-    else:
-        robot.loadViewerModel("pinocchio")
+    robot.loadViewerModel("pinocchio")
     robot.display(q0)
-

--- a/examples/sample-model-viewer.py
+++ b/examples/sample-model-viewer.py
@@ -1,0 +1,45 @@
+import pinocchio as pin
+pin.switchToNumpyMatrix()
+from pinocchio.visualize import MeshcatVisualizer, GepettoVisualizer
+from sys import argv
+from numpy import pi
+
+try:
+    # Python 2
+    input = raw_input  # noqa
+except NameError:
+    pass
+
+# GepettoVisualizer: -g
+# MeshcatVisualizer: -m
+VISUALIZER = None
+if len(argv)>1:
+    opt = argv[1]
+    if opt == '-g':
+        VISUALIZER = GepettoVisualizer
+    elif opt == '-m':
+        VISUALIZER = MeshcatVisualizer
+    else:
+        raise ValueError("Unrecognized option: " + opt)
+
+model = pin.buildSampleModelHumanoid()
+visual_model = pin.buildSampleGeometryModelHumanoid(model)
+collision_model = visual_model.copy()
+
+q0 = pin.neutral(model)
+
+if VISUALIZER:
+    viz = VISUALIZER(model, collision_model, visual_model)
+    viz.initViewer()
+    viz.loadViewerModel()
+    viz.display(q0)
+
+    input("Enter to check a new configuration")
+
+    q = q0.copy()
+    q[8] = pi/2
+    q[14] = pi/2
+    q[23] = -pi/2
+    q[29] = pi/2
+
+    viz.display(q)

--- a/src/parsers/sample-models.hxx
+++ b/src/parsers/sample-models.hxx
@@ -125,6 +125,8 @@ namespace pinocchio
         typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
         typedef typename Model::FrameIndex FrameIndex;
         typedef typename Model::SE3 SE3;
+
+        const Eigen::Vector4d meshColor(1., 1., 0.78, 1.0);
         
         FrameIndex parentFrame;
         
@@ -132,42 +134,66 @@ namespace pinocchio
         GeometryObject shoulderBall(pre+"shoulder_object",
                                     parentFrame, model.frames[parentFrame].parent,
                                     boost::shared_ptr<fcl::Sphere>(new fcl::Sphere(0.05)),
-                                    SE3::Identity());
+                                    SE3::Identity(),
+                                    "SPHERE",
+                                    Eigen::Vector3d::Ones(),
+                                    false,
+                                    meshColor);
         geom.addGeometryObject(shoulderBall);
         
         parentFrame = model.getBodyId(pre+"elbow_body");
         GeometryObject elbowBall(pre+"elbow_object",
                                  parentFrame, model.frames[parentFrame].parent,
                                  boost::shared_ptr<fcl::Sphere>(new fcl::Sphere(0.05)),
-                                 SE3::Identity());
+                                 SE3::Identity(),
+                                 "SPHERE",
+                                 Eigen::Vector3d::Ones(),
+                                 false,
+                                 meshColor);
         geom.addGeometryObject(elbowBall);
         
         parentFrame = model.getBodyId(pre+"wrist1_body");
         GeometryObject wristBall(pre+"wrist_object",
                                  parentFrame, model.frames[parentFrame].parent,
                                  boost::shared_ptr<fcl::Sphere>(new fcl::Sphere(0.05)),
-                                 SE3::Identity());
+                                 SE3::Identity(),
+                                 "SPHERE",
+                                 Eigen::Vector3d::Ones(),
+                                 false,
+                                 meshColor);
         geom.addGeometryObject(wristBall);
         
         parentFrame = model.getBodyId(pre+"upperarm_body");
         GeometryObject upperArm(pre+"upperarm_object",
                                 parentFrame, model.frames[parentFrame].parent,
                                 boost::shared_ptr<fcl::Capsule>(new fcl::Capsule(0.05, .8)),
-                                SE3(SE3::Matrix3::Identity(), typename  SE3::Vector3(0,0,0.5)) );
+                                SE3(SE3::Matrix3::Identity(), typename  SE3::Vector3(0,0,0.5)),
+                                "CAPSULE",
+                                Eigen::Vector3d::Ones(),
+                                false,
+                                meshColor);
         geom.addGeometryObject(upperArm);
         
         parentFrame = model.getBodyId(pre+"lowerarm_body");
         GeometryObject lowerArm(pre+"lowerarm_object",
                                 parentFrame, model.frames[parentFrame].parent,
                                 boost::shared_ptr<fcl::Capsule>(new fcl::Capsule(0.05, .8)),
-                                SE3(SE3::Matrix3::Identity(), typename SE3::Vector3(0,0,0.5)) );
+                                SE3(SE3::Matrix3::Identity(), typename SE3::Vector3(0,0,0.5)),
+                                "CAPSULE",
+                                Eigen::Vector3d::Ones(),
+                                false,
+                                meshColor);
         geom.addGeometryObject(lowerArm);
         
         parentFrame = model.getBodyId(pre+"effector_body");
         GeometryObject effectorArm(pre+"effector_object",
                                    parentFrame, model.frames[parentFrame].parent,
                                    boost::shared_ptr<fcl::Capsule>(new fcl::Capsule(0.05, .2)),
-                                   SE3(SE3::Matrix3::Identity(), typename SE3::Vector3(0,0,0.1)) );
+                                   SE3(SE3::Matrix3::Identity(), typename SE3::Vector3(0,0,0.1)),
+                                   "CAPSULE",
+                                   Eigen::Vector3d::Ones(),
+                                   false,
+                                   meshColor);
         geom.addGeometryObject(effectorArm);
       }
 #endif
@@ -371,11 +397,17 @@ namespace pinocchio
       
       FrameIndex parentFrame;
       
+      const Eigen::Vector4d meshColor(1., 1., 0.78, 1.0);
+      
       parentFrame = model.getBodyId("chest1_body");
       GeometryObject chestBall("chest_object",
                                parentFrame, model.frames[parentFrame].parent,
                                boost::shared_ptr<fcl::Sphere>(new fcl::Sphere(0.05)),
-                               SE3::Identity());
+                               SE3::Identity(),
+                               "SPHERE",
+                               Eigen::Vector3d::Ones(),
+                               false,
+                               meshColor);
       geom.addGeometryObject(chestBall);
       
       parentFrame = model.getBodyId("head2_body");
@@ -383,7 +415,11 @@ namespace pinocchio
                               parentFrame, model.frames[parentFrame].parent,
                               boost::shared_ptr<fcl::Sphere>(new fcl::Sphere(0.25)),
                               SE3(SE3::Matrix3::Identity(),
-                                  typename SE3::Vector3(0,0,0.5)));
+                                  typename SE3::Vector3(0,0,0.5)),
+                              "SPHERE",
+                               Eigen::Vector3d::Ones(),
+                               false,
+                               meshColor);
       geom.addGeometryObject(headBall);
       
       parentFrame = model.getBodyId("chest2_body");
@@ -391,7 +427,11 @@ namespace pinocchio
                               parentFrame, model.frames[parentFrame].parent,
                               boost::shared_ptr<fcl::Capsule>(new fcl::Capsule(0.05, .8)),
                               SE3(SE3::Matrix3::Identity(),
-                                  typename SE3::Vector3(0,0,0.5)));
+                                  typename SE3::Vector3(0,0,0.5)),
+                              "SPHERE",
+                              Eigen::Vector3d::Ones(),
+                              false,
+                              meshColor);
       geom.addGeometryObject(chestArm);
     }
 #endif

--- a/unittest/python/bindings_geometry_object.py
+++ b/unittest/python/bindings_geometry_object.py
@@ -32,7 +32,7 @@ class TestGeometryObjectBindings(unittest.TestCase):
 
     def test_meshpath_get(self):
         col = self.collision_model.geometryObjects[0]
-        self.assertTrue(col.meshPath == "")
+        self.assertTrue(col.meshPath is not None)
 
     def test_scale(self):
         scale = np.matrix([1.,2.,3.]).T


### PR DESCRIPTION
I meant to wait for a day or two for further testing and/or additions in order to deliver these commits, but then I saw #1003, so I told myself I might as well do the PR now.
- Compared to #1003, I think my solution is slightly more robust to different install configurations (with/without hppfcl, mostly).
- Additionally, I fixed the visualization of geometric primitives for meshcat too
- I now use Talos in the visualization examples. previously this was not possible, since the model contained some primitives which made the visualizer crash.
- I retained the Romeo example in [meshcat-viewer-dae.py](https://github.com/stack-of-tasks/pinocchio/blob/a78eefc877f8dae19b5b07ddae372b5f4a520bb5/examples/meshcat-viewer-dae.py) to show the specific  problems that arise with DAE files in meshcat. I determined that there is no problem of textures, since Romeo does not contain them: the issue is that meshcat does not parse colors in DAE files correctly.
- I added color to the sample model so that it can be easily visualized
- I created a script called [sample-model-viewer.py](https://github.com/stack-of-tasks/pinocchio/blob/38c69350553da4b6b1c2e30b480b5be2e2dd502d/examples/sample-model-viewer.py) to visualize the sample humanoid
- #1003 also incudes cones
- #1003 features a script testing all geometric shapes which might be interesting to integrate
