### PR TITLE
dIntegrateTransport algorithm.

### DIFF
--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -5,9 +5,7 @@
 #ifndef __pinocchio_algorithm_joint_configuration_hpp__
 #define __pinocchio_algorithm_joint_configuration_hpp__
 
-#include "pinocchio/multibody/fwd.hpp"
 #include "pinocchio/multibody/model.hpp"
-
 #include "pinocchio/multibody/liegroup/liegroup.hpp"
 
 namespace pinocchio
@@ -346,21 +344,21 @@ namespace pinocchio
     dIntegrate<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg,op);
   }
 
-
   /**
    *
-   * @brief   Transport an input matrix to the manifold defined by the dIntegrate computation.
+   * @brief   Transport a matrix from the terminal to the originate tangent space of the integrate operation.
    *
-   * @details This input and output has to be interpreted in terms of Lie group, not vector space: as such,
-   *          Thus, dIntegrate(q, v, J, arg) creates a manifold manifold M given by a small variation of the configuration vector or the tangent vector into the tangent space at identity.
-   *          We are moving our input matrix onto this manifold M.
+   * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
+   *          to the tangent space of \f$ q \f$.
+   *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
+   *          For Lie groups, its corresponds to the canonical vector field transportation.
    *
    * @param[in]  model   Model of the kinematic tree on which the integration operation is performed.
-   * @param[in]  q       Initial configuration (size model.nq)
-   * @param[in]  v       Joint velocity (size model.nv)
-   * @param[out] Jin     Input Matrix (number of rows = model.nv).
-   * @param[out] Jout    Output Matrix (same size as Jin).
-   * @param[in]  arg     Argument (either q or v) with respect to which the differentiation manifold M is generated.
+   * @param[in]  q            Initial configuration (size model.nq)
+   * @param[in]  v            Joint velocity (size model.nv)
+   * @param[out] Jin        Input matrix (number of rows = model.nv).
+   * @param[out] Jout      Output matrix (same size as Jin).
+   * @param[in]  arg        Argument (either ARG0 for q or ARG1 for v) with respect to which the differentation is performed.
    *
    */
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType1, typename JacobianMatrixType2>
@@ -373,20 +371,21 @@ namespace pinocchio
 
   /**
    *
-   * @brief   Transport an input matrix to the manifold defined by the dIntegrate computation.
+   * @brief   Transport a matrix from the terminal to the originate tangent space of the integrate operation.
    *
-   * @details This input and output has to be interpreted in terms of Lie group, not vector space: as such,
-   *          Thus, dIntegrate(q, v, J, arg) creates a manifold manifold M given by a small variation of the configuration vector or the tangent vector into the tangent space at identity.
-   *          We are moving our input matrix onto this manifold M.
+   * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
+   *          to the tangent space of \f$ q \f$.
+   *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
+   *          For Lie groups, its corresponds to the canonical vector field transportation.
    *
    * @param[in]  model   Model of the kinematic tree on which the integration operation is performed.
-   * @param[in]  q       Initial configuration (size model.nq)
-   * @param[in]  v       Joint velocity (size model.nv)
-   * @param[out] Jin     Input Matrix (number of rows = model.nv).
-   * @param[out] Jout    Output Matrix (same size as Jin).
-   * @param[in]  arg     Argument (either q or v) with respect to which the differentiation manifold M is generated.
+   * @param[in]  q            Initial configuration (size model.nq)
+   * @param[in]  v            Joint velocity (size model.nv)
+   * @param[out] Jin        Input matrix (number of rows = model.nv).
+   * @param[out] Jout      Output matrix (same size as Jin).
+   * @param[in]  arg        Argument (either ARG0 for q or ARG1 for v) with respect to which the differentation is performed.
    *
-   */
+  */
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType1, typename JacobianMatrixType2>
   void dIntegrateTransport(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                            const Eigen::MatrixBase<ConfigVectorType> & q,
@@ -398,51 +397,51 @@ namespace pinocchio
     dIntegrateTransport<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType1,JacobianMatrixType2>(model, q.derived(), v.derived(), Jin.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType2,Jout),arg);
   }
 
-
-
   /**
    *
-   * @brief   Transportinplace an input matrix to the manifold defined by the dIntegrate computation.
+   * @brief   Transport in place a matrix from the terminal to the originate tangent space of the integrate operation.
    *
-   * @details This input and output has to be interpreted in terms of Lie group, not vector space: as such,
-   *          Thus, dIntegrate(q, v, J, arg) creates a manifold manifold M given by a small variation of the configuration vector or the tangent vector into the tangent space at identity.
-   *          We are moving our input matrix onto this manifold M.
+   * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
+   *          to the tangent space of \f$ q \f$.
+   *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
+   *          For Lie groups, its corresponds to the canonical vector field transportation.
    *
-   * @param[in]  model   Model of the kinematic tree on which the integration operation is performed.
-   * @param[in]  q       Initial configuration (size model.nq)
-   * @param[in]  v       Joint velocity (size model.nv)
-   * @param[in,out]  J   Input Matrix (number of rows = model.nv).
-   * @param[in]  arg     Argument (either q or v) with respect to which the differentiation manifold M is generated.
+   * @param[in]     model   Model of the kinematic tree on which the integration operation is performed.
+   * @param[in]     q            Initial configuration (size model.nq)
+   * @param[in]     v            Joint velocity (size model.nv)
+   * @param[in,out] J            Input/output matrix (number of rows = model.nv).
+   * @param[in]     arg        Argument (either ARG0 for q or ARG1 for v) with respect to which the differentation is performed.
    *
-   */
+  */
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
   void dIntegrateTransportInPlace(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                           const Eigen::MatrixBase<ConfigVectorType> & q,
-                           const Eigen::MatrixBase<TangentVectorType> & v,
-                           const Eigen::MatrixBase<JacobianMatrixType> & J,
-                           const ArgumentPosition arg);
+                                  const Eigen::MatrixBase<ConfigVectorType> & q,
+                                  const Eigen::MatrixBase<TangentVectorType> & v,
+                                  const Eigen::MatrixBase<JacobianMatrixType> & J,
+                                  const ArgumentPosition arg);
 
   /**
    *
-   * @brief   Transport an input matrix to the manifold defined by the dIntegrate computation.
+   * @brief   Transport in place a matrix from the terminal to the originate tangent space of the integrate operation.
    *
-   * @details This input and output has to be interpreted in terms of Lie group, not vector space: as such,
-   *          Thus, dIntegrate(q, v, J, arg) creates a manifold manifold M given by a small variation of the configuration vector or the tangent vector into the tangent space at identity.
-   *          We are moving our input matrix onto this manifold M.
+   * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
+   *          to the tangent space of \f$ q \f$.
+   *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
+   *          For Lie groups, its corresponds to the canonical vector field transportation.
    *
-   * @param[in]  model   Model of the kinematic tree on which the integration operation is performed.
-   * @param[in]  q       Initial configuration (size model.nq)
-   * @param[in]  v       Joint velocity (size model.nv)
-   * @param[in,out]  J   Input Matrix (number of rows = model.nv).
-   * @param[in]  arg     Argument (either q or v) with respect to which the differentiation manifold M is generated.
+   * @param[in]     model   Model of the kinematic tree on which the integration operation is performed.
+   * @param[in]     q            Initial configuration (size model.nq)
+   * @param[in]     v            Joint velocity (size model.nv)
+   * @param[in,out] J            Input/output matrix (number of rows = model.nv).
+   * @param[in]     arg        Argument (either ARG0 for q or ARG1 for v) with respect to which the differentation is performed.
    *
-   */
+  */
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
   void dIntegrateTransportInPlace(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                           const Eigen::MatrixBase<ConfigVectorType> & q,
-                           const Eigen::MatrixBase<TangentVectorType> & v,
-                           const Eigen::MatrixBase<JacobianMatrixType> & J,
-                           const ArgumentPosition arg)
+                                  const Eigen::MatrixBase<ConfigVectorType> & q,
+                                  const Eigen::MatrixBase<TangentVectorType> & v,
+                                  const Eigen::MatrixBase<JacobianMatrixType> & J,
+                                  const ArgumentPosition arg)
   {
     dIntegrateTransportInPlace<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
   }

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -415,10 +415,10 @@ namespace pinocchio
   */
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
   void dIntegrateTransport(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                                  const Eigen::MatrixBase<ConfigVectorType> & q,
-                                  const Eigen::MatrixBase<TangentVectorType> & v,
-                                  const Eigen::MatrixBase<JacobianMatrixType> & J,
-                                  const ArgumentPosition arg);
+                           const Eigen::MatrixBase<ConfigVectorType> & q,
+                           const Eigen::MatrixBase<TangentVectorType> & v,
+                           const Eigen::MatrixBase<JacobianMatrixType> & J,
+                           const ArgumentPosition arg);
 
   /**
    *
@@ -438,12 +438,12 @@ namespace pinocchio
   */
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
   void dIntegrateTransport(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                                  const Eigen::MatrixBase<ConfigVectorType> & q,
-                                  const Eigen::MatrixBase<TangentVectorType> & v,
-                                  const Eigen::MatrixBase<JacobianMatrixType> & J,
-                                  const ArgumentPosition arg)
+                           const Eigen::MatrixBase<ConfigVectorType> & q,
+                           const Eigen::MatrixBase<TangentVectorType> & v,
+                           const Eigen::MatrixBase<JacobianMatrixType> & J,
+                           const ArgumentPosition arg)
   {
-    dIntegrateTransportInPlace<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
+    dIntegrateTransport<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
   }
 
   /**

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -287,7 +287,7 @@ namespace pinocchio
                   const Eigen::MatrixBase<JacobianMatrixType> & J,
                   const ArgumentPosition arg,
                   const AssignmentOperatorType op);
-
+  
   /**
    *
    * @brief   Computes the Jacobian of a small variation of the configuration vector or the tangent vector into the tangent space at identity.
@@ -345,6 +345,33 @@ namespace pinocchio
   {
     dIntegrate<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg,op);
   }
+
+
+  /**
+   *
+   * @brief   Transport an input matrix to the manifold defined by the dIntegrate computation.
+   *
+   * @details This input and output has to be interpreted in terms of Lie group, not vector space: as such,
+   *          Thus, dIntegrate(q, v, J, arg) creates a manifold manifold M given by a small variation of the configuration vector or the tangent vector into the tangent space at identity.
+   *          We are moving our input matrix onto this manifold M.
+   *
+   * @param[in]  model   Model of the kinematic tree on which the integration operation is performed.
+   * @param[in]  q       Initial configuration (size model.nq)
+   * @param[in]  v       Joint velocity (size model.nv)
+   * @param[out] Jin     Input Matrix (number of rows = model.nv).
+   * @param[out] Jout    Output Matrix (same size as Jin).
+   * @param[in]  arg     Argument (either q or v) with respect to which the differentiation manifold M is generated.
+   *
+   */
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType1, typename JacobianMatrixType2>
+  void dIntegrateTransport(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                           const Eigen::MatrixBase<ConfigVectorType> & q,
+                           const Eigen::MatrixBase<TangentVectorType> & v,
+                           const Eigen::MatrixBase<JacobianMatrixType1> & Jin,
+                           const Eigen::MatrixBase<JacobianMatrixType2> & Jout,
+                           const ArgumentPosition arg);
+
+  
   
   /**
    *

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -371,7 +371,32 @@ namespace pinocchio
                            const Eigen::MatrixBase<JacobianMatrixType2> & Jout,
                            const ArgumentPosition arg);
 
-  
+  /**
+   *
+   * @brief   Transport an input matrix to the manifold defined by the dIntegrate computation.
+   *
+   * @details This input and output has to be interpreted in terms of Lie group, not vector space: as such,
+   *          Thus, dIntegrate(q, v, J, arg) creates a manifold manifold M given by a small variation of the configuration vector or the tangent vector into the tangent space at identity.
+   *          We are moving our input matrix onto this manifold M.
+   *
+   * @param[in]  model   Model of the kinematic tree on which the integration operation is performed.
+   * @param[in]  q       Initial configuration (size model.nq)
+   * @param[in]  v       Joint velocity (size model.nv)
+   * @param[out] Jin     Input Matrix (number of rows = model.nv).
+   * @param[out] Jout    Output Matrix (same size as Jin).
+   * @param[in]  arg     Argument (either q or v) with respect to which the differentiation manifold M is generated.
+   *
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType1, typename JacobianMatrixType2>
+  void dIntegrateTransport(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                           const Eigen::MatrixBase<ConfigVectorType> & q,
+                           const Eigen::MatrixBase<TangentVectorType> & v,
+                           const Eigen::MatrixBase<JacobianMatrixType1> & Jin,
+                           const Eigen::MatrixBase<JacobianMatrixType2> & Jout,
+                           const ArgumentPosition arg)
+  {
+    dIntegrateTransport<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType1,JacobianMatrixType2>(model, q.derived(), v.derived(), Jin.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType2,Jout),arg);
+  }
   
   /**
    *

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -1,9 +1,9 @@
 //
-// Copyright (c) 2016-2019 CNRS INRIA
+// Copyright (c) 2016-2020 CNRS INRIA
 //
 
-#ifndef __pinocchio_joint_configuration_hpp__
-#define __pinocchio_joint_configuration_hpp__
+#ifndef __pinocchio_algorithm_joint_configuration_hpp__
+#define __pinocchio_algorithm_joint_configuration_hpp__
 
 #include "pinocchio/multibody/fwd.hpp"
 #include "pinocchio/multibody/model.hpp"
@@ -954,5 +954,4 @@ namespace pinocchio
 /* --- Details -------------------------------------------------------------------- */
 #include "pinocchio/algorithm/joint-configuration.hxx"
 
-#endif // ifndef __pinocchio_joint_configuration_hpp__
-
+#endif // ifndef __pinocchio_algorithm_joint_configuration_hpp__

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -414,7 +414,7 @@ namespace pinocchio
    *
   */
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
-  void dIntegrateTransportInPlace(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+  void dIntegrateTransport(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                                   const Eigen::MatrixBase<ConfigVectorType> & q,
                                   const Eigen::MatrixBase<TangentVectorType> & v,
                                   const Eigen::MatrixBase<JacobianMatrixType> & J,
@@ -437,13 +437,13 @@ namespace pinocchio
    *
   */
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
-  void dIntegrateTransportInPlace(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+  void dIntegrateTransport(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                                   const Eigen::MatrixBase<ConfigVectorType> & q,
                                   const Eigen::MatrixBase<TangentVectorType> & v,
                                   const Eigen::MatrixBase<JacobianMatrixType> & J,
                                   const ArgumentPosition arg)
   {
-    dIntegrateTransportInPlace<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
+    dIntegrateTransport<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
   }
 
   /**

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -349,7 +349,7 @@ namespace pinocchio
    * @brief   Transport a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the configuration or the velocity arguments.
    *
    * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
-   *          to the tangent space of \f$ q \f$.
+   *          to the tangent space at \f$ q \f$.
    *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
    *          For Lie groups, its corresponds to the canonical vector field transportation.
    *
@@ -374,7 +374,7 @@ namespace pinocchio
    * @brief   Transport a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the configuration or the velocity arguments.
    *
    * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
-   *          to the tangent space of \f$ q \f$.
+   *          to the tangent space at \f$ q \f$.
    *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
    *          For Lie groups, its corresponds to the canonical vector field transportation.
    *
@@ -402,7 +402,7 @@ namespace pinocchio
    * @brief   Transport in place a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the configuration or the velocity arguments.
    *
    * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
-   *          to the tangent space of \f$ q \f$.
+   *          to the tangent space at \f$ q \f$.
    *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
    *          For Lie groups, its corresponds to the canonical vector field transportation.
    *
@@ -425,7 +425,7 @@ namespace pinocchio
    * @brief   Transport in place a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the configuration or the velocity arguments.
    *
    * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
-   *          to the tangent space of \f$ q \f$.
+   *          to the tangent space at \f$ q \f$.
    *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
    *          For Lie groups, its corresponds to the canonical vector field transportation.
    *

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -443,7 +443,7 @@ namespace pinocchio
                                   const Eigen::MatrixBase<JacobianMatrixType> & J,
                                   const ArgumentPosition arg)
   {
-    dIntegrateTransport<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
+    dIntegrateTransportInPlace<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
   }
 
   /**

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -346,7 +346,7 @@ namespace pinocchio
 
   /**
    *
-   * @brief   Transport a matrix from the terminal to the originate tangent space of the integrate operation.
+   * @brief   Transport a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the configuration or the velocity arguments.
    *
    * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
    *          to the tangent space of \f$ q \f$.
@@ -371,7 +371,7 @@ namespace pinocchio
 
   /**
    *
-   * @brief   Transport a matrix from the terminal to the originate tangent space of the integrate operation.
+   * @brief   Transport a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the configuration or the velocity arguments.
    *
    * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
    *          to the tangent space of \f$ q \f$.
@@ -399,7 +399,7 @@ namespace pinocchio
 
   /**
    *
-   * @brief   Transport in place a matrix from the terminal to the originate tangent space of the integrate operation.
+   * @brief   Transport in place a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the configuration or the velocity arguments.
    *
    * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
    *          to the tangent space of \f$ q \f$.
@@ -422,7 +422,7 @@ namespace pinocchio
 
   /**
    *
-   * @brief   Transport in place a matrix from the terminal to the originate tangent space of the integrate operation.
+   * @brief   Transport in place a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the configuration or the velocity arguments.
    *
    * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
    *          to the tangent space of \f$ q \f$.

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -287,7 +287,7 @@ namespace pinocchio
                   const Eigen::MatrixBase<JacobianMatrixType> & J,
                   const ArgumentPosition arg,
                   const AssignmentOperatorType op);
-  
+
   /**
    *
    * @brief   Computes the Jacobian of a small variation of the configuration vector or the tangent vector into the tangent space at identity.

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -350,6 +350,9 @@ namespace pinocchio
    *
    * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
    *          to the tangent space at \f$ q \f$.
+   *          In other words, this functions transforms a tangent vector expressed at \f$ q \oplus v \f$ to a tangent vector expressed at \f$ q \f$, considering that the change of configuration between
+   *          \f$ q \oplus v \f$ and \f$ q \f$ may alter the value of this tangent vector.
+   *          A typical example of parallel transportation is the action operated by a rigid transformation \f$ M \in \text{SE}(3)\f$ on a spatial velocity \f$ v \in \text{se}(3)\f$.
    *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
    *          For Lie groups, its corresponds to the canonical vector field transportation.
    *
@@ -375,6 +378,9 @@ namespace pinocchio
    *
    * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
    *          to the tangent space at \f$ q \f$.
+   *          In other words, this functions transforms a tangent vector expressed at \f$ q \oplus v \f$ to a tangent vector expressed at \f$ q \f$, considering that the change of configuration between
+   *          \f$ q \oplus v \f$ and \f$ q \f$ may alter the value of this tangent vector.
+   *          A typical example of parallel transportation is the action operated by a rigid transformation \f$ M \in \text{SE}(3)\f$ on a spatial velocity \f$ v \in \text{se}(3)\f$.
    *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
    *          For Lie groups, its corresponds to the canonical vector field transportation.
    *
@@ -403,6 +409,9 @@ namespace pinocchio
    *
    * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
    *          to the tangent space at \f$ q \f$.
+   *          In other words, this functions transforms a tangent vector expressed at \f$ q \oplus v \f$ to a tangent vector expressed at \f$ q \f$, considering that the change of configuration between
+   *          \f$ q \oplus v \f$ and \f$ q \f$ may alter the value of this tangent vector.
+   *          A typical example of parallel transportation is the action operated by a rigid transformation \f$ M \in \text{SE}(3)\f$ on a spatial velocity \f$ v \in \text{se}(3)\f$.
    *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
    *          For Lie groups, its corresponds to the canonical vector field transportation.
    *
@@ -426,6 +435,9 @@ namespace pinocchio
    *
    * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
    *          to the tangent space at \f$ q \f$.
+   *          In other words, this functions transforms a tangent vector expressed at \f$ q \oplus v \f$ to a tangent vector expressed at \f$ q \f$, considering that the change of configuration between
+   *          \f$ q \oplus v \f$ and \f$ q \f$ may alter the value of this tangent vector.
+   *          A typical example of parallel transportation is the action operated by a rigid transformation \f$ M \in \text{SE}(3)\f$ on a spatial velocity \f$ v \in \text{se}(3)\f$.
    *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
    *          For Lie groups, its corresponds to the canonical vector field transportation.
    *

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -397,7 +397,56 @@ namespace pinocchio
   {
     dIntegrateTransport<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType1,JacobianMatrixType2>(model, q.derived(), v.derived(), Jin.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType2,Jout),arg);
   }
-  
+
+
+
+  /**
+   *
+   * @brief   Transportinplace an input matrix to the manifold defined by the dIntegrate computation.
+   *
+   * @details This input and output has to be interpreted in terms of Lie group, not vector space: as such,
+   *          Thus, dIntegrate(q, v, J, arg) creates a manifold manifold M given by a small variation of the configuration vector or the tangent vector into the tangent space at identity.
+   *          We are moving our input matrix onto this manifold M.
+   *
+   * @param[in]  model   Model of the kinematic tree on which the integration operation is performed.
+   * @param[in]  q       Initial configuration (size model.nq)
+   * @param[in]  v       Joint velocity (size model.nv)
+   * @param[in,out]  J   Input Matrix (number of rows = model.nv).
+   * @param[in]  arg     Argument (either q or v) with respect to which the differentiation manifold M is generated.
+   *
+   */
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
+  void dIntegrateTransportInPlace(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                           const Eigen::MatrixBase<ConfigVectorType> & q,
+                           const Eigen::MatrixBase<TangentVectorType> & v,
+                           const Eigen::MatrixBase<JacobianMatrixType> & J,
+                           const ArgumentPosition arg);
+
+  /**
+   *
+   * @brief   Transport an input matrix to the manifold defined by the dIntegrate computation.
+   *
+   * @details This input and output has to be interpreted in terms of Lie group, not vector space: as such,
+   *          Thus, dIntegrate(q, v, J, arg) creates a manifold manifold M given by a small variation of the configuration vector or the tangent vector into the tangent space at identity.
+   *          We are moving our input matrix onto this manifold M.
+   *
+   * @param[in]  model   Model of the kinematic tree on which the integration operation is performed.
+   * @param[in]  q       Initial configuration (size model.nq)
+   * @param[in]  v       Joint velocity (size model.nv)
+   * @param[in,out]  J   Input Matrix (number of rows = model.nv).
+   * @param[in]  arg     Argument (either q or v) with respect to which the differentiation manifold M is generated.
+   *
+   */
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
+  void dIntegrateTransportInPlace(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                           const Eigen::MatrixBase<ConfigVectorType> & q,
+                           const Eigen::MatrixBase<TangentVectorType> & v,
+                           const Eigen::MatrixBase<JacobianMatrixType> & J,
+                           const ArgumentPosition arg)
+  {
+    dIntegrateTransportInPlace<LieGroupMap,Scalar,Options,JointCollectionTpl,ConfigVectorType,TangentVectorType,JacobianMatrixType>(model, q.derived(), v.derived(), PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
+  }
+
   /**
    *
    * @brief   Computes the Jacobian of a small variation of the configuration vector into the tangent space at identity.

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -199,10 +199,10 @@ namespace pinocchio
 
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
   void dIntegrateTransportInPlace(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                           const Eigen::MatrixBase<ConfigVectorType> & q,
-                           const Eigen::MatrixBase<TangentVectorType> & v,
-                           const Eigen::MatrixBase<JacobianMatrixType> & J,
-                           const ArgumentPosition arg)
+                                  const Eigen::MatrixBase<ConfigVectorType> & q,
+                                  const Eigen::MatrixBase<TangentVectorType> & v,
+                                  const Eigen::MatrixBase<JacobianMatrixType> & J,
+                                  const ArgumentPosition arg)
   {
     PINOCCHIO_CHECK_INPUT_ARGUMENT(q.size() == model.nq, "The configuration vector is not of the right size");
     PINOCCHIO_CHECK_INPUT_ARGUMENT(v.size() == model.nv, "The joint velocity vector is not of the right size");

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -211,7 +211,7 @@ namespace pinocchio
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
     
-    typedef dIntegrateTransportStep<LieGroup_t,ConfigVectorType,TangentVectorType,JacobianMatrixType> Algo;
+    typedef dIntegrateTransportInPlaceStep<LieGroup_t,ConfigVectorType,TangentVectorType,JacobianMatrixType> Algo;
     typename Algo::ArgsType args(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
     for(JointIndex i=1; i<(JointIndex)model.njoints; ++i)
     {

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -196,6 +196,29 @@ namespace pinocchio
     }
   }
   
+
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
+  void dIntegrateTransportInPlace(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                           const Eigen::MatrixBase<ConfigVectorType> & q,
+                           const Eigen::MatrixBase<TangentVectorType> & v,
+                           const Eigen::MatrixBase<JacobianMatrixType> & J,
+                           const ArgumentPosition arg)
+  {
+    PINOCCHIO_CHECK_INPUT_ARGUMENT(q.size() == model.nq, "The configuration vector is not of the right size");
+    PINOCCHIO_CHECK_INPUT_ARGUMENT(v.size() == model.nv, "The joint velocity vector is not of the right size");
+    PINOCCHIO_CHECK_INPUT_ARGUMENT(J.rows() == model.nv, "The input matrix is not of the right size");
+
+    typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
+    typedef typename Model::JointIndex JointIndex;
+    
+    typedef dIntegrateTransportInPlaceStep<LieGroup_t,ConfigVectorType,TangentVectorType,JacobianMatrixType> Algo;
+    typename Algo::ArgsType args(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
+    for(JointIndex i=1; i<(JointIndex)model.njoints; ++i)
+    {
+      Algo::run(model.joints[i], args);
+    }
+  }
+  
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVector1, typename ConfigVector2, typename JacobianMatrix>
   void dDifference(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                    const Eigen::MatrixBase<ConfigVector1> & q0,

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -1,9 +1,9 @@
 //
-// Copyright (c) 2016-2019 CNRS INRIA
+// Copyright (c) 2016-2020 CNRS INRIA
 //
 
-#ifndef __pinocchio_joint_configuration_hxx__
-#define __pinocchio_joint_configuration_hxx__
+#ifndef __pinocchio_algorithm_joint_configuration_hxx__
+#define __pinocchio_algorithm_joint_configuration_hxx__
 
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/multibody/liegroup/liegroup-algo.hpp"
@@ -421,5 +421,4 @@ namespace pinocchio
 
 } // namespace pinocchio
 
-#endif // ifndef __pinocchio_joint_configuration_hxx__
-
+#endif // ifndef __pinocchio_algorithm_joint_configuration_hxx__

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -199,10 +199,10 @@ namespace pinocchio
 
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
   void dIntegrateTransport(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                                  const Eigen::MatrixBase<ConfigVectorType> & q,
-                                  const Eigen::MatrixBase<TangentVectorType> & v,
-                                  const Eigen::MatrixBase<JacobianMatrixType> & J,
-                                  const ArgumentPosition arg)
+                           const Eigen::MatrixBase<ConfigVectorType> & q,
+                           const Eigen::MatrixBase<TangentVectorType> & v,
+                           const Eigen::MatrixBase<JacobianMatrixType> & J,
+                           const ArgumentPosition arg)
   {
     PINOCCHIO_CHECK_INPUT_ARGUMENT(q.size() == model.nq, "The configuration vector is not of the right size");
     PINOCCHIO_CHECK_INPUT_ARGUMENT(v.size() == model.nv, "The joint velocity vector is not of the right size");

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -175,7 +175,7 @@ namespace pinocchio
   void dIntegrateTransport(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                            const Eigen::MatrixBase<ConfigVectorType> & q,
                            const Eigen::MatrixBase<TangentVectorType> & v,
-                           const Eigen::MatrixBase<JacobianMatrixType1> & J,
+                           const Eigen::MatrixBase<JacobianMatrixType1> & Jin,
                            const Eigen::MatrixBase<JacobianMatrixType2> & Jout,
                            const ArgumentPosition arg)
   {
@@ -188,8 +188,8 @@ namespace pinocchio
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
     
-    typedef dIntegrateStep<LieGroup_t,ConfigVectorType,TangentVectorType,JacobianMatrixType1,JacobianMatrixType2> Algo;
-    typename Algo::ArgsType args(q.derived(),v.derived(),Jin.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,Jout),arg);
+    typedef dIntegrateTransportStep<LieGroup_t,ConfigVectorType,TangentVectorType,JacobianMatrixType1,JacobianMatrixType2> Algo;
+    typename Algo::ArgsType args(q.derived(),v.derived(),Jin.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType2,Jout),arg);
     for(JointIndex i=1; i<(JointIndex)model.njoints; ++i)
     {
       Algo::run(model.joints[i], args);

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -171,6 +171,31 @@ namespace pinocchio
     }
   }
 
+  template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType1, typename JacobianMatrixType2>
+  void dIntegrateTransport(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                           const Eigen::MatrixBase<ConfigVectorType> & q,
+                           const Eigen::MatrixBase<TangentVectorType> & v,
+                           const Eigen::MatrixBase<JacobianMatrixType1> & J,
+                           const Eigen::MatrixBase<JacobianMatrixType2> & Jout,
+                           const ArgumentPosition arg)
+  {
+    PINOCCHIO_CHECK_INPUT_ARGUMENT(q.size() == model.nq, "The configuration vector is not of the right size");
+    PINOCCHIO_CHECK_INPUT_ARGUMENT(v.size() == model.nv, "The joint velocity vector is not of the right size");
+    PINOCCHIO_CHECK_INPUT_ARGUMENT(Jin.rows() == model.nv, "The input matrix is not of the right size");
+    PINOCCHIO_CHECK_INPUT_ARGUMENT(Jout.rows() == Jin.rows(), "The output argument should be the same size as input matrix");
+    PINOCCHIO_CHECK_INPUT_ARGUMENT(Jout.cols() == Jin.cols(), "The output argument should be the same size as input matrix");
+
+    typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
+    typedef typename Model::JointIndex JointIndex;
+    
+    typedef dIntegrateStep<LieGroup_t,ConfigVectorType,TangentVectorType,JacobianMatrixType1,JacobianMatrixType2> Algo;
+    typename Algo::ArgsType args(q.derived(),v.derived(),Jin.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,Jout),arg);
+    for(JointIndex i=1; i<(JointIndex)model.njoints; ++i)
+    {
+      Algo::run(model.joints[i], args);
+    }
+  }
+  
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVector1, typename ConfigVector2, typename JacobianMatrix>
   void dDifference(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                    const Eigen::MatrixBase<ConfigVector1> & q0,

--- a/src/algorithm/joint-configuration.hxx
+++ b/src/algorithm/joint-configuration.hxx
@@ -198,7 +198,7 @@ namespace pinocchio
   
 
   template<typename LieGroup_t, typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, typename JacobianMatrixType>
-  void dIntegrateTransportInPlace(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+  void dIntegrateTransport(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                                   const Eigen::MatrixBase<ConfigVectorType> & q,
                                   const Eigen::MatrixBase<TangentVectorType> & v,
                                   const Eigen::MatrixBase<JacobianMatrixType> & J,
@@ -211,7 +211,7 @@ namespace pinocchio
     typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
     
-    typedef dIntegrateTransportInPlaceStep<LieGroup_t,ConfigVectorType,TangentVectorType,JacobianMatrixType> Algo;
+    typedef dIntegrateTransportStep<LieGroup_t,ConfigVectorType,TangentVectorType,JacobianMatrixType> Algo;
     typename Algo::ArgsType args(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,J),arg);
     for(JointIndex i=1; i<(JointIndex)model.njoints; ++i)
     {

--- a/src/multibody/liegroup/cartesian-product.hpp
+++ b/src/multibody/liegroup/cartesian-product.hpp
@@ -204,7 +204,7 @@ namespace pinocchio
     
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransportInPlace_dq_impl(const Eigen::MatrixBase<Config_t > & q,
+    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & q,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<Jacobian_t> & Jin) const
     {
@@ -214,7 +214,7 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransportInPlace_dv_impl(const Eigen::MatrixBase<Config_t > & q,
+    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & q,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<Jacobian_t> & Jin) const
     {

--- a/src/multibody/liegroup/cartesian-product.hpp
+++ b/src/multibody/liegroup/cartesian-product.hpp
@@ -181,17 +181,25 @@ namespace pinocchio
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
     void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & q,
                                      const Eigen::MatrixBase<Tangent_t> & v,
-                                     const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+                                     const Eigen::MatrixBase<JacobianIn_t> & J_in,
+                                     const Eigen::MatrixBase<JacobianOut_t> & J_out) const
     {
+      JacobianOut_t& Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out);
+      JacobianOut_t& Jin = PINOCCHIO_EIGEN_CONST_CAST(JacobianIn_t,J_in);
+      lg1_.dIntegrateTransport_dq(Q1(q), V1(v), Jin.template topRows<LieGroup1::NV>(),Jout.template topRows<LieGroup1::NV>());
+      lg2_.dIntegrateTransport_dq(Q2(q), V2(v), Jin.template bottomRows<LieGroup2::NV>(),Jout.template bottomRows<LieGroup2::NV>());
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
     void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & q,
                                      const Eigen::MatrixBase<Tangent_t> & v,
-                                     const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+                                     const Eigen::MatrixBase<JacobianIn_t> & J_in,
+                                     const Eigen::MatrixBase<JacobianOut_t> & J_out) const
     {
+      JacobianOut_t& Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out);
+      JacobianOut_t& Jin = PINOCCHIO_EIGEN_CONST_CAST(JacobianIn_t,J_in);
+      lg1_.dIntegrateTransport_dv(Q1(q), V1(v), Jin.template topRows<LieGroup1::NV>(),Jout.template topRows<LieGroup1::NV>());
+      lg2_.dIntegrateTransport_dv(Q2(q), V2(v), Jin.template bottomRows<LieGroup2::NV>(),Jout.template bottomRows<LieGroup2::NV>());
     }
     
     template <class ConfigL_t, class ConfigR_t>

--- a/src/multibody/liegroup/cartesian-product.hpp
+++ b/src/multibody/liegroup/cartesian-product.hpp
@@ -202,6 +202,27 @@ namespace pinocchio
       lg2_.dIntegrateTransport_dv(Q2(q), V2(v), Jin.template bottomRows<LieGroup2::NV>(),Jout.template bottomRows<LieGroup2::NV>());
     }
     
+
+    template <class Config_t, class Tangent_t, class Jacobian_t>
+    void dIntegrateTransportInPlace_dq_impl(const Eigen::MatrixBase<Config_t > & q,
+                                     const Eigen::MatrixBase<Tangent_t> & v,
+                                     const Eigen::MatrixBase<Jacobian_t> & Jin) const
+    {
+      Jacobian_t& J = PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,Jin);
+      lg1_.dIntegrateTransport_dq(Q1(q), V1(v), J.template topRows<LieGroup1::NV>());
+      lg2_.dIntegrateTransport_dq(Q2(q), V2(v), J.template bottomRows<LieGroup2::NV>());
+    }
+
+    template <class Config_t, class Tangent_t, class Jacobian_t>
+    void dIntegrateTransportInPlace_dv_impl(const Eigen::MatrixBase<Config_t > & q,
+                                     const Eigen::MatrixBase<Tangent_t> & v,
+                                     const Eigen::MatrixBase<Jacobian_t> & Jin) const
+    {
+      Jacobian_t& J = PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,Jin);
+      lg1_.dIntegrateTransport_dv(Q1(q), V1(v), J.template topRows<LieGroup1::NV>());
+      lg2_.dIntegrateTransport_dv(Q2(q), V2(v), J.template bottomRows<LieGroup2::NV>());
+    }
+
     template <class ConfigL_t, class ConfigR_t>
     Scalar squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
                                 const Eigen::MatrixBase<ConfigR_t> & q1) const

--- a/src/multibody/liegroup/cartesian-product.hpp
+++ b/src/multibody/liegroup/cartesian-product.hpp
@@ -1,9 +1,9 @@
 //
-// Copyright (c) 2016-2018 CNRS
+// Copyright (c) 2016-2020 CNRS CNRS
 //
 
-#ifndef __pinocchio_cartesian_product_operation_hpp__
-#define __pinocchio_cartesian_product_operation_hpp__
+#ifndef __pinocchio_multibody_liegroup_cartesian_product_operation_hpp__
+#define __pinocchio_multibody_liegroup_cartesian_product_operation_hpp__
 
 #include <pinocchio/multibody/liegroup/liegroup-base.hpp>
 
@@ -295,4 +295,4 @@ namespace pinocchio
 
 } // namespace pinocchio
 
-#endif // ifndef __pinocchio_cartesian_product_operation_hpp__
+#endif // ifndef __pinocchio_multibody_liegroup_cartesian_product_operation_hpp__

--- a/src/multibody/liegroup/cartesian-product.hpp
+++ b/src/multibody/liegroup/cartesian-product.hpp
@@ -175,11 +175,25 @@ namespace pinocchio
         default:
           assert(false && "Wrong Op requesed value");
           break;
-        }      
-
-      
+        }
     }
 
+    template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & q,
+                                     const Eigen::MatrixBase<Tangent_t> & v,
+                                     const Eigen::MatrixBase<JacobianIn_t> & Jin,
+                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+    {
+    }
+
+    template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & q,
+                                     const Eigen::MatrixBase<Tangent_t> & v,
+                                     const Eigen::MatrixBase<JacobianIn_t> & Jin,
+                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+    {
+    }
+    
     template <class ConfigL_t, class ConfigR_t>
     Scalar squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
                                 const Eigen::MatrixBase<ConfigR_t> & q1) const

--- a/src/multibody/liegroup/liegroup-algo.hpp
+++ b/src/multibody/liegroup/liegroup-algo.hpp
@@ -1,14 +1,13 @@
 //
-// Copyright (c) 2018 CNRS
+// Copyright (c) 2018-2020 CNRS INRIA
 //
 
-#ifndef __pinocchio_lie_group_algo_hpp__
-#define __pinocchio_lie_group_algo_hpp__
+#ifndef __pinocchio_multibody_liegroup_liegroup_algo_hpp__
+#define __pinocchio_multibody_liegroup_liegroup_algo_hpp__
 
 #include "pinocchio/multibody/joint/joint-base.hpp"
 #include "pinocchio/multibody/liegroup/liegroup.hpp"
 
-/// Details
 #include "pinocchio/multibody/liegroup/liegroup-algo.hxx"
 
-#endif // ifndef __pinocchio_lie_group_algo_hpp__
+#endif // ifndef __pinocchio_multibody_liegroup_liegroup_algo_hpp__

--- a/src/multibody/liegroup/liegroup-algo.hxx
+++ b/src/multibody/liegroup/liegroup-algo.hxx
@@ -224,8 +224,8 @@ namespace pinocchio
       typename LieGroupMap::template operation<JointModel>::type lgo;
       lgo.dIntegrateTransport(jmodel.jointConfigSelector  (q.derived()),
                               jmodel.jointVelocitySelector(v.derived()),
-                              jmodel.jointBlock(mat_in.derived()),
-                              jmodel.jointBlock(PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixOutType,mat_out)),
+                              jmodel.jointRows(mat_in.derived()),
+                              jmodel.jointRows(PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixOutType,mat_out)),
                               arg);
     }
   };

--- a/src/multibody/liegroup/liegroup-algo.hxx
+++ b/src/multibody/liegroup/liegroup-algo.hxx
@@ -262,10 +262,10 @@ namespace pinocchio
       typedef typename Visitor::LieGroupMap LieGroupMap;
       
       typename LieGroupMap::template operation<JointModel>::type lgo;
-      lgo.dIntegrateTransportInPlace(jmodel.jointConfigSelector  (q.derived()),
-                                     jmodel.jointVelocitySelector(v.derived()),
-                                     jmodel.jointRows(PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,mat)),
-                                     arg);
+      lgo.dIntegrateTransport(jmodel.jointConfigSelector  (q.derived()),
+                              jmodel.jointVelocitySelector(v.derived()),
+                              jmodel.jointRows(PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,mat)),
+                              arg);
     }
   };
   

--- a/src/multibody/liegroup/liegroup-algo.hxx
+++ b/src/multibody/liegroup/liegroup-algo.hxx
@@ -233,11 +233,11 @@ namespace pinocchio
   PINOCCHIO_DETAILS_DISPATCH_JOINT_COMPOSITE_5(dIntegrateTransportStepAlgo);
 
 
-  template<typename Visitor, typename JointModel> struct dIntegrateTransportStepAlgo;
+  template<typename Visitor, typename JointModel> struct dIntegrateTransportInPlaceStepAlgo;
   
   template<typename LieGroup_t, typename ConfigVectorIn, typename TangentVectorIn, typename JacobianMatrixType>
-  struct dIntegrateTransportStep
-  : public fusion::JointUnaryVisitorBase< dIntegrateTransportStep<LieGroup_t,ConfigVectorIn,TangentVectorIn,JacobianMatrixType> >
+  struct dIntegrateTransportInPlaceStep
+  : public fusion::JointUnaryVisitorBase< dIntegrateTransportInPlaceStep<LieGroup_t,ConfigVectorIn,TangentVectorIn,JacobianMatrixType> >
   {
     typedef boost::fusion::vector<const ConfigVectorIn &,
                                   const TangentVectorIn &,
@@ -245,11 +245,12 @@ namespace pinocchio
                                   const ArgumentPosition &
                                   > ArgsType;
     
-    PINOCCHIO_DETAILS_VISITOR_METHOD_ALGO_4(dIntegrateTransportStepAlgo, dIntegrateTransportStep)
+    PINOCCHIO_DETAILS_VISITOR_METHOD_ALGO_4(dIntegrateTransportInPlaceStepAlgo,
+                                            dIntegrateTransportInPlaceStep)
   };
   
   template<typename Visitor, typename JointModel>
-  struct dIntegrateTransportStepAlgo
+  struct dIntegrateTransportInPlaceStepAlgo
   {
     template<typename ConfigVectorIn, typename TangentVector, typename JacobianMatrixType>
     static void run(const JointModelBase<JointModel> & jmodel,
@@ -261,14 +262,14 @@ namespace pinocchio
       typedef typename Visitor::LieGroupMap LieGroupMap;
       
       typename LieGroupMap::template operation<JointModel>::type lgo;
-      lgo.dIntegrateTransport(jmodel.jointConfigSelector  (q.derived()),
-                              jmodel.jointVelocitySelector(v.derived()),
-                              jmodel.jointRows(PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,mat)),
-                              arg);
+      lgo.dIntegrateTransportInPlace(jmodel.jointConfigSelector  (q.derived()),
+                                     jmodel.jointVelocitySelector(v.derived()),
+                                     jmodel.jointRows(PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,mat)),
+                                     arg);
     }
   };
   
-  PINOCCHIO_DETAILS_DISPATCH_JOINT_COMPOSITE_4(dIntegrateTransportStepAlgo);
+  PINOCCHIO_DETAILS_DISPATCH_JOINT_COMPOSITE_4(dIntegrateTransportInPlaceStepAlgo);
   
   template<typename Visitor, typename JointModel> struct dDifferenceStepAlgo;
   

--- a/src/multibody/liegroup/liegroup-algo.hxx
+++ b/src/multibody/liegroup/liegroup-algo.hxx
@@ -1,9 +1,9 @@
 //
-// Copyright (c) 2018-2019 CNRS INRIA
+// Copyright (c) 2018-2020 CNRS INRIA
 //
 
-#ifndef __pinocchio_lie_group_algo_hxx__
-#define __pinocchio_lie_group_algo_hxx__
+#ifndef __pinocchio_multibody_liegroup_liegroup_algo_hxx__
+#define __pinocchio_multibody_liegroup_liegroup_algo_hxx__
 
 #include "pinocchio/multibody/visitor.hpp"
 #include "pinocchio/multibody/joint/joint-composite.hpp"
@@ -601,4 +601,4 @@ namespace pinocchio
   
 }
 
-#endif // ifndef __pinocchio_lie_group_algo_hxx__
+#endif // ifndef __pinocchio_multibody_liegroup_liegroup_algo_hxx__

--- a/src/multibody/liegroup/liegroup-algo.hxx
+++ b/src/multibody/liegroup/liegroup-algo.hxx
@@ -191,6 +191,46 @@ namespace pinocchio
   };
   
   PINOCCHIO_DETAILS_DISPATCH_JOINT_COMPOSITE_5(dIntegrateStepAlgo);
+
+  template<typename Visitor, typename JointModel> struct dIntegrateTransportStepAlgo;
+  
+  template<typename LieGroup_t, typename ConfigVectorIn, typename TangentVectorIn, typename JacobianMatrixTypeIn, typename JacobianMatrixTypeOut>
+  struct dIntegrateTransportStep
+  : public fusion::JointUnaryVisitorBase< dIntegrateTransportStep<LieGroup_t,ConfigVectorIn,TangentVectorIn,JacobianMatrixTypeIn,JacobianMatrixTypeOut> >
+  {
+    typedef boost::fusion::vector<const ConfigVectorIn &,
+                                  const TangentVectorIn &,
+                                  JacobianMatrixTypeIn &,
+                                  JacobianMatrixTypeOut &,
+                                  const ArgumentPosition &
+                                  > ArgsType;
+    
+    PINOCCHIO_DETAILS_VISITOR_METHOD_ALGO_5(dIntegrateTransportStepAlgo, dIntegrateTransportStep)
+  };
+  
+  template<typename Visitor, typename JointModel>
+  struct dIntegrateTransportStepAlgo
+  {
+    template<typename ConfigVectorIn, typename TangentVector, typename JacobianMatrixInType, typename JacobianMatrixOutType>
+    static void run(const JointModelBase<JointModel> & jmodel,
+                    const Eigen::MatrixBase<ConfigVectorIn> & q,
+                    const Eigen::MatrixBase<TangentVector> & v,
+                    const Eigen::MatrixBase<JacobianMatrixInType> & mat_in,
+                    const Eigen::MatrixBase<JacobianMatrixOutType> & mat_out)
+    {
+      typedef typename Visitor::LieGroupMap LieGroupMap;
+      
+      typename LieGroupMap::template operation<JointModel>::type lgo;
+      lgo.dIntegrateTransport(jmodel.jointConfigSelector  (q.derived()),
+                              jmodel.jointVelocitySelector(v.derived()),
+                              jmodel.jointBlock(mat_in.derived()),
+                              jmodel.jointBlock(PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixOutType,mat_out)),
+                              arg);
+    }
+  };
+  
+  PINOCCHIO_DETAILS_DISPATCH_JOINT_COMPOSITE_5(dIntegrateTransportStepAlgo);
+
   
   template<typename Visitor, typename JointModel> struct dDifferenceStepAlgo;
   

--- a/src/multibody/liegroup/liegroup-algo.hxx
+++ b/src/multibody/liegroup/liegroup-algo.hxx
@@ -194,14 +194,14 @@ namespace pinocchio
 
   template<typename Visitor, typename JointModel> struct dIntegrateTransportStepAlgo;
   
-  template<typename LieGroup_t, typename ConfigVectorIn, typename TangentVectorIn, typename JacobianMatrixTypeIn, typename JacobianMatrixTypeOut>
+  template<typename LieGroup_t, typename ConfigVectorIn, typename TangentVectorIn, typename JacobianMatrixInType, typename JacobianMatrixOutType>
   struct dIntegrateTransportStep
-  : public fusion::JointUnaryVisitorBase< dIntegrateTransportStep<LieGroup_t,ConfigVectorIn,TangentVectorIn,JacobianMatrixTypeIn,JacobianMatrixTypeOut> >
+  : public fusion::JointUnaryVisitorBase< dIntegrateTransportStep<LieGroup_t,ConfigVectorIn,TangentVectorIn,JacobianMatrixInType,JacobianMatrixOutType> >
   {
     typedef boost::fusion::vector<const ConfigVectorIn &,
                                   const TangentVectorIn &,
-                                  JacobianMatrixTypeIn &,
-                                  JacobianMatrixTypeOut &,
+                                  const JacobianMatrixInType &,
+                                  JacobianMatrixOutType &,
                                   const ArgumentPosition &
                                   > ArgsType;
     
@@ -216,7 +216,8 @@ namespace pinocchio
                     const Eigen::MatrixBase<ConfigVectorIn> & q,
                     const Eigen::MatrixBase<TangentVector> & v,
                     const Eigen::MatrixBase<JacobianMatrixInType> & mat_in,
-                    const Eigen::MatrixBase<JacobianMatrixOutType> & mat_out)
+                    const Eigen::MatrixBase<JacobianMatrixOutType> & mat_out,
+                    const ArgumentPosition & arg)
     {
       typedef typename Visitor::LieGroupMap LieGroupMap;
       

--- a/src/multibody/liegroup/liegroup-algo.hxx
+++ b/src/multibody/liegroup/liegroup-algo.hxx
@@ -232,6 +232,43 @@ namespace pinocchio
   
   PINOCCHIO_DETAILS_DISPATCH_JOINT_COMPOSITE_5(dIntegrateTransportStepAlgo);
 
+
+  template<typename Visitor, typename JointModel> struct dIntegrateTransportInPlaceStepAlgo;
+  
+  template<typename LieGroup_t, typename ConfigVectorIn, typename TangentVectorIn, typename JacobianMatrixType>
+  struct dIntegrateTransportInPlaceStep
+  : public fusion::JointUnaryVisitorBase< dIntegrateTransportInPlaceStep<LieGroup_t,ConfigVectorIn,TangentVectorIn,JacobianMatrixType> >
+  {
+    typedef boost::fusion::vector<const ConfigVectorIn &,
+                                  const TangentVectorIn &,
+                                  JacobianMatrixType &,
+                                  const ArgumentPosition &
+                                  > ArgsType;
+    
+    PINOCCHIO_DETAILS_VISITOR_METHOD_ALGO_4(dIntegrateTransportInPlaceStepAlgo, dIntegrateTransportInPlaceStep)
+  };
+  
+  template<typename Visitor, typename JointModel>
+  struct dIntegrateTransportInPlaceStepAlgo
+  {
+    template<typename ConfigVectorIn, typename TangentVector, typename JacobianMatrixType>
+    static void run(const JointModelBase<JointModel> & jmodel,
+                    const Eigen::MatrixBase<ConfigVectorIn> & q,
+                    const Eigen::MatrixBase<TangentVector> & v,
+                    const Eigen::MatrixBase<JacobianMatrixType> & mat,
+                    const ArgumentPosition & arg)
+    {
+      typedef typename Visitor::LieGroupMap LieGroupMap;
+      
+      typename LieGroupMap::template operation<JointModel>::type lgo;
+      lgo.dIntegrateTransportInPlace(jmodel.jointConfigSelector  (q.derived()),
+                              jmodel.jointVelocitySelector(v.derived()),
+                              jmodel.jointRows(PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,mat)),
+                              arg);
+    }
+  };
+  
+  PINOCCHIO_DETAILS_DISPATCH_JOINT_COMPOSITE_4(dIntegrateTransportInPlaceStepAlgo);
   
   template<typename Visitor, typename JointModel> struct dDifferenceStepAlgo;
   

--- a/src/multibody/liegroup/liegroup-algo.hxx
+++ b/src/multibody/liegroup/liegroup-algo.hxx
@@ -233,11 +233,11 @@ namespace pinocchio
   PINOCCHIO_DETAILS_DISPATCH_JOINT_COMPOSITE_5(dIntegrateTransportStepAlgo);
 
 
-  template<typename Visitor, typename JointModel> struct dIntegrateTransportInPlaceStepAlgo;
+  template<typename Visitor, typename JointModel> struct dIntegrateTransportStepAlgo;
   
   template<typename LieGroup_t, typename ConfigVectorIn, typename TangentVectorIn, typename JacobianMatrixType>
-  struct dIntegrateTransportInPlaceStep
-  : public fusion::JointUnaryVisitorBase< dIntegrateTransportInPlaceStep<LieGroup_t,ConfigVectorIn,TangentVectorIn,JacobianMatrixType> >
+  struct dIntegrateTransportStep
+  : public fusion::JointUnaryVisitorBase< dIntegrateTransportStep<LieGroup_t,ConfigVectorIn,TangentVectorIn,JacobianMatrixType> >
   {
     typedef boost::fusion::vector<const ConfigVectorIn &,
                                   const TangentVectorIn &,
@@ -245,11 +245,11 @@ namespace pinocchio
                                   const ArgumentPosition &
                                   > ArgsType;
     
-    PINOCCHIO_DETAILS_VISITOR_METHOD_ALGO_4(dIntegrateTransportInPlaceStepAlgo, dIntegrateTransportInPlaceStep)
+    PINOCCHIO_DETAILS_VISITOR_METHOD_ALGO_4(dIntegrateTransportStepAlgo, dIntegrateTransportStep)
   };
   
   template<typename Visitor, typename JointModel>
-  struct dIntegrateTransportInPlaceStepAlgo
+  struct dIntegrateTransportStepAlgo
   {
     template<typename ConfigVectorIn, typename TangentVector, typename JacobianMatrixType>
     static void run(const JointModelBase<JointModel> & jmodel,
@@ -261,14 +261,14 @@ namespace pinocchio
       typedef typename Visitor::LieGroupMap LieGroupMap;
       
       typename LieGroupMap::template operation<JointModel>::type lgo;
-      lgo.dIntegrateTransportInPlace(jmodel.jointConfigSelector  (q.derived()),
+      lgo.dIntegrateTransport(jmodel.jointConfigSelector  (q.derived()),
                               jmodel.jointVelocitySelector(v.derived()),
                               jmodel.jointRows(PINOCCHIO_EIGEN_CONST_CAST(JacobianMatrixType,mat)),
                               arg);
     }
   };
   
-  PINOCCHIO_DETAILS_DISPATCH_JOINT_COMPOSITE_4(dIntegrateTransportInPlaceStepAlgo);
+  PINOCCHIO_DETAILS_DISPATCH_JOINT_COMPOSITE_4(dIntegrateTransportStepAlgo);
   
   template<typename Visitor, typename JointModel> struct dDifferenceStepAlgo;
   

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -161,6 +161,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      * @details This input and output has to be interpreted in terms of Lie group, not vector space:
      *          Thus, dIntegrate(q, v, J, arg) creates a manifold manifold M given by a small variation of the configuration vector or the tangent vector into the tangent space at identity.
      *          We are moving our input matrix onto this manifold M.
+     *
      * @param[in]  q    configuration vector.
      * @param[in]  v    tangent vector
      * @param[in]  Jin    the input matrix
@@ -182,6 +183,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      * @details This input and output has to be interpreted in terms of Lie group, not vector space:
      *          Thus, dIntegrate(q, v, J, ARG0) creates a manifold manifold M given by a small variation of the configuration vector into the tangent space at identity.
      *          We are moving our input matrix onto this manifold M.
+     *
      * @param[in]  q    configuration vector.
      * @param[in]  v    tangent vector
      * @param[in]  Jin    the input matrix
@@ -199,6 +201,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      * @details This input and output has to be interpreted in terms of Lie group, not vector space:
      *          Thus, dIntegrate(q, v, J, ARG1) creates a manifold manifold M given by a small variation of the tangent vector into the tangent space at identity.
      *          We are moving our input matrix onto this manifold M.
+     *
      * @param[in]  q    configuration vector.
      * @param[in]  v    tangent vector
      * @param[in]  Jin    the input matrix
@@ -218,6 +221,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      * @details This input and output has to be interpreted in terms of Lie group, not vector space:
      *          Thus, dIntegrate(q, v, J, arg) creates a manifold manifold M given by a small variation of the configuration vector or the tangent vector into the tangent space at identity.
      *          We are moving our input matrix onto this manifold M.
+     *
      * @param[in]  q    configuration vector.
      * @param[in]  v    tangent vector
      * @param[in,out]  J   the input matrix
@@ -225,7 +229,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      */
     
     template<class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransportInPlace(const Eigen::MatrixBase<Config_t >  & q,
+    void dIntegrateTransport(const Eigen::MatrixBase<Config_t >  & q,
                              const Eigen::MatrixBase<Tangent_t>  & v,
                              const Eigen::MatrixBase<Jacobian_t> & J,
                              const ArgumentPosition arg) const;
@@ -242,7 +246,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *
      */
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransportInPlace_dq(const Eigen::MatrixBase<Config_t >  & q,
+    void dIntegrateTransport_dq(const Eigen::MatrixBase<Config_t >  & q,
                                 const Eigen::MatrixBase<Tangent_t>  & v,
                                 const Eigen::MatrixBase<Jacobian_t> & J) const;
     /**
@@ -258,7 +262,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      * @param[out] Jout    Transported matrix
      */
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransportInPlace_dv(const Eigen::MatrixBase<Config_t >  & q,
+    void dIntegrateTransport_dv(const Eigen::MatrixBase<Config_t >  & q,
                                 const Eigen::MatrixBase<Tangent_t>  & v,
                                 const Eigen::MatrixBase<Jacobian_t> & J) const;
 

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -191,7 +191,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
     void dIntegrateTransport_dq(const Eigen::MatrixBase<Config_t >  & q,
                                 const Eigen::MatrixBase<Tangent_t>  & v,
-                                const Eigen::MatrixBase<Jacobianin_t> & Jin,
+                                const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                 const Eigen::MatrixBase<JacobianOut_t> & Jout) const;
     /**
      * @brief   Transport an input matrix to the manifold defined by the dIntegrate computation.

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -1,9 +1,9 @@
 //
-// Copyright (c) 2016-2019 CNRS INRIA
+// Copyright (c) 2016-2020 CNRS INRIA
 //
 
-#ifndef __pinocchio_lie_group_operation_base_hpp__
-#define __pinocchio_lie_group_operation_base_hpp__
+#ifndef __pinocchio_multibody_liegroup_liegroup_operation_base_hpp__
+#define __pinocchio_multibody_liegroup_liegroup_operation_base_hpp__
 
 #include "pinocchio/multibody/liegroup/fwd.hpp"
 
@@ -494,4 +494,4 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
 
 #include "pinocchio/multibody/liegroup/liegroup-base.hxx"
 
-#endif // ifndef __pinocchio_lie_group_operation_base_hpp__
+#endif // ifndef __pinocchio_multibody_liegroup_liegroup_operation_base_hpp__

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -156,20 +156,22 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
 
 
     /**
-     * @brief   Transport an input matrix to the manifold defined by the dIntegrate computation.
      *
-     * @details This input and output has to be interpreted in terms of Lie group, not vector space:
-     *          Thus, dIntegrate(q, v, J, arg) creates a manifold manifold M given by a small variation of the configuration vector or the tangent vector into the tangent space at identity.
-     *          We are moving our input matrix onto this manifold M.
+     * @brief   Transport a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the configuration or the velocity arguments.
      *
-     * @param[in]  q    configuration vector.
-     * @param[in]  v    tangent vector
+     * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
+     *          to the tangent space of \f$ q \f$.
+     *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
+     *          For Lie groups, its corresponds to the canonical vector field transportation.
+     *
+     * @param[in]  q        configuration vector.
+     * @param[in]  v        tangent vector
      * @param[in]  Jin    the input matrix
-     * @param[in] arg  ARG0 (resp. ARG1) to get the Jacobian with respect to q (resp. v).
+     * @param[in]  arg    argument with respect to which the differentiation is performed (ARG0 corresponding to q, and ARG1 to v)
      *
      * @param[out] Jout    Transported matrix
+     *
      */
-    
     template<class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
     void dIntegrateTransport(const Eigen::MatrixBase<Config_t >  & q,
                              const Eigen::MatrixBase<Tangent_t>  & v,
@@ -178,11 +180,13 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
                              const ArgumentPosition arg) const;
 
     /**
-     * @brief   Transport an input matrix to the manifold defined by the dIntegrate computation.
      *
-     * @details This input and output has to be interpreted in terms of Lie group, not vector space:
-     *          Thus, dIntegrate(q, v, J, ARG0) creates a manifold manifold M given by a small variation of the configuration vector into the tangent space at identity.
-     *          We are moving our input matrix onto this manifold M.
+     * @brief   Transport a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the configuration argument.
+     *
+     * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
+     *          to the tangent space of \f$ q \f$.
+     *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
+     *          For Lie groups, its corresponds to the canonical vector field transportation.
      *
      * @param[in]  q    configuration vector.
      * @param[in]  v    tangent vector
@@ -196,11 +200,13 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
                                 const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                 const Eigen::MatrixBase<JacobianOut_t> & Jout) const;
     /**
-     * @brief   Transport an input matrix to the manifold defined by the dIntegrate computation.
      *
-     * @details This input and output has to be interpreted in terms of Lie group, not vector space:
-     *          Thus, dIntegrate(q, v, J, ARG1) creates a manifold manifold M given by a small variation of the tangent vector into the tangent space at identity.
-     *          We are moving our input matrix onto this manifold M.
+     * @brief   Transport a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the velocity argument.
+     *
+     * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
+     *          to the tangent space of \f$ q \f$.
+     *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
+     *          For Lie groups, its corresponds to the canonical vector field transportation.
      *
      * @param[in]  q    configuration vector.
      * @param[in]  v    tangent vector
@@ -216,18 +222,19 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
   
 
     /**
-     * @brief   TransportInPlace an input matrix to the manifold defined by the dIntegrate computation.
      *
-     * @details This input and output has to be interpreted in terms of Lie group, not vector space:
-     *          Thus, dIntegrate(q, v, J, arg) creates a manifold manifold M given by a small variation of the configuration vector or the tangent vector into the tangent space at identity.
-     *          We are moving our input matrix onto this manifold M.
+     * @brief   Transport in place a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the configuration or the velocity arguments.
      *
-     * @param[in]  q    configuration vector.
-     * @param[in]  v    tangent vector
-     * @param[in,out]  J   the input matrix
-     * @param[in] arg  ARG0 (resp. ARG1) to get the Jacobian with respect to q (resp. v).
+     * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
+     *          to the tangent space of \f$ q \f$.
+     *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
+     *          For Lie groups, its corresponds to the canonical vector field transportation.
+     *
+     * @param[in]     q       configuration vector.
+     * @param[in]     v       tangent vector
+     * @param[in,out] J       the input matrix
+     * @param[in]     arg  argument with respect to which the differentiation is performed (ARG0 corresponding to q, and ARG1 to v)
      */
-    
     template<class Config_t, class Tangent_t, class Jacobian_t>
     void dIntegrateTransport(const Eigen::MatrixBase<Config_t >  & q,
                              const Eigen::MatrixBase<Tangent_t>  & v,
@@ -235,32 +242,39 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
                              const ArgumentPosition arg) const;
 
     /**
-     * @brief   Transportinplace an input matrix to the manifold defined by the dIntegrate computation.
      *
-     * @details This input and output has to be interpreted in terms of Lie group, not vector space:
-     *          Thus, dIntegrate(q, v, J, ARG0) creates a manifold manifold M given by a small variation of the configuration vector into the tangent space at identity.
-     *          We are moving our input matrix onto this manifold M.
+     * @brief   Transport in place a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the configuration argument.
+     *
+     * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
+     *          to the tangent space of \f$ q \f$.
+     *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
+     *          For Lie groups, its corresponds to the canonical vector field transportation.
+     *
      * @param[in]  q    configuration vector.
      * @param[in]  v    tangent vector
-     * @param[in,out]  J   the input matrix
+     * @param[in]  Jin    the input matrix
      *
-     */
+     * @param[out] Jout    Transported matrix
+    */
     template <class Config_t, class Tangent_t, class Jacobian_t>
     void dIntegrateTransport_dq(const Eigen::MatrixBase<Config_t >  & q,
                                 const Eigen::MatrixBase<Tangent_t>  & v,
                                 const Eigen::MatrixBase<Jacobian_t> & J) const;
     /**
-     * @brief   TransportInPlace an input matrix to the manifold defined by the dIntegrate computation.
      *
-     * @details This input and output has to be interpreted in terms of Lie group, not vector space:
-     *          Thus, dIntegrate(q, v, J, ARG1) creates a manifold manifold M given by a small variation of the tangent vector into the tangent space at identity.
-     *          We are moving our input matrix onto this manifold M.
+     * @brief   Transport in place a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the velocity argument.
+     *
+     * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
+     *          to the tangent space of \f$ q \f$.
+     *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
+     *          For Lie groups, its corresponds to the canonical vector field transportation.
+     *
      * @param[in]  q    configuration vector.
      * @param[in]  v    tangent vector
-     * @param[in,out]  J   the input matrix
+     * @param[in]  Jin    the input matrix
      *
      * @param[out] Jout    Transported matrix
-     */
+    */
     template <class Config_t, class Tangent_t, class Jacobian_t>
     void dIntegrateTransport_dv(const Eigen::MatrixBase<Config_t >  & q,
                                 const Eigen::MatrixBase<Tangent_t>  & v,

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -160,7 +160,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      * @brief   Transport a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the configuration or the velocity arguments.
      *
      * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
-     *          to the tangent space of \f$ q \f$.
+     *          to the tangent space at \f$ q \f$.
      *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
      *          For Lie groups, its corresponds to the canonical vector field transportation.
      *
@@ -184,7 +184,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      * @brief   Transport a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the configuration argument.
      *
      * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
-     *          to the tangent space of \f$ q \f$.
+     *          to the tangent space at \f$ q \f$.
      *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
      *          For Lie groups, its corresponds to the canonical vector field transportation.
      *
@@ -204,7 +204,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      * @brief   Transport a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the velocity argument.
      *
      * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
-     *          to the tangent space of \f$ q \f$.
+     *          to the tangent space at \f$ q \f$.
      *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
      *          For Lie groups, its corresponds to the canonical vector field transportation.
      *
@@ -226,7 +226,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      * @brief   Transport in place a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the configuration or the velocity arguments.
      *
      * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
-     *          to the tangent space of \f$ q \f$.
+     *          to the tangent space at \f$ q \f$.
      *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
      *          For Lie groups, its corresponds to the canonical vector field transportation.
      *
@@ -246,7 +246,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      * @brief   Transport in place a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the configuration argument.
      *
      * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
-     *          to the tangent space of \f$ q \f$.
+     *          to the tangent space at \f$ q \f$.
      *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
      *          For Lie groups, its corresponds to the canonical vector field transportation.
      *
@@ -265,7 +265,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      * @brief   Transport in place a matrix from the terminal to the originate tangent space of the integrate operation, with respect to the velocity argument.
      *
      * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
-     *          to the tangent space of \f$ q \f$.
+     *          to the tangent space at \f$ q \f$.
      *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
      *          For Lie groups, its corresponds to the canonical vector field transportation.
      *

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -154,6 +154,63 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
                        const Eigen::MatrixBase<JacobianOut_t> & J,
                        const AssignmentOperatorType op) const;
 
+
+    /**
+     * @brief   Transport an input matrix to the manifold defined by the dIntegrate computation.
+     *
+     * @details This input and output has to be interpreted in terms of Lie group, not vector space:
+     *          Thus, dIntegrate(q, v, J, arg) creates a manifold manifold M given by a small variation of the configuration vector or the tangent vector into the tangent space at identity.
+     *          We are moving our input matrix onto this manifold M.
+     * @param[in]  q    configuration vector.
+     * @param[in]  v    tangent vector
+     * @param[in]  J    the input matrix
+     * @param[in] arg  ARG0 (resp. ARG1) to get the Jacobian with respect to q (resp. v).
+     *
+     * @param[out] Jout    Transported matrix
+     */
+    
+    template<class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+    void dIntegrateTransport(const Eigen::MatrixBase<Config_t >  & q,
+                             const Eigen::MatrixBase<Tangent_t>  & v,
+                             const Eigen::MatrixBase<JacobianIn_t> & Jin,
+                             const Eigen::MatrixBase<JacobianOut_t> & Jout,
+                             const ArgumentPosition arg) const;
+
+    /**
+     * @brief   Transport an input matrix to the manifold defined by the dIntegrate computation.
+     *
+     * @details This input and output has to be interpreted in terms of Lie group, not vector space:
+     *          Thus, dIntegrate(q, v, J, ARG0) creates a manifold manifold M given by a small variation of the configuration vector into the tangent space at identity.
+     *          We are moving our input matrix onto this manifold M.
+     * @param[in]  q    configuration vector.
+     * @param[in]  v    tangent vector
+     * @param[in]  J    the input matrix
+     *
+     * @param[out] Jout    Transported matrix
+     */
+    template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+    void dIntegrateTransport_dq(const Eigen::MatrixBase<Config_t >  & q,
+                                const Eigen::MatrixBase<Tangent_t>  & v,
+                                const Eigen::MatrixBase<Jacobianin_t> & Jin,
+                                const Eigen::MatrixBase<JacobianOut_t> & Jout) const;
+    /**
+     * @brief   Transport an input matrix to the manifold defined by the dIntegrate computation.
+     *
+     * @details This input and output has to be interpreted in terms of Lie group, not vector space:
+     *          Thus, dIntegrate(q, v, J, ARG1) creates a manifold manifold M given by a small variation of the tangent vector into the tangent space at identity.
+     *          We are moving our input matrix onto this manifold M.
+     * @param[in]  q    configuration vector.
+     * @param[in]  v    tangent vector
+     * @param[in]  J    the input matrix
+     *
+     * @param[out] Jout    Transported matrix
+     */
+    template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+    void dIntegrateTransport_dv(const Eigen::MatrixBase<Config_t >  & q,
+                                const Eigen::MatrixBase<Tangent_t>  & v,
+                                const Eigen::MatrixBase<JacobianIn_t> & Jin,
+                                const Eigen::MatrixBase<JacobianOut_t> & Jout) const;
+    
     /**
      * @brief      Interpolation between two joint's configurations
      *

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -210,7 +210,58 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
                                 const Eigen::MatrixBase<Tangent_t>  & v,
                                 const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                 const Eigen::MatrixBase<JacobianOut_t> & Jout) const;
+  
+
+    /**
+     * @brief   TransportInPlace an input matrix to the manifold defined by the dIntegrate computation.
+     *
+     * @details This input and output has to be interpreted in terms of Lie group, not vector space:
+     *          Thus, dIntegrate(q, v, J, arg) creates a manifold manifold M given by a small variation of the configuration vector or the tangent vector into the tangent space at identity.
+     *          We are moving our input matrix onto this manifold M.
+     * @param[in]  q    configuration vector.
+     * @param[in]  v    tangent vector
+     * @param[in,out]  J   the input matrix
+     * @param[in] arg  ARG0 (resp. ARG1) to get the Jacobian with respect to q (resp. v).
+     */
     
+    template<class Config_t, class Tangent_t, class Jacobian_t>
+    void dIntegrateTransportInPlace(const Eigen::MatrixBase<Config_t >  & q,
+                             const Eigen::MatrixBase<Tangent_t>  & v,
+                             const Eigen::MatrixBase<Jacobian_t> & J,
+                             const ArgumentPosition arg) const;
+
+    /**
+     * @brief   Transportinplace an input matrix to the manifold defined by the dIntegrate computation.
+     *
+     * @details This input and output has to be interpreted in terms of Lie group, not vector space:
+     *          Thus, dIntegrate(q, v, J, ARG0) creates a manifold manifold M given by a small variation of the configuration vector into the tangent space at identity.
+     *          We are moving our input matrix onto this manifold M.
+     * @param[in]  q    configuration vector.
+     * @param[in]  v    tangent vector
+     * @param[in,out]  J   the input matrix
+     *
+     */
+    template <class Config_t, class Tangent_t, class Jacobian_t>
+    void dIntegrateTransportInPlace_dq(const Eigen::MatrixBase<Config_t >  & q,
+                                const Eigen::MatrixBase<Tangent_t>  & v,
+                                const Eigen::MatrixBase<Jacobian_t> & J) const;
+    /**
+     * @brief   TransportInPlace an input matrix to the manifold defined by the dIntegrate computation.
+     *
+     * @details This input and output has to be interpreted in terms of Lie group, not vector space:
+     *          Thus, dIntegrate(q, v, J, ARG1) creates a manifold manifold M given by a small variation of the tangent vector into the tangent space at identity.
+     *          We are moving our input matrix onto this manifold M.
+     * @param[in]  q    configuration vector.
+     * @param[in]  v    tangent vector
+     * @param[in,out]  J   the input matrix
+     *
+     * @param[out] Jout    Transported matrix
+     */
+    template <class Config_t, class Tangent_t, class Jacobian_t>
+    void dIntegrateTransportInPlace_dv(const Eigen::MatrixBase<Config_t >  & q,
+                                const Eigen::MatrixBase<Tangent_t>  & v,
+                                const Eigen::MatrixBase<Jacobian_t> & J) const;
+
     /**
      * @brief      Interpolation between two joint's configurations
      *

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -163,7 +163,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *          We are moving our input matrix onto this manifold M.
      * @param[in]  q    configuration vector.
      * @param[in]  v    tangent vector
-     * @param[in]  J    the input matrix
+     * @param[in]  Jin    the input matrix
      * @param[in] arg  ARG0 (resp. ARG1) to get the Jacobian with respect to q (resp. v).
      *
      * @param[out] Jout    Transported matrix
@@ -184,7 +184,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *          We are moving our input matrix onto this manifold M.
      * @param[in]  q    configuration vector.
      * @param[in]  v    tangent vector
-     * @param[in]  J    the input matrix
+     * @param[in]  Jin    the input matrix
      *
      * @param[out] Jout    Transported matrix
      */
@@ -201,7 +201,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *          We are moving our input matrix onto this manifold M.
      * @param[in]  q    configuration vector.
      * @param[in]  v    tangent vector
-     * @param[in]  J    the input matrix
+     * @param[in]  Jin    the input matrix
      *
      * @param[out] Jout    Transported matrix
      */

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -161,6 +161,9 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *
      * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
      *          to the tangent space at \f$ q \f$.
+   *          In other words, this functions transforms a tangent vector expressed at \f$ q \oplus v \f$ to a tangent vector expressed at \f$ q \f$, considering that the change of configuration between
+   *          \f$ q \oplus v \f$ and \f$ q \f$ may alter the value of this tangent vector.
+   *          A typical example of parallel transportation is the action operated by a rigid transformation \f$ M \in \text{SE}(3)\f$ on a spatial velocity \f$ v \in \text{se}(3)\f$.
      *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
      *          For Lie groups, its corresponds to the canonical vector field transportation.
      *
@@ -185,6 +188,9 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *
      * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
      *          to the tangent space at \f$ q \f$.
+   *          In other words, this functions transforms a tangent vector expressed at \f$ q \oplus v \f$ to a tangent vector expressed at \f$ q \f$, considering that the change of configuration between
+   *          \f$ q \oplus v \f$ and \f$ q \f$ may alter the value of this tangent vector.
+   *          A typical example of parallel transportation is the action operated by a rigid transformation \f$ M \in \text{SE}(3)\f$ on a spatial velocity \f$ v \in \text{se}(3)\f$.
      *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
      *          For Lie groups, its corresponds to the canonical vector field transportation.
      *
@@ -205,6 +211,9 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *
      * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
      *          to the tangent space at \f$ q \f$.
+   *          In other words, this functions transforms a tangent vector expressed at \f$ q \oplus v \f$ to a tangent vector expressed at \f$ q \f$, considering that the change of configuration between
+   *          \f$ q \oplus v \f$ and \f$ q \f$ may alter the value of this tangent vector.
+   *          A typical example of parallel transportation is the action operated by a rigid transformation \f$ M \in \text{SE}(3)\f$ on a spatial velocity \f$ v \in \text{se}(3)\f$.
      *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
      *          For Lie groups, its corresponds to the canonical vector field transportation.
      *
@@ -227,6 +236,9 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *
      * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
      *          to the tangent space at \f$ q \f$.
+   *          In other words, this functions transforms a tangent vector expressed at \f$ q \oplus v \f$ to a tangent vector expressed at \f$ q \f$, considering that the change of configuration between
+   *          \f$ q \oplus v \f$ and \f$ q \f$ may alter the value of this tangent vector.
+   *          A typical example of parallel transportation is the action operated by a rigid transformation \f$ M \in \text{SE}(3)\f$ on a spatial velocity \f$ v \in \text{se}(3)\f$.
      *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
      *          For Lie groups, its corresponds to the canonical vector field transportation.
      *
@@ -247,6 +259,9 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *
      * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
      *          to the tangent space at \f$ q \f$.
+   *          In other words, this functions transforms a tangent vector expressed at \f$ q \oplus v \f$ to a tangent vector expressed at \f$ q \f$, considering that the change of configuration between
+   *          \f$ q \oplus v \f$ and \f$ q \f$ may alter the value of this tangent vector.
+   *          A typical example of parallel transportation is the action operated by a rigid transformation \f$ M \in \text{SE}(3)\f$ on a spatial velocity \f$ v \in \text{se}(3)\f$.
      *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
      *          For Lie groups, its corresponds to the canonical vector field transportation.
      *
@@ -266,6 +281,9 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *
      * @details This function performs the parallel transportation of an input matrix whose columns are expressed in the tangent space of the integrated element \f$ q \oplus v \f$,
      *          to the tangent space at \f$ q \f$.
+   *          In other words, this functions transforms a tangent vector expressed at \f$ q \oplus v \f$ to a tangent vector expressed at \f$ q \f$, considering that the change of configuration between
+   *          \f$ q \oplus v \f$ and \f$ q \f$ may alter the value of this tangent vector.
+   *          A typical example of parallel transportation is the action operated by a rigid transformation \f$ M \in \text{SE}(3)\f$ on a spatial velocity \f$ v \in \text{se}(3)\f$.
      *          In the context of configuration spaces assimilated as vectorial spaces, this operation corresponds to Identity.
      *          For Lie groups, its corresponds to the canonical vector field transportation.
      *

--- a/src/multibody/liegroup/liegroup-base.hxx
+++ b/src/multibody/liegroup/liegroup-base.hxx
@@ -87,7 +87,61 @@ namespace pinocchio {
                                  PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J),
                                  op);
   }
+  
 
+  template <class Derived>
+  template<class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+  void LieGroupBase<Derived>::dIntegrateTransport(const Eigen::MatrixBase<Config_t >  & q,
+                                                  const Eigen::MatrixBase<Tangent_t>  & v,
+                                                  const Eigen::MatrixBase<JacobianIn_t> & Jin,
+                                                  const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+  {
+    assert((arg==ARG0||arg==ARG1) && "arg should be either ARG0 or ARG1");
+    
+    switch (arg) {
+    case ARG0:
+      dIntegrateTransport_dq(q.derived(),v.derived(),Jin.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout)); return;
+    case ARG1:
+      dIntegrateTransport_dv(q.derived(),v.derived(),Jin.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout)); return;
+    default: return;
+    }
+  }
+
+  template <class Derived>
+  template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+  void LieGroupBase<Derived>::dIntegrateTransport_dq(
+      const Eigen::MatrixBase<Config_t >  & q,
+      const Eigen::MatrixBase<Tangent_t>  & v,
+      const Eigen::MatrixBase<JacobianIn_t> & Jin,
+      const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+  {
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Config_t     , ConfigVector_t);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Tangent_t    , TangentVector_t);
+    //EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(JacobianOut_t, JacobianMatrix_t);
+    derived().dIntegrateTransport_dq_impl(q.derived(),
+                                          v.derived(),
+                                          Jin.derived(),
+                                          PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout));
+  }
+
+  template <class Derived>
+  template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+  void LieGroupBase<Derived>::dIntegrateTransport_dv(
+      const Eigen::MatrixBase<Config_t >  & q,
+      const Eigen::MatrixBase<Tangent_t>  & v,
+      const Eigen::MatrixBase<JacobianIn_t> & Jin,
+      const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+  {
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Config_t     , ConfigVector_t);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Tangent_t    , TangentVector_t);
+    //EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(JacobianOut_t, JacobianMatrix_t);
+    derived().dIntegrateTransport_dq_impl(q.derived(),
+                                          v.derived(),
+                                          Jin.derived(),
+                                          PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout));
+  }
+
+  
   /**
    * @brief      Interpolation between two joint's configurations
    *

--- a/src/multibody/liegroup/liegroup-base.hxx
+++ b/src/multibody/liegroup/liegroup-base.hxx
@@ -48,9 +48,13 @@ namespace pinocchio {
     
     switch (arg) {
       case ARG0:
-        dIntegrate_dq(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J),op); return;
+        dIntegrate_dq(q.derived(),v.derived(),
+                      PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J),op);
+        return;
       case ARG1:
-        dIntegrate_dv(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J),op); return;
+        dIntegrate_dv(q.derived(),v.derived(),
+                      PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J),op);
+        return;
       default: return;
     }
   }
@@ -90,8 +94,8 @@ namespace pinocchio {
 
   template <class Derived>
   template<class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-  void LieGroupBase<Derived>::dIntegrateTransport(const Eigen::MatrixBase<Config_t >  & q,
-                                                  const Eigen::MatrixBase<Tangent_t>  & v,
+  void LieGroupBase<Derived>::dIntegrateTransport(const Eigen::MatrixBase<Config_t > & q,
+                                                  const Eigen::MatrixBase<Tangent_t> & v,
                                                   const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                                   const Eigen::MatrixBase<JacobianOut_t> & Jout,
                                                   const ArgumentPosition arg) const
@@ -99,21 +103,25 @@ namespace pinocchio {
     assert((arg==ARG0||arg==ARG1) && "arg should be either ARG0 or ARG1");
     
     switch (arg) {
-    case ARG0:
-      dIntegrateTransport_dq(q.derived(),v.derived(),Jin.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout)); return;
-    case ARG1:
-      dIntegrateTransport_dv(q.derived(),v.derived(),Jin.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout)); return;
-    default: return;
+      case ARG0:
+        dIntegrateTransport_dq(q.derived(),v.derived(),Jin.derived(),
+                               PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout));
+        return;
+      case ARG1:
+        dIntegrateTransport_dv(q.derived(),v.derived(),Jin.derived(),
+                               PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout));
+        return;
+      default:
+        return;
     }
   }
 
   template <class Derived>
   template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-  void LieGroupBase<Derived>::dIntegrateTransport_dq(
-      const Eigen::MatrixBase<Config_t >  & q,
-      const Eigen::MatrixBase<Tangent_t>  & v,
-      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-      const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+  void LieGroupBase<Derived>::dIntegrateTransport_dq(const Eigen::MatrixBase<Config_t > & q,
+                                                     const Eigen::MatrixBase<Tangent_t> & v,
+                                                     const Eigen::MatrixBase<JacobianIn_t> & Jin,
+                                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
   {
     EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Config_t     , ConfigVector_t);
     EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Tangent_t    , TangentVector_t);
@@ -126,11 +134,10 @@ namespace pinocchio {
 
   template <class Derived>
   template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-  void LieGroupBase<Derived>::dIntegrateTransport_dv(
-      const Eigen::MatrixBase<Config_t >  & q,
-      const Eigen::MatrixBase<Tangent_t>  & v,
-      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-      const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+  void LieGroupBase<Derived>::dIntegrateTransport_dv(const Eigen::MatrixBase<Config_t >  & q,
+                                                     const Eigen::MatrixBase<Tangent_t>  & v,
+                                                     const Eigen::MatrixBase<JacobianIn_t> & Jin,
+                                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
   {
     EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Config_t     , ConfigVector_t);
     EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Tangent_t    , TangentVector_t);
@@ -144,7 +151,7 @@ namespace pinocchio {
 
   template <class Derived>
   template<class Config_t, class Tangent_t, class Jacobian_t>
-  void LieGroupBase<Derived>::dIntegrateTransportInPlace(const Eigen::MatrixBase<Config_t >  & q,
+  void LieGroupBase<Derived>::dIntegrateTransport(const Eigen::MatrixBase<Config_t >  & q,
                                                   const Eigen::MatrixBase<Tangent_t>  & v,
                                                   const Eigen::MatrixBase<Jacobian_t> & J,
                                                   const ArgumentPosition arg) const
@@ -152,17 +159,22 @@ namespace pinocchio {
     assert((arg==ARG0||arg==ARG1) && "arg should be either ARG0 or ARG1");
     
     switch (arg) {
-    case ARG0:
-      dIntegrateTransportInPlace_dq(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J)); return;
-    case ARG1:
-      dIntegrateTransportInPlace_dv(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J)); return;
-    default: return;
+      case ARG0:
+        dIntegrateTransport_dq(q.derived(),v.derived(),
+                               PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J));
+        return;
+      case ARG1:
+        dIntegrateTransport_dv(q.derived(),v.derived(),
+                               PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J));
+        return;
+      default:
+        return;
     }
   }
 
   template <class Derived>
   template <class Config_t, class Tangent_t, class Jacobian_t>
-  void LieGroupBase<Derived>::dIntegrateTransportInPlace_dq(
+  void LieGroupBase<Derived>::dIntegrateTransport_dq(
       const Eigen::MatrixBase<Config_t >  & q,
       const Eigen::MatrixBase<Tangent_t>  & v,
       const Eigen::MatrixBase<Jacobian_t> & J) const
@@ -170,24 +182,23 @@ namespace pinocchio {
     EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Config_t     , ConfigVector_t);
     EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Tangent_t    , TangentVector_t);
     //EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(JacobianOut_t, JacobianMatrix_t);
-    derived().dIntegrateTransportInPlace_dq_impl(q.derived(),
+    derived().dIntegrateTransport_dq_impl(q.derived(),
                                           v.derived(),
                                           PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J));
   }
 
   template <class Derived>
   template <class Config_t, class Tangent_t, class Jacobian_t>
-  void LieGroupBase<Derived>::dIntegrateTransportInPlace_dv(
-      const Eigen::MatrixBase<Config_t >  & q,
-      const Eigen::MatrixBase<Tangent_t>  & v,
-      const Eigen::MatrixBase<Jacobian_t> & J) const
+  void LieGroupBase<Derived>::dIntegrateTransport_dv(const Eigen::MatrixBase<Config_t > & q,
+                                                     const Eigen::MatrixBase<Tangent_t> & v,
+                                                     const Eigen::MatrixBase<Jacobian_t> & J) const
   {
     EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Config_t     , ConfigVector_t);
     EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Tangent_t    , TangentVector_t);
     //EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(JacobianOut_t, JacobianMatrix_t);
-    derived().dIntegrateTransportInPlace_dv_impl(q.derived(),
-                                                 v.derived(),
-                                                 PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J));
+    derived().dIntegrateTransport_dv_impl(q.derived(),
+                                          v.derived(),
+                                          PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J));
   }
 
   /**

--- a/src/multibody/liegroup/liegroup-base.hxx
+++ b/src/multibody/liegroup/liegroup-base.hxx
@@ -87,7 +87,6 @@ namespace pinocchio {
                                  PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J),
                                  op);
   }
-  
 
   template <class Derived>
   template<class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>

--- a/src/multibody/liegroup/liegroup-base.hxx
+++ b/src/multibody/liegroup/liegroup-base.hxx
@@ -94,7 +94,8 @@ namespace pinocchio {
   void LieGroupBase<Derived>::dIntegrateTransport(const Eigen::MatrixBase<Config_t >  & q,
                                                   const Eigen::MatrixBase<Tangent_t>  & v,
                                                   const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                                  const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+                                                  const Eigen::MatrixBase<JacobianOut_t> & Jout,
+                                                  const ArgumentPosition arg) const
   {
     assert((arg==ARG0||arg==ARG1) && "arg should be either ARG0 or ARG1");
     

--- a/src/multibody/liegroup/liegroup-base.hxx
+++ b/src/multibody/liegroup/liegroup-base.hxx
@@ -136,7 +136,7 @@ namespace pinocchio {
     EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Config_t     , ConfigVector_t);
     EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Tangent_t    , TangentVector_t);
     //EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(JacobianOut_t, JacobianMatrix_t);
-    derived().dIntegrateTransport_dq_impl(q.derived(),
+    derived().dIntegrateTransport_dv_impl(q.derived(),
                                           v.derived(),
                                           Jin.derived(),
                                           PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout));

--- a/src/multibody/liegroup/liegroup-base.hxx
+++ b/src/multibody/liegroup/liegroup-base.hxx
@@ -1,9 +1,9 @@
 //
-// Copyright (c) 2016-2019 CNRS INRIA
+// Copyright (c) 2016-2020 CNRS INRIA
 //
 
-#ifndef __pinocchio_lie_group_operation_base_hxx__
-#define __pinocchio_lie_group_operation_base_hxx__
+#ifndef __pinocchio_multibody_liegroup_liegroup_operation_base_hxx__
+#define __pinocchio_multibody_liegroup_liegroup_operation_base_hxx__
 
 #include "pinocchio/macros.hpp"
 
@@ -463,4 +463,4 @@ namespace pinocchio {
 
 } // namespace pinocchio
 
-#endif // __pinocchio_lie_group_operation_base_hxx__
+#endif // __pinocchio_multibody_liegroup_liegroup_operation_base_hxx__

--- a/src/multibody/liegroup/liegroup-base.hxx
+++ b/src/multibody/liegroup/liegroup-base.hxx
@@ -141,7 +141,55 @@ namespace pinocchio {
                                           PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout));
   }
 
-  
+
+  template <class Derived>
+  template<class Config_t, class Tangent_t, class Jacobian_t>
+  void LieGroupBase<Derived>::dIntegrateTransportInPlace(const Eigen::MatrixBase<Config_t >  & q,
+                                                  const Eigen::MatrixBase<Tangent_t>  & v,
+                                                  const Eigen::MatrixBase<Jacobian_t> & J,
+                                                  const ArgumentPosition arg) const
+  {
+    assert((arg==ARG0||arg==ARG1) && "arg should be either ARG0 or ARG1");
+    
+    switch (arg) {
+    case ARG0:
+      dIntegrateTransportInPlace_dq(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J)); return;
+    case ARG1:
+      dIntegrateTransportInPlace_dv(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J)); return;
+    default: return;
+    }
+  }
+
+  template <class Derived>
+  template <class Config_t, class Tangent_t, class Jacobian_t>
+  void LieGroupBase<Derived>::dIntegrateTransportInPlace_dq(
+      const Eigen::MatrixBase<Config_t >  & q,
+      const Eigen::MatrixBase<Tangent_t>  & v,
+      const Eigen::MatrixBase<Jacobian_t> & J) const
+  {
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Config_t     , ConfigVector_t);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Tangent_t    , TangentVector_t);
+    //EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(JacobianOut_t, JacobianMatrix_t);
+    derived().dIntegrateTransportInPlace_dq_impl(q.derived(),
+                                          v.derived(),
+                                          PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J));
+  }
+
+  template <class Derived>
+  template <class Config_t, class Tangent_t, class Jacobian_t>
+  void LieGroupBase<Derived>::dIntegrateTransportInPlace_dv(
+      const Eigen::MatrixBase<Config_t >  & q,
+      const Eigen::MatrixBase<Tangent_t>  & v,
+      const Eigen::MatrixBase<Jacobian_t> & J) const
+  {
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Config_t     , ConfigVector_t);
+    EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(Tangent_t    , TangentVector_t);
+    //EIGEN_STATIC_ASSERT_SAME_VECTOR_SIZE(JacobianOut_t, JacobianMatrix_t);
+    derived().dIntegrateTransportInPlace_dv_impl(q.derived(),
+                                                 v.derived(),
+                                                 PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J));
+  }
+
   /**
    * @brief      Interpolation between two joint's configurations
    *

--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -236,9 +236,9 @@ namespace pinocchio
     }
 
     template <ArgumentPosition arg, class ConfigL_t, class ConfigR_t, class JacobianOut_t>
-    void dDifference_impl (const Eigen::MatrixBase<ConfigL_t> & q0,
-                           const Eigen::MatrixBase<ConfigR_t> & q1,
-                           const Eigen::MatrixBase<JacobianOut_t>& J) const
+    void dDifference_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+                          const Eigen::MatrixBase<ConfigR_t> & q1,
+                          const Eigen::MatrixBase<JacobianOut_t>& J) const
     {
       Matrix2 R0, R1; Vector2 t0, t1;
       forwardKinematics(R0, t0, q0);
@@ -378,15 +378,19 @@ namespace pinocchio
       Eigen::Matrix<Scalar,6,6> Jtmp6;
       Jexp6(nu, Jtmp6);
       
-      Jout.template topRows<2>().noalias() = Jtmp6.template topLeftCorner<2,2>() * Jin.template topRows<2>();
-      Jout.template topRows<2>().noalias() += Jtmp6.template topRightCorner<2,1>() * Jin.template bottomRows<1>();
-      Jout.template bottomRows<1>().noalias() = Jtmp6.template bottomLeftCorner<1,2>()* Jin.template topRows<2>();
-      Jout.template bottomRows<1>().noalias() += Jtmp6.template bottomRightCorner<1,1>() * Jin.template bottomRows<1>();
+      Jout.template topRows<2>().noalias()
+      = Jtmp6.template topLeftCorner<2,2>() * Jin.template topRows<2>();
+      Jout.template topRows<2>().noalias()
+      += Jtmp6.template topRightCorner<2,1>() * Jin.template bottomRows<1>();
+      Jout.template bottomRows<1>().noalias()
+      = Jtmp6.template bottomLeftCorner<1,2>()* Jin.template topRows<2>();
+      Jout.template bottomRows<1>().noalias()
+      += Jtmp6.template bottomRightCorner<1,1>() * Jin.template bottomRows<1>();
 
     }
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransportInPlace_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<Jacobian_t> & J) const
     {
@@ -396,7 +400,7 @@ namespace pinocchio
       exp(v, R, t);
 
       Vector2 tinv = (R.transpose() * t).reverse();
-      tinv[0] *= Scalar(-1.);
+      tinv[0] *= Scalar(-1);
       //TODO: Aliasing
       Jout.template topRows<2>() = R.transpose() * Jout.template topRows<2>();
       //No Aliasing
@@ -404,7 +408,7 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransportInPlace_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<Jacobian_t> & J) const
     {
@@ -414,33 +418,24 @@ namespace pinocchio
       Eigen::Matrix<Scalar,6,6> Jtmp6;
       Jexp6(nu, Jtmp6);
       //TODO: Remove aliasing
-      Jout.template topRows<2>() = Jtmp6.template topLeftCorner<2,2>() * Jout.template topRows<2>();
-      Jout.template topRows<2>().noalias() += Jtmp6.template topRightCorner<2,1>() * Jout.template bottomRows<1>();
-      Jout.template bottomRows<1>() = Jtmp6.template bottomRightCorner<1,1>() * Jout.template bottomRows<1>();
-      Jout.template bottomRows<1>().noalias() += Jtmp6.template bottomLeftCorner<1,2>()* Jout.template topRows<2>();
+      Jout.template topRows<2>()
+      = Jtmp6.template topLeftCorner<2,2>() * Jout.template topRows<2>();
+      Jout.template topRows<2>().noalias()
+      += Jtmp6.template topRightCorner<2,1>() * Jout.template bottomRows<1>();
+      Jout.template bottomRows<1>()
+      = Jtmp6.template bottomRightCorner<1,1>() * Jout.template bottomRows<1>();
+      Jout.template bottomRows<1>().noalias()
+      += Jtmp6.template bottomLeftCorner<1,2>() * Jout.template topRows<2>();
     }
 
-
-
-
-    // interpolate_impl use default implementation.
-    // template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
-    // static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
-                                 // const Eigen::MatrixBase<ConfigR_t> & q1,
-                                 // const Scalar& u,
-                                 // const Eigen::MatrixBase<ConfigOut_t>& qout)
-
-    // template <class ConfigL_t, class ConfigR_t>
-    // static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
-                                       // const Eigen::MatrixBase<ConfigR_t> & q1)
     template <class Config_t>
-    static void normalize_impl (const Eigen::MatrixBase<Config_t>& qout)
+    static void normalize_impl(const Eigen::MatrixBase<Config_t> & qout)
     {
       PINOCCHIO_EIGEN_CONST_CAST(Config_t,qout).template tail<2>().normalize();
     }
 
     template <class Config_t>
-    void random_impl (const Eigen::MatrixBase<Config_t>& qout) const
+    void random_impl(const Eigen::MatrixBase<Config_t> & qout) const
     {
       R2crossSO2_t().random(qout);
     }
@@ -656,7 +651,7 @@ namespace pinocchio
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
 
       switch(op)
-        {
+      {
         case SETTO:
           Jout = exp6(MotionRef<const Tangent_t>(v.derived())).toDualActionMatrix().transpose();
           break;
@@ -669,7 +664,7 @@ namespace pinocchio
         default:
           assert(false && "Wrong Op requesed value");
           break;
-        }      
+      }
     }
 
     template <class Config_t, class Tangent_t, class JacobianOut_t>
@@ -679,20 +674,20 @@ namespace pinocchio
                                    const AssignmentOperatorType op)
     {
       switch(op)
-        {
+      {
         case SETTO:
           Jexp6<SETTO>(MotionRef<const Tangent_t>(v.derived()), J.derived());
           break;
         case ADDTO:
-          Jexp6<ADDTO>(MotionRef<const Tangent_t>(v.derived()), J.derived());          
+          Jexp6<ADDTO>(MotionRef<const Tangent_t>(v.derived()), J.derived());
           break;
         case RMTO:
-          Jexp6<RMTO>(MotionRef<const Tangent_t>(v.derived()), J.derived());          
+          Jexp6<RMTO>(MotionRef<const Tangent_t>(v.derived()), J.derived());
           break;
         default:
           assert(false && "Wrong Op requesed value");
           break;
-        }      
+      }
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
@@ -705,9 +700,12 @@ namespace pinocchio
       Eigen::Matrix<Scalar,6,6> Jtmp6;
       Jtmp6 = exp6(MotionRef<const Tangent_t>(v.derived())).toDualActionMatrix().transpose();
       
-      Jout.template topRows<3>().noalias() = Jtmp6.template topLeftCorner<3,3>() * Jin.template topRows<3>();
-      Jout.template topRows<3>().noalias() += Jtmp6.template topRightCorner<3,3>() * Jin.template bottomRows<3>();
-      Jout.template bottomRows<3>().noalias() = Jtmp6.template bottomRightCorner<3,3>() * Jin.template bottomRows<3>();
+      Jout.template topRows<3>().noalias()
+      = Jtmp6.template topLeftCorner<3,3>() * Jin.template topRows<3>();
+      Jout.template topRows<3>().noalias()
+      += Jtmp6.template topRightCorner<3,3>() * Jin.template bottomRows<3>();
+      Jout.template bottomRows<3>().noalias()
+      = Jtmp6.template bottomRightCorner<3,3>() * Jin.template bottomRows<3>();
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
@@ -720,14 +718,17 @@ namespace pinocchio
       Eigen::Matrix<Scalar,6,6> Jtmp6;
       Jexp6<SETTO>(MotionRef<const Tangent_t>(v.derived()), Jtmp6);
 
-      Jout.template topRows<3>().noalias() = Jtmp6.template topLeftCorner<3,3>() * Jin.template topRows<3>();
-      Jout.template topRows<3>().noalias() += Jtmp6.template topRightCorner<3,3>() * Jin.template bottomRows<3>();
-      Jout.template bottomRows<3>().noalias() = Jtmp6.template bottomRightCorner<3,3>() * Jin.template bottomRows<3>();
+      Jout.template topRows<3>().noalias()
+      = Jtmp6.template topLeftCorner<3,3>() * Jin.template topRows<3>();
+      Jout.template topRows<3>().noalias()
+      += Jtmp6.template topRightCorner<3,3>() * Jin.template bottomRows<3>();
+      Jout.template bottomRows<3>().noalias()
+      = Jtmp6.template bottomRightCorner<3,3>() * Jin.template bottomRows<3>();
     }
 
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransportInPlace_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<Jacobian_t> & J_out) const
     {
@@ -736,13 +737,16 @@ namespace pinocchio
       Jtmp6 = exp6(MotionRef<const Tangent_t>(v.derived())).toDualActionMatrix().transpose();
 
       //Aliasing
-      Jout.template topRows<3>() = Jtmp6.template topLeftCorner<3,3>() * Jout.template topRows<3>();
-      Jout.template topRows<3>().noalias() += Jtmp6.template topRightCorner<3,3>() * Jout.template bottomRows<3>();
-      Jout.template bottomRows<3>() = Jtmp6.template bottomRightCorner<3,3>() * Jout.template bottomRows<3>();
+      Jout.template topRows<3>()
+      = Jtmp6.template topLeftCorner<3,3>() * Jout.template topRows<3>();
+      Jout.template topRows<3>().noalias()
+      += Jtmp6.template topRightCorner<3,3>() * Jout.template bottomRows<3>();
+      Jout.template bottomRows<3>()
+      = Jtmp6.template bottomRightCorner<3,3>() * Jout.template bottomRows<3>();
     }
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransportInPlace_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<Jacobian_t> & J_out) const
     {
@@ -750,21 +754,13 @@ namespace pinocchio
       Eigen::Matrix<Scalar,6,6> Jtmp6;
       Jexp6<SETTO>(MotionRef<const Tangent_t>(v.derived()), Jtmp6);
 
-      Jout.template topRows<3>() = Jtmp6.template topLeftCorner<3,3>() * Jout.template topRows<3>();
-      Jout.template topRows<3>().noalias() += Jtmp6.template topRightCorner<3,3>() * Jout.template bottomRows<3>();
-      Jout.template bottomRows<3>() = Jtmp6.template bottomRightCorner<3,3>() * Jout.template bottomRows<3>();
+      Jout.template topRows<3>()
+      = Jtmp6.template topLeftCorner<3,3>() * Jout.template topRows<3>();
+      Jout.template topRows<3>().noalias()
+      += Jtmp6.template topRightCorner<3,3>() * Jout.template bottomRows<3>();
+      Jout.template bottomRows<3>()
+      = Jtmp6.template bottomRightCorner<3,3>() * Jout.template bottomRows<3>();
     }
-
-    
-    
-    // interpolate_impl use default implementation.
-    // template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
-    // static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
-                                 // const Eigen::MatrixBase<ConfigR_t> & q1,
-                                 // const Scalar& u,
-                                 // const Eigen::MatrixBase<ConfigOut_t>& qout)
-    // {
-    // }
 
     template <class ConfigL_t, class ConfigR_t>
     static Scalar squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,

--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -348,7 +348,7 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & q,
+    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                      const Eigen::MatrixBase<JacobianOut_t> & J_out) const
@@ -658,7 +658,7 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & q,
+    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                      const Eigen::MatrixBase<JacobianOut_t> & J_out) const
@@ -673,7 +673,7 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & q,
+    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                      const Eigen::MatrixBase<JacobianOut_t> & J_out) const

--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -358,7 +358,7 @@ namespace pinocchio
       Vector2 t;
       exp(v, R, t);
 
-      typename PINOCCHIO_EIGEN_PLAIN_TYPE(Vector2Like) tinv((R.transpose() * t).reverse());
+      Vector2 tinv = (R.transpose() * t).reverse();
       tinv[0] *= Scalar(-1.);
 
       Jout.template topRows<2>().noalias() = R.transpose() * Jin.template topRows<2>();
@@ -381,7 +381,8 @@ namespace pinocchio
       Jout.template topRows<2>().noalias() = Jtmp6.template topLeftCorner<2,2>() * Jin.template topRows<2>();
       Jout.template topRows<2>().noalias() += Jtmp6.template topRightCorner<2,1>() * Jin.template bottomRows<1>();
       Jout.template bottomRows<1>().noalias() = Jtmp6.template bottomLeftCorner<1,2>()* Jin.template topRows<2>();
-      Jout.template bottomRows<1>().noalias() += Jtmp6.template bottomRightCorner<1,1>() * Jin.template bottomRows<1>();      
+      Jout.template bottomRows<1>().noalias() += Jtmp6.template bottomRightCorner<1,1>() * Jin.template bottomRows<1>();
+
     }
 
     // interpolate_impl use default implementation.
@@ -666,24 +667,24 @@ namespace pinocchio
       Eigen::Matrix<Scalar,6,6> Jtmp6;
       Jtmp6 = exp6(MotionRef<const Tangent_t>(v.derived())).toDualActionMatrix().transpose();
       
-      Jout.template topRows<3>().noalias = Jtmp6.template topLeftCorner<3,3>() * Jin.template topRows<3>();
-      Jout.template topRows<3>().noalias += Jtmp6.template topRightCorner<3,3>() * Jin.template bottomRows<3>();
-      Jout.template bottomRows<3>().noalias = Jtmp6.template bottomRightCorner<3,3>() * Jin.template bottomRows<3>();
+      Jout.template topRows<3>().noalias() = Jtmp6.template topLeftCorner<3,3>() * Jin.template topRows<3>();
+      Jout.template topRows<3>().noalias() += Jtmp6.template topRightCorner<3,3>() * Jin.template bottomRows<3>();
+      Jout.template bottomRows<3>().noalias() = Jtmp6.template bottomRightCorner<3,3>() * Jin.template bottomRows<3>();
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
     void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & q,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+                                     const Eigen::MatrixBase<JacobianOut_t> & J_out) const
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out);
       Eigen::Matrix<Scalar,6,6> Jtmp6;
       Jexp6<SETTO>(MotionRef<const Tangent_t>(v.derived()), Jtmp6);
 
-      Jout.template topRows<3>().noalias = Jtmp6.template topLeftCorner<3,3>() * Jin.template topRows<3>();
-      Jout.template topRows<3>().noalias += Jtmp6.template topRightCorner<3,3>() * Jin.template bottomRows<3>();
-      Jout.template bottomRows<3>().noalias = Jtmp6.template bottomRightCorner<3,3>() * Jin.template bottomRows<3>();
+      Jout.template topRows<3>().noalias() = Jtmp6.template topLeftCorner<3,3>() * Jin.template topRows<3>();
+      Jout.template topRows<3>().noalias() += Jtmp6.template topRightCorner<3,3>() * Jin.template bottomRows<3>();
+      Jout.template bottomRows<3>().noalias() = Jtmp6.template bottomRightCorner<3,3>() * Jin.template bottomRows<3>();
     }
 
     

--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -351,8 +351,19 @@ namespace pinocchio
     void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & q,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+                                     const Eigen::MatrixBase<JacobianOut_t> & J_out) const
     {
+      JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out);
+      Matrix2 R;
+      Vector2 t;
+      exp(v, R, t);
+
+      typename PINOCCHIO_EIGEN_PLAIN_TYPE(Vector2Like) tinv((R.transpose() * t).reverse());
+      tinv[0] *= Scalar(-1.);
+
+      Jout.template topRows<2>().noalias() = R.transpose() * Jin.template topRows<2>();
+      Jout.template topRows<2>().noalias() += tinv * Jin.template bottomRows<1>();
+      Jout.template bottomRows<1>() = Jin.template bottomRows<1>();
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
@@ -649,8 +660,15 @@ namespace pinocchio
     void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & q,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+                                     const Eigen::MatrixBase<JacobianOut_t> & J_out) const
     {
+      JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out);
+      Eigen::Matrix<Scalar,6,6> Jtmp6;
+      Jtmp6 = exp6(MotionRef<const Tangent_t>(v.derived())).toDualActionMatrix().transpose();
+      
+      Jout.template topRows<3>().noalias = Jtmp6.template topLeftCorner<3,3>() * Jin.template topRows<3>();
+      Jout.template topRows<3>().noalias += Jtmp6.template topRightCorner<3,3>() * Jin.template bottomRows<3>();
+      Jout.template bottomRows<3>().noalias = Jtmp6.template bottomRightCorner<3,3>() * Jin.template bottomRows<3>();
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
@@ -659,12 +677,13 @@ namespace pinocchio
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                      const Eigen::MatrixBase<JacobianOut_t> & Jout) const
     {
+      JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out);
       Eigen::Matrix<Scalar,6,6> Jtmp6;
       Jexp6<SETTO>(MotionRef<const Tangent_t>(v.derived()), Jtmp6);
 
       Jout.template topRows<3>().noalias = Jtmp6.template topLeftCorner<3,3>() * Jin.template topRows<3>();
       Jout.template topRows<3>().noalias += Jtmp6.template topRightCorner<3,3>() * Jin.template bottomRows<3>();
-      Jout.template bottomRows<3>().noalias += Jtmp6.template bottomRightCorner<3,3>() * Jin.template bottomRows<3>();
+      Jout.template bottomRows<3>().noalias = Jtmp6.template bottomRightCorner<3,3>() * Jin.template bottomRows<3>();
     }
 
     

--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -345,8 +345,22 @@ namespace pinocchio
           assert(false && "Wrong Op requesed value");
           break;
         }
+    }
 
-      
+    template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & q,
+                                     const Eigen::MatrixBase<Tangent_t> & v,
+                                     const Eigen::MatrixBase<JacobianIn_t> & Jin,
+                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+    {
+    }
+
+    template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & q,
+                                     const Eigen::MatrixBase<Tangent_t> & v,
+                                     const Eigen::MatrixBase<JacobianIn_t> & Jin,
+                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+    {
     }
 
     // interpolate_impl use default implementation.
@@ -621,6 +635,23 @@ namespace pinocchio
         }      
     }
 
+    template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & q,
+                                     const Eigen::MatrixBase<Tangent_t> & v,
+                                     const Eigen::MatrixBase<JacobianIn_t> & Jin,
+                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+    {
+    }
+
+    template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & q,
+                                     const Eigen::MatrixBase<Tangent_t> & v,
+                                     const Eigen::MatrixBase<JacobianIn_t> & Jin,
+                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+    {
+    }
+
+    
     // interpolate_impl use default implementation.
     // template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
     // static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,

--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -416,8 +416,8 @@ namespace pinocchio
       //TODO: Remove aliasing
       Jout.template topRows<2>() = Jtmp6.template topLeftCorner<2,2>() * Jout.template topRows<2>();
       Jout.template topRows<2>().noalias() += Jtmp6.template topRightCorner<2,1>() * Jout.template bottomRows<1>();
-      Jout.template bottomRows<1>().noalias() = Jtmp6.template bottomLeftCorner<1,2>()* Jout.template topRows<2>();
-      Jout.template bottomRows<1>() += Jtmp6.template bottomRightCorner<1,1>() * Jout.template bottomRows<1>();
+      Jout.template bottomRows<1>() = Jtmp6.template bottomRightCorner<1,1>() * Jout.template bottomRows<1>();
+      Jout.template bottomRows<1>().noalias() += Jtmp6.template bottomLeftCorner<1,2>()* Jout.template topRows<2>();
     }
 
 

--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -1,9 +1,9 @@
 //
-// Copyright (c) 2016-2019 CNRS INRIA
+// Copyright (c) 2016-2020 CNRS INRIA
 //
 
-#ifndef __pinocchio_special_euclidean_operation_hpp__
-#define __pinocchio_special_euclidean_operation_hpp__
+#ifndef __pinocchio_multibody_liegroup_special_euclidean_operation_hpp__
+#define __pinocchio_multibody_liegroup_special_euclidean_operation_hpp__
 
 #include <limits>
 
@@ -808,4 +808,4 @@ namespace pinocchio
 
 } // namespace pinocchio
 
-#endif // ifndef __pinocchio_special_euclidean_operation_hpp__
+#endif // ifndef __pinocchio_multibody_liegroup_special_euclidean_operation_hpp__

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -225,6 +225,7 @@ namespace pinocchio
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                      const Eigen::MatrixBase<JacobianOut_t> & Jout) const
     {
+      PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out) = Jin;
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
@@ -233,6 +234,7 @@ namespace pinocchio
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                      const Eigen::MatrixBase<JacobianOut_t> & Jout) const
     {
+      PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out) = Jin;
     }
     
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
@@ -443,7 +445,6 @@ namespace pinocchio
                                    const Eigen::MatrixBase<JacobianOut_t> & J,
                                    const AssignmentOperatorType op)
     {
-      
       switch(op)
         {
         case SETTO:
@@ -465,16 +466,23 @@ namespace pinocchio
     void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & q,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+                                     const Eigen::MatrixBase<JacobianOut_t> & J_out) const
     {
+      JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out);
+      const Matrix3 Jtmp3 = exp3(-v);
+      Jout.noalias() = Jtmp3 * Jin;
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
     void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & q,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+                                     const Eigen::MatrixBase<JacobianOut_t> & J_out) const
     {
+      JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out);
+      const Matrix3 Jtmp3 = exp3(-v);
+      Jexp3<SETTO>(v, Jtmp3);
+      Jout.noalias() = Jtmp3 * Jout;
     }
     
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -220,8 +220,8 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & q,
-                                     const Eigen::MatrixBase<Tangent_t> & v,
+    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+                                     const Eigen::MatrixBase<Tangent_t> & /*v*/,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                      const Eigen::MatrixBase<JacobianOut_t> & Jout) const
     {
@@ -229,8 +229,8 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & q,
-                                     const Eigen::MatrixBase<Tangent_t> & v,
+    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+                                     const Eigen::MatrixBase<Tangent_t> & /*v*/,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                      const Eigen::MatrixBase<JacobianOut_t> & Jout) const
     {
@@ -463,7 +463,7 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & q,
+    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                      const Eigen::MatrixBase<JacobianOut_t> & J_out) const
@@ -475,7 +475,7 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & q,
+    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                      const Eigen::MatrixBase<JacobianOut_t> & J_out) const
@@ -484,7 +484,7 @@ namespace pinocchio
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out);
       Matrix3 Jtmp3;
       Jexp3<SETTO>(v, Jtmp3);
-      Jout.noalias() = Jtmp3 * Jout;
+      Jout.noalias() = Jtmp3 * Jin;
     }
     
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -219,6 +219,22 @@ namespace pinocchio
         }      
     }
 
+    template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & q,
+                                     const Eigen::MatrixBase<Tangent_t> & v,
+                                     const Eigen::MatrixBase<JacobianIn_t> & Jin,
+                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+    {
+    }
+
+    template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & q,
+                                     const Eigen::MatrixBase<Tangent_t> & v,
+                                     const Eigen::MatrixBase<JacobianIn_t> & Jin,
+                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+    {
+    }
+    
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
     static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
                                  const Eigen::MatrixBase<ConfigR_t> & q1,
@@ -445,6 +461,22 @@ namespace pinocchio
         }      
     }
 
+    template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & q,
+                                     const Eigen::MatrixBase<Tangent_t> & v,
+                                     const Eigen::MatrixBase<JacobianIn_t> & Jin,
+                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+    {
+    }
+
+    template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & q,
+                                     const Eigen::MatrixBase<Tangent_t> & v,
+                                     const Eigen::MatrixBase<JacobianIn_t> & Jin,
+                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+    {
+    }
+    
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
     static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
                                  const Eigen::MatrixBase<ConfigR_t> & q1,

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -236,6 +236,18 @@ namespace pinocchio
     {
       PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout) = Jin;
     }
+
+    template <class Config_t, class Tangent_t, class Jacobian_t>
+    void dIntegrateTransportInPlace_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+                                     const Eigen::MatrixBase<Tangent_t> & /*v*/,
+                                     const Eigen::MatrixBase<Jacobian_t> & /*J*/) const {}
+
+    template <class Config_t, class Tangent_t, class Jacobian_t>
+    void dIntegrateTransportInPlace_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+                                     const Eigen::MatrixBase<Tangent_t> & /*v*/,
+                                     const Eigen::MatrixBase<Jacobian_t> & /*J*/) const {}
+    
+
     
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
     static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
@@ -486,6 +498,30 @@ namespace pinocchio
       Jexp3<SETTO>(v, Jtmp3);
       Jout.noalias() = Jtmp3 * Jin;
     }
+
+    template <class Config_t, class Tangent_t, class Jacobian_t>
+    void dIntegrateTransportInPlace_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+                                     const Eigen::MatrixBase<Tangent_t> & v,
+                                     const Eigen::MatrixBase<Jacobian_t> & J_out) const
+    {
+      typedef typename SE3::Matrix3 Matrix3;
+      Jacobian_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J_out);
+      const Matrix3 Jtmp3 = exp3(-v);
+      Jout = Jtmp3 * Jout;
+    }
+
+    template <class Config_t, class Tangent_t, class Jacobian_t>
+    void dIntegrateTransportInPlace_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+                                     const Eigen::MatrixBase<Tangent_t> & v,
+                                     const Eigen::MatrixBase<Jacobian_t> & J_out) const
+    {
+      typedef typename SE3::Matrix3 Matrix3;
+      Jacobian_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J_out);
+      Matrix3 Jtmp3;
+      Jexp3<SETTO>(v, Jtmp3);
+      Jout = Jtmp3 * Jout;
+    }
+
     
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
     static void interpolate_impl(const Eigen::MatrixBase<ConfigL_t> & q0,

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -2,8 +2,8 @@
 // Copyright (c) 2016-2020 CNRS INRIA
 //
 
-#ifndef __pinocchio_special_orthogonal_operation_hpp__
-#define __pinocchio_special_orthogonal_operation_hpp__
+#ifndef __pinocchio_multibody_liegroup_special_orthogonal_operation_hpp__
+#define __pinocchio_multibody_liegroup_special_orthogonal_operation_hpp__
 
 #include <limits>
 
@@ -581,4 +581,4 @@ namespace pinocchio
   
 } // namespace pinocchio
 
-#endif // ifndef __pinocchio_special_orthogonal_operation_hpp__
+#endif // ifndef __pinocchio_multibody_liegroup_special_orthogonal_operation_hpp__

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -238,12 +238,12 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransportInPlace_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & /*v*/,
                                      const Eigen::MatrixBase<Jacobian_t> & /*J*/) const {}
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransportInPlace_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & /*v*/,
                                      const Eigen::MatrixBase<Jacobian_t> & /*J*/) const {}
     
@@ -282,10 +282,6 @@ namespace pinocchio
       }
     }
 
-    // template <class ConfigL_t, class ConfigR_t>
-    // static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
-                                       // const Eigen::MatrixBase<ConfigR_t> & q1)
-    
     template <class Config_t>
     static void normalize_impl (const Eigen::MatrixBase<Config_t> & qout)
     {
@@ -306,8 +302,7 @@ namespace pinocchio
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
     void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> &,
                                   const Eigen::MatrixBase<ConfigR_t> &,
-                                  const Eigen::MatrixBase<ConfigOut_t> & qout)
-      const
+                                  const Eigen::MatrixBase<ConfigOut_t> & qout) const
     {
       random_impl(qout);
     }
@@ -452,8 +447,8 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class JacobianOut_t>
-    static void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
-                                   const Eigen::MatrixBase<Tangent_t>  & v,
+    static void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+                                   const Eigen::MatrixBase<Tangent_t> & v,
                                    const Eigen::MatrixBase<JacobianOut_t> & J,
                                    const AssignmentOperatorType op)
     {
@@ -500,7 +495,7 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransportInPlace_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<Jacobian_t> & J_out) const
     {
@@ -511,7 +506,7 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransportInPlace_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<Jacobian_t> & J_out) const
     {

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -225,7 +225,7 @@ namespace pinocchio
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                      const Eigen::MatrixBase<JacobianOut_t> & Jout) const
     {
-      PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out) = Jin;
+      PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout) = Jin;
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
@@ -234,7 +234,7 @@ namespace pinocchio
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                      const Eigen::MatrixBase<JacobianOut_t> & Jout) const
     {
-      PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out) = Jin;
+      PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout) = Jin;
     }
     
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
@@ -468,6 +468,7 @@ namespace pinocchio
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                      const Eigen::MatrixBase<JacobianOut_t> & J_out) const
     {
+      typedef typename SE3::Matrix3 Matrix3;
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out);
       const Matrix3 Jtmp3 = exp3(-v);
       Jout.noalias() = Jtmp3 * Jin;
@@ -479,8 +480,9 @@ namespace pinocchio
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
                                      const Eigen::MatrixBase<JacobianOut_t> & J_out) const
     {
+      typedef typename SE3::Matrix3 Matrix3;
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out);
-      const Matrix3 Jtmp3 = exp3(-v);
+      Matrix3 Jtmp3;
       Jexp3<SETTO>(v, Jtmp3);
       Jout.noalias() = Jtmp3 * Jout;
     }

--- a/src/multibody/liegroup/vector-space.hpp
+++ b/src/multibody/liegroup/vector-space.hpp
@@ -2,8 +2,8 @@
 // Copyright (c) 2016-2020 CNRS INRIA
 //
 
-#ifndef __pinocchio_vector_space_operation_hpp__
-#define __pinocchio_vector_space_operation_hpp__
+#ifndef __pinocchio_multibody_liegroup_vector_space_operation_hpp__
+#define __pinocchio_multibody_liegroup_vector_space_operation_hpp__
 
 #include "pinocchio/multibody/liegroup/liegroup-base.hpp"
 
@@ -223,4 +223,4 @@ namespace pinocchio
 
 } // namespace pinocchio
 
-#endif // ifndef __pinocchio_vector_space_operation_hpp__
+#endif // ifndef __pinocchio_multibody_liegroup_vector_space_operation_hpp__

--- a/src/multibody/liegroup/vector-space.hpp
+++ b/src/multibody/liegroup/vector-space.hpp
@@ -170,14 +170,14 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransportInPlace_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & /*v*/,
                                      const Eigen::MatrixBase<Jacobian_t> & /*J*/) const {}
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransportInPlace_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & /*v*/,
-                                     const Eigen::MatrixBase<Jacobian_t> & J) const {}
+                                     const Eigen::MatrixBase<Jacobian_t> & /*J*/) const {}
 
 
 

--- a/src/multibody/liegroup/vector-space.hpp
+++ b/src/multibody/liegroup/vector-space.hpp
@@ -151,6 +151,18 @@ namespace pinocchio
     }
 
 
+    template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+                                     const Eigen::MatrixBase<Tangent_t> & /*v*/,
+                                     const Eigen::MatrixBase<JacobianIn_t> & /*Jin*/,
+                                     const Eigen::MatrixBase<JacobianOut_t> & /*Jout*/) const {Jout = Jin}
+
+    template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
+    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & q,
+                                     const Eigen::MatrixBase<Tangent_t> & v,
+                                     const Eigen::MatrixBase<JacobianIn_t> & Jin,
+                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const {Jout = Jin}
+
     // template <class ConfigL_t, class ConfigR_t>
     // static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
                                        // const Eigen::MatrixBase<ConfigR_t> & q1)

--- a/src/multibody/liegroup/vector-space.hpp
+++ b/src/multibody/liegroup/vector-space.hpp
@@ -154,14 +154,20 @@ namespace pinocchio
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
     void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & /*v*/,
-                                     const Eigen::MatrixBase<JacobianIn_t> & /*Jin*/,
-                                     const Eigen::MatrixBase<JacobianOut_t> & /*Jout*/) const {Jout = Jin}
+                                     const Eigen::MatrixBase<JacobianIn_t> & Jin,
+                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+    {
+      PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout) = Jin;
+    }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & q,
-                                     const Eigen::MatrixBase<Tangent_t> & v,
+    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+                                     const Eigen::MatrixBase<Tangent_t> & /*v*/,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const {Jout = Jin}
+                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+    {
+      PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout) = Jin;
+    }
 
     // template <class ConfigL_t, class ConfigR_t>
     // static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,

--- a/src/multibody/liegroup/vector-space.hpp
+++ b/src/multibody/liegroup/vector-space.hpp
@@ -169,6 +169,18 @@ namespace pinocchio
       PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout) = Jin;
     }
 
+    template <class Config_t, class Tangent_t, class Jacobian_t>
+    void dIntegrateTransportInPlace_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+                                     const Eigen::MatrixBase<Tangent_t> & /*v*/,
+                                     const Eigen::MatrixBase<Jacobian_t> & /*J*/) const {}
+
+    template <class Config_t, class Tangent_t, class Jacobian_t>
+    void dIntegrateTransportInPlace_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+                                     const Eigen::MatrixBase<Tangent_t> & /*v*/,
+                                     const Eigen::MatrixBase<Jacobian_t> & J) const {}
+
+
+
     // template <class ConfigL_t, class ConfigR_t>
     // static double squaredDistance_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
                                        // const Eigen::MatrixBase<ConfigR_t> & q1)

--- a/unittest/joint-configurations.cpp
+++ b/unittest/joint-configurations.cpp
@@ -273,6 +273,20 @@ BOOST_AUTO_TEST_CASE ( dIntegrate_assignementop_test )
   dIntegrate(model,qs,vs,results[1],ARG1,RMTO);
   BOOST_CHECK(results[1].isApprox(results[2] - results[0]));
 
+  //Transport
+  std::vector<Eigen::MatrixXd> J(3,Eigen::MatrixXd::Zero(model.nv,2*model.nv));
+  J[1] = Eigen::MatrixXd::Random(model.nv, 2*model.nv);
+  J[2] = J[1];
+  dIntegrate(model,qs,vs,J[0],ARG0,SETTO);
+  dIntegrateTransport(model,qs,vs,J[2],J[1],ARG0);
+  BOOST_CHECK(results[1].isApprox(J[0] * J[2]));
+
+  J[1] = Eigen::MatrixXd::Random(model.nv, 2*model.nv);
+  J[2] = J[1];
+  J[0].setZero();
+  dIntegrate(model,qs,vs,J[0],ARG1,SETTO);
+  dIntegrateTransport(model,qs,vs,J[2],J[1],ARG1);
+  BOOST_CHECK(results[1].isApprox(J[0] * J[2]));  
 }
 
 BOOST_AUTO_TEST_CASE ( integrate_difference_test )

--- a/unittest/joint-configurations.cpp
+++ b/unittest/joint-configurations.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016-2019 CNRS INRIA
+// Copyright (c) 2016-2020 CNRS INRIA
 //
 
 #include "pinocchio/parsers/sample-models.hpp"

--- a/unittest/joint-configurations.cpp
+++ b/unittest/joint-configurations.cpp
@@ -300,10 +300,6 @@ BOOST_AUTO_TEST_CASE ( dIntegrate_assignementop_test )
   results[0].setZero();
   dIntegrate(model,qs,vs,results[0],ARG1,SETTO);
   dIntegrateTransportInPlace(model,qs,vs,J[1],ARG1);
-  std::cerr<<Eigen::MatrixXd(results[0].row(11))<<std::endl;
-  std::cerr<<Eigen::MatrixXd(J[0].row(11))<<std::endl;
-  std::cerr<<Eigen::MatrixXd(J[1].row(11))<<std::endl;
-  std::cerr<<J[1]-results[0] * J[0]<<std::endl;
   BOOST_CHECK(J[1].isApprox(results[0] * J[0]));  
 
 }

--- a/unittest/joint-configurations.cpp
+++ b/unittest/joint-configurations.cpp
@@ -274,18 +274,38 @@ BOOST_AUTO_TEST_CASE ( dIntegrate_assignementop_test )
   BOOST_CHECK(results[1].isApprox(results[2] - results[0]));
 
   //Transport
-  std::vector<Eigen::MatrixXd> J(3,Eigen::MatrixXd::Zero(model.nv,2*model.nv));
-  J[1] = Eigen::MatrixXd::Random(model.nv, 2*model.nv);
+  std::vector<Eigen::MatrixXd> J(2,Eigen::MatrixXd::Zero(model.nv,2*model.nv));
+  J[0] = Eigen::MatrixXd::Random(model.nv, 2*model.nv);
   results[0].setZero();
   dIntegrate(model,qs,vs,results[0],ARG0,SETTO);
-  dIntegrateTransport(model,qs,vs,J[1],J[2],ARG0);
-  BOOST_CHECK(J[2].isApprox(results[0] * J[1]));
+  dIntegrateTransport(model,qs,vs,J[0],J[1],ARG0);
+  BOOST_CHECK(J[1].isApprox(results[0] * J[0]));
 
-  J[1] = Eigen::MatrixXd::Random(model.nv, 2*model.nv);
+  J[0] = Eigen::MatrixXd::Random(model.nv, 2*model.nv);
   results[0].setZero();
   dIntegrate(model,qs,vs,results[0],ARG1,SETTO);
-  dIntegrateTransport(model,qs,vs,J[1],J[2],ARG1);
-  BOOST_CHECK(J[2].isApprox(results[0] * J[1]));  
+  dIntegrateTransport(model,qs,vs,J[0],J[1],ARG1);
+  BOOST_CHECK(J[1].isApprox(results[0] * J[0]));  
+
+  //TransportInPlace
+  J[1] = Eigen::MatrixXd::Random(model.nv, 2*model.nv);
+  J[0] = J[1];
+  results[0].setZero();
+  dIntegrate(model,qs,vs,results[0],ARG0,SETTO);
+  dIntegrateTransportInPlace(model,qs,vs,J[1],ARG0);
+  BOOST_CHECK(J[1].isApprox(results[0] * J[0]));
+
+  J[1] = Eigen::MatrixXd::Random(model.nv, 2*model.nv);
+  J[0] = J[1];
+  results[0].setZero();
+  dIntegrate(model,qs,vs,results[0],ARG1,SETTO);
+  dIntegrateTransportInPlace(model,qs,vs,J[1],ARG1);
+  std::cerr<<Eigen::MatrixXd(results[0].row(11))<<std::endl;
+  std::cerr<<Eigen::MatrixXd(J[0].row(11))<<std::endl;
+  std::cerr<<Eigen::MatrixXd(J[1].row(11))<<std::endl;
+  std::cerr<<J[1]-results[0] * J[0]<<std::endl;
+  BOOST_CHECK(J[1].isApprox(results[0] * J[0]));  
+
 }
 
 BOOST_AUTO_TEST_CASE ( integrate_difference_test )

--- a/unittest/joint-configurations.cpp
+++ b/unittest/joint-configurations.cpp
@@ -276,17 +276,16 @@ BOOST_AUTO_TEST_CASE ( dIntegrate_assignementop_test )
   //Transport
   std::vector<Eigen::MatrixXd> J(3,Eigen::MatrixXd::Zero(model.nv,2*model.nv));
   J[1] = Eigen::MatrixXd::Random(model.nv, 2*model.nv);
-  J[2] = J[1];
-  dIntegrate(model,qs,vs,J[0],ARG0,SETTO);
-  dIntegrateTransport(model,qs,vs,J[2],J[1],ARG0);
-  BOOST_CHECK(results[1].isApprox(J[0] * J[2]));
+  results[0].setZero();
+  dIntegrate(model,qs,vs,results[0],ARG0,SETTO);
+  dIntegrateTransport(model,qs,vs,J[1],J[2],ARG0);
+  BOOST_CHECK(J[2].isApprox(results[0] * J[1]));
 
   J[1] = Eigen::MatrixXd::Random(model.nv, 2*model.nv);
-  J[2] = J[1];
-  J[0].setZero();
-  dIntegrate(model,qs,vs,J[0],ARG1,SETTO);
-  dIntegrateTransport(model,qs,vs,J[2],J[1],ARG1);
-  BOOST_CHECK(results[1].isApprox(J[0] * J[2]));  
+  results[0].setZero();
+  dIntegrate(model,qs,vs,results[0],ARG1,SETTO);
+  dIntegrateTransport(model,qs,vs,J[1],J[2],ARG1);
+  BOOST_CHECK(J[2].isApprox(results[0] * J[1]));  
 }
 
 BOOST_AUTO_TEST_CASE ( integrate_difference_test )

--- a/unittest/joint-configurations.cpp
+++ b/unittest/joint-configurations.cpp
@@ -292,14 +292,14 @@ BOOST_AUTO_TEST_CASE ( dIntegrate_assignementop_test )
   J[0] = J[1];
   results[0].setZero();
   dIntegrate(model,qs,vs,results[0],ARG0,SETTO);
-  dIntegrateTransportInPlace(model,qs,vs,J[1],ARG0);
+  dIntegrateTransport(model,qs,vs,J[1],ARG0);
   BOOST_CHECK(J[1].isApprox(results[0] * J[0]));
 
   J[1] = Eigen::MatrixXd::Random(model.nv, 2*model.nv);
   J[0] = J[1];
   results[0].setZero();
   dIntegrate(model,qs,vs,results[0],ARG1,SETTO);
-  dIntegrateTransportInPlace(model,qs,vs,J[1],ARG1);
+  dIntegrateTransport(model,qs,vs,J[1],ARG1);
   BOOST_CHECK(J[1].isApprox(results[0] * J[0]));  
 
 }


### PR DESCRIPTION
This PR adds the signature corresponding to transport of an input matrix along the manifold defined by the dIntegrate, as discussed in https://github.com/stack-of-tasks/pinocchio/issues/1163