### PR TITLE
Topic/nparray

### DIFF
--- a/bindings/python/fwd.hpp
+++ b/bindings/python/fwd.hpp
@@ -18,6 +18,9 @@ namespace pinocchio
     void exposeMotion();
     void exposeInertia();
     void exposeExplog();
+    void exposeSkew();
+
+    // Expose math module
     void exposeRpy();
     
     // Expose multibody classes

--- a/bindings/python/module.cpp
+++ b/bindings/python/module.cpp
@@ -53,7 +53,8 @@ BOOST_PYTHON_MODULE(libpinocchio_pywrap)
   exposeJoints();
   exposeExplog();
   exposeRpy();
-  
+  exposeSkew();
+
   bp::enum_< ::pinocchio::ReferenceFrame >("ReferenceFrame")
   .value("WORLD",::pinocchio::WORLD)
   .value("LOCAL",::pinocchio::LOCAL)

--- a/bindings/python/pinocchio/derivative/lambdas.py
+++ b/bindings/python/pinocchio/derivative/lambdas.py
@@ -3,8 +3,8 @@
 #
 
 import numpy as np
-from pinocchio import Motion,Force
-from pinocchio.utils import skew,zero
+from pinocchio import Motion, Force, skew
+from pinocchio.utils import zero
 
 def jFromIdx(idxv,robot):
     '''Return the joint index from the velocity index'''

--- a/bindings/python/pinocchio/romeo_wrapper.py
+++ b/bindings/python/pinocchio/romeo_wrapper.py
@@ -12,7 +12,7 @@ class RomeoWrapper(RobotWrapper):
 
     def __init__(self, filename, package_dirs=None, verbose=False):
         self.initFromURDF(filename, package_dirs=package_dirs, root_joint=pin.JointModelFreeFlyer(), verbose=verbose)
-        self.q0 = np.matrix([
+        self.q0 = np.array([
             0, 0, 0.840252, 0, 0, 0, 1,                      # Free flyer
             0, 0, -0.3490658, 0.6981317, -0.3490658, 0,      # left leg
             0, 0, -0.3490658, 0.6981317, -0.3490658, 0,      # right leg
@@ -20,7 +20,9 @@ class RomeoWrapper(RobotWrapper):
             1.5, 0.6, -0.5, -1.05, -0.4, -0.3, -0.2,         # left arm
             0, 0, 0, 0,                                      # head
             1.5, -0.6, 0.5, 1.05, -0.4, -0.3, -0.2,          # right arm
-        ]).T
+        ])
+        if pin.getNumpyType()==np.matrix:
+            self.q0 = np.matrix(self.q0).T
 
         self.opCorrespondances = {"lh": "LWristPitch",
                                   "rh": "RWristPitch",

--- a/bindings/python/pinocchio/utils.py
+++ b/bindings/python/pinocchio/utils.py
@@ -60,6 +60,8 @@ def mprint(M, name="ans",eps=1e-15):
     '''
     if isinstance(M, pin.SE3):
         M = M.homogeneous
+    if len(M.shape==1):
+        M = np.expand_dims(M, axis=0)
     ncol = M.shape[1]
     NC = 6
     print(name, " = ")

--- a/bindings/python/pinocchio/utils.py
+++ b/bindings/python/pinocchio/utils.py
@@ -22,11 +22,9 @@ rand = lambda n: np.matrix(np.random.rand(n, 1) if isinstance(n, int) else np.ra
 def cross(a, b):
     return np.matrix(np.cross(a.T, b.T).T, np.double)
 
-
+@deprecated('Now useless. You can directly have access to this function from the main scope of Pinocchio')
 def skew(p):
-    x, y, z = p
-    return np.matrix([[0, -z, y], [z, 0, -x], [-y, x, 0]], np.double)
-
+    return pin.skew(p)
 
 @deprecated('Now useless. You can directly have access to this function from the main scope of Pinocchio')
 def se3ToXYZQUAT(M):

--- a/bindings/python/pinocchio/utils.py
+++ b/bindings/python/pinocchio/utils.py
@@ -14,17 +14,24 @@ from .rpy import matrixToRpy, npToTTuple, npToTuple, rotate, rpyToMatrix
 
 from .deprecation import deprecated
 
-@deprecated("Please use numpy.eye")
 def eye(n):
-    return np.matrix(np.eye(n))
+    res = np.eye(n)
+    if pin.getNumpyType()==np.matrix:
+        return np.matrix(res)
+    else:
+        return res
 
-@deprecated("Please use numpy.zero")
 def zero(n):
-    return np.matrix(np.zeros([n, 1] if isinstance(n, int) else n))
+    if pin.getNumpyType()==np.matrix:
+        return np.matrix(np.zeros([n, 1] if isinstance(n, int) else n))
+    else:
+        return np.zeros(n)
 
-@deprecated("Please use numpy.random.rand")
 def rand(n):
-    return np.matrix(np.random.rand(n, 1) if isinstance(n, int) else np.random.rand(n[0], n[1]))
+    if pin.getNumpyType()==np.matrix:
+        return np.matrix(np.random.rand(n, 1) if isinstance(n, int) else np.random.rand(n[0], n[1]))
+    else:
+        return np.random.rand(n) if isinstance(n, int) else np.random.rand(n[0], n[1])
 
 @deprecated("Please use numpy.cross(a, b) or numpy.cross(a, b, axis=0).")
 def cross(a, b):

--- a/bindings/python/pinocchio/utils.py
+++ b/bindings/python/pinocchio/utils.py
@@ -14,13 +14,21 @@ from .rpy import matrixToRpy, npToTTuple, npToTuple, rotate, rpyToMatrix
 
 from .deprecation import deprecated
 
-eye = lambda n: np.matrix(np.eye(n), np.double)
-zero = lambda n: np.matrix(np.zeros([n, 1] if isinstance(n, int) else n), np.double)
-rand = lambda n: np.matrix(np.random.rand(n, 1) if isinstance(n, int) else np.random.rand(n[0], n[1]), np.double)
+@deprecated("Please use numpy.eye")
+def eye(n):
+    return np.matrix(np.eye(n))
 
+@deprecated("Please use numpy.zero")
+def zero(n):
+    return np.matrix(np.zeros([n, 1] if isinstance(n, int) else n))
 
+@deprecated("Please use numpy.random.rand")
+def rand(n):
+    return np.matrix(np.random.rand(n, 1) if isinstance(n, int) else np.random.rand(n[0], n[1]))
+
+@deprecated("Please use numpy.cross(a, b) or numpy.cross(a, b, axis=0).")
 def cross(a, b):
-    return np.matrix(np.cross(a.T, b.T).T, np.double)
+    return np.matrix(np.cross(a, b, axis=0))
 
 @deprecated('Now useless. You can directly have access to this function from the main scope of Pinocchio')
 def skew(p):

--- a/bindings/python/spatial/expose-skew.cpp
+++ b/bindings/python/spatial/expose-skew.cpp
@@ -1,0 +1,42 @@
+//
+// Copyright (c) 2015-2019 CNRS INRIA
+// Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
+//
+
+#include "pinocchio/bindings/python/fwd.hpp"
+#include <boost/python.hpp>
+#include "pinocchio/spatial/skew.hpp"
+
+namespace pinocchio
+{
+  namespace python
+  {
+    namespace bp = boost::python;
+
+    Eigen::Matrix3d skew_proxy(const Eigen::Vector3d & v)
+    {
+      return pinocchio::skew(v);
+    }
+
+    Eigen::Vector3d unSkew_proxy(const Eigen::Matrix3d & M)
+    {
+      return pinocchio::unSkew(M);
+    }
+
+    void exposeSkew()
+    {
+
+      bp::def("skew",&skew_proxy,
+              bp::arg("Angular velocity (vector of size 3)"),
+              "Computes the skew representation of a given 3D vector, "
+              "i.e. the antisymmetric matrix representation of the cross product operator.");
+
+      bp::def("unSkew",&unSkew_proxy,
+              bp::arg("M: a 3x3 matrix."),
+              "Inverse of skew operator. From a given skew-symmetric matrix M "
+              "of dimension 3x3, it extracts the supporting vector, i.e. the entries of M."
+              "Mathematically speacking, it computes v such that M x = cross(x, v).");
+    }
+
+  } // namespace python
+} // namespace pinocchio

--- a/bindings/python/spatial/expose-skew.cpp
+++ b/bindings/python/spatial/expose-skew.cpp
@@ -16,6 +16,20 @@ namespace pinocchio
     namespace bp = boost::python;
   
     // We need to resort to another call, because it seems that Boost.Python is not aligning the Eigen::MatrixBase. TODO: fix it!
+    template<typename Vector3>
+    Eigen::Matrix<typename Vector3::Scalar,3,3,Vector3::Options> skew(const Vector3 & v)
+    {
+      return pinocchio::skew(v);
+    }
+  
+    // We need to resort to another call, because it seems that Boost.Python is not aligning the Eigen::MatrixBase. TODO: fix it!
+    template<typename Vector3>
+    Eigen::Matrix<typename Vector3::Scalar,3,3,Vector3::Options> skewSquare(const Vector3 & u, const Vector3 & v)
+    {
+      return pinocchio::skewSquare(u,v);
+    }
+  
+    // We need to resort to another call, because it seems that Boost.Python is not aligning the Eigen::MatrixBase. TODO: fix it!
     template<typename Matrix3>
     Eigen::Matrix<typename Matrix3::Scalar,3,1,Matrix3::Options> unSkew(const Matrix3 & mat)
     {
@@ -34,7 +48,7 @@ namespace pinocchio
               "Parameters:\n"
               "\tu: the input vector of dimension 3");
       
-      bp::def("skewSquare",&skewSquare<Vector3,Vector3>,
+      bp::def("skewSquare",&skewSquare<Vector3>,
               bp::args("u","v"),
               "Computes the skew square representation of two given 3d vectors, "
               "i.e. the antisymmetric matrix representation of the chained cross product operator, u x (v x w), where w is another 3d vector.\n"

--- a/bindings/python/spatial/expose-skew.cpp
+++ b/bindings/python/spatial/expose-skew.cpp
@@ -1,10 +1,12 @@
 //
-// Copyright (c) 2015-2019 CNRS INRIA
-// Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
+// Copyright (c) 2015-2020 CNRS INRIA
+// Copyright (c) 2020 Wandercraft
 //
 
-#include "pinocchio/bindings/python/fwd.hpp"
 #include <boost/python.hpp>
+
+#include "pinocchio/bindings/python/fwd.hpp"
+#include "pinocchio/spatial/se3.hpp"
 #include "pinocchio/spatial/skew.hpp"
 
 namespace pinocchio
@@ -12,30 +14,41 @@ namespace pinocchio
   namespace python
   {
     namespace bp = boost::python;
-
-    Eigen::Matrix3d skew_proxy(const Eigen::Vector3d & v)
+  
+    // We need to resort to another call, because it seems that Boost.Python is not aligning the Eigen::MatrixBase. TODO: fix it!
+    template<typename Matrix3>
+    Eigen::Matrix<typename Matrix3::Scalar,3,1,Matrix3::Options> unSkew(const Matrix3 & mat)
     {
-      return pinocchio::skew(v);
+      return pinocchio::unSkew(mat);
     }
-
-    Eigen::Vector3d unSkew_proxy(const Eigen::Matrix3d & M)
-    {
-      return pinocchio::unSkew(M);
-    }
-
+  
     void exposeSkew()
     {
+      typedef SE3::Matrix3 Matrix3;
+      typedef SE3::Vector3 Vector3;
+      
+      bp::def("skew",&skew<Vector3>,
+              bp::arg("u"),
+              "Computes the skew representation of a given 3d vector, "
+              "i.e. the antisymmetric matrix representation of the cross product operator, aka U = [u]x.\n"
+              "Parameters:\n"
+              "\tu: the input vector of dimension 3");
+      
+      bp::def("skewSquare",&skewSquare<Vector3,Vector3>,
+              bp::args("u","v"),
+              "Computes the skew square representation of two given 3d vectors, "
+              "i.e. the antisymmetric matrix representation of the chained cross product operator, u x (v x w), where w is another 3d vector.\n"
+              "Parameters:\n"
+              "\tu: the first input vector of dimension 3\n"
+              "\tv: the second input vector of dimension 3");
 
-      bp::def("skew",&skew_proxy,
-              bp::arg("Angular velocity (vector of size 3)"),
-              "Computes the skew representation of a given 3D vector, "
-              "i.e. the antisymmetric matrix representation of the cross product operator.");
-
-      bp::def("unSkew",&unSkew_proxy,
-              bp::arg("M: a 3x3 matrix."),
-              "Inverse of skew operator. From a given skew-symmetric matrix M "
-              "of dimension 3x3, it extracts the supporting vector, i.e. the entries of M."
-              "Mathematically speacking, it computes v such that M x = cross(x, v).");
+      bp::def("unSkew",&unSkew<Matrix3>,
+              bp::arg("U"),
+              "Inverse of skew operator. From a given skew symmetric matrix U (i.e U = -U.T)"
+              "of dimension 3x3, it extracts the supporting vector, i.e. the entries of U.\n"
+              "Mathematically speacking, it computes v such that U.dot(x) = cross(u, x).\n"
+              "Parameters:\n"
+              "\tU: the input skew symmetric matrix of dimension 3x3.");
     }
 
   } // namespace python

--- a/src/spatial/skew.hpp
+++ b/src/spatial/skew.hpp
@@ -185,7 +185,7 @@ namespace pinocchio
   /// \param[in] u A 3 dimensional vector.
   /// \param[in] v A 3 dimensional vector.
   ///
-  /// \return The square cross product matrix C.
+  /// \return The square cross product matrix skew[u] * skew[v].
   ///
   template <typename V1, typename V2>
   inline Eigen::Matrix<typename V1::Scalar,3,3,PINOCCHIO_EIGEN_PLAIN_TYPE(V1)::Options>

--- a/unittest/python/CMakeLists.txt
+++ b/unittest/python/CMakeLists.txt
@@ -13,6 +13,7 @@ SET(${PROJECT_NAME}_PYTHON_TESTS
   bindings_force
   bindings_frame
   bindings_inertia
+  bindings_spatial
   bindings_joint_composite
   bindings_motion
   bindings_SE3

--- a/unittest/python/bindings.py
+++ b/unittest/python/bindings.py
@@ -1,7 +1,7 @@
 import unittest
 import pinocchio as pin
 pin.switchToNumpyMatrix()
-from pinocchio.utils import np, npl, rand, skew, zero
+from pinocchio.utils import np, npl, rand, zero
 
 from test_case import PinocchioTestCase as TestCase
 
@@ -17,7 +17,7 @@ class TestSE3(TestCase):
 
     def test_se3(self):
         R, p, m = self.R, self.p, self.m
-        X = np.vstack([np.hstack([R, skew(p) * R]), np.hstack([zero([3, 3]), R])])
+        X = np.vstack([np.hstack([R, pin.skew(p) * R]), np.hstack([zero([3, 3]), R])])
         self.assertApprox(m.action, X)
         M = np.vstack([np.hstack([R, p]), np.matrix([0., 0., 0., 1.], np.double)])
         self.assertApprox(m.homogeneous, M)

--- a/unittest/python/bindings_SE3.py
+++ b/unittest/python/bindings_SE3.py
@@ -2,7 +2,7 @@ import unittest
 import pinocchio as pin
 pin.switchToNumpyMatrix()
 import numpy as np
-from pinocchio.utils import eye,zero,rand,skew
+from pinocchio.utils import eye,zero,rand
 
 ones = lambda n: np.matrix(np.ones([n, 1] if isinstance(n, int) else n), np.double)
 
@@ -59,7 +59,7 @@ class TestSE3Bindings(unittest.TestCase):
         aXb = amb.action
         self.assertTrue(np.allclose(aXb[:3,:3], amb.rotation)) # top left 33 corner = rotation of amb
         self.assertTrue(np.allclose(aXb[3:,3:], amb.rotation)) # bottom right 33 corner = rotation of amb
-        tblock = skew(amb.translation)*amb.rotation
+        tblock = pin.skew(amb.translation)*amb.rotation
         self.assertTrue(np.allclose(aXb[:3,3:], tblock))       # top right 33 corner = translation + rotation
         self.assertTrue(np.allclose(aXb[3:,:3], zero([3,3])))  # bottom left 33 corner = 0
 

--- a/unittest/python/bindings_inertia.py
+++ b/unittest/python/bindings_inertia.py
@@ -2,7 +2,7 @@ import unittest
 import pinocchio as pin
 pin.switchToNumpyMatrix()
 import numpy as np
-from pinocchio.utils import eye,zero,rand,skew
+from pinocchio.utils import eye,zero,rand
 
 from test_case import PinocchioTestCase as TestCase
 
@@ -84,7 +84,7 @@ class TestInertiaBindings(TestCase):
         self.assertApprox(v[0], I.mass)
         self.assertApprox(v[1:4], I.mass * I.lever)
 
-        I_o = I.inertia + I.mass * skew(I.lever).transpose() * skew(I.lever)
+        I_o = I.inertia + I.mass * pin.skew(I.lever).transpose() * pin.skew(I.lever)
         I_ov = np.matrix(
                 [[float(v[4]), float(v[5]), float(v[7])],
                  [float(v[5]), float(v[6]), float(v[8])],

--- a/unittest/python/bindings_spatial.py
+++ b/unittest/python/bindings_spatial.py
@@ -1,0 +1,32 @@
+import unittest
+
+import numpy as np
+from numpy.random import rand
+
+import pinocchio as pin
+pin.switchToNumpyMatrix()
+from pinocchio import skew, unSkew
+
+from test_case import PinocchioTestCase
+
+class TestSpatial(PinocchioTestCase):
+    def test_skew(self):
+        v3 = rand(3)
+        self.assertApprox(v3, unSkew(skew(v3)))
+        self.assertLess(np.linalg.norm(skew(v3).dot(v3)), 1e-10)
+
+        x, y, z = tuple(rand(3).tolist())
+        M = np.array([[ 0.,  x, y],
+                      [-x,  0., z],
+                      [-y, -z, 0.]])
+        self.assertApprox(M, skew(unSkew(M)))
+
+        rhs = rand(3)
+        self.assertApprox(np.cross(v3,rhs,axis=0), skew(v3).dot(rhs))
+        self.assertApprox(M.dot(rhs), np.cross(unSkew(M),rhs,axis=0))
+
+        x, y, z = tuple(v3.tolist())
+        self.assertApprox(skew(v3), np.array([[0, -z, y], [z, 0, -x], [-y, x, 0]]))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/unittest/python/test_case.py
+++ b/unittest/python/test_case.py
@@ -9,5 +9,6 @@ def tracefunc(frame, event, arg):
     return tracefunc
 
 class PinocchioTestCase(unittest.TestCase):
-    def assertApprox(self, a, b):
-        return self.assertTrue(isapprox(a, b))
+    def assertApprox(self, a, b, eps=1e-6):
+        return self.assertTrue(isapprox(a, b, eps),
+                               "\n%s\nis not approximately equal to\n%s\nwith precision %f" % (a, b, eps))

--- a/unittest/python/utils.py
+++ b/unittest/python/utils.py
@@ -4,17 +4,11 @@ from math import sqrt
 import numpy as np
 import pinocchio as pin
 pin.switchToNumpyMatrix()
-from pinocchio.utils import cross, isapprox
+from pinocchio.utils import isapprox
 
 from test_case import PinocchioTestCase as TestCase
 
 class TestUtils(TestCase):
-    def test_cross(self):
-        a = np.matrix('2. 0. 0.').T
-        b = np.matrix('0. 3. 0.').T
-        c = np.matrix('0. 0. 6.').T
-        self.assertApprox(cross(a, b), c)
-
     def test_se3ToXYZQUAT_XYZQUATToSe3(self):
         m = pin.SE3.Identity()
         m.translation = np.matrix('1. 2. 3.').T


### PR DESCRIPTION
I think this pretty much closes the critical transition to array.
I exposed `skew` and `unSkew`, deprecating `pinocchio.utils.skew`.
I deprecated `numpy.cross`.
I wanted to deprecate `eye`, `zero`, and `rand` in `pinocchio.utils`, but I changed my mind because they appear in too many places, causing lots of warnings and being a pain to replace if I had wanted to remove the warnings! For now, they actively check the numpy type. The same does `q0` in `RomeoWrapper`.
I fixed `mprint` so that it works with arrays.

I think this closes the critical part. Pinocchio methods now all work equally well with `numpy.array` or `numpy.matrix`.

I recommend a new release, and a new APT release of both eigenpy and Pinocchio.

Once the apt release of eigenpy is out, we will be able to
- remove `pin.switchToNumpyMatrix()` from the tests and the examples
- adapt them
- deprecate `eye`, `zero` and `rand`
- replace the above three methods by simply replacing `from pinocchio.utils import eye, zero, rand` with `from numpy import eye, zero` and `from numpy.random import rand`

