### PR TITLE
[examples/inverse-kinematics] Remove Jlog and use DLS instead

### DIFF
--- a/examples/inverse-kinematics.cpp
+++ b/examples/inverse-kinematics.cpp
@@ -22,7 +22,7 @@ int main(int /* argc */, char ** /* argv */)
   pinocchio::Data::Matrix6x J(6,model.nv);
   J.setZero();
 
-  bool success;
+  bool success = false;
   typedef Eigen::Matrix<double, 6, 1> Vector6d;
   Vector6d err;
   Eigen::VectorXd v(model.nv);

--- a/examples/inverse-kinematics.py
+++ b/examples/inverse-kinematics.py
@@ -1,6 +1,8 @@
 from __future__ import print_function
 
 import numpy as np
+from numpy.linalg import norm, solve
+
 import pinocchio
 pinocchio.switchToNumpyMatrix()
 
@@ -14,23 +16,30 @@ q      = pinocchio.neutral(model)
 eps    = 1e-4
 IT_MAX = 1000
 DT     = 1e-1
+damp   = 1e-6
 
 i=0
 while True:
     pinocchio.forwardKinematics(model,data,q)
     dMi = oMdes.actInv(data.oMi[JOINT_ID])
     err = pinocchio.log(dMi).vector
-    if np.linalg.norm(err) < eps:
-        print("Convergence achieved!")
+    if norm(err) < eps:
+        success = True
         break
     if i >= IT_MAX:
-        print("\nWarning: the iterative algorithm has not reached convergence to the desired precision")
+        success = False
         break
-    J   = pinocchio.Jlog6(dMi) * pinocchio.computeJointJacobian(model,data,q,JOINT_ID)
-    v   = - np.linalg.pinv(J)*err
-    q   = pinocchio.integrate(model,q,v*DT)
-    if not i % 10:        print('error = %s' % err.T)
+    J = pinocchio.computeJointJacobian(model,data,q,JOINT_ID)
+    v = - J.T.dot(solve(J.dot(J.T) + damp * np.eye(6), err))
+    q = pinocchio.integrate(model,q,v*DT)
+    if not i % 10:
+        print('%d: error = %s' % (i, err.T))
     i += 1
+
+if success:
+    print("Convergence achieved!")
+else:
+    print("\nWarning: the iterative algorithm has not reached convergence to the desired precision")
 
 print('\nresult: %s' % q.flatten().tolist())
 print('\nfinal error: %s' % err.T)


### PR DESCRIPTION
Related to https://github.com/stack-of-tasks/pinocchio/pull/982#discussion_r355190193.
Following discussions with @nmansard, I found out why the example was not working for me without `Jlog`.

The problem is that the initial guess is `pinocchio.neutral(model)`, which is a singular configuration. Simple pseudo-inversion of the kinematic Jacobian kept it singular. Somehow, adding `Jlog` pulled the robot out of the singular configuration.

I have examined the problem carefully, and it does seem that `Jlog * err = err` and `pinv(Jlog) * err = err`, making the inclusion of `Jlog` useless for this particular case.
However, it seems that when the kinematic Jacobian `J` is singular, `pinv(Jlog * J) * err` and `pinv(J) * err` lead to different results. I am not sure wether this is a mathematical truth or a numerical artifact, but I do not find it surprising, since the the equality `pinv(Jlog * J) == pinv(J) * pinv(Jlog)` is not valid in general if one of the two matrices is singular.

These being the facts, I had two options for removing `Jlog`: starting from a non-singular configuration or using the damped pseudo-inverse. Both solutions work; I opted for the latter one, as it is more general. Also, I made some small cosmetic changes. I updated the doc accordingly.

My analysis can be confirmed by [this enhanced version of the Python script](https://gist.github.com/gabrielebndn/c994080a739bea79cbf33e2f8d88f2f1), in  my gists.
