### PR TITLE
package.xml: Prepare for Ubuntu 20.04 / Python3

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<package format="2">
+<package format="3">
   <name>pinocchio</name>
   <version>2.4.2</version>
   <description>A fast and flexible implementation of Rigid Body Dynamics algorithms and their analytical derivatives.</description>

--- a/package.xml
+++ b/package.xml
@@ -14,8 +14,10 @@
   <build_depend>git</build_depend>
   <build_depend>doxygen</build_depend>
   <doc_depend>doxygen</doc_depend>
-  <depend>python</depend>
-  <depend>python-numpy</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 2">python</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 3">python3</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</depend>
+  <depend condition="$ROS_PYTHON_VERSION == 3">python3-numpy</depend>
   <depend>liburdfdom-dev</depend>
   <depend>eigen</depend>
   <depend>boost</depend>


### PR DESCRIPTION
This adds compatibility with Ubuntu 20.04 and distributions that default to Python 3.

Tested in a 20.04 CI. Does not work yet due to PkgConfig dependency for EigenPy in `bindings/python/CMakeLists.txt`.