### PR TITLE
[Minor] Change default material of collision object.

### DIFF
--- a/src/parsers/urdf/geometry.hxx
+++ b/src/parsers/urdf/geometry.hxx
@@ -284,7 +284,7 @@ namespace pinocchio
       (const ::urdf::CollisionSharedPtr, std::string& meshTexturePath,
        Eigen::Vector4d & meshColor, const std::vector<std::string> &)
       {
-        meshColor.setZero();
+        meshColor << 0.9, 0.9, 0.9, 1.;
         meshTexturePath = "";
         return false;
       }


### PR DESCRIPTION
The only required element is that alpha which should not be 0.