### PR TITLE
dIntegrate with ADDTO and RMTO assignment operators.

### DIFF
--- a/bindings/python/algorithm/expose-joints.cpp
+++ b/bindings/python/algorithm/expose-joints.cpp
@@ -30,8 +30,8 @@ namespace pinocchio
       Eigen::MatrixXd J0(Eigen::MatrixXd::Zero(model.nv,model.nv));
       Eigen::MatrixXd J1(Eigen::MatrixXd::Zero(model.nv,model.nv));
 
-      dIntegrate(model,q,v,J0,ARG0);
-      dIntegrate(model,q,v,J1,ARG1);
+      dIntegrate(model,q,v,J0,ARG0,SETTO);
+      dIntegrate(model,q,v,J1,ARG1,SETTO);
 
       return bp::make_tuple(J0,J1);
     }
@@ -43,7 +43,7 @@ namespace pinocchio
     {
       Eigen::MatrixXd J(Eigen::MatrixXd::Zero(model.nv,model.nv));
       
-      dIntegrate(model,q,v,J,arg);
+      dIntegrate(model,q,v,J,arg, SETTO);
       
       return J;
     }

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -280,7 +280,7 @@ namespace pinocchio
    * @param[in]  arg     Argument (either q or v) with respect to which the differentiation is performed.
    *
    */
-  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType, AssignmentOperatorType op=SETTO>
+  template<typename LieGroup_t, AssignmentOperatorType op, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
   void dIntegrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                   const Eigen::MatrixBase<ConfigVectorType> & q,
                   const Eigen::MatrixBase<TangentVectorType> & v,
@@ -305,16 +305,45 @@ namespace pinocchio
    * @param[in]  arg        Argument (either q or v) with respect to which the differentiation is performed.
    *
    */
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType, AssignmentOperatorType op=SETTO>
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
   void dIntegrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                   const Eigen::MatrixBase<ConfigVectorType> & q,
                   const Eigen::MatrixBase<TangentVectorType> & v,
                   const Eigen::MatrixBase<JacobianMatrixType> & J,
                   const ArgumentPosition arg)
   {
-    dIntegrate<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType,op>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
+    dIntegrate<LieGroupMap,SETTO,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
   }
 
+  /**
+   *
+   * @brief   Computes the Jacobian of a small variation of the configuration vector or the tangent vector into the tangent space at identity.
+   *
+   * @details This jacobian has to be interpreted in terms of Lie group, not vector space: as such,
+   *          it is expressed in the tangent space only, not the configuration space.
+   *          Calling \f$ f(q, v) \f$ the integrate function, these jacobians satisfy the following relationships in the
+   *          tangent space:
+   *           - Jacobian relative to q: \f$ f(q \oplus \delta q, v) \ominus f(q, v) = J_q(q, v) \delta q + o(\delta q)\f$.
+   *           - Jacobian relative to v: \f$ f(q, v + \delta v) \ominus f(q, v) = J_v(q, v) \delta v + o(\delta v)\f$.
+   *
+   * @param[in]  model   Model of the kinematic tree on which the integration operation is performed.
+   * @param[in]  q            Initial configuration (size model.nq)
+   * @param[in]  v            Joint velocity (size model.nv)
+   * @param[out] J            Jacobian of the Integrate operation, either with respect to q or v (size model.nv x model.nv).
+   * @param[in]  arg        Argument (either q or v) with respect to which the differentiation is performed.
+   *
+   */
+
+  template<AssignmentOperatorType op, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
+  void dIntegrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                  const Eigen::MatrixBase<ConfigVectorType> & q,
+                  const Eigen::MatrixBase<TangentVectorType> & v,
+                  const Eigen::MatrixBase<JacobianMatrixType> & J,
+                  const ArgumentPosition arg)
+  {
+    dIntegrate<LieGroupMap,op,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
+  }
+  
   /**
    *
    * @brief   Computes the Jacobian of a small variation of the configuration vector into the tangent space at identity.

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -280,7 +280,7 @@ namespace pinocchio
    * @param[in]  arg     Argument (either q or v) with respect to which the differentiation is performed.
    *
    */
-  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType, AssignmentOperatorType op=SETTO>
   void dIntegrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                   const Eigen::MatrixBase<ConfigVectorType> & q,
                   const Eigen::MatrixBase<TangentVectorType> & v,
@@ -305,14 +305,14 @@ namespace pinocchio
    * @param[in]  arg        Argument (either q or v) with respect to which the differentiation is performed.
    *
    */
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType, AssignmentOperatorType op=SETTO>
   void dIntegrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                   const Eigen::MatrixBase<ConfigVectorType> & q,
                   const Eigen::MatrixBase<TangentVectorType> & v,
                   const Eigen::MatrixBase<JacobianMatrixType> & J,
                   const ArgumentPosition arg)
   {
-    dIntegrate<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
+    dIntegrate<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType,op>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
   }
 
   /**

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -280,12 +280,13 @@ namespace pinocchio
    * @param[in]  arg     Argument (either q or v) with respect to which the differentiation is performed.
    *
    */
-  template<typename LieGroup_t, AssignmentOperatorType op, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
   void dIntegrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                   const Eigen::MatrixBase<ConfigVectorType> & q,
                   const Eigen::MatrixBase<TangentVectorType> & v,
                   const Eigen::MatrixBase<JacobianMatrixType> & J,
-                  const ArgumentPosition arg);
+                  const ArgumentPosition arg,
+                  const AssignmentOperatorType op);
 
   /**
    *
@@ -312,8 +313,9 @@ namespace pinocchio
                   const Eigen::MatrixBase<JacobianMatrixType> & J,
                   const ArgumentPosition arg)
   {
-    dIntegrate<LieGroupMap,SETTO,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
+    dIntegrate<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg,SETTO);
   }
+
 
   /**
    *
@@ -333,15 +335,15 @@ namespace pinocchio
    * @param[in]  arg        Argument (either q or v) with respect to which the differentiation is performed.
    *
    */
-
-  template<AssignmentOperatorType op, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
   void dIntegrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                   const Eigen::MatrixBase<ConfigVectorType> & q,
                   const Eigen::MatrixBase<TangentVectorType> & v,
                   const Eigen::MatrixBase<JacobianMatrixType> & J,
-                  const ArgumentPosition arg)
+                  const ArgumentPosition arg,
+                  const AssignmentOperatorType op)
   {
-    dIntegrate<LieGroupMap,op,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
+    dIntegrate<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg,op);
   }
   
   /**

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -147,7 +147,7 @@ namespace pinocchio
     }
   }
 
-  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType, AssignmentOperatorType op>
   void dIntegrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                   const Eigen::MatrixBase<ConfigVectorType> & q,
                   const Eigen::MatrixBase<TangentVectorType> & v,

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -162,7 +162,7 @@ namespace pinocchio
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
     
-    typedef dIntegrateStep<LieGroup_t,ConfigVectorType,TangentVectorType,JacobianMatrixType> Algo;
+    typedef dIntegrateStep<LieGroup_t,ConfigVectorType,TangentVectorType,JacobianMatrixType,op> Algo;
     typename Algo::ArgsType args(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
     for(JointIndex i=1; i<(JointIndex)model.njoints; ++i)
     {

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -147,7 +147,7 @@ namespace pinocchio
     }
   }
 
-  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType, AssignmentOperatorType op>
+  template<typename LieGroup_t, AssignmentOperatorType op, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
   void dIntegrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                   const Eigen::MatrixBase<ConfigVectorType> & q,
                   const Eigen::MatrixBase<TangentVectorType> & v,

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -147,12 +147,13 @@ namespace pinocchio
     }
   }
 
-  template<typename LieGroup_t, AssignmentOperatorType op, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
   void dIntegrate(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                   const Eigen::MatrixBase<ConfigVectorType> & q,
                   const Eigen::MatrixBase<TangentVectorType> & v,
                   const Eigen::MatrixBase<JacobianMatrixType> & J,
-                  const ArgumentPosition arg)
+                  const ArgumentPosition arg,
+                  const AssignmentOperatorType op)
   {
     PINOCCHIO_CHECK_INPUT_ARGUMENT(q.size() == model.nq, "The configuration vector is not of the right size");
     PINOCCHIO_CHECK_INPUT_ARGUMENT(v.size() == model.nv, "The joint velocity vector is not of the right size");
@@ -162,8 +163,8 @@ namespace pinocchio
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
     
-    typedef dIntegrateStep<LieGroup_t,ConfigVectorType,TangentVectorType,JacobianMatrixType,op> Algo;
-    typename Algo::ArgsType args(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
+    typedef dIntegrateStep<LieGroup_t,ConfigVectorType,TangentVectorType,JacobianMatrixType> Algo;
+    typename Algo::ArgsType args(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg,op);
     for(JointIndex i=1; i<(JointIndex)model.njoints; ++i)
     {
       Algo::run(model.joints[i], args);

--- a/src/fwd.hpp
+++ b/src/fwd.hpp
@@ -60,9 +60,7 @@ namespace pinocchio
   {
     SETTO,
     ADDTO,
-    RMTO,
-    APPLY_ON_THE_LEFT,
-    APPLY_ON_THE_RIGHT
+    RMTO
   };
 
   

--- a/src/fwd.hpp
+++ b/src/fwd.hpp
@@ -55,6 +55,17 @@ namespace pinocchio
     ARG3 = 3,
     ARG4 = 4
   };
+
+  enum AssignmentOperatorType
+  {
+    SETTO,
+    ADDTO,
+    RMTO,
+    APPLY_ON_THE_LEFT,
+    APPLY_ON_THE_RIGHT
+  };
+
+  
   
   /// \brief Return type undefined
   ///        This is an helper structure to help internal diagnosis.

--- a/src/multibody/liegroup/cartesian-product.hpp
+++ b/src/multibody/liegroup/cartesian-product.hpp
@@ -128,10 +128,34 @@ namespace pinocchio
                             const Eigen::MatrixBase<JacobianOut_t> & J,
                             const AssignmentOperatorType op) const
     {
-      J12(J).setZero();
-      J21(J).setZero();
-      lg1_.dIntegrate_dq(Q1(q), V1(v), J11(J));
-      lg2_.dIntegrate_dq(Q2(q), V2(v), J22(J));
+      switch(op)
+        {
+        case SETTO:
+          J12(J).setZero();
+          J21(J).setZero();
+          lg1_.dIntegrate_dq(Q1(q), V1(v), J11(J),SETTO);
+          lg2_.dIntegrate_dq(Q2(q), V2(v), J22(J),SETTO);
+          break;
+        case ADDTO:
+          lg1_.dIntegrate_dq(Q1(q), V1(v), J11(J),ADDTO);
+          lg2_.dIntegrate_dq(Q2(q), V2(v), J22(J),ADDTO);
+          break;
+        case RMTO:
+          lg1_.dIntegrate_dq(Q1(q), V1(v), J11(J),RMTO);
+          lg2_.dIntegrate_dq(Q2(q), V2(v), J22(J),RMTO);
+          break;
+        case APPLY_ON_THE_LEFT:
+          //TODO: Not Implemented Yet
+          assert(false && "Wrong Op requesed value");
+          break;
+        case APPLY_ON_THE_RIGHT:
+          //TODO: Not Implemented Yet
+          assert(false && "Wrong Op requesed value");
+          break;
+        default:
+          assert(false && "Wrong Op requesed value");
+          break;
+        }      
     }
 
     template <class Config_t, class Tangent_t, class JacobianOut_t>
@@ -140,10 +164,36 @@ namespace pinocchio
                             const Eigen::MatrixBase<JacobianOut_t> & J,
                             const AssignmentOperatorType op) const
     {
-      J12(J).setZero();
-      J21(J).setZero();
-      lg1_.dIntegrate_dv(Q1(q), V1(v), J11(J));
-      lg2_.dIntegrate_dv(Q2(q), V2(v), J22(J));
+      switch(op)
+        {
+        case SETTO:
+          J12(J).setZero();
+          J21(J).setZero();
+          lg1_.dIntegrate_dv(Q1(q), V1(v), J11(J),SETTO);
+          lg2_.dIntegrate_dv(Q2(q), V2(v), J22(J),SETTO);
+          break;
+        case ADDTO:
+          lg1_.dIntegrate_dv(Q1(q), V1(v), J11(J),ADDTO);
+          lg2_.dIntegrate_dv(Q2(q), V2(v), J22(J),ADDTO);
+          break;
+        case RMTO:
+          lg1_.dIntegrate_dv(Q1(q), V1(v), J11(J),RMTO);
+          lg2_.dIntegrate_dv(Q2(q), V2(v), J22(J),RMTO);
+          break;
+        case APPLY_ON_THE_LEFT:
+          //TODO: Not Implemented Yet
+          assert(false && "Wrong Op requesed value");
+          break;
+        case APPLY_ON_THE_RIGHT:
+          //TODO: Not Implemented Yet
+          assert(false && "Wrong Op requesed value");
+          break;
+        default:
+          assert(false && "Wrong Op requesed value");
+          break;
+        }      
+
+      
     }
 
     template <class ConfigL_t, class ConfigR_t>

--- a/src/multibody/liegroup/cartesian-product.hpp
+++ b/src/multibody/liegroup/cartesian-product.hpp
@@ -125,7 +125,8 @@ namespace pinocchio
     template <class Config_t, class Tangent_t, class JacobianOut_t>
     void dIntegrate_dq_impl(const Eigen::MatrixBase<Config_t > & q,
                             const Eigen::MatrixBase<Tangent_t> & v,
-                            const Eigen::MatrixBase<JacobianOut_t> & J) const
+                            const Eigen::MatrixBase<JacobianOut_t> & J,
+                            const AssignmentOperatorType op) const
     {
       J12(J).setZero();
       J21(J).setZero();
@@ -136,7 +137,8 @@ namespace pinocchio
     template <class Config_t, class Tangent_t, class JacobianOut_t>
     void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t > & q,
                             const Eigen::MatrixBase<Tangent_t> & v,
-                            const Eigen::MatrixBase<JacobianOut_t> & J) const
+                            const Eigen::MatrixBase<JacobianOut_t> & J,
+                            const AssignmentOperatorType op) const
     {
       J12(J).setZero();
       J21(J).setZero();

--- a/src/multibody/liegroup/cartesian-product.hpp
+++ b/src/multibody/liegroup/cartesian-product.hpp
@@ -144,14 +144,6 @@ namespace pinocchio
           lg1_.dIntegrate_dq(Q1(q), V1(v), J11(J),RMTO);
           lg2_.dIntegrate_dq(Q2(q), V2(v), J22(J),RMTO);
           break;
-        case APPLY_ON_THE_LEFT:
-          //TODO: Not Implemented Yet
-          assert(false && "Wrong Op requesed value");
-          break;
-        case APPLY_ON_THE_RIGHT:
-          //TODO: Not Implemented Yet
-          assert(false && "Wrong Op requesed value");
-          break;
         default:
           assert(false && "Wrong Op requesed value");
           break;
@@ -179,14 +171,6 @@ namespace pinocchio
         case RMTO:
           lg1_.dIntegrate_dv(Q1(q), V1(v), J11(J),RMTO);
           lg2_.dIntegrate_dv(Q2(q), V2(v), J22(J),RMTO);
-          break;
-        case APPLY_ON_THE_LEFT:
-          //TODO: Not Implemented Yet
-          assert(false && "Wrong Op requesed value");
-          break;
-        case APPLY_ON_THE_RIGHT:
-          //TODO: Not Implemented Yet
-          assert(false && "Wrong Op requesed value");
           break;
         default:
           assert(false && "Wrong Op requesed value");

--- a/src/multibody/liegroup/liegroup-algo.hxx
+++ b/src/multibody/liegroup/liegroup-algo.hxx
@@ -30,6 +30,7 @@ namespace pinocchio
 #define PINOCCHIO_DETAILS_WRITE_ARGS_2(JM) PINOCCHIO_DETAILS_WRITE_ARGS_1(JM), typename boost::fusion::result_of::at_c<ArgsType, 1>::type a1
 #define PINOCCHIO_DETAILS_WRITE_ARGS_3(JM) PINOCCHIO_DETAILS_WRITE_ARGS_2(JM), typename boost::fusion::result_of::at_c<ArgsType, 2>::type a2
 #define PINOCCHIO_DETAILS_WRITE_ARGS_4(JM) PINOCCHIO_DETAILS_WRITE_ARGS_3(JM), typename boost::fusion::result_of::at_c<ArgsType, 3>::type a3
+#define PINOCCHIO_DETAILS_WRITE_ARGS_5(JM) PINOCCHIO_DETAILS_WRITE_ARGS_4(JM), typename boost::fusion::result_of::at_c<ArgsType, 4>::type a4
     
 #define PINOCCHIO_DETAILS_DISPATCH_JOINT_COMPOSITE_1(Algo)                          \
   template <typename Visitor, typename JointCollection>                       \
@@ -61,6 +62,14 @@ namespace pinocchio
     typedef typename Visitor::ArgsType ArgsType;                  \
     static void run (PINOCCHIO_DETAILS_WRITE_ARGS_4(JointModelCompositeTpl<JointCollection>))         \
     { ::pinocchio::details::Dispatch< Visitor >::run(jmodel.derived(), ArgsType(a0,a1,a2,a3)); } \
+  }
+
+#define PINOCCHIO_DETAILS_DISPATCH_JOINT_COMPOSITE_5(Algo)                 \
+  template <typename Visitor, typename JointCollection>                    \
+  struct Algo <Visitor, JointModelCompositeTpl<JointCollection> > {        \
+    typedef typename Visitor::ArgsType ArgsType;                  \
+    static void run (PINOCCHIO_DETAILS_WRITE_ARGS_5(JointModelCompositeTpl<JointCollection>))         \
+    { ::pinocchio::details::Dispatch< Visitor >::run(jmodel.derived(), ArgsType(a0,a1,a2,a3,a4)); } \
   }
     
 #define PINOCCHIO_DETAILS_VISITOR_METHOD_ALGO_1(Algo, Visitor)                      \
@@ -98,6 +107,16 @@ namespace pinocchio
     template<typename JointModel>                            \
     struct AlgoDispatch : Algo<Visitor, JointModel>                            \
     { using Algo<Visitor, JointModel>::run; };
+
+#define PINOCCHIO_DETAILS_VISITOR_METHOD_ALGO_5(Algo, Visitor)                      \
+    typedef LieGroup_t LieGroupMap;                                              \
+    template<typename JointModel>                                              \
+    static void algo(PINOCCHIO_DETAILS_WRITE_ARGS_5(JointModel))                     \
+    { AlgoDispatch<JointModel>::run(jmodel, a0, a1, a2, a3, a4); }         \
+    template<typename JointModel>                            \
+    struct AlgoDispatch : Algo<Visitor, JointModel>                            \
+    { using Algo<Visitor, JointModel>::run; };
+    
   } // namespace details
   
   template<typename Visitor, typename JointModel> struct IntegrateStepAlgo;
@@ -134,29 +153,23 @@ namespace pinocchio
   
   PINOCCHIO_DETAILS_DISPATCH_JOINT_COMPOSITE_3(IntegrateStepAlgo);
   
-  template<typename Visitor, typename JointModel, AssignmentOperatorType op> struct dIntegrateStepAlgo;
+  template<typename Visitor, typename JointModel> struct dIntegrateStepAlgo;
   
-  template<typename LieGroup_t, typename ConfigVectorIn, typename TangentVectorIn, typename JacobianMatrixType, AssignmentOperatorType op>
+  template<typename LieGroup_t, typename ConfigVectorIn, typename TangentVectorIn, typename JacobianMatrixType>
   struct dIntegrateStep
-    : public fusion::JointUnaryVisitorBase< dIntegrateStep<LieGroup_t,ConfigVectorIn,TangentVectorIn,JacobianMatrixType,op> >
+  : public fusion::JointUnaryVisitorBase< dIntegrateStep<LieGroup_t,ConfigVectorIn,TangentVectorIn,JacobianMatrixType> >
   {
     typedef boost::fusion::vector<const ConfigVectorIn &,
                                   const TangentVectorIn &,
                                   JacobianMatrixType &,
-                                  const ArgumentPosition &
+                                  const ArgumentPosition &,
+                                  const AssignmentOperatorType&
                                   > ArgsType;
-    typedef LieGroup_t LieGroupMap;
-    template<typename JointModel>
-    static void algo(PINOCCHIO_DETAILS_WRITE_ARGS_4(JointModel))
-    //, typename boost::fusion::result_of::at_c<ArgsType, 4>::type a4)
-    { AlgoDispatch<JointModel, op>::run(jmodel, a0, a1, a2, a3); }
-    template<typename JointModel, AssignmentOperatorType _op>
-    struct AlgoDispatch : dIntegrateStepAlgo<dIntegrateStep, JointModel, _op>
-    { using dIntegrateStepAlgo<dIntegrateStep, JointModel, _op>::run; };
-    //PINOCCHIO_DETAILS_VISITOR_METHOD_ALGO_4(dIntegrateStepAlgo, dIntegrateStep)
+    
+    PINOCCHIO_DETAILS_VISITOR_METHOD_ALGO_5(dIntegrateStepAlgo, dIntegrateStep)
   };
   
-  template<typename Visitor, typename JointModel, AssignmentOperatorType op>
+  template<typename Visitor, typename JointModel>
   struct dIntegrateStepAlgo
   {
     template<typename ConfigVectorIn, typename TangentVector, typename JacobianMatrixType>
@@ -164,7 +177,8 @@ namespace pinocchio
                     const Eigen::MatrixBase<ConfigVectorIn> & q,
                     const Eigen::MatrixBase<TangentVector> & v,
                     const Eigen::MatrixBase<JacobianMatrixType> & mat,
-                    const ArgumentPosition & arg)
+                    const ArgumentPosition & arg,
+                    const AssignmentOperatorType& op)
     {
       typedef typename Visitor::LieGroupMap LieGroupMap;
       
@@ -172,18 +186,11 @@ namespace pinocchio
       lgo.dIntegrate(jmodel.jointConfigSelector  (q.derived()),
                      jmodel.jointVelocitySelector(v.derived()),
                      jmodel.jointBlock(PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,mat)),
-                     arg,
-                     op);
+                     arg, op);
     }
   };
-
-  template <typename Visitor, typename JointCollection, AssignmentOperatorType op>
-  struct dIntegrateStepAlgo <Visitor, JointModelCompositeTpl<JointCollection>, op >
-  {
-    typedef typename Visitor::ArgsType ArgsType;
-    static void run (PINOCCHIO_DETAILS_WRITE_ARGS_4(JointModelCompositeTpl<JointCollection>))
-    { ::pinocchio::details::Dispatch< Visitor >::run(jmodel.derived(), ArgsType(a0,a1,a2,a3)); }
-  };
+  
+  PINOCCHIO_DETAILS_DISPATCH_JOINT_COMPOSITE_5(dIntegrateStepAlgo);
   
   template<typename Visitor, typename JointModel> struct dDifferenceStepAlgo;
   

--- a/src/multibody/liegroup/liegroup-algo.hxx
+++ b/src/multibody/liegroup/liegroup-algo.hxx
@@ -172,7 +172,8 @@ namespace pinocchio
       lgo.dIntegrate(jmodel.jointConfigSelector  (q.derived()),
                      jmodel.jointVelocitySelector(v.derived()),
                      jmodel.jointBlock(PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,mat)),
-                     arg);
+                     arg,
+                     op);
     }
   };
 

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -134,7 +134,8 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
     template <class Config_t, class Tangent_t, class JacobianOut_t>
     void dIntegrate_dq(const Eigen::MatrixBase<Config_t >  & q,
                        const Eigen::MatrixBase<Tangent_t>  & v,
-                       const Eigen::MatrixBase<JacobianOut_t> & J) const;
+                       const Eigen::MatrixBase<JacobianOut_t> & J,
+                       const AssignmentOperatorType op) const;
 
     /**
      * @brief      Computes the Jacobian of a small variation of the tangent vector into tangent space at identity.
@@ -150,7 +151,8 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
     template <class Config_t, class Tangent_t, class JacobianOut_t>
     void dIntegrate_dv(const Eigen::MatrixBase<Config_t >  & q,
                        const Eigen::MatrixBase<Tangent_t>  & v,
-                       const Eigen::MatrixBase<JacobianOut_t> & J) const;
+                       const Eigen::MatrixBase<JacobianOut_t> & J,
+                       const AssignmentOperatorType op) const;
 
     /**
      * @brief      Interpolation between two joint's configurations

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -92,13 +92,13 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *
      * @param[out] J    the Jacobian of the Integrate operation w.r.t. the argument arg.
      */
-    template <ArgumentPosition arg, class Config_t, class Tangent_t, class JacobianOut_t>
+    template <ArgumentPosition arg, class Config_t, class Tangent_t, class JacobianOut_t, AssignmentOperatorType op=SETTO>
     void dIntegrate(const Eigen::MatrixBase<Config_t >  & q,
                     const Eigen::MatrixBase<Tangent_t>  & v,
                     const Eigen::MatrixBase<JacobianOut_t> & J) const
     {
       PINOCCHIO_STATIC_ASSERT(arg==ARG0||arg==ARG1, arg_SHOULD_BE_ARG0_OR_ARG1);
-      return dIntegrate(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J),arg);
+      return dIntegrate(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J),arg,op);
     }
     
     /**
@@ -117,7 +117,8 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
     void dIntegrate(const Eigen::MatrixBase<Config_t >  & q,
                     const Eigen::MatrixBase<Tangent_t>  & v,
                     const Eigen::MatrixBase<JacobianOut_t> & J,
-                    const ArgumentPosition arg) const;
+                    const ArgumentPosition arg,
+                    const AssignmentOperatorType op) const;
 
     /**
      * @brief      Computes the Jacobian of a small variation of the configuration vector into tangent space at identity.

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -92,7 +92,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *
      * @param[out] J    the Jacobian of the Integrate operation w.r.t. the argument arg.
      */
-    template <ArgumentPosition arg, class Config_t, class Tangent_t, class JacobianOut_t, AssignmentOperatorType op=SETTO>
+    template <ArgumentPosition arg, AssignmentOperatorType op, class Config_t, class Tangent_t, class JacobianOut_t>
     void dIntegrate(const Eigen::MatrixBase<Config_t >  & q,
                     const Eigen::MatrixBase<Tangent_t>  & v,
                     const Eigen::MatrixBase<JacobianOut_t> & J) const

--- a/src/multibody/liegroup/liegroup-base.hxx
+++ b/src/multibody/liegroup/liegroup-base.hxx
@@ -41,7 +41,8 @@ namespace pinocchio {
   void LieGroupBase<Derived>::dIntegrate(const Eigen::MatrixBase<Config_t >  & q,
                                          const Eigen::MatrixBase<Tangent_t>  & v,
                                          const Eigen::MatrixBase<JacobianOut_t> & J,
-                                         const ArgumentPosition arg) const
+                                         const ArgumentPosition arg,
+                                         const AssignmentOperatorType op) const
   {
     assert((arg==ARG0||arg==ARG1) && "arg should be either ARG0 or ARG1");
     

--- a/src/multibody/liegroup/liegroup-base.hxx
+++ b/src/multibody/liegroup/liegroup-base.hxx
@@ -48,9 +48,9 @@ namespace pinocchio {
     
     switch (arg) {
       case ARG0:
-        dIntegrate_dq(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J)); return;
+        dIntegrate_dq(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J),op); return;
       case ARG1:
-        dIntegrate_dv(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J)); return;
+        dIntegrate_dv(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J),op); return;
       default: return;
     }
   }
@@ -60,14 +60,15 @@ namespace pinocchio {
   void LieGroupBase<Derived>::dIntegrate_dq(
       const Eigen::MatrixBase<Config_t >  & q,
       const Eigen::MatrixBase<Tangent_t>  & v,
-      const Eigen::MatrixBase<JacobianOut_t> & J) const
+      const Eigen::MatrixBase<JacobianOut_t> & J,
+      const AssignmentOperatorType op) const
   {
     EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Config_t     , ConfigVector_t);
     EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Tangent_t    , TangentVector_t);
     EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(JacobianOut_t, JacobianMatrix_t);
     derived().dIntegrate_dq_impl(q.derived(),
                                  v.derived(),
-                                 PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J));
+                                 PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J),op);
   }
 
   template <class Derived>
@@ -75,14 +76,16 @@ namespace pinocchio {
   void LieGroupBase<Derived>::dIntegrate_dv(
       const Eigen::MatrixBase<Config_t >  & q,
       const Eigen::MatrixBase<Tangent_t>  & v,
-      const Eigen::MatrixBase<JacobianOut_t> & J) const
+      const Eigen::MatrixBase<JacobianOut_t> & J,
+      const AssignmentOperatorType op) const
   {
     EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Config_t     , ConfigVector_t);
     EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Tangent_t    , TangentVector_t);
     EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(JacobianOut_t, JacobianMatrix_t);
     derived().dIntegrate_dv_impl(q.derived(),
                                  v.derived(),
-                                 PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J));
+                                 PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J),
+                                 op);
   }
 
   /**

--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -277,7 +277,8 @@ namespace pinocchio
     template <class Config_t, class Tangent_t, class JacobianOut_t>
     static void dIntegrate_dq_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t>  & v,
-                                   const Eigen::MatrixBase<JacobianOut_t>& J)
+                                   const Eigen::MatrixBase<JacobianOut_t>& J,
+                                   const AssignmentOperatorType op)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
 
@@ -291,7 +292,8 @@ namespace pinocchio
     template <class Config_t, class Tangent_t, class JacobianOut_t>
     static void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t> & v,
-                                   const Eigen::MatrixBase<JacobianOut_t> & J)
+                                   const Eigen::MatrixBase<JacobianOut_t> & J,
+                                   const AssignmentOperatorType op)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
       // TODO sparse version
@@ -529,7 +531,8 @@ namespace pinocchio
     template <class Config_t, class Tangent_t, class JacobianOut_t>
     static void dIntegrate_dq_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t>  & v,
-                                   const Eigen::MatrixBase<JacobianOut_t>& J)
+                                   const Eigen::MatrixBase<JacobianOut_t>& J,
+                                   const AssignmentOperatorType op)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
       Jout = exp6(MotionRef<const Tangent_t>(v.derived())).toDualActionMatrix().transpose();
@@ -538,7 +541,8 @@ namespace pinocchio
     template <class Config_t, class Tangent_t, class JacobianOut_t>
     static void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t>  & v,
-                                   const Eigen::MatrixBase<JacobianOut_t>& J)
+                                   const Eigen::MatrixBase<JacobianOut_t>& J,
+                                   const AssignmentOperatorType op)
     {
       Jexp6(MotionRef<const Tangent_t>(v.derived()), J.derived());
     }

--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -116,20 +116,6 @@ namespace pinocchio
           Mout.template topRightCorner<2,1>() -= tinv;
           Mout(2,2) -= (Scalar)1;
           break;
-        case APPLY_ON_THE_LEFT:
-          // TODO: Aliasing here.
-          Mout.template topLeftCorner<2,2>() = R.transpose() * Mout.template topLeftCorner<2,2>();
-          Mout.template topRightCorner<2,1>() = R.transpose() * Mout.template topRightCorner<2,1>();
-          //No aliasing here.
-          Mout.template topLeftCorner<2,2>().noalias() += tinv * Mout.template bottomLeftCorner<1,2>();
-          Mout.template topRightCorner<2,1>().noalias() += tinv * Mout(2,2);
-          break;
-        case APPLY_ON_THE_RIGHT:
-          // TODO: Aliasing here.
-          Mout.template leftCols<2>() = Mout.template leftCols<2>() * R.transpose();
-          //No aliasing here.
-          Mout.template rightCols<1>().noalias() += Mout.template leftCols<2>() * tinv;
-          break;
         default:
           assert(false && "Wrong Op requesed value");
           break;
@@ -354,20 +340,6 @@ namespace pinocchio
           Jout.template topRightCorner<2,1>() -= Jtmp6.template topRightCorner<2,1>();
           Jout.template bottomLeftCorner<1,2>() -= Jtmp6.template bottomLeftCorner<1,2>();
           Jout.template bottomRightCorner<1,1>() -= Jtmp6.template bottomRightCorner<1,1>();
-          break;
-        case APPLY_ON_THE_LEFT:
-          Jtmp6.template block<2, 1>(0,2) = Jtmp6.template topRightCorner<2,1>();
-          Jtmp6.template block<1, 2>(2,0) = Jtmp6.template bottomLeftCorner<1,2>();
-          Jtmp6(2,2) = Jtmp6(5,5);
-          //TODO: Aliasing here.
-          Jout = Jtmp6.template topLeftCorner<3,3>() * Jout;
-          break;
-        case APPLY_ON_THE_RIGHT:
-          Jtmp6.template block<2, 1>(0,2) = Jtmp6.template topRightCorner<2,1>();
-          Jtmp6.template block<1, 2>(2,0) = Jtmp6.template bottomLeftCorner<1,2>();
-          Jtmp6(2,2) = Jtmp6(5,5);
-          //TODO: Aliasing here.
-          Jout = Jout * Jtmp6.template topLeftCorner<3,3>();
           break;
         default:
           assert(false && "Wrong Op requesed value");
@@ -620,12 +592,6 @@ namespace pinocchio
         case RMTO:
           Jout -= exp6(MotionRef<const Tangent_t>(v.derived())).toDualActionMatrix().transpose();
           break;
-        case APPLY_ON_THE_LEFT:
-          Jout = exp6(MotionRef<const Tangent_t>(v.derived())).toDualActionMatrix().transpose() * Jout;
-          break;
-        case APPLY_ON_THE_RIGHT:
-          Jout = Jout * exp6(MotionRef<const Tangent_t>(v.derived())).toDualActionMatrix().transpose();
-          break;
         default:
           assert(false && "Wrong Op requesed value");
           break;
@@ -649,16 +615,10 @@ namespace pinocchio
         case RMTO:
           Jexp6<RMTO>(MotionRef<const Tangent_t>(v.derived()), J.derived());          
           break;
-        case APPLY_ON_THE_LEFT:
-          break;
-        case APPLY_ON_THE_RIGHT:
-          break;
         default:
           assert(false && "Wrong Op requesed value");
           break;
         }      
-
-      
     }
 
     // interpolate_impl use default implementation.

--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -340,7 +340,7 @@ namespace pinocchio
       switch(op)
         {
         case SETTO:
-          Jout << Jtmp6.template    topLeftCorner<2,2>(), Jtmp6.template    topRightCorner<2,1>(),
+          Jout << Jtmp6.template topLeftCorner<2,2>(), Jtmp6.template topRightCorner<2,1>(),
             Jtmp6.template bottomLeftCorner<1,2>(), Jtmp6.template bottomRightCorner<1,1>();
           break;
         case ADDTO:
@@ -608,7 +608,28 @@ namespace pinocchio
                                    const AssignmentOperatorType op)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
-      Jout = exp6(MotionRef<const Tangent_t>(v.derived())).toDualActionMatrix().transpose();
+
+      switch(op)
+        {
+        case SETTO:
+          Jout = exp6(MotionRef<const Tangent_t>(v.derived())).toDualActionMatrix().transpose();
+          break;
+        case ADDTO:
+          Jout += exp6(MotionRef<const Tangent_t>(v.derived())).toDualActionMatrix().transpose();
+          break;
+        case RMTO:
+          Jout -= exp6(MotionRef<const Tangent_t>(v.derived())).toDualActionMatrix().transpose();
+          break;
+        case APPLY_ON_THE_LEFT:
+          Jout = exp6(MotionRef<const Tangent_t>(v.derived())).toDualActionMatrix().transpose() * Jout;
+          break;
+        case APPLY_ON_THE_RIGHT:
+          Jout = Jout * exp6(MotionRef<const Tangent_t>(v.derived())).toDualActionMatrix().transpose();
+          break;
+        default:
+          assert(false && "Wrong Op requesed value");
+          break;
+        }      
     }
 
     template <class Config_t, class Tangent_t, class JacobianOut_t>
@@ -617,7 +638,27 @@ namespace pinocchio
                                    const Eigen::MatrixBase<JacobianOut_t>& J,
                                    const AssignmentOperatorType op)
     {
-      Jexp6(MotionRef<const Tangent_t>(v.derived()), J.derived());
+      switch(op)
+        {
+        case SETTO:
+          Jexp6<SETTO>(MotionRef<const Tangent_t>(v.derived()), J.derived());
+          break;
+        case ADDTO:
+          Jexp6<ADDTO>(MotionRef<const Tangent_t>(v.derived()), J.derived());          
+          break;
+        case RMTO:
+          Jexp6<RMTO>(MotionRef<const Tangent_t>(v.derived()), J.derived());          
+          break;
+        case APPLY_ON_THE_LEFT:
+          break;
+        case APPLY_ON_THE_RIGHT:
+          break;
+        default:
+          assert(false && "Wrong Op requesed value");
+          break;
+        }      
+
+      
     }
 
     // interpolate_impl use default implementation.

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -198,7 +198,7 @@ namespace pinocchio
         default:
           assert(false && "Wrong Op requesed value");
           break;
-        }      
+        }
     }
 
     template <class Config_t, class Tangent_t, class JacobianOut_t>
@@ -416,7 +416,29 @@ namespace pinocchio
                                    const AssignmentOperatorType op)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
-      Jout = exp3(-v);
+      switch(op)
+        {
+        case SETTO:
+          Jout = exp3(-v);
+          break;
+        case ADDTO:
+          Jout += exp3(-v);
+          break;
+        case RMTO:
+          Jout -= exp3(-v);
+          break;
+        case APPLY_ON_THE_LEFT:
+          //TODO: Improve implementation
+          Jout = exp3(-v) * Jout;
+          break;
+        case APPLY_ON_THE_RIGHT:
+          //TODO: Improve implementation
+          Jout = Jout * exp3(-v);
+          break;
+        default:
+          assert(false && "Wrong Op requesed value");
+          break;
+        }      
     }
 
     template <class Config_t, class Tangent_t, class JacobianOut_t>
@@ -425,7 +447,26 @@ namespace pinocchio
                                    const Eigen::MatrixBase<JacobianOut_t> & J,
                                    const AssignmentOperatorType op)
     {
-      Jexp3(v, J.derived());
+      
+      switch(op)
+        {
+        case SETTO:
+          Jexp3<SETTO>(v, J.derived());
+          break;
+        case ADDTO:
+          Jexp3<ADDTO>(v, J.derived());
+          break;
+        case RMTO:
+          Jexp3<RMTO>(v, J.derived());
+          break;
+        case APPLY_ON_THE_LEFT:
+          break;
+        case APPLY_ON_THE_RIGHT:
+          break;
+        default:
+          assert(false && "Wrong Op requesed value");
+          break;
+        }      
     }
 
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -174,7 +174,8 @@ namespace pinocchio
     template <class Config_t, class Tangent_t, class JacobianOut_t>
     static void dIntegrate_dq_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t>  & /*v*/,
-                                   const Eigen::MatrixBase<JacobianOut_t>& J)
+                                   const Eigen::MatrixBase<JacobianOut_t>& J,
+                                   const AssignmentOperatorType op)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
       Jout(0,0) = 1;
@@ -183,7 +184,8 @@ namespace pinocchio
     template <class Config_t, class Tangent_t, class JacobianOut_t>
     static void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t>  & /*v*/,
-                                   const Eigen::MatrixBase<JacobianOut_t>& J)
+                                   const Eigen::MatrixBase<JacobianOut_t>& J,
+                                   const AssignmentOperatorType op)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
       Jout(0,0) = 1;
@@ -370,7 +372,8 @@ namespace pinocchio
     template <class Config_t, class Tangent_t, class JacobianOut_t>
     static void dIntegrate_dq_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t>  & v,
-                                   const Eigen::MatrixBase<JacobianOut_t> & J)
+                                   const Eigen::MatrixBase<JacobianOut_t> & J,
+                                   const AssignmentOperatorType op)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
       Jout = exp3(-v);
@@ -379,7 +382,8 @@ namespace pinocchio
     template <class Config_t, class Tangent_t, class JacobianOut_t>
     static void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t>  & v,
-                                   const Eigen::MatrixBase<JacobianOut_t> & J)
+                                   const Eigen::MatrixBase<JacobianOut_t> & J,
+                                   const AssignmentOperatorType op)
     {
       Jexp3(v, J.derived());
     }

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -189,12 +189,6 @@ namespace pinocchio
         case RMTO:
           Jout(0,0) -= 1;
           break;
-        case APPLY_ON_THE_LEFT:
-          //Do Nothing
-          break;
-        case APPLY_ON_THE_RIGHT:
-          //Do Nothing
-          break;
         default:
           assert(false && "Wrong Op requesed value");
           break;
@@ -218,12 +212,6 @@ namespace pinocchio
           break;
         case RMTO:
           Jout(0,0) -= 1;
-          break;
-        case APPLY_ON_THE_LEFT:
-          //Do Nothing
-          break;
-        case APPLY_ON_THE_RIGHT:
-          //Do Nothing
           break;
         default:
           assert(false && "Wrong Op requesed value");
@@ -427,14 +415,6 @@ namespace pinocchio
         case RMTO:
           Jout -= exp3(-v);
           break;
-        case APPLY_ON_THE_LEFT:
-          //TODO: Improve implementation
-          Jout = exp3(-v) * Jout;
-          break;
-        case APPLY_ON_THE_RIGHT:
-          //TODO: Improve implementation
-          Jout = Jout * exp3(-v);
-          break;
         default:
           assert(false && "Wrong Op requesed value");
           break;
@@ -458,10 +438,6 @@ namespace pinocchio
           break;
         case RMTO:
           Jexp3<RMTO>(v, J.derived());
-          break;
-        case APPLY_ON_THE_LEFT:
-          break;
-        case APPLY_ON_THE_RIGHT:
           break;
         default:
           assert(false && "Wrong Op requesed value");

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016-2018 CNRS
+// Copyright (c) 2016-2020 CNRS INRIA
 //
 
 #ifndef __pinocchio_special_orthogonal_operation_hpp__
@@ -81,7 +81,7 @@ namespace pinocchio
     {
       typedef typename Matrix2Like::Scalar Scalar;
       EIGEN_STATIC_ASSERT_MATRIX_SPECIFIC_SIZE(Matrix2Like,2,2);
-      return (Scalar)1;
+      return Scalar(1);
     }
 
     /// Get dimension of Lie Group vector representation
@@ -172,22 +172,22 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class JacobianOut_t>
-    static void dIntegrate_dq_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
-                                   const Eigen::MatrixBase<Tangent_t>  & /*v*/,
-                                   const Eigen::MatrixBase<JacobianOut_t>& J,
+    static void dIntegrate_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+                                   const Eigen::MatrixBase<Tangent_t> & /*v*/,
+                                   const Eigen::MatrixBase<JacobianOut_t> & J,
                                    const AssignmentOperatorType op)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
       switch(op)
         {
         case SETTO:
-          Jout(0,0) = 1;
+          Jout(0,0) = Scalar(1);
           break;
         case ADDTO:
-          Jout(0,0) += 1;
+          Jout(0,0) += Scalar(1);
           break;
         case RMTO:
-          Jout(0,0) -= 1;
+          Jout(0,0) -= Scalar(1);
           break;
         default:
           assert(false && "Wrong Op requesed value");
@@ -196,22 +196,22 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class JacobianOut_t>
-    static void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
-                                   const Eigen::MatrixBase<Tangent_t>  & /*v*/,
-                                   const Eigen::MatrixBase<JacobianOut_t>& J,
+    static void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+                                   const Eigen::MatrixBase<Tangent_t> & /*v*/,
+                                   const Eigen::MatrixBase<JacobianOut_t> & J,
                                    const AssignmentOperatorType op)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
       switch(op)
         {
         case SETTO:
-          Jout(0,0) = 1;
+          Jout(0,0) = Scalar(1);
           break;
         case ADDTO:
-          Jout(0,0) += 1;
+          Jout(0,0) += Scalar(1);
           break;
         case RMTO:
-          Jout(0,0) -= 1;
+          Jout(0,0) -= Scalar(1);
           break;
         default:
           assert(false && "Wrong Op requesed value");
@@ -484,8 +484,7 @@ namespace pinocchio
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
     void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> &,
                                   const Eigen::MatrixBase<ConfigR_t> &,
-                                  const Eigen::MatrixBase<ConfigOut_t> & qout)
-      const
+                                  const Eigen::MatrixBase<ConfigOut_t> & qout) const
     {
       random_impl(qout);
     }

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -178,7 +178,27 @@ namespace pinocchio
                                    const AssignmentOperatorType op)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
-      Jout(0,0) = 1;
+      switch(op)
+        {
+        case SETTO:
+          Jout(0,0) = 1;
+          break;
+        case ADDTO:
+          Jout(0,0) += 1;
+          break;
+        case RMTO:
+          Jout(0,0) -= 1;
+          break;
+        case APPLY_ON_THE_LEFT:
+          //Do Nothing
+          break;
+        case APPLY_ON_THE_RIGHT:
+          //Do Nothing
+          break;
+        default:
+          assert(false && "Wrong Op requesed value");
+          break;
+        }      
     }
 
     template <class Config_t, class Tangent_t, class JacobianOut_t>
@@ -188,7 +208,27 @@ namespace pinocchio
                                    const AssignmentOperatorType op)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
-      Jout(0,0) = 1;
+      switch(op)
+        {
+        case SETTO:
+          Jout(0,0) = 1;
+          break;
+        case ADDTO:
+          Jout(0,0) += 1;
+          break;
+        case RMTO:
+          Jout(0,0) -= 1;
+          break;
+        case APPLY_ON_THE_LEFT:
+          //Do Nothing
+          break;
+        case APPLY_ON_THE_RIGHT:
+          //Do Nothing
+          break;
+        default:
+          assert(false && "Wrong Op requesed value");
+          break;
+        }      
     }
 
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>

--- a/src/multibody/liegroup/vector-space.hpp
+++ b/src/multibody/liegroup/vector-space.hpp
@@ -121,12 +121,6 @@ namespace pinocchio
         case RMTO:
           Jout.diagonal().array() -= 1.;
           break;
-        case APPLY_ON_THE_LEFT:
-          //Do Nothing
-          break;
-        case APPLY_ON_THE_RIGHT:
-          //Do Nothing
-          break;
         default:
           assert(false && "Wrong Op requesed value");
           break;
@@ -150,12 +144,6 @@ namespace pinocchio
           break;
         case RMTO:
           Jout.diagonal().array() -= 1.;
-          break;
-        case APPLY_ON_THE_LEFT:
-          //Do Nothing
-          break;
-        case APPLY_ON_THE_RIGHT:
-          //Do Nothing
           break;
         default:
           assert(false && "Wrong Op requesed value");

--- a/src/multibody/liegroup/vector-space.hpp
+++ b/src/multibody/liegroup/vector-space.hpp
@@ -109,7 +109,28 @@ namespace pinocchio
                                    const Eigen::MatrixBase<JacobianOut_t>& J,
                                    const AssignmentOperatorType op)
     {
-      PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J).setIdentity();
+      Eigen::MatrixBase<JacobianOut_t>& Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
+      switch(op)
+        {
+        case SETTO:
+          Jout.setIdentity();
+          break;
+        case ADDTO:
+          Jout.diagonal().array() += 1.;
+          break;
+        case RMTO:
+          Jout.diagonal().array() -= 1.;
+          break;
+        case APPLY_ON_THE_LEFT:
+          //Do Nothing
+          break;
+        case APPLY_ON_THE_RIGHT:
+          //Do Nothing
+          break;
+        default:
+          assert(false && "Wrong Op requesed value");
+          break;
+        }
     }
 
     template <class Config_t, class Tangent_t, class JacobianOut_t>
@@ -118,7 +139,28 @@ namespace pinocchio
                                    const Eigen::MatrixBase<JacobianOut_t>& J,
                                    const AssignmentOperatorType op)
     {
-      PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J).setIdentity();
+      Eigen::MatrixBase<JacobianOut_t>& Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
+      switch(op)
+        {
+        case SETTO:
+          Jout.setIdentity();
+          break;
+        case ADDTO:
+          Jout.diagonal().array() += 1.;
+          break;
+        case RMTO:
+          Jout.diagonal().array() -= 1.;
+          break;
+        case APPLY_ON_THE_LEFT:
+          //Do Nothing
+          break;
+        case APPLY_ON_THE_RIGHT:
+          //Do Nothing
+          break;
+        default:
+          assert(false && "Wrong Op requesed value");
+          break;
+        }
     }
 
 

--- a/src/multibody/liegroup/vector-space.hpp
+++ b/src/multibody/liegroup/vector-space.hpp
@@ -1,14 +1,13 @@
 //
-// Copyright (c) 2016-2018 CNRS
+// Copyright (c) 2016-2020 CNRS INRIA
 //
 
 #ifndef __pinocchio_vector_space_operation_hpp__
 #define __pinocchio_vector_space_operation_hpp__
 
-#include <stdexcept>
-
 #include "pinocchio/multibody/liegroup/liegroup-base.hpp"
 
+#include <stdexcept>
 #include <boost/integer/static_min_max.hpp>
 
 namespace pinocchio
@@ -80,10 +79,10 @@ namespace pinocchio
     template <ArgumentPosition arg, class ConfigL_t, class ConfigR_t, class JacobianOut_t>
     void dDifference_impl (const Eigen::MatrixBase<ConfigL_t> &,
                            const Eigen::MatrixBase<ConfigR_t> &,
-                           const Eigen::MatrixBase<JacobianOut_t>& J) const
+                           const Eigen::MatrixBase<JacobianOut_t> & J) const
     {
       if (arg == ARG0)
-        PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J).noalias() = - JacobianMatrix_t::Identity();
+        PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J) = -JacobianMatrix_t::Identity();
       else if (arg == ARG1)
         PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J).setIdentity();
     }
@@ -104,9 +103,9 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class JacobianOut_t>
-    static void dIntegrate_dq_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
-                                   const Eigen::MatrixBase<Tangent_t>  & /*v*/,
-                                   const Eigen::MatrixBase<JacobianOut_t>& J,
+    static void dIntegrate_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+                                   const Eigen::MatrixBase<Tangent_t> & /*v*/,
+                                   const Eigen::MatrixBase<JacobianOut_t> & J,
                                    const AssignmentOperatorType op)
     {
       Eigen::MatrixBase<JacobianOut_t>& Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
@@ -116,10 +115,10 @@ namespace pinocchio
           Jout.setIdentity();
           break;
         case ADDTO:
-          Jout.diagonal().array() += 1.;
+          Jout.diagonal().array() += Scalar(1);
           break;
         case RMTO:
-          Jout.diagonal().array() -= 1.;
+          Jout.diagonal().array() -= Scalar(1);
           break;
         default:
           assert(false && "Wrong Op requesed value");
@@ -128,9 +127,9 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class JacobianOut_t>
-    static void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
-                                   const Eigen::MatrixBase<Tangent_t>  & /*v*/,
-                                   const Eigen::MatrixBase<JacobianOut_t>& J,
+    static void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+                                   const Eigen::MatrixBase<Tangent_t> & /*v*/,
+                                   const Eigen::MatrixBase<JacobianOut_t> & J,
                                    const AssignmentOperatorType op)
     {
       Eigen::MatrixBase<JacobianOut_t>& Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
@@ -140,10 +139,10 @@ namespace pinocchio
           Jout.setIdentity();
           break;
         case ADDTO:
-          Jout.diagonal().array() += 1.;
+          Jout.diagonal().array() += Scalar(1);
           break;
         case RMTO:
-          Jout.diagonal().array() -= 1.;
+          Jout.diagonal().array() -= Scalar(1);
           break;
         default:
           assert(false && "Wrong Op requesed value");

--- a/src/multibody/liegroup/vector-space.hpp
+++ b/src/multibody/liegroup/vector-space.hpp
@@ -106,7 +106,8 @@ namespace pinocchio
     template <class Config_t, class Tangent_t, class JacobianOut_t>
     static void dIntegrate_dq_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t>  & /*v*/,
-                                   const Eigen::MatrixBase<JacobianOut_t>& J)
+                                   const Eigen::MatrixBase<JacobianOut_t>& J,
+                                   const AssignmentOperatorType op)
     {
       PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J).setIdentity();
     }
@@ -114,7 +115,8 @@ namespace pinocchio
     template <class Config_t, class Tangent_t, class JacobianOut_t>
     static void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t>  & /*v*/,
-                                   const Eigen::MatrixBase<JacobianOut_t>& J)
+                                   const Eigen::MatrixBase<JacobianOut_t>& J,
+                                   const AssignmentOperatorType op)
     {
       PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J).setIdentity();
     }

--- a/src/spatial/act-on-set.hpp
+++ b/src/spatial/act-on-set.hpp
@@ -11,13 +11,6 @@
 namespace pinocchio
 {
   
-  enum AssignmentOperatorType
-  {
-    SETTO,
-    ADDTO,
-    RMTO
-  };
-  
   namespace forceSet
   {
     ///

--- a/src/spatial/explog.hpp
+++ b/src/spatial/explog.hpp
@@ -156,10 +156,6 @@ namespace pinocchio
         Jout(1,2) -= -b*r[0]; Jout(2,1) -= b*r[0]; 
         Jout.noalias() -= c * r * r.transpose();
         break;
-      case APPLY_ON_THE_LEFT:
-        break;
-      case APPLY_ON_THE_RIGHT:
-        break;
       default:
         assert(false && "Wrong Op requesed value");
         break;
@@ -180,7 +176,6 @@ namespace pinocchio
   {
     Jexp3<SETTO>(r, Jexp);
   }
-  
   
   /** \brief Derivative of log3
    *
@@ -432,10 +427,6 @@ namespace pinocchio
           - Jtmp3 * J;
         break;
       }
-      case APPLY_ON_THE_LEFT:
-        break;
-      case APPLY_ON_THE_RIGHT:
-        break;
       default:
         assert(false && "Wrong Op requesed value");
         break;
@@ -451,7 +442,6 @@ namespace pinocchio
     Jexp6<SETTO>(nu, Jexp);
   }
 
-  
   /** \brief Derivative of log6
    *  \f[
    *  \left(\begin{array}{cc}

--- a/src/spatial/explog.hpp
+++ b/src/spatial/explog.hpp
@@ -107,7 +107,7 @@ namespace pinocchio
   ///   + \frac{1}{||n||^2} (1-\frac{\sin{||r||}}{||r||}) r r^T
   /// \f]
   ///
-  template<typename Vector3Like, typename Matrix3Like>
+  template<AssignmentOperatorType op, typename Vector3Like, typename Matrix3Like>
   void Jexp3(const Eigen::MatrixBase<Vector3Like> & r,
              const Eigen::MatrixBase<Matrix3Like> & Jexp)
   {
@@ -141,6 +141,22 @@ namespace pinocchio
 
     Jout.noalias() += c * r * r.transpose();
   }
+
+  ///
+  /// \brief Derivative of \f$ \exp{r} \f$
+  /// \f[
+  ///     \frac{\sin{||r||}}{||r||}                       I_3
+  ///   - \frac{1-\cos{||r||}}{||r||^2}                   \left[ r \right]_x
+  ///   + \frac{1}{||n||^2} (1-\frac{\sin{||r||}}{||r||}) r r^T
+  /// \f]
+  ///
+  template<typename Vector3Like, typename Matrix3Like>
+  void Jexp3(const Eigen::MatrixBase<Vector3Like> & r,
+             const Eigen::MatrixBase<Matrix3Like> & Jexp)
+  {
+    Jexp3<SETTO>(r, Jexp);
+  }
+  
   
   /** \brief Derivative of log3
    *
@@ -310,7 +326,7 @@ namespace pinocchio
  
   /// \brief Derivative of exp6
   /// Computed as the inverse of Jlog6
-  template<typename MotionDerived, typename Matrix6Like>
+  template<AssignmentOperatorType op, typename MotionDerived, typename Matrix6Like>
   void Jexp6(const MotionDense<MotionDerived>     & nu,
              const Eigen::MatrixBase<Matrix6Like> & Jexp)
   {
@@ -326,11 +342,6 @@ namespace pinocchio
     const Scalar t2 = w.squaredNorm();
     const Scalar t = math::sqrt(t2);
 
-    // Matrix3 J3;
-    // Jexp3(w, J3);
-    Jexp3(w, Jout.template bottomRightCorner<3,3>());
-    Jout.template topLeftCorner<3,3>() = Jout.template bottomRightCorner<3,3>();
-
     const Scalar tinv = Scalar(1)/t,
                  t2inv = tinv*tinv;
     Scalar st,ct; SINCOS (t, &st, &ct);
@@ -345,7 +356,13 @@ namespace pinocchio
                                                               Scalar(1)/Scalar(360),
                                                               -Scalar(2)*t2inv*t2inv + (Scalar(1) + st*tinv) * t2inv * inv_2_2ct);
 
-    Vector3 p (Jout.template topLeftCorner<3,3>().transpose() * v);
+    // Matrix3 J3;
+    // Jexp3(w, J3);
+    
+    Jexp3(w, Jout.template bottomRightCorner<3,3>());
+    Jout.template topLeftCorner<3,3>() = Jout.template bottomRightCorner<3,3>();
+
+    const Vector3 p = Jout.template topLeftCorner<3,3>().transpose() * v;
     Scalar wTp (w.dot (p));
     Matrix3 J (alphaSkew(.5, p) +
           (beta_dot_over_theta*wTp)                *w*w.transpose()
@@ -358,6 +375,16 @@ namespace pinocchio
     Jout.template bottomLeftCorner<3,3>().setZero();
   }
 
+  /// \brief Derivative of exp6
+  /// Computed as the inverse of Jlog6
+  template<typename MotionDerived, typename Matrix6Like>
+  void Jexp6(const MotionDense<MotionDerived>     & nu,
+             const Eigen::MatrixBase<Matrix6Like> & Jexp)
+  {
+    Jexp6<SETTO>(nu, Jexp);
+  }
+
+  
   /** \brief Derivative of log6
    *  \f[
    *  \left(\begin{array}{cc}

--- a/unittest/joint-configurations.cpp
+++ b/unittest/joint-configurations.cpp
@@ -235,80 +235,47 @@ BOOST_AUTO_TEST_CASE ( dIntegrate_assignementop_test )
 
   //SETTO
   dIntegrate(model,qs,vs,results[0],ARG0);
-  dIntegrate<SETTO>(model,qs,vs,results[1],ARG0);
+  dIntegrate(model,qs,vs,results[1],ARG0,SETTO);
   BOOST_CHECK(results[0].isApprox(results[1]));
 
   //ADDTO
   results[1] = Eigen::MatrixXd::Random(model.nv, model.nv);
   results[2] = results[1];
   results[0].setZero();
-  dIntegrate<SETTO>(model,qs,vs,results[0],ARG0);
-  dIntegrate<ADDTO>(model,qs,vs,results[1],ARG0);
+  dIntegrate(model,qs,vs,results[0],ARG0,SETTO);
+  dIntegrate(model,qs,vs,results[1],ARG0,ADDTO);
   BOOST_CHECK(results[1].isApprox(results[2] + results[0]));
 
   //RMTO
   results[1] = Eigen::MatrixXd::Random(model.nv, model.nv);
   results[2] = results[1];
   results[0].setZero();
-  dIntegrate<SETTO>(model,qs,vs,results[0],ARG0);
-  dIntegrate<RMTO>(model,qs,vs,results[1],ARG0);
+  dIntegrate(model,qs,vs,results[0],ARG0,SETTO);
+  dIntegrate(model,qs,vs,results[1],ARG0,RMTO);
   BOOST_CHECK(results[1].isApprox(results[2] - results[0]));
-
-  //MUL_LEFT
-  results[1] = Eigen::MatrixXd::Random(model.nv, model.nv);
-  results[2] = results[1];
-  results[0].setZero();
-  dIntegrate<SETTO>(model,qs,vs,results[0],ARG0);
-  dIntegrate<APPLY_ON_THE_LEFT>(model,qs,vs,results[1],ARG0);
-  BOOST_CHECK(results[1].isApprox(results[0] * results[2]));  
-
-  //MUL_RIGHT
-  results[1] = Eigen::MatrixXd::Random(model.nv, model.nv);
-  results[2] = results[1];
-  results[0].setZero();
-  dIntegrate<SETTO>(model,qs,vs,results[0],ARG0);
-  dIntegrate<APPLY_ON_THE_RIGHT>(model,qs,vs,results[1],ARG0);
-  BOOST_CHECK(results[1].isApprox(results[2] * results[0]));
 
   //SETTO
   results[0].setZero();
   results[1].setZero();
   dIntegrate(model,qs,vs,results[0],ARG1);
-  dIntegrate<SETTO>(model,qs,vs,results[1],ARG1);
+  dIntegrate(model,qs,vs,results[1],ARG1,SETTO);
   BOOST_CHECK(results[0].isApprox(results[1]));
 
   //ADDTO
   results[1] = Eigen::MatrixXd::Random(model.nv, model.nv);
   results[2] = results[1];
   results[0].setZero();
-  dIntegrate<SETTO>(model,qs,vs,results[0],ARG1);
-  dIntegrate<ADDTO>(model,qs,vs,results[1],ARG1);
+  dIntegrate(model,qs,vs,results[0],ARG1,SETTO);
+  dIntegrate(model,qs,vs,results[1],ARG1,ADDTO);
   BOOST_CHECK(results[1].isApprox(results[2] + results[0]));
 
   //RMTO
   results[1] = Eigen::MatrixXd::Random(model.nv, model.nv);
   results[2] = results[1];
   results[0].setZero();
-  dIntegrate<SETTO>(model,qs,vs,results[0],ARG1);
-  dIntegrate<RMTO>(model,qs,vs,results[1],ARG1);
+  dIntegrate(model,qs,vs,results[0],ARG1,SETTO);
+  dIntegrate(model,qs,vs,results[1],ARG1,RMTO);
   BOOST_CHECK(results[1].isApprox(results[2] - results[0]));
-
-  //MUL_LEFT
-  results[1] = Eigen::MatrixXd::Random(model.nv, model.nv);
-  results[2] = results[1];
-  results[0].setZero();
-  dIntegrate<SETTO>(model,qs,vs,results[0],ARG1);
-  dIntegrate<APPLY_ON_THE_LEFT>(model,qs,vs,results[1],ARG1);
-  BOOST_CHECK(results[1].isApprox(results[0] * results[2]));  
-
-  //MUL_RIGHT
-  results[1] = Eigen::MatrixXd::Random(model.nv, model.nv);
-  results[2] = results[1];
-  results[0].setZero();
-  dIntegrate<SETTO>(model,qs,vs,results[0],ARG1);
-  dIntegrate<APPLY_ON_THE_RIGHT>(model,qs,vs,results[1],ARG1);
-  BOOST_CHECK(results[1].isApprox(results[2] * results[0]));
-
 
 }
 

--- a/unittest/joint-configurations.cpp
+++ b/unittest/joint-configurations.cpp
@@ -222,16 +222,12 @@ BOOST_AUTO_TEST_CASE ( dIntegrate_assignementop_test )
 {
   Model model; buildModel(model);
   
-  Eigen::VectorXd qs;
-  Eigen::VectorXd vs;
-  Eigen::VectorXd vs2;
   std::vector<Eigen::MatrixXd> results(3,Eigen::MatrixXd::Zero(model.nv,model.nv));
   
-  qs = Eigen::VectorXd::Ones(model.nq);
+  Eigen::VectorXd qs = Eigen::VectorXd::Ones(model.nq);
   normalize(model,qs);
   
-  vs = Eigen::VectorXd::Random(model.nv);
-  vs2 = Eigen::VectorXd::Zero(model.nv);
+  Eigen::VectorXd vs = Eigen::VectorXd::Random(model.nv);
 
   //SETTO
   dIntegrate(model,qs,vs,results[0],ARG0);

--- a/unittest/joint-configurations.cpp
+++ b/unittest/joint-configurations.cpp
@@ -244,10 +244,8 @@ BOOST_AUTO_TEST_CASE ( dIntegrate_assignementop_test )
   results[0].setZero();
   dIntegrate<SETTO>(model,qs,vs,results[0],ARG0);
   dIntegrate<ADDTO>(model,qs,vs,results[1],ARG0);
-  std::cerr<<"why"<<results[1]-(results[2] + results[0])<<std::endl;
   BOOST_CHECK(results[1].isApprox(results[2] + results[0]));
 
-  /*
   //RMTO
   results[1] = Eigen::MatrixXd::Random(model.nv, model.nv);
   results[2] = results[1];
@@ -271,7 +269,47 @@ BOOST_AUTO_TEST_CASE ( dIntegrate_assignementop_test )
   dIntegrate<SETTO>(model,qs,vs,results[0],ARG0);
   dIntegrate<APPLY_ON_THE_RIGHT>(model,qs,vs,results[1],ARG0);
   BOOST_CHECK(results[1].isApprox(results[2] * results[0]));
-  */
+
+  //SETTO
+  results[0].setZero();
+  results[1].setZero();
+  dIntegrate(model,qs,vs,results[0],ARG1);
+  dIntegrate<SETTO>(model,qs,vs,results[1],ARG1);
+  BOOST_CHECK(results[0].isApprox(results[1]));
+
+  //ADDTO
+  results[1] = Eigen::MatrixXd::Random(model.nv, model.nv);
+  results[2] = results[1];
+  results[0].setZero();
+  dIntegrate<SETTO>(model,qs,vs,results[0],ARG1);
+  dIntegrate<ADDTO>(model,qs,vs,results[1],ARG1);
+  BOOST_CHECK(results[1].isApprox(results[2] + results[0]));
+
+  //RMTO
+  results[1] = Eigen::MatrixXd::Random(model.nv, model.nv);
+  results[2] = results[1];
+  results[0].setZero();
+  dIntegrate<SETTO>(model,qs,vs,results[0],ARG1);
+  dIntegrate<RMTO>(model,qs,vs,results[1],ARG1);
+  BOOST_CHECK(results[1].isApprox(results[2] - results[0]));
+
+  //MUL_LEFT
+  results[1] = Eigen::MatrixXd::Random(model.nv, model.nv);
+  results[2] = results[1];
+  results[0].setZero();
+  dIntegrate<SETTO>(model,qs,vs,results[0],ARG1);
+  dIntegrate<APPLY_ON_THE_LEFT>(model,qs,vs,results[1],ARG1);
+  BOOST_CHECK(results[1].isApprox(results[0] * results[2]));  
+
+  //MUL_RIGHT
+  results[1] = Eigen::MatrixXd::Random(model.nv, model.nv);
+  results[2] = results[1];
+  results[0].setZero();
+  dIntegrate<SETTO>(model,qs,vs,results[0],ARG1);
+  dIntegrate<APPLY_ON_THE_RIGHT>(model,qs,vs,results[1],ARG1);
+  BOOST_CHECK(results[1].isApprox(results[2] * results[0]));
+
+
 }
 
 BOOST_AUTO_TEST_CASE ( integrate_difference_test )

--- a/unittest/joint-configurations.cpp
+++ b/unittest/joint-configurations.cpp
@@ -218,6 +218,62 @@ BOOST_AUTO_TEST_CASE ( diff_difference_vs_diff_integrate )
 }
 
 
+BOOST_AUTO_TEST_CASE ( dIntegrate_assignementop_test )
+{
+  Model model; buildModel(model);
+  
+  Eigen::VectorXd qs;
+  Eigen::VectorXd vs;
+  Eigen::VectorXd vs2;
+  std::vector<Eigen::MatrixXd> results(3,Eigen::MatrixXd::Zero(model.nv,model.nv));
+  
+  qs = Eigen::VectorXd::Ones(model.nq);
+  normalize(model,qs);
+  
+  vs = Eigen::VectorXd::Random(model.nv);
+  vs2 = Eigen::VectorXd::Zero(model.nv);
+
+  //SETTO
+  dIntegrate(model,qs,vs,results[0],ARG0);
+  dIntegrate<SETTO>(model,qs,vs,results[1],ARG0);
+  BOOST_CHECK(results[0].isApprox(results[1]));
+
+  //ADDTO
+  results[1] = Eigen::MatrixXd::Random(model.nv, model.nv);
+  results[2] = results[1];
+  results[0].setZero();
+  dIntegrate<SETTO>(model,qs,vs,results[0],ARG0);
+  dIntegrate<ADDTO>(model,qs,vs,results[1],ARG0);
+  std::cerr<<"why"<<results[1]-(results[2] + results[0])<<std::endl;
+  BOOST_CHECK(results[1].isApprox(results[2] + results[0]));
+
+  /*
+  //RMTO
+  results[1] = Eigen::MatrixXd::Random(model.nv, model.nv);
+  results[2] = results[1];
+  results[0].setZero();
+  dIntegrate<SETTO>(model,qs,vs,results[0],ARG0);
+  dIntegrate<RMTO>(model,qs,vs,results[1],ARG0);
+  BOOST_CHECK(results[1].isApprox(results[2] - results[0]));
+
+  //MUL_LEFT
+  results[1] = Eigen::MatrixXd::Random(model.nv, model.nv);
+  results[2] = results[1];
+  results[0].setZero();
+  dIntegrate<SETTO>(model,qs,vs,results[0],ARG0);
+  dIntegrate<APPLY_ON_THE_LEFT>(model,qs,vs,results[1],ARG0);
+  BOOST_CHECK(results[1].isApprox(results[0] * results[2]));  
+
+  //MUL_RIGHT
+  results[1] = Eigen::MatrixXd::Random(model.nv, model.nv);
+  results[2] = results[1];
+  results[0].setZero();
+  dIntegrate<SETTO>(model,qs,vs,results[0],ARG0);
+  dIntegrate<APPLY_ON_THE_RIGHT>(model,qs,vs,results[1],ARG0);
+  BOOST_CHECK(results[1].isApprox(results[2] * results[0]));
+  */
+}
+
 BOOST_AUTO_TEST_CASE ( integrate_difference_test )
 {
  Model model; buildModel(model);

--- a/unittest/liegroups.cpp
+++ b/unittest/liegroups.cpp
@@ -316,8 +316,8 @@ struct LieGroup_Jintegrate{
     ConfigVector_t q_v = lg.integrate (q, v);
 
     JacobianMatrix_t Jq, Jv;
-    lg.dIntegrate_dq (q, v, Jq);
-    lg.dIntegrate_dv (q, v, Jv);
+    lg.dIntegrate_dq (q, v, Jq, SETTO);
+    lg.dIntegrate_dv (q, v, Jv, SETTO);
 
     const Scalar eps = 1e-6;
     for (int i = 0; i < v.size(); ++i)
@@ -361,7 +361,7 @@ struct LieGroup_JintegrateJdifference{
     JacobianMatrix_t Jd_qb, Ji_v;
 
     lg.template dDifference<ARG1> (qa, qb, Jd_qb);
-    lg.template dIntegrate <ARG1> (qa, v , Ji_v );
+    lg.template dIntegrate <ARG1, SETTO> (qa, v , Ji_v );
 
     BOOST_CHECK_MESSAGE ((Jd_qb * Ji_v).isIdentity(),
         "Jd_qb\n" <<


### PR DESCRIPTION
This PR fixes #1163 , for the time being.

Some API stuff in this PR:
1) the `dintegrate(...., ARG, OP)` user API
2) `enum AssignmentOperatorType` is moved from the pinocchio/spatial to pinocchio/fwd (to reside along with `enum ArgumentType`)