### PR TITLE
Simplify RPY code

### DIFF
--- a/src/math/rpy.hpp
+++ b/src/math/rpy.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016-2020 CNRS, INRIA
+// Copyright (c) 2016-2020 CNRS INRIA
 //
 
 #ifndef __pinocchio_math_rpy_hpp__
@@ -66,26 +66,27 @@ namespace pinocchio
     Eigen::Matrix<typename Matrix3Like::Scalar,3,1,PINOCCHIO_EIGEN_PLAIN_TYPE(Matrix3Like)::Options>
     matrixToRpy(const Eigen::MatrixBase<Matrix3Like> & R)
     {
-      PINOCCHIO_ASSERT_MATRIX_SPECIFIC_SIZE (Matrix3Like, R, 3, 3);
+      PINOCCHIO_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix3Like, R, 3, 3);
       assert(R.isUnitary() && "R is not a unitary matrix");
 
       typedef typename Matrix3Like::Scalar Scalar;
       typedef Eigen::Matrix<Scalar,3,1,PINOCCHIO_EIGEN_PLAIN_TYPE(Matrix3Like)::Options> ReturnType;
+      static const Scalar pi = PI<Scalar>();
 
       ReturnType res = R.eulerAngles(2,1,0).reverse();
 
-      if(res[1] < -Scalar(M_PI/2))
-        res[1] += Scalar(2 * M_PI);
+      if(res[1] < -pi/2)
+        res[1] += 2*pi;
 
-      if(res[1] > Scalar(M_PI/2))
+      if(res[1] > pi/2)
       {
-        res[1] = Scalar(M_PI) - res[1];
-        if(res[0] < Scalar(0.0))
-          res[0] += Scalar(M_PI);
+        res[1] = pi - res[1];
+        if(res[0] < Scalar(0))
+          res[0] += pi;
         else
-          res[0] -= Scalar(M_PI);
+          res[0] -= pi;
         // res[2] > 0 according to Eigen's eulerAngles doc, no need to check its sign
-        res[2] -= Scalar(M_PI);
+        res[2] -= pi;
       }
 
       return res;

--- a/src/math/rpy.hpp
+++ b/src/math/rpy.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016-2019 CNRS, INRIA
+// Copyright (c) 2016-2020 CNRS, INRIA
 //
 
 #ifndef __pinocchio_math_rpy_hpp__
@@ -7,8 +7,6 @@
 
 #include "pinocchio/math/fwd.hpp"
 #include "pinocchio/math/comparison-operators.hpp"
-#include "pinocchio/math/sincos.hpp"
-#include <boost/type_traits.hpp>
 
 #include <Eigen/Geometry>
 
@@ -24,7 +22,9 @@ namespace pinocchio
     /// around axis \f$\alpha\f$.
     ///
     template<typename Scalar>
-    Eigen::Matrix<Scalar,3,3> rpyToMatrix(const Scalar r, const Scalar p, const Scalar y)
+    Eigen::Matrix<Scalar,3,3> rpyToMatrix(const Scalar & r,
+                                          const Scalar & p,
+                                          const Scalar & y)
     {
       typedef Eigen::AngleAxis<Scalar> AngleAxis;
       typedef Eigen::Matrix<Scalar,3,1> Vector3s;
@@ -45,8 +45,7 @@ namespace pinocchio
     Eigen::Matrix<typename Vector3Like::Scalar,3,3,PINOCCHIO_EIGEN_PLAIN_TYPE(Vector3Like)::Options>
     rpyToMatrix(const Eigen::MatrixBase<Vector3Like> & rpy)
     {
-      PINOCCHIO_ASSERT_MATRIX_SPECIFIC_SIZE (Vector3Like, rpy, 3, 1);
-
+      PINOCCHIO_ASSERT_MATRIX_SPECIFIC_SIZE(Vector3Like, rpy, 3, 1);
       return rpyToMatrix(rpy[0], rpy[1], rpy[2]);
     }
 
@@ -67,22 +66,12 @@ namespace pinocchio
     matrixToRpy(const Eigen::MatrixBase<Matrix3Like> & R)
     {
       PINOCCHIO_ASSERT_MATRIX_SPECIFIC_SIZE (Matrix3Like, R, 3, 3);
+      assert(R.isUnitary() && "R is not a unitary matrix");
+      
       typedef typename Matrix3Like::Scalar Scalar;
-      typedef Eigen::Matrix<Scalar,3,1> ResultType;
-      ResultType res;
+      typedef Eigen::Matrix<Scalar,3,1,PINOCCHIO_EIGEN_PLAIN_TYPE(Matrix3Like)::Options> ReturnType;
 
-      Scalar m = sqrt(R(2, 1) * R(2, 1) + R(2, 2) * R(2, 2));
-      Scalar p = atan2(-R(2, 0), m);
-      Scalar r, y;
-      if (fabs(fabs(p) - M_PI / 2.) < 0.001) {
-        r = 0;
-        y = -atan2(R(0, 1), R(1, 1));
-      } else {
-        y = atan2(R(1, 0), R(0, 0));
-        r = atan2(R(2, 1), R(2, 2));
-      }
-      res << r, p, y;
-      return res;
+      return -R.transpose().eulerAngles(0,1,2);
     }
   } // namespace rpy
 }

--- a/src/math/rpy.hpp
+++ b/src/math/rpy.hpp
@@ -22,9 +22,9 @@ namespace pinocchio
     /// around axis \f$\alpha\f$.
     ///
     template<typename Scalar>
-    Eigen::Matrix<Scalar,3,3> rpyToMatrix(const Scalar & r,
-                                          const Scalar & p,
-                                          const Scalar & y)
+    Eigen::Matrix<Scalar,3,3> rpyToMatrix(const Scalar r,
+                                          const Scalar p,
+                                          const Scalar y)
     {
       typedef Eigen::AngleAxis<Scalar> AngleAxis;
       typedef Eigen::Matrix<Scalar,3,1> Vector3s;

--- a/src/parsers/sample-models.hxx
+++ b/src/parsers/sample-models.hxx
@@ -304,6 +304,8 @@ namespace pinocchio
       
       typename Model::JointIndex idx,chest,ffidx;
       
+      static const Scalar pi = PI<Scalar>();
+      
       SE3 Marm(SE3::Matrix3::Identity(),SE3::Vector3::UnitZ());
       SE3 I4 = SE3::Identity();
       Inertia Ijoint(.1,Inertia::Vector3::Zero(),Inertia::Matrix3::Identity()*.01);
@@ -331,16 +333,16 @@ namespace pinocchio
       /* --- Lower limbs --- */
       
       details::addManipulator(model,ffidx,
-                              SE3(details::rotate(M_PI,SE3::Vector3::UnitX()),
+                              SE3(details::rotate(pi,SE3::Vector3::UnitX()),
                                   typename  SE3::Vector3(0,-0.2,-.1)),"rleg_");
       details::addManipulator(model,ffidx,
-                              SE3(details::rotate(M_PI,SE3::Vector3::UnitX()),
+                              SE3(details::rotate(pi,SE3::Vector3::UnitX()),
                                   typename  SE3::Vector3(0, 0.2,-.1)),"lleg_");
       
       model.jointPlacements[7 ].rotation()
-      = details::rotate(M_PI/2,SE3::Vector3::UnitY()); // rotate right foot
+      = details::rotate(pi/2,SE3::Vector3::UnitY()); // rotate right foot
       model.jointPlacements[13].rotation()
-      = details::rotate(M_PI/2,SE3::Vector3::UnitY()); // rotate left  foot
+      = details::rotate(pi/2,SE3::Vector3::UnitY()); // rotate left  foot
       
       /* --- Chest --- */
       idx = model.addJoint(ffidx,typename JC::JointModelRX(),I4 ,"chest1_joint",
@@ -373,10 +375,10 @@ namespace pinocchio
       
       /* --- Upper Limbs --- */
       details::addManipulator(model,chest,
-                              SE3(details::rotate(M_PI,SE3::Vector3::UnitX()),
+                              SE3(details::rotate(pi,SE3::Vector3::UnitX()),
                                   typename SE3::Vector3(0,-0.3, 1.)),"rarm_");
       details::addManipulator(model,chest,
-                              SE3(details::rotate(M_PI,SE3::Vector3::UnitX()),
+                              SE3(details::rotate(pi,SE3::Vector3::UnitX()),
                                   typename SE3::Vector3(0, 0.3, 1.)),"larm_");
     }
     

--- a/unittest/rpy.cpp
+++ b/unittest/rpy.cpp
@@ -1,8 +1,9 @@
 //
-// Copyright (c) 2019 INRIA
+// Copyright (c) 2019-2020 INRIA
 //
 
 #include <pinocchio/math/rpy.hpp>
+#include <pinocchio/math/quaternion.hpp>
 
 #include <boost/variant.hpp> // to avoid C99 warnings
 
@@ -13,41 +14,46 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
 
 BOOST_AUTO_TEST_CASE(test_rpyToMatrix)
 {
-  double r = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
-  double p = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/M_PI)) - (M_PI/2);
-  double y = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
-
-  Eigen::Matrix3d R = pinocchio::rpy::rpyToMatrix(r, p, y);
-
-  Eigen::Matrix3d R_Eig = (Eigen::AngleAxisd(y, Eigen::Vector3d::UnitZ())
-                           * Eigen::AngleAxisd(p, Eigen::Vector3d::UnitY())
-                           * Eigen::AngleAxisd(r, Eigen::Vector3d::UnitX())
-                          ).toRotationMatrix();
-
-  BOOST_CHECK(R.isApprox(R_Eig));
-
-  Eigen::Vector3d v;
-  v << r, p, y;
-
-  Eigen::Matrix3d Rv = pinocchio::rpy::rpyToMatrix(v);
-
-  BOOST_CHECK(Rv.isApprox(R_Eig));
+  const int n = 1e5;
+  for(int k = 0; k < n ; ++k)
+  {
+    double r = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
+    double p = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/M_PI)) - (M_PI/2);
+    double y = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
+    
+    Eigen::Matrix3d R = pinocchio::rpy::rpyToMatrix(r, p, y);
+    
+    Eigen::Matrix3d Raa = (Eigen::AngleAxisd(y, Eigen::Vector3d::UnitZ())
+                             * Eigen::AngleAxisd(p, Eigen::Vector3d::UnitY())
+                             * Eigen::AngleAxisd(r, Eigen::Vector3d::UnitX())
+                             ).toRotationMatrix();
+    
+    BOOST_CHECK(R.isApprox(Raa));
+    
+    Eigen::Vector3d v;
+    v << r, p, y;
+    
+    Eigen::Matrix3d Rv = pinocchio::rpy::rpyToMatrix(v);
+    
+    BOOST_CHECK(Rv.isApprox(Raa));
+    BOOST_CHECK(Rv.isApprox(R));
+  }
 }
 
 BOOST_AUTO_TEST_CASE(test_matrixToRpy)
 {
-  double r = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
-  double p = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/M_PI)) - (M_PI/2);
-  double y = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
-
-  Eigen::Matrix3d R = pinocchio::rpy::rpyToMatrix(r, p, y);
-
-  Eigen::Vector3d v = pinocchio::rpy::matrixToRpy(R);
-
-  BOOST_CHECK_CLOSE(r,v[0],1e-12);
-  BOOST_CHECK_CLOSE(p,v[1],1e-12);
-  BOOST_CHECK_CLOSE(y,v[2],1e-12);
+  const int n = 1e6;
+  for(int k = 0; k < n ; ++k)
+  {
+    Eigen::Quaterniond quat;
+    pinocchio::quaternion::uniformRandom(quat);
+    const Eigen::Matrix3d R = quat.toRotationMatrix();
+    
+    const Eigen::Vector3d v = pinocchio::rpy::matrixToRpy(R);
+    Eigen::Matrix3d Rprime = pinocchio::rpy::rpyToMatrix(v);
+    
+    BOOST_CHECK(Rprime.isApprox(R));
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()
-

--- a/unittest/rpy.cpp
+++ b/unittest/rpy.cpp
@@ -66,7 +66,7 @@ BOOST_AUTO_TEST_CASE(test_matrixToRpy)
     const Eigen::Matrix3d R = pinocchio::rpy::rpyToMatrix(rpy);
     const Eigen::Vector3d rpy2 = pinocchio::rpy::matrixToRpy(R);
 
-    BOOST_CHECK(rpy.isApprox(rpy2));
+    BOOST_CHECK(rpy.isApprox(rpy2, 1e-6));
   }
 }
 

--- a/unittest/rpy.cpp
+++ b/unittest/rpy.cpp
@@ -54,6 +54,20 @@ BOOST_AUTO_TEST_CASE(test_matrixToRpy)
     
     BOOST_CHECK(Rprime.isApprox(R));
   }
+
+  for(int k = 0; k < n ; ++k)
+  {
+    double r = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
+    double p = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/M_PI)) - (M_PI/2);
+    double y = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
+    Eigen::Vector3d rpy;
+    rpy << r, p, y;
+
+    const Eigen::Matrix3d R = pinocchio::rpy::rpyToMatrix(rpy);
+    const Eigen::Vector3d rpy2 = pinocchio::rpy::matrixToRpy(R);
+
+    BOOST_CHECK(rpy.isApprox(rpy2));
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/rpy.cpp
+++ b/unittest/rpy.cpp
@@ -101,68 +101,6 @@ BOOST_AUTO_TEST_CASE(test_matrixToRpy)
     BOOST_CHECK(-M_PI/2 <= v[1] && v[1] <= M_PI/2);
     BOOST_CHECK(-M_PI <= v[2] && v[2] <= M_PI);
   }
-
-  for(int k = 0; k < n ; ++k)
-  {
-    double r = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
-    double p = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/M_PI)) - (M_PI/2);
-    double y = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
-    Eigen::Vector3d rpy;
-    rpy << r, p, y;
-
-    const Eigen::Matrix3d R = pinocchio::rpy::rpyToMatrix(rpy);
-    const Eigen::Vector3d rpy2 = pinocchio::rpy::matrixToRpy(R);
-
-    BOOST_CHECK(rpy.isApprox(rpy2, 1e-6));
-  }
-
-  // Test singular case theta = pi/2
-  {
-    double r = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
-    double y = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
-    Eigen::Matrix3d Rp;
-    Rp <<  0.0, 0.0, 1.0,
-           0.0, 1.0, 0.0,
-          -1.0, 0.0, 0.0;
-    const Eigen::Matrix3d R = Eigen::AngleAxisd(y, Eigen::Vector3d::UnitZ()).toRotationMatrix()
-                            * Rp
-                            * Eigen::AngleAxisd(r, Eigen::Vector3d::UnitX()).toRotationMatrix();
-    Eigen::Vector3d rpy;
-    rpy << r, (M_PI/2), y;
-
-    const Eigen::Vector3d rpy2 = pinocchio::rpy::matrixToRpy(R);
-
-    // For this singular case, only the difference between pitch and yaw can be inferred
-    std::cout << "Singular rpy: theta = pi/2" << std::endl;
-    std::cout << "rpy:  " << rpy.transpose() << std::endl;
-    std::cout << "rpy2: " << rpy2.transpose() << std::endl;
-    BOOST_CHECK(Eigen::internal::isApprox(rpy[1], rpy2[1]));
-    BOOST_CHECK(Eigen::internal::isApprox(rpy[2]-rpy[0], rpy2[2]-rpy2[0]));
-  }
-
-  // Test singular case theta = -pi/2
-  {
-    double r = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
-    double y = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
-    Eigen::Matrix3d Rp;
-    Rp << 0.0, 0.0, -1.0,
-          0.0, 1.0,  0.0,
-          1.0, 0.0,  0.0;
-    const Eigen::Matrix3d R = Eigen::AngleAxisd(y, Eigen::Vector3d::UnitZ()).toRotationMatrix()
-                            * Rp
-                            * Eigen::AngleAxisd(r, Eigen::Vector3d::UnitX()).toRotationMatrix();
-    Eigen::Vector3d rpy;
-    rpy << r, (-M_PI/2), y;
-
-    const Eigen::Vector3d rpy2 = pinocchio::rpy::matrixToRpy(R);
-
-    // For this singular case, only the sum of pitch and yaw can be inferred
-    std::cout << "Singular rpy: theta = -pi/2" << std::endl;
-    std::cout << "rpy:  " << rpy.transpose() << std::endl;
-    std::cout << "rpy2: " << rpy2.transpose() << std::endl;
-    BOOST_CHECK(Eigen::internal::isApprox(rpy[1], rpy2[1]));
-    BOOST_CHECK(Eigen::internal::isApprox(rpy[2]+rpy[0], rpy2[2]+rpy2[0]));
-  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/rpy.cpp
+++ b/unittest/rpy.cpp
@@ -58,6 +58,50 @@ BOOST_AUTO_TEST_CASE(test_matrixToRpy)
     BOOST_CHECK(-M_PI <= v[2] && v[2] <= M_PI);
   }
 
+  // Test singular case theta = pi/2
+  {
+    double r = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
+    double y = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
+    Eigen::Matrix3d Rp;
+    Rp <<  0.0, 0.0, 1.0,
+           0.0, 1.0, 0.0,
+          -1.0, 0.0, 0.0;
+    const Eigen::Matrix3d R = Eigen::AngleAxisd(y, Eigen::Vector3d::UnitZ()).toRotationMatrix()
+                            * Rp
+                            * Eigen::AngleAxisd(r, Eigen::Vector3d::UnitX()).toRotationMatrix();
+
+    const Eigen::Vector3d v = pinocchio::rpy::matrixToRpy(R);
+    Eigen::Matrix3d Rprime = pinocchio::rpy::rpyToMatrix(v);
+
+    BOOST_CHECK(Rprime.isApprox(R));
+    BOOST_CHECK(-M_PI <= v[0] && v[0] <= M_PI);
+    BOOST_CHECK(-M_PI/2 <= v[1] && v[1] <= M_PI/2);
+    BOOST_CHECK(-M_PI <= v[2] && v[2] <= M_PI);
+  }
+
+  // Test singular case theta = -pi/2
+  {
+    double r = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
+    double y = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
+    Eigen::Matrix3d Rp;
+    Rp << 0.0, 0.0, -1.0,
+          0.0, 1.0,  0.0,
+          1.0, 0.0,  0.0;
+    const Eigen::Matrix3d R = Eigen::AngleAxisd(y, Eigen::Vector3d::UnitZ()).toRotationMatrix()
+                            * Rp
+                            * Eigen::AngleAxisd(r, Eigen::Vector3d::UnitX()).toRotationMatrix();
+    Eigen::Vector3d rpy;
+    rpy << r, (-M_PI/2), y;
+
+    const Eigen::Vector3d v = pinocchio::rpy::matrixToRpy(R);
+    Eigen::Matrix3d Rprime = pinocchio::rpy::rpyToMatrix(v);
+
+    BOOST_CHECK(Rprime.isApprox(R));
+    BOOST_CHECK(-M_PI <= v[0] && v[0] <= M_PI);
+    BOOST_CHECK(-M_PI/2 <= v[1] && v[1] <= M_PI/2);
+    BOOST_CHECK(-M_PI <= v[2] && v[2] <= M_PI);
+  }
+
   for(int k = 0; k < n ; ++k)
   {
     double r = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;

--- a/unittest/rpy.cpp
+++ b/unittest/rpy.cpp
@@ -68,6 +68,54 @@ BOOST_AUTO_TEST_CASE(test_matrixToRpy)
 
     BOOST_CHECK(rpy.isApprox(rpy2, 1e-6));
   }
+
+  // Test singular case theta = pi/2
+  {
+    double r = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
+    double y = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
+    Eigen::Matrix3d Rp;
+    Rp <<  0.0, 0.0, 1.0,
+           0.0, 1.0, 0.0,
+          -1.0, 0.0, 0.0;
+    const Eigen::Matrix3d R = Eigen::AngleAxisd(y, Eigen::Vector3d::UnitZ()).toRotationMatrix()
+                            * Rp
+                            * Eigen::AngleAxisd(r, Eigen::Vector3d::UnitX()).toRotationMatrix();
+    Eigen::Vector3d rpy;
+    rpy << r, (M_PI/2), y;
+
+    const Eigen::Vector3d rpy2 = pinocchio::rpy::matrixToRpy(R);
+
+    // For this singular case, only the difference between pitch and yaw can be inferred
+    std::cout << "Singular rpy: theta = pi/2" << std::endl;
+    std::cout << "rpy:  " << rpy.transpose() << std::endl;
+    std::cout << "rpy2: " << rpy2.transpose() << std::endl;
+    BOOST_CHECK(Eigen::internal::isApprox(rpy[1], rpy2[1]));
+    BOOST_CHECK(Eigen::internal::isApprox(rpy[2]-rpy[0], rpy2[2]-rpy2[0]));
+  }
+
+  // Test singular case theta = -pi/2
+  {
+    double r = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
+    double y = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
+    Eigen::Matrix3d Rp;
+    Rp << 0.0, 0.0, -1.0,
+          0.0, 1.0,  0.0,
+          1.0, 0.0,  0.0;
+    const Eigen::Matrix3d R = Eigen::AngleAxisd(y, Eigen::Vector3d::UnitZ()).toRotationMatrix()
+                            * Rp
+                            * Eigen::AngleAxisd(r, Eigen::Vector3d::UnitX()).toRotationMatrix();
+    Eigen::Vector3d rpy;
+    rpy << r, (-M_PI/2), y;
+
+    const Eigen::Vector3d rpy2 = pinocchio::rpy::matrixToRpy(R);
+
+    // For this singular case, only the sum of pitch and yaw can be inferred
+    std::cout << "Singular rpy: theta = -pi/2" << std::endl;
+    std::cout << "rpy:  " << rpy.transpose() << std::endl;
+    std::cout << "rpy2: " << rpy2.transpose() << std::endl;
+    BOOST_CHECK(Eigen::internal::isApprox(rpy[1], rpy2[1]));
+    BOOST_CHECK(Eigen::internal::isApprox(rpy[2]+rpy[0], rpy2[2]+rpy2[0]));
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/rpy.cpp
+++ b/unittest/rpy.cpp
@@ -48,11 +48,14 @@ BOOST_AUTO_TEST_CASE(test_matrixToRpy)
     Eigen::Quaterniond quat;
     pinocchio::quaternion::uniformRandom(quat);
     const Eigen::Matrix3d R = quat.toRotationMatrix();
-    
+
     const Eigen::Vector3d v = pinocchio::rpy::matrixToRpy(R);
     Eigen::Matrix3d Rprime = pinocchio::rpy::rpyToMatrix(v);
-    
+
     BOOST_CHECK(Rprime.isApprox(R));
+    BOOST_CHECK(-M_PI <= v[0] && v[0] <= M_PI);
+    BOOST_CHECK(-M_PI/2 <= v[1] && v[1] <= M_PI/2);
+    BOOST_CHECK(-M_PI <= v[2] && v[2] <= M_PI);
   }
 
   for(int k = 0; k < n ; ++k)

--- a/unittest/rpy.cpp
+++ b/unittest/rpy.cpp
@@ -58,7 +58,10 @@ BOOST_AUTO_TEST_CASE(test_matrixToRpy)
     BOOST_CHECK(-M_PI <= v[2] && v[2] <= M_PI);
   }
 
+  const int n2 = 1e3;
+
   // Test singular case theta = pi/2
+  for(int k = 0; k < n2 ; ++k)
   {
     double r = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
     double y = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
@@ -80,6 +83,7 @@ BOOST_AUTO_TEST_CASE(test_matrixToRpy)
   }
 
   // Test singular case theta = -pi/2
+  for(int k = 0; k < n2 ; ++k)
   {
     double r = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
     double y = static_cast <double> (rand()) / (static_cast <double> (RAND_MAX/(2*M_PI))) - M_PI;
@@ -90,8 +94,6 @@ BOOST_AUTO_TEST_CASE(test_matrixToRpy)
     const Eigen::Matrix3d R = Eigen::AngleAxisd(y, Eigen::Vector3d::UnitZ()).toRotationMatrix()
                             * Rp
                             * Eigen::AngleAxisd(r, Eigen::Vector3d::UnitX()).toRotationMatrix();
-    Eigen::Vector3d rpy;
-    rpy << r, (-M_PI/2), y;
 
     const Eigen::Vector3d v = pinocchio::rpy::matrixToRpy(R);
     Eigen::Matrix3d Rprime = pinocchio::rpy::rpyToMatrix(v);


### PR DESCRIPTION
The idea is to rely on Eigen's code which seems to be more numerically robust.
As future work, it would be necessary to adapt this code to handle Autodiff support.