### PR TITLE
Implement rpy in C++

### DIFF
--- a/bindings/python/fwd.hpp
+++ b/bindings/python/fwd.hpp
@@ -18,6 +18,7 @@ namespace pinocchio
     void exposeMotion();
     void exposeInertia();
     void exposeExplog();
+    void exposeRpy();
     
     // Expose multibody classes
     void exposeJoints();

--- a/bindings/python/math/expose-rpy.cpp
+++ b/bindings/python/math/expose-rpy.cpp
@@ -1,0 +1,59 @@
+//
+// Copyright (c) 2019 CNRS INRIA
+//
+
+#include "pinocchio/bindings/python/fwd.hpp"
+#include <boost/python.hpp>
+//#include "pinocchio/bindings/python/utils/namespace.hpp"
+#include "pinocchio/math/rpy.hpp"
+
+namespace pinocchio
+{
+  namespace python
+  {
+    namespace bp = boost::python;
+
+    Eigen::Matrix3d rpyToMatrix_proxy(const Eigen::Vector3d & rpy)
+    {
+      return pinocchio::rpy::rpyToMatrix(rpy);
+    }
+
+    Eigen::Vector3d matrixToRpy_proxy(const Eigen::Matrix3d & R)
+    {
+      return pinocchio::rpy::matrixToRpy(R);
+    }
+    
+    void exposeRpy()
+    {
+      using namespace Eigen;
+      using namespace pinocchio::rpy;
+
+      {
+        // using the rpy scope
+        //bp::scope current_scope = getOrCreatePythonNamespace("rpy");
+        
+        bp::def("_rpyToMatrix",
+                static_cast<Matrix3d (*)(const double, const double, const double)>(&rpyToMatrix),
+                bp::args("roll", "pitch", "yaw"),
+                "Given (r, p, y), the rotation is given as R = R_z(y)R_y(p)R_x(r),"
+                " where R_a(theta) denotes the rotation of theta degrees axis a");
+
+        bp::def("_rpyToMatrix",
+                &rpyToMatrix_proxy,
+                bp::arg("rpy"),
+                "Given (r, p, y), the rotation is given as R = R_z(y)R_y(p)R_x(r),"
+                " where R_a(theta) denotes the rotation of theta degrees axis a");
+
+        bp::def("_matrixToRpy",
+                &matrixToRpy_proxy,
+                bp::arg("R"),
+                "Given a rotation matrix R, the angles (r, p, y) are given so that R = R_z(y)R_y(p)R_x(r),"
+                " where R_a(theta) denotes the rotation of theta degrees axis a."
+                " The angles are guaranteed to be in the ranges: r in [-pi,pi],"
+                " p in[-pi/2,pi/2], y in [-pi,pi]");
+      }
+      
+    }
+    
+  } // namespace python
+} // namespace pinocchio

--- a/bindings/python/module.cpp
+++ b/bindings/python/module.cpp
@@ -52,6 +52,7 @@ BOOST_PYTHON_MODULE(libpinocchio_pywrap)
   exposeInertia();
   exposeJoints();
   exposeExplog();
+  exposeRpy();
   
   bp::enum_< ::pinocchio::ReferenceFrame >("ReferenceFrame")
   .value("WORLD",::pinocchio::WORLD)

--- a/bindings/python/pinocchio/rpy.py
+++ b/bindings/python/pinocchio/rpy.py
@@ -6,6 +6,8 @@ import numpy as np
 
 from . import libpinocchio_pywrap as pin
 
+from .libpinocchio_pywrap import _rpyToMatrix as rpyToMatrix
+from .libpinocchio_pywrap import _matrixToRpy as matrixToRpy
 
 def npToTTuple(M):
     L = M.tolist()
@@ -33,9 +35,5 @@ def rotate(axis, ang):
     u = np.zeros(3)
     u[cood[axis]] = 1.0
     return pin.AngleAxis(ang, u).matrix()
-
-
-rpyToMatrix = pin._rpyToMatrix
-matrixToRpy = pin._matrixToRpy
 
 __all__ = ['npToTTuple', 'npToTuple', 'rotate', 'rpyToMatrix', 'matrixToRpy']

--- a/bindings/python/pinocchio/rpy.py
+++ b/bindings/python/pinocchio/rpy.py
@@ -30,7 +30,7 @@ def rotate(axis, ang):
     eg. T = rot('x', pi / 4): rotate pi/4 rad about x axis
     '''
     cood = {'x': 0, 'y': 1, 'z': 2}
-    u = np.matrix(np.zeros([3, 1]), np.double)
+    u = np.zeros(3)
     u[cood[axis]] = 1.0
     return pin.AngleAxis(ang, u).matrix()
 

--- a/bindings/python/pinocchio/rpy.py
+++ b/bindings/python/pinocchio/rpy.py
@@ -2,8 +2,6 @@
 # Copyright (c) 2015 CNRS
 #
 
-from math import atan2, pi, sqrt
-
 import numpy as np
 
 from . import libpinocchio_pywrap as pin
@@ -37,27 +35,7 @@ def rotate(axis, ang):
     return pin.AngleAxis(ang, u).matrix()
 
 
-def rpyToMatrix(rpy):
-    '''
-    # Convert from Roll, Pitch, Yaw to transformation Matrix
-    '''
-    return rotate('z', rpy[2, 0]).dot(rotate('y', rpy[1, 0])).dot(rotate('x', rpy[0, 0]))
+rpyToMatrix = pin._rpyToMatrix
+matrixToRpy = pin._matrixToRpy
 
-
-def matrixToRpy(M):
-    '''
-    # Convert from Transformation Matrix to Roll, Pitch, Yaw
-    '''
-    m = sqrt(M[2, 1] ** 2 + M[2, 2] ** 2)
-    p = atan2(-M[2, 0], m)
-
-    if abs(abs(p) - pi / 2) < 0.001:
-        r = 0
-        y = -atan2(M[0, 1], M[1, 1])
-    else:
-        y = atan2(M[1, 0], M[0, 0])  # alpha
-        r = atan2(M[2, 1], M[2, 2])  # gamma
-
-    lst = [[r], [p], [y]]
-    is_matrix = isinstance(M, np.matrix)
-    return np.matrix(lst) if is_matrix else np.array(lst)
+__all__ = ['npToTTuple', 'npToTuple', 'rotate', 'rpyToMatrix', 'matrixToRpy']

--- a/doc/treeview.dox
+++ b/doc/treeview.dox
@@ -135,6 +135,9 @@ namespace pinocchio {
   /// \namespace pinocchio::quaternion
   /// \brief Quaternion operations
 
+  /// \namespace pinocchio::rpy
+  /// \brief Roll-pitch-yaw operations
+
   /// \namespace pinocchio::urdf
   /// \brief URDF parsing
 

--- a/src/math/rpy.hpp
+++ b/src/math/rpy.hpp
@@ -24,7 +24,7 @@ namespace pinocchio
     /// around axis \f$\alpha\f$.
     ///
     template<typename Scalar>
-    Eigen::Matrix<Scalar,3,3> rpyToMatrix(Scalar r, Scalar p, Scalar y)
+    Eigen::Matrix<Scalar,3,3> rpyToMatrix(const Scalar r, const Scalar p, const Scalar y)
     {
       return (Eigen::AngleAxisd(y, Eigen::Vector3d::UnitZ())
               * Eigen::AngleAxisd(p, Eigen::Vector3d::UnitY())
@@ -41,11 +41,11 @@ namespace pinocchio
     ///
     template<typename Vector3Like>
     Eigen::Matrix<typename Vector3Like::Scalar,3,3,PINOCCHIO_EIGEN_PLAIN_TYPE(Vector3Like)::Options>
-    rpyToMatrix(const Eigen::MatrixBase<Vector3Like> & v)
+    rpyToMatrix(const Eigen::MatrixBase<Vector3Like> & rpy)
     {
-      PINOCCHIO_ASSERT_MATRIX_SPECIFIC_SIZE (Vector3Like, v, 3, 1);
+      PINOCCHIO_ASSERT_MATRIX_SPECIFIC_SIZE (Vector3Like, rpy, 3, 1);
 
-      return rpyToMatrix(v[0],v[1],v[2]);
+      return rpyToMatrix(rpy[0], rpy[1], rpy[2]);
     }
 
     ///

--- a/src/math/rpy.hpp
+++ b/src/math/rpy.hpp
@@ -1,0 +1,65 @@
+//
+// Copyright (c) 2016-2019 CNRS, INRIA
+//
+
+#ifndef __pinocchio_math_rpy_hpp__
+#define __pinocchio_math_rpy_hpp__
+
+#include "pinocchio/math/fwd.hpp"
+#include "pinocchio/math/comparison-operators.hpp"
+#include "pinocchio/math/sincos.hpp"
+#include <boost/type_traits.hpp>
+
+#include <Eigen/Geometry>
+
+namespace pinocchio
+{
+  namespace rpy
+  {
+    ///
+    /// \brief Convert from Roll, Pitch, Yaw to transformation Matrix
+    ///
+    /// Given \f$r, p, y\f$, the rotation is given as \f$ R = R_z(y)R_y(p)R_x(r) \f$,
+    /// where \f$R_{\alpha}(\theta)\f$ denotes the rotation of \f$\theta\f$ degrees
+    /// around axis \f$\alpha\f$.
+    /// As this is a specialized implementation, it is expected to be very efficient
+    ///
+    template<typename Scalar>
+    Eigen::Matrix<Scalar,3,3> rpyToMatrix(Scalar r, Scalar p, Scalar y)
+    {
+      typedef Eigen::Matrix<Scalar,3,3> ResultType;
+      ResultType res;
+
+      Scalar sr, cr;
+      SINCOS(r,&sr,&cr);
+      Scalar sp, cp;
+      SINCOS(p,&sp,&cp);
+      Scalar sy, cy;
+      SINCOS(y,&sy,&cy);
+
+      res <<  cp*cy, cy*sp*sr - cr*sy, sr*sy + cr*cy*sp,
+              cp*sy, cr*cy + sp*sr*sy, cr*sp*sy - cy*sr,
+                -sp,            cp*sr,            cp*cr;
+
+      return res;         
+    }
+
+    ///
+    /// \brief Convert from Roll, Pitch, Yaw to transformation Matrix
+    ///
+    /// Given a vector \f$(r, p, y)\f$, the rotation is given as \f$ R = R_z(y)R_y(p)R_x(r) \f$,
+    /// where \f$R_{\alpha}(\theta)\f$ denotes the rotation of \f$\theta\f$ degrees
+    /// around axis \f$\alpha\f$.
+    /// As this is a specialized implementation, it is expected to be very efficient
+    ///
+    template<typename Vector3Like>
+    Eigen::Matrix<typename Vector3Like::Scalar,3,3,PINOCCHIO_EIGEN_PLAIN_TYPE(Vector3Like)::Options>
+    rpyToMatrix(const Eigen::MatrixBase<Vector3Like> & v)
+    {
+      PINOCCHIO_ASSERT_MATRIX_SPECIFIC_SIZE (Vector3Like, v, 3, 1);
+
+      return rpyToMatrix(v[0],v[1],v[2]);
+    }
+  } // namespace rpy
+}
+#endif //#ifndef __pinocchio_math_rpy_hpp__

--- a/src/math/rpy.hpp
+++ b/src/math/rpy.hpp
@@ -17,7 +17,7 @@ namespace pinocchio
   namespace rpy
   {
     ///
-    /// \brief Convert from Roll, Pitch, Yaw to transformation Matrix
+    /// \brief Convert from Roll, Pitch, Yaw to rotation Matrix
     ///
     /// Given \f$r, p, y\f$, the rotation is given as \f$ R = R_z(y)R_y(p)R_x(r) \f$,
     /// where \f$R_{\alpha}(\theta)\f$ denotes the rotation of \f$\theta\f$ degrees
@@ -26,14 +26,16 @@ namespace pinocchio
     template<typename Scalar>
     Eigen::Matrix<Scalar,3,3> rpyToMatrix(const Scalar r, const Scalar p, const Scalar y)
     {
-      return (Eigen::AngleAxisd(y, Eigen::Vector3d::UnitZ())
-              * Eigen::AngleAxisd(p, Eigen::Vector3d::UnitY())
-              * Eigen::AngleAxisd(r, Eigen::Vector3d::UnitX())
+      typedef Eigen::AngleAxis<Scalar> AngleAxis;
+      typedef Eigen::Matrix<Scalar,3,1> Vector3s;
+      return (AngleAxis(y, Vector3s::UnitZ())
+              * AngleAxis(p, Vector3s::UnitY())
+              * AngleAxis(r, Vector3s::UnitX())
              ).toRotationMatrix();
     }
 
     ///
-    /// \brief Convert from Roll, Pitch, Yaw to transformation Matrix
+    /// \brief Convert from Roll, Pitch, Yaw to rotation Matrix
     ///
     /// Given a vector \f$(r, p, y)\f$, the rotation is given as \f$ R = R_z(y)R_y(p)R_x(r) \f$,
     /// where \f$R_{\alpha}(\theta)\f$ denotes the rotation of \f$\theta\f$ degrees

--- a/src/math/rpy.hpp
+++ b/src/math/rpy.hpp
@@ -22,26 +22,14 @@ namespace pinocchio
     /// Given \f$r, p, y\f$, the rotation is given as \f$ R = R_z(y)R_y(p)R_x(r) \f$,
     /// where \f$R_{\alpha}(\theta)\f$ denotes the rotation of \f$\theta\f$ degrees
     /// around axis \f$\alpha\f$.
-    /// As this is a specialized implementation, it is expected to be very efficient
     ///
     template<typename Scalar>
     Eigen::Matrix<Scalar,3,3> rpyToMatrix(Scalar r, Scalar p, Scalar y)
     {
-      typedef Eigen::Matrix<Scalar,3,3> ResultType;
-      ResultType res;
-
-      Scalar sr, cr;
-      SINCOS(r,&sr,&cr);
-      Scalar sp, cp;
-      SINCOS(p,&sp,&cp);
-      Scalar sy, cy;
-      SINCOS(y,&sy,&cy);
-
-      res <<  cp*cy, cy*sp*sr - cr*sy, sr*sy + cr*cy*sp,
-              cp*sy, cr*cy + sp*sr*sy, cr*sp*sy - cy*sr,
-                -sp,            cp*sr,            cp*cr;
-
-      return res;         
+      return (Eigen::AngleAxisd(y, Eigen::Vector3d::UnitZ())
+              * Eigen::AngleAxisd(p, Eigen::Vector3d::UnitY())
+              * Eigen::AngleAxisd(r, Eigen::Vector3d::UnitX())
+             ).toRotationMatrix();
     }
 
     ///
@@ -50,7 +38,6 @@ namespace pinocchio
     /// Given a vector \f$(r, p, y)\f$, the rotation is given as \f$ R = R_z(y)R_y(p)R_x(r) \f$,
     /// where \f$R_{\alpha}(\theta)\f$ denotes the rotation of \f$\theta\f$ degrees
     /// around axis \f$\alpha\f$.
-    /// As this is a specialized implementation, it is expected to be very efficient
     ///
     template<typename Vector3Like>
     Eigen::Matrix<typename Vector3Like::Scalar,3,3,PINOCCHIO_EIGEN_PLAIN_TYPE(Vector3Like)::Options>
@@ -70,7 +57,6 @@ namespace pinocchio
     /// around axis \f$\alpha\f$.
     /// The angles are guaranteed to be in the ranges \f$r\in[-\pi,\pi]\f$
     /// \f$p\in[-\frac{\pi}{2},\frac{\pi}{2}]\f$ \f$y\in[-\pi,\pi]\f$.
-    /// As this is a specialized implementation, it is expected to be very efficient.
     ///
     /// \warning the method assumes \f$R\f$ is a rotation matrix. If it is not, the result is undefined.
     ///

--- a/src/math/rpy.hpp
+++ b/src/math/rpy.hpp
@@ -60,6 +60,42 @@ namespace pinocchio
 
       return rpyToMatrix(v[0],v[1],v[2]);
     }
+
+    ///
+    /// \brief Convert from Transformation Matrix to Roll, Pitch, Yaw
+    ///
+    /// Given a rotation matrix \f$R\f$, the angles \f$r, p, y\f$ are given
+    /// so that \f$ R = R_z(y)R_y(p)R_x(r) \f$,
+    /// where \f$R_{\alpha}(\theta)\f$ denotes the rotation of \f$\theta\f$ degrees
+    /// around axis \f$\alpha\f$.
+    /// The angles are guaranteed to be in the ranges \f$r\in[-\pi,\pi]\f$
+    /// \f$p\in[-\frac{\pi}{2},\frac{\pi}{2}]\f$ \f$y\in[-\pi,\pi]\f$.
+    /// As this is a specialized implementation, it is expected to be very efficient.
+    ///
+    /// \warning the method assumes \f$R\f$ is a rotation matrix. If it is not, the result is undefined.
+    ///
+    template<typename Matrix3Like>
+    Eigen::Matrix<typename Matrix3Like::Scalar,3,1,PINOCCHIO_EIGEN_PLAIN_TYPE(Matrix3Like)::Options>
+    matrixToRpy(const Eigen::MatrixBase<Matrix3Like> & R)
+    {
+      PINOCCHIO_ASSERT_MATRIX_SPECIFIC_SIZE (Matrix3Like, R, 3, 3);
+      typedef typename Matrix3Like::Scalar Scalar;
+      typedef Eigen::Matrix<Scalar,3,1> ResultType;
+      ResultType res;
+
+      Scalar m = sqrt(R(2, 1) * R(2, 1) + R(2, 2) * R(2, 2));
+      Scalar p = atan2(-R(2, 0), m);
+      Scalar r, y;
+      if (fabs(fabs(p) - M_PI / 2.) < 0.001) {
+        r = 0;
+        y = -atan2(R(0, 1), R(1, 1));
+      } else {
+        y = atan2(R(1, 0), R(0, 0));
+        r = atan2(R(2, 1), R(2, 2));
+      }
+      res << r, p, y;
+      return res;
+    }
   } // namespace rpy
 }
 #endif //#ifndef __pinocchio_math_rpy_hpp__

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -47,6 +47,7 @@ ADD_PINOCCHIO_UNIT_TEST(eigen-basic-op)
 ADD_PINOCCHIO_UNIT_TEST(eigen-tensor)
 ADD_PINOCCHIO_UNIT_TEST(sincos)
 ADD_PINOCCHIO_UNIT_TEST(quaternion)
+ADD_PINOCCHIO_UNIT_TEST(rpy)
 ADD_PINOCCHIO_UNIT_TEST(rotation)
 
 # Pinocchio features

--- a/unittest/python/rpy.py
+++ b/unittest/python/rpy.py
@@ -24,6 +24,7 @@ class TestRPY(TestCase):
         self.assertApprox(rpyToMatrix(matrixToRpy(m)), m)
         rpy = np.matrix(list(range(3))).T * pi / 2
         self.assertApprox(matrixToRpy(rpyToMatrix(rpy)), rpy)
+        self.assertApprox(rpyToMatrix(rpy), rpyToMatrix(float(rpy[0]), float(rpy[1]), float(rpy[2])))
 
 if __name__ == '__main__':
     unittest.main()

--- a/unittest/rpy.cpp
+++ b/unittest/rpy.cpp
@@ -34,5 +34,20 @@ BOOST_AUTO_TEST_CASE(test_rpyToMatrix)
   BOOST_CHECK(Rv.isApprox(R_Eig));
 }
 
+BOOST_AUTO_TEST_CASE(test_matrixToRpy)
+{
+  double r = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
+  double p = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/M_PI)) - (M_PI/2);
+  double y = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
+
+  Eigen::Matrix3d R = pinocchio::rpy::rpyToMatrix(r, p, y);
+
+  Eigen::Vector3d v = pinocchio::rpy::matrixToRpy(R);
+
+  BOOST_CHECK_CLOSE(r,v[0],1e-12);
+  BOOST_CHECK_CLOSE(p,v[1],1e-12);
+  BOOST_CHECK_CLOSE(y,v[2],1e-12);
+}
+
 BOOST_AUTO_TEST_SUITE_END()
 

--- a/unittest/rpy.cpp
+++ b/unittest/rpy.cpp
@@ -1,0 +1,38 @@
+//
+// Copyright (c) 2019 INRIA
+//
+
+#include <pinocchio/math/rpy.hpp>
+
+#include <boost/variant.hpp> // to avoid C99 warnings
+
+#include <boost/test/unit_test.hpp>
+#include <boost/utility/binary.hpp>
+
+BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+
+BOOST_AUTO_TEST_CASE(test_rpyToMatrix)
+{
+  double r = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
+  double p = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/M_PI)) - (M_PI/2);
+  double y = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
+
+  Eigen::Matrix3d R = pinocchio::rpy::rpyToMatrix(r, p, y);
+
+  Eigen::Matrix3d R_Eig = (Eigen::AngleAxisd(y, Eigen::Vector3d::UnitZ())
+                           * Eigen::AngleAxisd(p, Eigen::Vector3d::UnitY())
+                           * Eigen::AngleAxisd(r, Eigen::Vector3d::UnitX())
+                          ).toRotationMatrix();
+
+  BOOST_CHECK(R.isApprox(R_Eig));
+
+  Eigen::Vector3d v;
+  v << r, p, y;
+
+  Eigen::Matrix3d Rv = pinocchio::rpy::rpyToMatrix(v);
+
+  BOOST_CHECK(Rv.isApprox(R_Eig));
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+


### PR DESCRIPTION
Related to #1026.
This implements `rpyToMatrix` and `matrixToRpy` in C++. They are available as C++ methods in the namespace `rpy`, and they are exposed in replacement to the old Python implementations.
This makes the behavior of the Python functions analogous to most other ones concerning the use of eigenpy.

I kept the old Python implementation for `npToTTuple`, `npToTuple` and `rotate`, for the following reasons:
- They already work well w.r.t. eignepy
- I don't think it makes sense to implement them in C++
- I had problems with creating the submodule `rpy` from C++
- I do not have time to do better than this right now and we want to have something acceptable as soon as possible :)

Concerning `rpyToMatrix`: I was amazed to see that a naive implementation employing the closed-form formula (first implemented in https://github.com/stack-of-tasks/pinocchio/pull/1042/commits/74723582b2b11b56097e5d54283caea1da753517) was four times _slower_ than
```cpp
(Eigen::AngleAxisd(y, Eigen::Vector3d::UnitZ())
              * Eigen::AngleAxisd(p, Eigen::Vector3d::UnitY())
              * Eigen::AngleAxisd(r, Eigen::Vector3d::UnitX())
             ).toRotationMatrix();
````
when compiled in release mode on my laptop.
I had made a little benchmark to test it, but alas, it is on my laptop, which is at home.
Therefore, I kept the latter implementation (see commit https://github.com/stack-of-tasks/pinocchio/pull/1042/commits/b0bdcd526ea44c09d2ac9ea405aca0893a74eeb8)

Concering `matrixToRpy`: eigen offers method `eulerAngles()`, but this is rarely what we want because the range of the output angles. Performance-wise, the timings of my implementation and those of `eulerAngles()` seem to be similar. I did not test it against `unsupported/Eigen/EulerAngles`, but I do not expect great difference (and I would rather avoid using that module).