### PR TITLE
Python bindings: add Panda3D based viewer

### DIFF
--- a/bindings/python/pinocchio/visualize/panda3d_visualizer.py
+++ b/bindings/python/pinocchio/visualize/panda3d_visualizer.py
@@ -1,4 +1,3 @@
-import multiprocessing
 import numpy as np
 import os
 import sys

--- a/bindings/python/pinocchio/visualize/panda3d_visualizer.py
+++ b/bindings/python/pinocchio/visualize/panda3d_visualizer.py
@@ -16,8 +16,10 @@ __all__ = ['Panda3dVisualizer', 'Panda3dViewer', 'ViewerClosedError']
 
 
 class Panda3dVisualizer(BaseVisualizer):
-    """A Pinocchio display using panda3d engine."""
 
+    """
+    A Pinocchio display using panda3d engine.
+    """
 
     def initViewer(self, viewer=None, load_model=False): # pylint: disable=arguments-differ
         """Init the viewer by attaching to / creating a GUI viewer."""

--- a/bindings/python/pinocchio/visualize/panda3d_visualizer.py
+++ b/bindings/python/pinocchio/visualize/panda3d_visualizer.py
@@ -17,7 +17,7 @@ __all__ = ['Panda3dVisualizer', 'Panda3dViewer', 'ViewerClosedError']
 
 class Panda3dVisualizer(BaseVisualizer):
     """A Pinocchio display using panda3d engine."""
-    
+
 
     def initViewer(self, viewer=None, load_model=False): # pylint: disable=arguments-differ
         """Init the viewer by attaching to / creating a GUI viewer."""

--- a/bindings/python/pinocchio/visualize/panda3d_visualizer.py
+++ b/bindings/python/pinocchio/visualize/panda3d_visualizer.py
@@ -33,14 +33,10 @@ class Panda3dVisualizer(BaseVisualizer):
             self.viewer = Panda3dViewer(window_title="python-pinocchio")
 
         if load_model:
-            self.loadViewerModel()
+            self.loadViewerModel(group_name=self.model.name)
 
-    def loadViewerModel(self, group_name='', color=None):
-        """Create the scene displaying the robot meshes in the viewer."""
-        # generate a unique group name if not specified
-        if not group_name:
-            group_name = str(uuid.uuid4())
-
+    def loadViewerModel(self, group_name, color=None):
+        """Create a group of nodes displaying the robot meshes in the viewer"""
         self.visual_group = group_name + "/visuals"
         self.collision_group = group_name + "/collisions"
 

--- a/bindings/python/pinocchio/visualize/panda3d_visualizer.py
+++ b/bindings/python/pinocchio/visualize/panda3d_visualizer.py
@@ -18,7 +18,7 @@ __all__ = ['Panda3dVisualizer', 'Panda3dViewer', 'ViewerClosedError']
 class Panda3dVisualizer(BaseVisualizer):
     """A Pinocchio display using panda3d engine."""
 
-    def initViewer(self, viewer=None, load_model=False):
+    def initViewer(self, viewer=None, load_model=False): # pylint: disable=arguments-differ
         """Init the viewer by attaching to / creating a GUI viewer."""
         self.visual_group = None
         self.collision_group = None
@@ -32,7 +32,7 @@ class Panda3dVisualizer(BaseVisualizer):
         if load_model:
             self.loadViewerModel(group_name=self.model.name)
 
-    def loadViewerModel(self, group_name, color=None):
+    def loadViewerModel(self, group_name, color=None): # pylint: disable=arguments-differ
         """Create a group of nodes displaying the robot meshes in the viewer."""
         self.visual_group = group_name + "/visuals"
         self.collision_group = group_name + "/collisions"

--- a/bindings/python/pinocchio/visualize/panda3d_visualizer.py
+++ b/bindings/python/pinocchio/visualize/panda3d_visualizer.py
@@ -17,6 +17,7 @@ __all__ = ['Panda3dVisualizer', 'Panda3dViewer', 'ViewerClosedError']
 
 class Panda3dVisualizer(BaseVisualizer):
     """A Pinocchio display using panda3d engine."""
+    
 
     def initViewer(self, viewer=None, load_model=False): # pylint: disable=arguments-differ
         """Init the viewer by attaching to / creating a GUI viewer."""

--- a/bindings/python/pinocchio/visualize/panda3d_visualizer.py
+++ b/bindings/python/pinocchio/visualize/panda3d_visualizer.py
@@ -1,12 +1,9 @@
 import numpy as np
-import os
-import sys
-import uuid
 import warnings
 
-from pinocchio import libpinocchio_pywrap as pin
-from pinocchio.visualize.base_visualizer import BaseVisualizer
-from pinocchio.utils import npToTuple
+from .. import libpinocchio_pywrap as pin
+from ..utils import npToTuple
+from .base_visualizer import BaseVisualizer
 
 try:
     import hppfcl

--- a/bindings/python/pinocchio/visualize/panda3d_visualizer.py
+++ b/bindings/python/pinocchio/visualize/panda3d_visualizer.py
@@ -1,0 +1,129 @@
+import multiprocessing
+import numpy as np
+import os
+import sys
+import uuid
+import warnings
+
+from pinocchio import libpinocchio_pywrap as pin
+from pinocchio.visualize.base_visualizer import BaseVisualizer
+from pinocchio.utils import npToTuple
+
+try:
+    import hppfcl
+    WITH_HPP_FCL_BINDINGS = True
+except:
+    WITH_HPP_FCL_BINDINGS = False
+
+from panda3d_viewer import Viewer as Panda3dViewer, ViewerClosedError
+
+__all__ = ['Panda3dVisualizer', 'Panda3dViewer', 'ViewerClosedError']
+
+
+class Panda3dVisualizer(BaseVisualizer):
+    """A Pinocchio display using panda3d engine."""
+    def initViewer(self, viewer=None, load_model=False):
+        """Init the viewer by attaching to / creating a GUI viewer."""
+        self.visual_group = None
+        self.collision_group = None
+        self.display_visuals = False
+        self.display_collisions = False
+        self.viewer = viewer
+
+        if viewer is None:
+            self.viewer = Panda3dViewer(window_title="python-pinocchio")
+
+        if load_model:
+            self.loadViewerModel()
+
+    def loadViewerModel(self, group_name='', color=None):
+        """Create the scene displaying the robot meshes in the viewer."""
+        # generate a unique group name if not specified
+        if not group_name:
+            group_name = str(uuid.uuid4())
+
+        self.visual_group = group_name + "/visuals"
+        self.collision_group = group_name + "/collisions"
+
+        self.viewer.append_group(self.visual_group)
+        self.viewer.append_group(self.collision_group)
+
+        def append(root, obj):
+            geom = obj.geometry
+            if WITH_HPP_FCL_BINDINGS and isinstance(geom, hppfcl.ShapeBase):
+                # append a primitive geometry
+                if isinstance(geom, hppfcl.Capsule):
+                    r, l = geom.radius, 2 * geom.halfLength
+                    self.viewer.append_capsule(root, obj.name, r, l)
+                elif isinstance(geom, hppfcl.Cylinder):
+                    r, l = geom.radius, 2 * geom.halfLength
+                    self.viewer.append_cylinder(root, obj.name, r, l)
+                elif isinstance(geom, hppfcl.Box):
+                    size = npToTuple(2. * geom.halfSide)
+                    self.viewer.append_box(root, obj.name, size)
+                elif isinstance(geom, hppfcl.Sphere):
+                    self.viewer.append_sphere(root, obj.name, geom.radius)
+                else:
+                    msg = "Unsupported geometry type for %s (%s)" % (
+                        obj.name, type(geom))
+                    warnings.warn(msg, category=UserWarning, stacklevel=2)
+                    return
+            else:
+                # append a mesh
+                scale = npToTuple(obj.meshScale)
+                self.viewer.append_mesh(root, obj.name, obj.meshPath, scale)
+
+            if obj.overrideMaterial:
+                rgba = npToTuple(obj.meshColor)
+                path = obj.meshTexturePath
+                self.viewer.set_material(root, obj.name, rgba, path)
+            elif color is not None:
+                self.viewer.set_material(root, obj.name, color)
+
+        self.displayVisuals(False)
+        self.displayCollisions(False)
+
+        for obj in self.visual_model.geometryObjects:
+            append(self.visual_group, obj)
+
+        for obj in self.collision_model.geometryObjects:
+            append(self.collision_group, obj)
+
+        self.displayVisuals(True)
+
+    def getViewerNodeName(self, geometry_object, geometry_type):
+        """Return the name of the geometry object inside the viewer."""
+        if geometry_type is pin.GeometryType.VISUAL:
+            return self.visual_group + '/' + geometry_object.name
+        elif geometry_type is pin.GeometryType.COLLISION:
+            return self.collision_group + '/' + geometry_object.name
+
+    def display(self, q):
+        """Display the robot at configuration q in the viewer by placing all the bodies."""
+        pin.forwardKinematics(self.model, self.data, q)
+
+        def move(group, model, data):
+            pin.updateGeometryPlacements(self.model, self.data, model, data)
+            name_pose_dict = {}
+            for obj in model.geometryObjects:
+                oMg = data.oMg[model.getGeometryId(obj.name)]
+                x, y, z, qx, qy, qz, qw = pin.SE3ToXYZQUATtuple(oMg)
+                name_pose_dict[obj.name] = (x, y, z), (qw, qx, qy, qz)
+            self.viewer.move_nodes(group, name_pose_dict)
+
+        if self.display_visuals:
+            move(self.visual_group, self.visual_model, self.visual_data)
+
+        if self.display_collisions:
+            move(self.collision_group, self.collision_model,
+                 self.collision_data)
+
+    def displayCollisions(self, visibility):
+        """Set whether to display collision objects or not."""
+        self.viewer.show_group(self.collision_group, visibility)
+        self.display_collisions = visibility
+
+    def displayVisuals(self, visibility):
+        """Set whether to display visual objects or not."""
+        self.viewer.show_group(self.visual_group, visibility)
+        self.display_visuals = visibility

--- a/bindings/python/pinocchio/visualize/panda3d_visualizer.py
+++ b/bindings/python/pinocchio/visualize/panda3d_visualizer.py
@@ -1,4 +1,3 @@
-import numpy as np
 import warnings
 
 from .. import libpinocchio_pywrap as pin
@@ -8,7 +7,7 @@ from .base_visualizer import BaseVisualizer
 try:
     import hppfcl
     WITH_HPP_FCL_BINDINGS = True
-except:
+except ImportError:
     WITH_HPP_FCL_BINDINGS = False
 
 from panda3d_viewer import Viewer as Panda3dViewer, ViewerClosedError
@@ -18,6 +17,7 @@ __all__ = ['Panda3dVisualizer', 'Panda3dViewer', 'ViewerClosedError']
 
 class Panda3dVisualizer(BaseVisualizer):
     """A Pinocchio display using panda3d engine."""
+
     def initViewer(self, viewer=None, load_model=False):
         """Init the viewer by attaching to / creating a GUI viewer."""
         self.visual_group = None
@@ -33,7 +33,7 @@ class Panda3dVisualizer(BaseVisualizer):
             self.loadViewerModel(group_name=self.model.name)
 
     def loadViewerModel(self, group_name, color=None):
-        """Create a group of nodes displaying the robot meshes in the viewer"""
+        """Create a group of nodes displaying the robot meshes in the viewer."""
         self.visual_group = group_name + "/visuals"
         self.collision_group = group_name + "/collisions"
 

--- a/bindings/python/pinocchio/visualize/panda3d_visualizer.py
+++ b/bindings/python/pinocchio/visualize/panda3d_visualizer.py
@@ -16,7 +16,6 @@ __all__ = ['Panda3dVisualizer', 'Panda3dViewer', 'ViewerClosedError']
 
 
 class Panda3dVisualizer(BaseVisualizer):
-
     """
     A Pinocchio display using panda3d engine.
     """

--- a/examples/panda3d-viewer-play.py
+++ b/examples/panda3d-viewer-play.py
@@ -15,7 +15,7 @@ sys.path.append(path)
 from example_robot_data import loadTalos
 
 # import visualizer
-from pinocchio.visualize.panda3d_visualizer import Panda3dVisualizer, Panda3dViewer
+from pinocchio.visualize.panda3d_visualizer import Panda3dVisualizer, ViewerClosedError
 
 talos = loadTalos()
 talos.setVisualizer(Panda3dVisualizer())

--- a/examples/panda3d-viewer-play.py
+++ b/examples/panda3d-viewer-play.py
@@ -20,7 +20,7 @@ from pinocchio.visualize.panda3d_visualizer import Panda3dVisualizer, ViewerClos
 talos = loadTalos()
 talos.setVisualizer(Panda3dVisualizer())
 talos.initViewer()
-talos.loadViewerModel(color=(1, 1, 1, 1))
+talos.loadViewerModel(group_name='talos', color=(1, 1, 1, 1))
 
 
 # Play a sample trajectory in a loop

--- a/examples/panda3d-viewer-play.py
+++ b/examples/panda3d-viewer-play.py
@@ -1,0 +1,53 @@
+# This examples shows how to load and move a robot in panda3d_viewer.
+# Note: this feature requires panda3d_viewer to be installed, this can be done using
+# pip install --user panda3d_viewer
+
+import pinocchio as pin
+pin.switchToNumpyMatrix()
+import numpy as np
+import sys
+
+from os.path import dirname, join, abspath
+
+# add path to the example-robot-data package
+path = join(dirname(dirname(abspath(__file__))), 'models', 'others', 'python')
+sys.path.append(path)
+from example_robot_data import loadTalos
+
+# import visualizer
+from pinocchio.visualize.panda3d_visualizer import Panda3dVisualizer, Panda3dViewer
+
+talos = loadTalos()
+talos.setVisualizer(Panda3dVisualizer())
+talos.initViewer()
+talos.loadViewerModel(color=(1, 1, 1, 1))
+
+
+# Play a sample trajectory in a loop
+def play_sample_trajectory():
+    update_rate = 60
+    cycle_time = 3
+    traj = np.repeat(talos.q0, cycle_time * update_rate, axis=1)
+    beta = np.linspace(0, 1, traj.shape[1])
+    traj[[2, 9, 10, 11, 22, 15, 16, 17, 30]] = (
+        0.39 + 0.685 * np.cos(beta),
+        -beta,
+        2.0 * beta,
+        -beta,
+        0.1 + beta * 1.56,
+        -beta,
+        2.0 * beta,
+        -beta,
+        -0.1 - beta * 1.56,
+    )
+
+    while True:
+        talos.play(traj, 1. / update_rate)
+        traj = np.flip(traj, 1)
+
+
+try:
+    play_sample_trajectory()
+except ViewerClosedError:
+    # an exception will be thrown when the window is closed
+    pass

--- a/examples/panda3d-viewer.py
+++ b/examples/panda3d-viewer.py
@@ -4,7 +4,6 @@
 
 import pinocchio as pin
 pin.switchToNumpyMatrix()
-import numpy as np
 import sys
 
 from os.path import dirname, join, abspath

--- a/examples/panda3d-viewer.py
+++ b/examples/panda3d-viewer.py
@@ -28,7 +28,7 @@ for i, load in enumerate(loaders):
     robot = load()
     robot.setVisualizer(Panda3dVisualizer())
     robot.initViewer(viewer=viewer)  # attach to a viewer's scene
-    robot.loadViewerModel(color=(1, 1, 1, 1))
+    robot.loadViewerModel(group_name=robot.model.name)
 
     q = robot.q0[:]
     q[1] = 3 - i

--- a/examples/panda3d-viewer.py
+++ b/examples/panda3d-viewer.py
@@ -1,0 +1,40 @@
+# This examples shows how to load several robots in panda3d_viewer.
+# Note: this feature requires panda3d_viewer to be installed, this can be done using
+# pip install --user panda3d_viewer
+
+import pinocchio as pin
+pin.switchToNumpyMatrix()
+import numpy as np
+import sys
+
+from os.path import dirname, join, abspath
+
+# add path to the example-robot-data package
+path = join(dirname(dirname(abspath(__file__))), 'models', 'others', 'python')
+sys.path.append(path)
+from example_robot_data import loadTalos, loadRomeo, loadICub, loadTiago
+from example_robot_data import loadSolo, loadHyQ, loadHector
+
+# import visualizer
+from pinocchio.visualize.panda3d_visualizer import Panda3dVisualizer, Panda3dViewer
+
+# open a GUI window
+viewer = Panda3dViewer(window_title='python-pinocchio')
+
+loaders = (loadTalos, loadRomeo, loadICub, loadTiago, loadSolo, loadHyQ,
+           loadHector)
+
+for i, load in enumerate(loaders):
+    robot = load()
+    robot.setVisualizer(Panda3dVisualizer())
+    robot.initViewer(viewer=viewer)  # attach to a viewer's scene
+    robot.loadViewerModel(color=(1, 1, 1, 1))
+
+    q = robot.q0[:]
+    q[1] = 3 - i
+    if load is loadRomeo:
+        q[2] = 0.87
+
+    robot.display(q)
+
+viewer.join()


### PR DESCRIPTION
Simple and efficient cross-platform visualizer based on [panda3d_viewer](https://github.com/ikalevatykh/panda3d_viewer).

This feature requires panda3d_viewer to be installed, this can be done using
`pip install --user panda3d_viewer`
