### PR TITLE
Python: warn user when trying to display geometric primitive without HPP-FCL

### DIFF
--- a/bindings/python/pinocchio/visualize/gepetto_visualizer.py
+++ b/bindings/python/pinocchio/visualize/gepetto_visualizer.py
@@ -91,6 +91,10 @@ class GepettoVisualizer(BaseVisualizer):
             if WITH_HPP_FCL_BINDINGS and isinstance(geometry_object.geometry, hppfcl.ShapeBase):
                 success = self.loadPrimitive(meshName, geometry_object)
             else:
+                if meshName == "":
+                    msg = "Display of geometric primitives is supported only if pinocchio is build with HPP-FCL bindings."
+                    warnings.warn(msg, category=UserWarning, stacklevel=2)
+                    return
                 success = gui.addMesh(meshName, meshPath)
             if not success:
                 return

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -68,11 +68,13 @@ class MeshcatVisualizer(BaseVisualizer):
         return obj
 
     def loadMesh(self, geometry_object):
-    
+
         import meshcat.geometry
 
         # Mesh path is empty if Pinocchio is built without HPP-FCL bindings
         if geometry_object.meshPath == "":
+            msg = "Display of geometric primitives is supported only if pinocchio is build with HPP-FCL bindings."
+            warnings.warn(msg, category=UserWarning, stacklevel=2)
             return None
 
         # Get file type from filename extension.


### PR DESCRIPTION
Print a warning when the user tries to display a urdf containing  geometric primitives without HPP-FCL enabled.

See #1132 