### PR TITLE
Deactivate unfixed warnings

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -115,6 +115,11 @@ IF(BUILD_PYTHON_INTERFACE)
   ADD_LIBRARY(${PYWRAP} SHARED ${${PYWRAP}_SOURCES} ${${PYWRAP}_HEADERS})
   ADD_DEPENDENCIES(python ${PYWRAP})
 
+  # Do not report:
+  #  -Wconversion as the BOOST_PYTHON_FUNCTION_OVERLOADS implicitly converts.
+  #  -Wcomment as latex equations have multi-line comments.
+  TARGET_COMPILE_OPTIONS(${PYWRAP} PRIVATE -Wno-conversion -Wno-comment)
+
   SET_TARGET_PROPERTIES(${PYWRAP} PROPERTIES VERSION ${PROJECT_VERSION})
   IF(BUILD_WITH_COMMIT_VERSION)
     TAG_LIBRARY_VERSION(${PYWRAP})

--- a/src/parsers/utils.hpp
+++ b/src/parsers/utils.hpp
@@ -50,7 +50,7 @@ namespace pinocchio
 
   /**
    * @brief      Retrieve the path of the file whose path is given in an url-format.
-   *             Currently convert from the folliwing patterns : package:// or file://
+   *             Currently convert from the following patterns : package:// or file://
    *
    * @param[in]  string          The path given in the url-format
    * @param[in]  package_dirs    A list of packages directories where to search for files 


### PR DESCRIPTION
This PR deactivates two kinds of warnings as they are unlikely to be fixed in code and may hide important warnings that are worth fixing:

- **Conversion:** In general, I am hesitant in deactivating this warning due to `double` to `int` conversion bugs. However, we get a ton of these warnings due to `BOOST_PYTHON_FUNCTION_OVERLOADS`.
- **Multi-line comment:** There are two sources (a) commented out macros that appear as multi-line comments and (b) Latex code.

This reduces our compiler warnings from at present 104 to 3.

The remaining warnings after this PR are:
```
In file included from ~/git/pinocchio/build/include/pinocchio/math/quaternion.hpp:11:0,
                 from ~/git/pinocchio/build/include/pinocchio/spatial/se3-tpl.hpp:12,
                 from ~/git/pinocchio/build/include/pinocchio/spatial/se3.hpp:44,
                 from ~/git/pinocchio/build/include/pinocchio/multibody/model.hpp:10,
                 from ~/git/pinocchio/build/include/pinocchio/algorithm/joint-configuration.hpp:8,
                 from ~/git/pinocchio/bindings/python/algorithm/expose-joints.cpp:6:
~/git/pinocchio/build/include/pinocchio/utils/static-if.hpp: In static member function ‘static pinocchio::internal::if_then_else_impl<condition_type, condition_type, ThenType, ElseType>::ReturnType pinocchio::internal::if_then_else_impl<condition_type, condition_type, ThenType, ElseType>::run(pinocchio::internal::ComparisonOperators, const condition_type&, const condition_type&, const ThenType&, const ElseType&) [with condition_type = double; ThenType = double; ElseType = double]’:
~/git/pinocchio/build/include/pinocchio/utils/static-if.hpp:71:7: warning: control reaches end of non-void function [-Wreturn-type]
       }
       ^
In file included from ~/git/pinocchio/build/include/pinocchio/spatial/explog.hpp:10:0,
                 from ~/git/pinocchio/build/include/pinocchio/bindings/python/spatial/explog.hpp:9,
                 from ~/git/pinocchio/bindings/python/spatial/expose-explog.cpp:6:
~/git/pinocchio/build/include/pinocchio/utils/static-if.hpp: In static member function ‘static pinocchio::internal::if_then_else_impl<condition_type, condition_type, ThenType, ElseType>::ReturnType pinocchio::internal::if_then_else_impl<condition_type, condition_type, ThenType, ElseType>::run(pinocchio::internal::ComparisonOperators, const condition_type&, const condition_type&, const ThenType&, const ElseType&) [with condition_type = double; ThenType = double; ElseType = double]’:
~/git/pinocchio/build/include/pinocchio/utils/static-if.hpp:71:7: warning: control reaches end of non-void function [-Wreturn-type]
       }
       ^
In file included from ~/git/pinocchio/build/include/pinocchio/math/quaternion.hpp:11:0,
                 from ~/git/pinocchio/build/include/pinocchio/spatial/se3-tpl.hpp:12,
                 from ~/git/pinocchio/build/include/pinocchio/spatial/se3.hpp:44,
                 from ~/git/pinocchio/build/include/pinocchio/bindings/python/spatial/se3.hpp:12,
                 from ~/git/pinocchio/bindings/python/spatial/expose-SE3.cpp:6:
~/git/pinocchio/build/include/pinocchio/utils/static-if.hpp: In static member function ‘static pinocchio::internal::if_then_else_impl<condition_type, condition_type, ThenType, ElseType>::ReturnType pinocchio::internal::if_then_else_impl<condition_type, condition_type, ThenType, ElseType>::run(pinocchio::internal::ComparisonOperators, const condition_type&, const condition_type&, const ThenType&, const ElseType&) [with condition_type = double; ThenType = double; ElseType = double]’:
~/git/pinocchio/build/include/pinocchio/utils/static-if.hpp:71:7: warning: control reaches end of non-void function [-Wreturn-type]
       }
       ^
```