### PR TITLE
Add converter from Python list to std::vector<T>

### DIFF
--- a/bindings/python/algorithm/expose-model.cpp
+++ b/bindings/python/algorithm/expose-model.cpp
@@ -12,16 +12,6 @@ namespace pinocchio
   {
 
     namespace bp = boost::python;
-
-    template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
-    ModelTpl<Scalar,Options,JointCollectionTpl>
-    buildReducedModel(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                      const bp::list & list_of_joints_to_lock,
-                      const Eigen::MatrixBase<ConfigVectorType> & reference_configuration)
-    {
-      const std::vector<JointIndex> vec_of_joints_to_lock = extract<JointIndex>(list_of_joints_to_lock);
-      return buildReducedModel(model,vec_of_joints_to_lock,reference_configuration);
-    }
   
     template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
     bp::tuple appendModel(const ModelTpl<Scalar,Options,JointCollectionTpl> & modelA,
@@ -55,23 +45,6 @@ namespace pinocchio
       return bp::make_tuple(reduced_model,reduced_geom_model);
     }
   
-    template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
-    bp::tuple
-    buildReducedModel(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                      const GeometryModel & geom_model,
-                      const bp::list & list_of_joints_to_lock,
-                      const Eigen::MatrixBase<ConfigVectorType> & reference_configuration)
-    {
-      typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
-      Model reduced_model; GeometryModel reduced_geom_model;
-      
-      const std::vector<JointIndex> vec_of_joints_to_lock = extract<JointIndex>(list_of_joints_to_lock);
-      buildReducedModel(model,geom_model,vec_of_joints_to_lock,
-                        reference_configuration,reduced_model,reduced_geom_model);
-      
-      return bp::make_tuple(reduced_model,reduced_geom_model);
-    }
-  
     void exposeModelAlgo()
     {
       using namespace Eigen;
@@ -97,17 +70,6 @@ namespace pinocchio
               " aMb: pose of modelB universe joint (index 0) in frameInModelA\n");
 
       bp::def("buildReducedModel",
-              (Model (*)(const Model &, const bp::list &, const Eigen::MatrixBase<VectorXd> &))
-              buildReducedModel<double,0,JointCollectionDefaultTpl,VectorXd>,
-              bp::args("model",
-                       "list_of_joints_to_lock",
-                       "reference_configuration"),
-              "Build a reduce model from a given input model and a list of joint to lock.\n\n"
-              " model: input kinematic modell to reduce\n"
-              " list_of_joints_to_lock: list of joint indexes to lock\n"
-              " reference_configuration: reference configuration to compute the placement of the lock joints\n");
-
-      bp::def("buildReducedModel",
               (Model (*)(const Model &, const std::vector<JointIndex> &, const Eigen::MatrixBase<VectorXd> &))
               &pinocchio::buildReducedModel<double,0,JointCollectionDefaultTpl,VectorXd>,
               bp::args("model",
@@ -120,20 +82,6 @@ namespace pinocchio
 
       bp::def("buildReducedModel",
               (bp::tuple (*)(const Model &, const GeometryModel &, const std::vector<JointIndex> &, const Eigen::MatrixBase<VectorXd> &))
-              &buildReducedModel<double,0,JointCollectionDefaultTpl,VectorXd>,
-              bp::args("model",
-                       "geom_model",
-                       "list_of_joints_to_lock",
-                       "reference_configuration"),
-              "Build a reduced model and a rededuced geometry model  from a given input model,"
-              "a given input geometry model and a list of joint to lock.\n\n"
-              " model: input kinematic modell to reduce\n"
-              " geom_model: input geometry model to reduce\n"
-              " list_of_joints_to_lock: list of joint indexes to lock\n"
-              " reference_configuration: reference configuration to compute the placement of the lock joints\n");
-
-      bp::def("buildReducedModel",
-              (bp::tuple (*)(const Model &, const GeometryModel &, const bp::list &, const Eigen::MatrixBase<VectorXd> &))
               &buildReducedModel<double,0,JointCollectionDefaultTpl,VectorXd>,
               bp::args("model",
                        "geom_model",

--- a/bindings/python/algorithm/expose-rnea.cpp
+++ b/bindings/python/algorithm/expose-rnea.cpp
@@ -10,21 +10,6 @@ namespace pinocchio
 {
   namespace python
   {
-    
-    template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType1, typename TangentVectorType2, typename Force>
-    const typename DataTpl<Scalar,Options,JointCollectionTpl>::TangentVectorType &
-    rnea_proxy_list(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                    DataTpl<Scalar,Options,JointCollectionTpl> & data,
-                    const Eigen::MatrixBase<ConfigVectorType> & q,
-                    const Eigen::MatrixBase<TangentVectorType1> & v,
-                    const Eigen::MatrixBase<TangentVectorType2> & a,
-                    const bp::list & fext_list)
-    {
-      container::aligned_vector<Force> fext;
-      extract(fext_list,fext.base());
-      
-      return rnea(model,data,q.derived(),v.derived(),a.derived(),fext);
-    }
   
     void exposeRNEA()
     {
@@ -46,16 +31,6 @@ namespace pinocchio
                        "Velocity v (size Model::nv)",
                        "Acceleration a (size Model::nv)",
                        "Vector of external forces expressed in the local frame of each joint (size Model::njoints)"),
-              "Compute the RNEA with external forces, store the result in Data and return it.",
-              bp::return_value_policy<bp::return_by_value>());
-
-      bp::def("rnea",
-              &rnea_proxy_list<double,0,JointCollectionDefaultTpl,VectorXd,VectorXd,VectorXd,Force>,
-              bp::args("Model","Data",
-                       "Configuration q (size Model::nq)",
-                       "Velocity v (size Model::nv)",
-                       "Acceleration a (size Model::nv)",
-                       "List of external forces expressed in the local frame of each joint (size Model::njoints)"),
               "Compute the RNEA with external forces, store the result in Data and return it.",
               bp::return_value_policy<bp::return_by_value>());
 

--- a/bindings/python/module.cpp
+++ b/bindings/python/module.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2015-2019 CNRS INRIA
+// Copyright (c) 2015-2020 CNRS INRIA
 // Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 
@@ -10,6 +10,8 @@
 #include "pinocchio/bindings/python/utils/dependencies.hpp"
 #include "pinocchio/bindings/python/utils/conversions.hpp"
 #include "pinocchio/bindings/python/utils/registration.hpp"
+
+#include "pinocchio/bindings/python/utils/std-vector.hpp"
 
 #include <eigenpy/eigenpy.hpp>
 
@@ -31,6 +33,8 @@ BOOST_PYTHON_MODULE(libpinocchio_pywrap)
     eigenpy::exposeQuaternion();
   if(not register_symbolic_link_to_registered_type<Eigen::AngleAxisd>())
     eigenpy::exposeAngleAxis();
+  
+  StdContainerFromPythonList< std::vector<std::string> >::register_converter();
 
   typedef Eigen::Matrix<double,6,6> Matrix6d;
   typedef Eigen::Matrix<double,6,1> Vector6d;

--- a/bindings/python/parsers/parsers.hpp
+++ b/bindings/python/parsers/parsers.hpp
@@ -146,27 +146,6 @@ namespace pinocchio
         
         return geometry_model;
       }
-      
-      static GeometryModel
-      buildGeomFromUrdf(const Model & model,
-                        const std::string & filename,
-                        const GeometryType type,
-                        const bp::list & package_dirs)
-      {
-        std::vector<std::string> package_dirs_ = extract<std::string>(package_dirs);
-        return buildGeomFromUrdf(model,filename,type,package_dirs_);
-      }
-      
-      static GeometryModel &
-      buildGeomFromUrdf(const Model & model,
-                        const std::string & filename,
-                        const GeometryType type,
-                        GeometryModel & geometry_model,
-                        const bp::list & package_dirs)
-      {
-        std::vector<std::string> package_dirs_ = extract<std::string>(package_dirs);
-        return buildGeomFromUrdf(model,filename,type,geometry_model,package_dirs_);
-      }
 
       static GeometryModel
       buildGeomFromUrdf(const Model & model,
@@ -243,29 +222,6 @@ namespace pinocchio
         pinocchio::urdf::buildGeom(model,filename,type,geometry_model,package_dirs,meshLoader);
         
         return geometry_model;
-      }
-      
-      static GeometryModel
-      buildGeomFromUrdf(const Model & model,
-                        const std::string & filename,
-                        const GeometryType type,
-                        const bp::list & package_dirs,
-                        const fcl::MeshLoaderPtr & meshLoader)
-      {
-        std::vector<std::string> package_dirs_ = extract<std::string>(package_dirs);
-        return buildGeomFromUrdf(model,filename,type,package_dirs_,meshLoader);
-      }
-      
-      static GeometryModel &
-      buildGeomFromUrdf(const Model & model,
-                        const std::string & filename,
-                        const GeometryType type,
-                        GeometryModel & geometry_model,
-                        const bp::list & package_dirs,
-                        const fcl::MeshLoaderPtr & meshLoader)
-      {
-        std::vector<std::string> package_dirs_ = extract<std::string>(package_dirs);
-        return buildGeomFromUrdf(model,filename,type,geometry_model,package_dirs_,meshLoader);
       }
 
       static GeometryModel
@@ -421,32 +377,6 @@ namespace pinocchio
               );
       
       bp::def("buildGeomFromUrdf",
-              static_cast <GeometryModel (*) (const Model &, const std::string &, const GeometryType, const bp::list &)> (&ParsersPythonVisitor::buildGeomFromUrdf),
-              bp::args("model","urdf_filename","geom_type","package_dirs"),
-              "Parse the URDF file given as input looking for the geometry of the given input model and\n"
-              "return a GeometryModel containing either the collision geometries (GeometryType.COLLISION) or the visual geometries (GeometryType.VISUAL).\n"
-              "Parameters:\n"
-              "\tmodel: model of the robot\n"
-              "\turdf_filename: path to the URDF file containing the model of the robot\n"
-              "\tpackage_dirs: Python list of paths pointing to the folders containing the meshes of the robot\n"
-              "\tgeom_type: type of geometry to extract from the URDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
-              );
-      
-      bp::def("buildGeomFromUrdf",
-              static_cast <GeometryModel & (*) (const Model &, const std::string &, const GeometryType, GeometryModel &, const bp::list &)> (&ParsersPythonVisitor::buildGeomFromUrdf),
-              bp::args("model","urdf_filename","geom_type","geom_model","package_dirs"),
-              "Parse the URDF file given as input looking for the geometry of the given input model and\n"
-              "and store either the collision geometries (GeometryType.COLLISION) or the visual geometries (GeometryType.VISUAL) in the geom_model given as input.\n"
-              "Parameters:\n"
-              "\tmodel: model of the robot\n"
-              "\turdf_filename: path to the URDF file containing the model of the robot\n"
-              "\tgeom_type: type of geometry to extract from the URDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
-              "\tgeom_model: reference where to store the parsed information\n"
-              "\tpackage_dirs: Python list of paths pointing to the folders containing the meshes of the robot\n",
-              bp::return_internal_reference<4>()
-              );
-      
-      bp::def("buildGeomFromUrdf",
               static_cast <GeometryModel (*) (const Model &, const std::string &, const GeometryType)> (&ParsersPythonVisitor::buildGeomFromUrdf),
               bp::args("model","urdf_filename","geom_type"),
               "Parse the URDF file given as input looking for the geometry of the given input model and\n"
@@ -526,34 +456,6 @@ namespace pinocchio
               "\tgeom_type: type of geometry to extract from the URDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
               "\tgeom_model: reference where to store the parsed information\n"
               "\tpackage_dirs: vector of paths pointing to the folders containing the model of the robot\n"
-              "\tmesh_loader: an hpp-fcl mesh loader (to load only once the related geometries).",
-              bp::return_internal_reference<4>()
-              );
-      
-      bp::def("buildGeomFromUrdf",
-              static_cast <GeometryModel (*) (const Model &, const std::string &, const GeometryType, const bp::list &, const fcl::MeshLoaderPtr&)> (&ParsersPythonVisitor::buildGeomFromUrdf),
-              bp::args("model","urdf_filename","geom_type","package_dirs","mesh_loader"),
-              "Parse the URDF file given as input looking for the geometry of the given input model and\n"
-              "return a GeometryModel containing either the collision geometries (GeometryType.COLLISION) or the visual geometries (GeometryType.VISUAL).\n"
-              "Parameters:\n"
-              "\tmodel: model of the robot\n"
-              "\turdf_filename: path to the URDF file containing the model of the robot\n"
-              "\tgeom_type: type of geometry to extract from the URDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
-              "\tpackage_dirs: Python list of paths pointing to the folders containing the meshes of the robot\n"
-              "\tmesh_loader: an hpp-fcl mesh loader (to load only once the related geometries)."
-              );
-      
-      bp::def("buildGeomFromUrdf",
-              static_cast <GeometryModel & (*) (const Model &, const std::string &, const GeometryType, GeometryModel &, const bp::list &, const fcl::MeshLoaderPtr&)> (&ParsersPythonVisitor::buildGeomFromUrdf),
-              bp::args("model","urdf_filename","geom_type","geom_model","package_dirs","mesh_loader"),
-              "Parse the URDF file given as input looking for the geometry of the given input model and\n"
-              "and store either the collision geometries (GeometryType.COLLISION) or the visual geometries (GeometryType.VISUAL) in the geom_model given as input.\n"
-              "Parameters:\n"
-              "\tmodel: model of the robot\n"
-              "\turdf_filename: path to the URDF file containing the model of the robot\n"
-              "\tgeom_type: type of geometry to extract from the URDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
-              "\tgeom_model: reference where to store the parsed information\n"
-              "\tpackage_dirs: Python list of paths pointing to the folders containing the meshes of the robot\n"
               "\tmesh_loader: an hpp-fcl mesh loader (to load only once the related geometries).",
               bp::return_internal_reference<4>()
               );

--- a/bindings/python/utils/pickle-vector.hpp
+++ b/bindings/python/utils/pickle-vector.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2019 CNRS
+// Copyright (c) 2019-2020 CNRS INRIA
 //
 
 #ifndef __pinocchio_python_utils_pickle_vector_hpp__
@@ -13,7 +13,6 @@ namespace pinocchio
 {
   namespace python
   {
-    namespace bp = boost::python;
     ///
     /// \brief Create a pickle interface for the std::vector and aligned vector
     ///
@@ -22,15 +21,20 @@ namespace pinocchio
     /// \sa Pickle
     ///
     template<typename VecType>
-    struct PickleVector : bp::pickle_suite
+    struct PickleVector : boost::python::pickle_suite
     { 
-      static bp::tuple getinitargs(const VecType&) {    return bp::make_tuple();      }
-      static bp::tuple getstate(bp::object op)
-      { return bp::make_tuple(bp::list(bp::extract<const VecType&>(op)()));           }
-      static void setstate(bp::object op, bp::tuple tup)
+      static boost::python::tuple getinitargs(const VecType&)
+      { return boost::python::make_tuple(); }
+      
+      static boost::python::tuple getstate(boost::python::object op)
       {
-        VecType& o = bp::extract<VecType&>(op)(); 
-        bp::stl_input_iterator<typename VecType::value_type> begin(tup[0]), end;
+        return boost::python::make_tuple(boost::python::list(boost::python::extract<const VecType&>(op)()));
+      }
+      
+      static void setstate(boost::python::object op, boost::python::tuple tup)
+      {
+        VecType & o = boost::python::extract<VecType&>(op)();
+        boost::python::stl_input_iterator<typename VecType::value_type> begin(tup[0]), end;
         o.insert(o.begin(),begin,end);
       }
     };

--- a/bindings/python/utils/std-aligned-vector.hpp
+++ b/bindings/python/utils/std-aligned-vector.hpp
@@ -19,8 +19,6 @@ namespace pinocchio
   namespace python
   {
     
-    namespace bp = boost::python;
-    
     ///
     /// \brief Expose an container::aligned_vector from a type given as template argument.
     ///
@@ -31,7 +29,7 @@ namespace pinocchio
     ///
     template<class T, bool NoProxy = false, bool EnableFromPythonListConverter = true>
     struct StdAlignedVectorPythonVisitor
-    : public bp::vector_indexing_suite<typename container::aligned_vector<T>,NoProxy>
+    : public ::boost::python::vector_indexing_suite<typename container::aligned_vector<T>,NoProxy>
     , public StdContainerFromPythonList< container::aligned_vector<T> >
     {
       typedef container::aligned_vector<T> vector_type;
@@ -40,8 +38,8 @@ namespace pinocchio
       static void expose(const std::string & class_name,
                          const std::string & doc_string = "")
       {
-        bp::class_<vector_type>(class_name.c_str(),
-                                doc_string.c_str())
+        ::boost::python::class_<vector_type>(class_name.c_str(),
+                                             doc_string.c_str())
         .def(StdAlignedVectorPythonVisitor())
         .def_pickle(PickleVector<vector_type>());
         

--- a/bindings/python/utils/std-aligned-vector.hpp
+++ b/bindings/python/utils/std-aligned-vector.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016 CNRS
+// Copyright (c) 2016-2020 CNRS INRIA
 //
 
 #ifndef __pinocchio_python_utils_std_aligned_vector_hpp__
@@ -8,8 +8,11 @@
 #include <boost/python.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <string>
+
 #include "pinocchio/container/aligned-vector.hpp"
+
 #include "pinocchio/bindings/python/utils/pickle-vector.hpp"
+#include "pinocchio/bindings/python/utils/std-vector.hpp"
 
 namespace pinocchio
 {
@@ -21,21 +24,30 @@ namespace pinocchio
     ///
     /// \brief Expose an container::aligned_vector from a type given as template argument.
     ///
-    /// \tparam T Type to expose as std::vector<T>.
+    /// \tparam T Type to expose as container::aligned_vector<T>.
+    /// \tparam EnableFromPythonListConverter Enables the conversion from a Python list to a container::aligned_vector<T>.
     ///
     /// \sa StdAlignedVectorPythonVisitor
     ///
-    template<class T, bool NoProxy = false>
+    template<class T, bool NoProxy = false, bool EnableFromPythonListConverter = true>
     struct StdAlignedVectorPythonVisitor
-    : public bp::vector_indexing_suite< typename container::aligned_vector<T>,NoProxy >
+    : public bp::vector_indexing_suite<typename container::aligned_vector<T>,NoProxy>
+    , public StdContainerFromPythonList< container::aligned_vector<T> >
     {
+      typedef container::aligned_vector<T> vector_type;
+      typedef StdContainerFromPythonList<vector_type> FromPythonListConverter;
       
       static void expose(const std::string & class_name,
                          const std::string & doc_string = "")
       {
-        bp::class_< typename container::aligned_vector<T> >(class_name.c_str(),doc_string.c_str())
+        bp::class_<vector_type>(class_name.c_str(),
+                                doc_string.c_str())
         .def(StdAlignedVectorPythonVisitor())
-        .def_pickle(PickleVector<typename container::aligned_vector<T> >());
+        .def_pickle(PickleVector<vector_type>());
+        
+        // Register conversion
+        if(EnableFromPythonListConverter)
+          FromPythonListConverter::register_converter();
       }
     };
   } // namespace python

--- a/bindings/python/utils/std-vector.hpp
+++ b/bindings/python/utils/std-vector.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016 CNRS
+// Copyright (c) 2016-2020 CNRS INRIA
 //
 
 #ifndef __pinocchio_python_utils_std_vector_hpp__
@@ -9,6 +9,7 @@
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <string>
 #include <vector>
+
 #include "pinocchio/bindings/python/utils/pickle-vector.hpp"
 
 namespace pinocchio
@@ -17,27 +18,105 @@ namespace pinocchio
   {
     
     namespace bp = boost::python;
+  
+    ///
+    /// \brief Register the conversion from a Python list to a std::vector
+    ///
+    /// \tparam vector_type A std container (e.g. std::vector or std::list)
+    ///
+    template<typename vector_type>
+    struct StdContainerFromPythonList
+    {
+      typedef typename vector_type::value_type T;
+      
+      /// \brief Check if obj_ptr can be converted
+      static void* convertible(PyObject* obj_ptr)
+      {
+        // Check if it is a list
+        if(!PyList_Check(obj_ptr)) return 0;
+        
+        // Retrieve the underlying list
+        bp::object bp_obj(bp::handle<>(bp::borrowed(obj_ptr)));
+        bp::list bp_list(bp_obj);
+        bp::ssize_t list_size = bp::len(bp_list);
+        
+        // Check if all the elements contained in the current vector is of type T
+        for(bp::ssize_t k = 0; k < list_size; ++k)
+        {
+          bp::extract<T> elt(bp_list[k]);
+          if(!elt.check()) return 0;
+        }
+        
+        return obj_ptr;
+      }
+      
+      /// \brief Allocate the std::vector and fill it with the element contained in the list
+      static void construct(PyObject* obj_ptr,
+                            boost::python::converter::rvalue_from_python_stage1_data * memory)
+      {
+        // Extract the list
+        bp::object bp_obj(bp::handle<>(bp::borrowed(obj_ptr)));
+        bp::list bp_list(bp_obj);
+        bp::ssize_t list_size = bp::len(bp_list);
+        
+        void * storage = reinterpret_cast<bp::converter::rvalue_from_python_storage<vector_type>*>
+        (reinterpret_cast<void*>(memory))->storage.bytes;
+        
+        // Build the std::vector
+        new (storage) vector_type;
+        vector_type & vector = *reinterpret_cast<vector_type*>(storage);
+        vector.reserve((size_t)list_size);
+        
+        // Populate the vector
+        for(bp::ssize_t k = 0; k < list_size; ++k)
+        {
+          bp::extract<T> elt(bp_list[k]);
+          vector.push_back(elt());
+        }
+        
+        // Validate the construction
+        memory->convertible = storage;
+      }
+      
+      static void register_converter()
+      {
+        bp::converter::registry::push_back(&convertible,
+                                           &construct,
+                                           bp::type_id<vector_type>());
+      }
+    };
     
     ///
     /// \brief Expose an std::vector from a type given as template argument.
     ///
     /// \tparam T Type to expose as std::vector<T>.
+    /// \tparam Allocator Type for the Allocator in std::vector<T,Allocator>.
+    /// \tparam NoProxy When set to false, the elements will be copied when returned to Python.
+    /// \tparam EnableFromPythonListConverter Enables the conversion from a Python list to a std::vector<T,Allocator>
     ///
     /// \sa StdAlignedVectorPythonVisitor
     ///
-    template<class T, bool NoProxy = false>
+    template<class T, class Allocator = std::allocator<T>, bool NoProxy = false, bool EnableFromPythonListConverter = true>
     struct StdVectorPythonVisitor
-    : public bp::vector_indexing_suite< typename std::vector<T>,NoProxy >
+    : public bp::vector_indexing_suite<typename std::vector<T,Allocator>, NoProxy>
+    , public StdContainerFromPythonList< std::vector<T,Allocator> >
     {
+      typedef std::vector<T,Allocator> vector_type;
+      typedef StdContainerFromPythonList<vector_type> FromPythonListConverter;
       
       static void expose(const std::string & class_name,
                          const std::string & doc_string = "")
       {
-        bp::class_< std::vector<T> >(class_name.c_str(),doc_string.c_str())
+        bp::class_<vector_type>(class_name.c_str(),doc_string.c_str())
         .def(StdVectorPythonVisitor())
-        .def_pickle(PickleVector<typename std::vector<T> >());        
+        .def_pickle(PickleVector<vector_type>());
+        
+        // Register conversion
+        if(EnableFromPythonListConverter)
+          FromPythonListConverter::register_converter();
       }
     };
+    
   } // namespace python
 } // namespace pinocchio
 

--- a/bindings/python/utils/std-vector.hpp
+++ b/bindings/python/utils/std-vector.hpp
@@ -57,7 +57,7 @@ namespace pinocchio
         ::boost::python::list bp_list(bp_obj);
         ::boost::python::ssize_t list_size = ::boost::python::len(bp_list);
         
-        void * storage = reinterpret_cast<::boost::python::converter::rvalue_from_python_storage<vector_type>*>
+        void * storage = reinterpret_cast< ::boost::python::converter::rvalue_from_python_storage<vector_type>*>
         (reinterpret_cast<void*>(memory))->storage.bytes;
         
         // Build the std::vector

--- a/bindings/python/utils/std-vector.hpp
+++ b/bindings/python/utils/std-vector.hpp
@@ -17,8 +17,6 @@ namespace pinocchio
   namespace python
   {
     
-    namespace bp = boost::python;
-  
     ///
     /// \brief Register the conversion from a Python list to a std::vector
     ///
@@ -36,14 +34,14 @@ namespace pinocchio
         if(!PyList_Check(obj_ptr)) return 0;
         
         // Retrieve the underlying list
-        bp::object bp_obj(bp::handle<>(bp::borrowed(obj_ptr)));
-        bp::list bp_list(bp_obj);
-        bp::ssize_t list_size = bp::len(bp_list);
+        ::boost::python::object bp_obj(::boost::python::handle<>(::boost::python::borrowed(obj_ptr)));
+        ::boost::python::list bp_list(bp_obj);
+        ::boost::python::ssize_t list_size = ::boost::python::len(bp_list);
         
         // Check if all the elements contained in the current vector is of type T
-        for(bp::ssize_t k = 0; k < list_size; ++k)
+        for(::boost::python::ssize_t k = 0; k < list_size; ++k)
         {
-          bp::extract<T> elt(bp_list[k]);
+          ::boost::python::extract<T> elt(bp_list[k]);
           if(!elt.check()) return 0;
         }
         
@@ -55,11 +53,11 @@ namespace pinocchio
                             boost::python::converter::rvalue_from_python_stage1_data * memory)
       {
         // Extract the list
-        bp::object bp_obj(bp::handle<>(bp::borrowed(obj_ptr)));
-        bp::list bp_list(bp_obj);
-        bp::ssize_t list_size = bp::len(bp_list);
+        ::boost::python::object bp_obj(::boost::python::handle<>(::boost::python::borrowed(obj_ptr)));
+        ::boost::python::list bp_list(bp_obj);
+        ::boost::python::ssize_t list_size = ::boost::python::len(bp_list);
         
-        void * storage = reinterpret_cast<bp::converter::rvalue_from_python_storage<vector_type>*>
+        void * storage = reinterpret_cast<::boost::python::converter::rvalue_from_python_storage<vector_type>*>
         (reinterpret_cast<void*>(memory))->storage.bytes;
         
         // Build the std::vector
@@ -68,9 +66,9 @@ namespace pinocchio
         vector.reserve((size_t)list_size);
         
         // Populate the vector
-        for(bp::ssize_t k = 0; k < list_size; ++k)
+        for(::boost::python::ssize_t k = 0; k < list_size; ++k)
         {
-          bp::extract<T> elt(bp_list[k]);
+          ::boost::python::extract<T> elt(bp_list[k]);
           vector.push_back(elt());
         }
         
@@ -80,9 +78,9 @@ namespace pinocchio
       
       static void register_converter()
       {
-        bp::converter::registry::push_back(&convertible,
-                                           &construct,
-                                           bp::type_id<vector_type>());
+        ::boost::python::converter::registry::push_back(&convertible,
+                                                        &construct,
+                                                        ::boost::python::type_id<vector_type>());
       }
     };
     
@@ -98,7 +96,7 @@ namespace pinocchio
     ///
     template<class T, class Allocator = std::allocator<T>, bool NoProxy = false, bool EnableFromPythonListConverter = true>
     struct StdVectorPythonVisitor
-    : public bp::vector_indexing_suite<typename std::vector<T,Allocator>, NoProxy>
+    : public ::boost::python::vector_indexing_suite<typename std::vector<T,Allocator>, NoProxy>
     , public StdContainerFromPythonList< std::vector<T,Allocator> >
     {
       typedef std::vector<T,Allocator> vector_type;
@@ -107,7 +105,7 @@ namespace pinocchio
       static void expose(const std::string & class_name,
                          const std::string & doc_string = "")
       {
-        bp::class_<vector_type>(class_name.c_str(),doc_string.c_str())
+        ::boost::python::class_<vector_type>(class_name.c_str(),doc_string.c_str())
         .def(StdVectorPythonVisitor())
         .def_pickle(PickleVector<vector_type>());
         

--- a/src/autodiff/casadi.hpp
+++ b/src/autodiff/casadi.hpp
@@ -56,7 +56,7 @@ namespace Eigen
   
 #if EIGEN_VERSION_AT_LEAST(3,2,90) && !EIGEN_VERSION_AT_LEAST(3,2,93)
     template<typename Scalar, bool IsInteger>
-    struct significant_decimals_default_impl<::casadi::Matrix<Scalar>,IsInteger>
+    struct significant_decimals_default_impl< ::casadi::Matrix<Scalar>,IsInteger>
     {
       static inline int run()
       {
@@ -208,13 +208,13 @@ namespace pinocchio
     namespace internal
     {
       template<typename Scalar>
-      struct return_type_max<::casadi::Matrix<Scalar>,::casadi::Matrix<Scalar>>
+      struct return_type_max< ::casadi::Matrix<Scalar>,::casadi::Matrix<Scalar>>
       {
         typedef ::casadi::Matrix<Scalar> type;
       };
       
       template<typename Scalar, typename T>
-      struct return_type_max<::casadi::Matrix<Scalar>,T>
+      struct return_type_max< ::casadi::Matrix<Scalar>,T>
       {
         typedef ::casadi::Matrix<Scalar> type;
       };
@@ -226,7 +226,7 @@ namespace pinocchio
       };
       
       template<typename Scalar>
-      struct call_max<::casadi::Matrix<Scalar>,::casadi::Matrix<Scalar> >
+      struct call_max< ::casadi::Matrix<Scalar>,::casadi::Matrix<Scalar> >
       {
         static inline ::casadi::Matrix<Scalar> run(const ::casadi::Matrix<Scalar> & a,
                                                    const ::casadi::Matrix<Scalar> & b)
@@ -234,7 +234,7 @@ namespace pinocchio
       };
       
       template<typename S1, typename S2>
-      struct call_max<::casadi::Matrix<S1>,S2>
+      struct call_max< ::casadi::Matrix<S1>,S2>
       {
         typedef ::casadi::Matrix<S1> CasadiType;
         static inline ::casadi::Matrix<S1> run(const ::casadi::Matrix<S1> & a,
@@ -265,7 +265,7 @@ namespace pinocchio
     {
       
       template<typename _Scalar>
-      struct quaternionbase_assign_impl<::casadi::Matrix<_Scalar> >
+      struct quaternionbase_assign_impl< ::casadi::Matrix<_Scalar> >
       {
         typedef ::casadi::Matrix<_Scalar> Scalar;
         template<typename Matrix3, typename QuaternionDerived>
@@ -351,7 +351,7 @@ namespace pinocchio
 //    };
     
     template<typename Scalar, typename then_type, typename else_type>
-    struct if_then_else_impl<::casadi::Matrix<Scalar>,then_type,else_type>
+    struct if_then_else_impl< ::casadi::Matrix<Scalar>,then_type,else_type>
     {
       typedef typename traits<if_then_else_impl>::ReturnType ReturnType;
       

--- a/unittest/python/CMakeLists.txt
+++ b/unittest/python/CMakeLists.txt
@@ -17,6 +17,7 @@ SET(${PROJECT_NAME}_PYTHON_TESTS
   bindings_motion
   bindings_SE3
   bindings_geometry_model
+  bindings_rnea
   explog
   rpy
   utils

--- a/unittest/python/bindings_rnea.py
+++ b/unittest/python/bindings_rnea.py
@@ -1,0 +1,42 @@
+import unittest
+from test_case import PinocchioTestCase as TestCase
+
+import pinocchio as pin
+
+pin.switchToNumpyArray()
+
+from pinocchio.utils import rand, zero
+import numpy as np
+
+class TestRNEA(TestCase):
+
+    def setUp(self):
+        self.model = pin.buildSampleModelHumanoidRandom()
+        self.data = self.model.createData()
+
+        qmax = np.matrix(np.full((self.model.nq,1),np.pi))
+        self.q = pin.randomConfiguration(self.model,-qmax,qmax)
+        self.v = np.random.rand(self.model.nv)
+        self.a = np.random.rand(self.model.nv)
+
+    def test_rnea(self):
+        model = self.model
+        tau = pin.rnea(self.model,self.data,self.q,self.v,self.a)
+
+        null_fext = pin.StdVec_Force()
+        for k in range(model.njoints):
+          null_fext.append(pin.Force.Zero())
+
+        tau_null_fext = pin.rnea(self.model,self.data,self.q,self.v,self.a,null_fext)
+        self.assertApprox(tau_null_fext,tau)
+
+        null_fext_list = []
+        for f in null_fext:
+            null_fext_list.append(f)
+
+        print('size:',len(null_fext_list))
+        tau_null_fext_list = pin.rnea(self.model,self.data,self.q,self.v,self.a,null_fext_list)
+        self.assertApprox(tau_null_fext_list,tau)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This new feature avoids implementing dedicated signatures taking into account boost::python::list as argument