### PR TITLE
fix API changes in #1169

### DIFF
--- a/bindings/python/algorithm/expose-joints.cpp
+++ b/bindings/python/algorithm/expose-joints.cpp
@@ -30,8 +30,8 @@ namespace pinocchio
       Eigen::MatrixXd J0(Eigen::MatrixXd::Zero(model.nv,model.nv));
       Eigen::MatrixXd J1(Eigen::MatrixXd::Zero(model.nv,model.nv));
 
-      dIntegrate(model,q,v,J0,ARG0,SETTO);
-      dIntegrate(model,q,v,J1,ARG1,SETTO);
+      dIntegrate(model,q,v,J0,ARG0);
+      dIntegrate(model,q,v,J1,ARG1);
 
       return bp::make_tuple(J0,J1);
     }

--- a/src/algorithm/joint-configuration.hpp
+++ b/src/algorithm/joint-configuration.hpp
@@ -284,7 +284,7 @@ namespace pinocchio
                   const Eigen::MatrixBase<TangentVectorType> & v,
                   const Eigen::MatrixBase<JacobianMatrixType> & J,
                   const ArgumentPosition arg,
-                  const AssignmentOperatorType op);
+                  const AssignmentOperatorType op=SETTO);
 
   /**
    *

--- a/src/multibody/liegroup/cartesian-product.hpp
+++ b/src/multibody/liegroup/cartesian-product.hpp
@@ -126,7 +126,7 @@ namespace pinocchio
     void dIntegrate_dq_impl(const Eigen::MatrixBase<Config_t > & q,
                             const Eigen::MatrixBase<Tangent_t> & v,
                             const Eigen::MatrixBase<JacobianOut_t> & J,
-                            const AssignmentOperatorType op) const
+                            const AssignmentOperatorType op=SETTO) const
     {
       switch(op)
         {
@@ -154,7 +154,7 @@ namespace pinocchio
     void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t > & q,
                             const Eigen::MatrixBase<Tangent_t> & v,
                             const Eigen::MatrixBase<JacobianOut_t> & J,
-                            const AssignmentOperatorType op) const
+                            const AssignmentOperatorType op=SETTO) const
     {
       switch(op)
         {

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -135,7 +135,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
     void dIntegrate_dq(const Eigen::MatrixBase<Config_t >  & q,
                        const Eigen::MatrixBase<Tangent_t>  & v,
                        const Eigen::MatrixBase<JacobianOut_t> & J,
-                       const AssignmentOperatorType op) const;
+                       const AssignmentOperatorType op=SETTO) const;
 
     /**
      * @brief      Computes the Jacobian of a small variation of the tangent vector into tangent space at identity.
@@ -152,7 +152,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
     void dIntegrate_dv(const Eigen::MatrixBase<Config_t >  & q,
                        const Eigen::MatrixBase<Tangent_t>  & v,
                        const Eigen::MatrixBase<JacobianOut_t> & J,
-                       const AssignmentOperatorType op) const;
+                       const AssignmentOperatorType op=SETTO) const;
 
 
     /**

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -92,7 +92,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *
      * @param[out] J    the Jacobian of the Integrate operation w.r.t. the argument arg.
      */
-    template <ArgumentPosition arg, AssignmentOperatorType op, class Config_t, class Tangent_t, class JacobianOut_t>
+    template <ArgumentPosition arg, AssignmentOperatorType op = SETTO, class Config_t, class Tangent_t, class JacobianOut_t>
     void dIntegrate(const Eigen::MatrixBase<Config_t >  & q,
                     const Eigen::MatrixBase<Tangent_t>  & v,
                     const Eigen::MatrixBase<JacobianOut_t> & J) const

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -88,14 +88,16 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *
      * @param[in]  q    configuration vector.
      * @param[in]  v    tangent vector.
+     * @param[in]  op   assignment operator (SETTO, ADDTO or RMTO).
      * @tparam     arg  ARG0 (resp. ARG1) to get the Jacobian with respect to q (resp. v).
      *
      * @param[out] J    the Jacobian of the Integrate operation w.r.t. the argument arg.
      */
-    template <ArgumentPosition arg, class Config_t, class Tangent_t, class JacobianOut_t, AssignmentOperatorType op = SETTO>
+    template <ArgumentPosition arg, class Config_t, class Tangent_t, class JacobianOut_t>
     void dIntegrate(const Eigen::MatrixBase<Config_t >  & q,
                     const Eigen::MatrixBase<Tangent_t>  & v,
-                    const Eigen::MatrixBase<JacobianOut_t> & J) const
+                    const Eigen::MatrixBase<JacobianOut_t> & J,
+                    AssignmentOperatorType op = SETTO) const
     {
       PINOCCHIO_STATIC_ASSERT(arg==ARG0||arg==ARG1, arg_SHOULD_BE_ARG0_OR_ARG1);
       return dIntegrate(q.derived(),v.derived(),PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J),arg,op);
@@ -110,6 +112,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      * @param[in]  q    configuration vector.
      * @param[in]  v    tangent vector.
      * @param[in] arg  ARG0 (resp. ARG1) to get the Jacobian with respect to q (resp. v).
+     * @param[in]  op   assignment operator (SETTO, ADDTO and RMTO).
      *
      * @param[out] J    the Jacobian of the Integrate operation w.r.t. the argument arg.
      */
@@ -128,6 +131,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *
      * @param[in]  q    configuration vector.
      * @param[in]  v    tangent vector.
+     * @param[in]  op   assignment operator (SETTO, ADDTO or RMTO).
      *
      * @param[out] J    the Jacobian of the Integrate operation w.r.t. the configuration vector q.
      */
@@ -145,6 +149,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *
      * @param[in]  q    configuration vector.
      * @param[in]  v    tangent vector.
+     * @param[in]  op   assignment operator (SETTO, ADDTO or RMTO).
      *
      * @param[out] J    the Jacobian of the Integrate operation w.r.t. the tangent vector v.
      */
@@ -153,7 +158,6 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
                        const Eigen::MatrixBase<Tangent_t>  & v,
                        const Eigen::MatrixBase<JacobianOut_t> & J,
                        const AssignmentOperatorType op = SETTO) const;
-
 
     /**
      *

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -92,7 +92,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
      *
      * @param[out] J    the Jacobian of the Integrate operation w.r.t. the argument arg.
      */
-    template <ArgumentPosition arg, AssignmentOperatorType op = SETTO, class Config_t, class Tangent_t, class JacobianOut_t>
+    template <ArgumentPosition arg, class Config_t, class Tangent_t, class JacobianOut_t, AssignmentOperatorType op = SETTO>
     void dIntegrate(const Eigen::MatrixBase<Config_t >  & q,
                     const Eigen::MatrixBase<Tangent_t>  & v,
                     const Eigen::MatrixBase<JacobianOut_t> & J) const
@@ -118,7 +118,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
                     const Eigen::MatrixBase<Tangent_t>  & v,
                     const Eigen::MatrixBase<JacobianOut_t> & J,
                     const ArgumentPosition arg,
-                    const AssignmentOperatorType op) const;
+                    const AssignmentOperatorType op = SETTO) const;
 
     /**
      * @brief      Computes the Jacobian of a small variation of the configuration vector into tangent space at identity.
@@ -135,7 +135,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
     void dIntegrate_dq(const Eigen::MatrixBase<Config_t >  & q,
                        const Eigen::MatrixBase<Tangent_t>  & v,
                        const Eigen::MatrixBase<JacobianOut_t> & J,
-                       const AssignmentOperatorType op=SETTO) const;
+                       const AssignmentOperatorType op = SETTO) const;
 
     /**
      * @brief      Computes the Jacobian of a small variation of the tangent vector into tangent space at identity.
@@ -152,7 +152,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
     void dIntegrate_dv(const Eigen::MatrixBase<Config_t >  & q,
                        const Eigen::MatrixBase<Tangent_t>  & v,
                        const Eigen::MatrixBase<JacobianOut_t> & J,
-                       const AssignmentOperatorType op=SETTO) const;
+                       const AssignmentOperatorType op = SETTO) const;
 
 
     /**

--- a/src/multibody/liegroup/special-euclidean.hpp
+++ b/src/multibody/liegroup/special-euclidean.hpp
@@ -296,7 +296,7 @@ namespace pinocchio
     static void dIntegrate_dq_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t>  & v,
                                    const Eigen::MatrixBase<JacobianOut_t>& J,
-                                   const AssignmentOperatorType op)
+                                   const AssignmentOperatorType op=SETTO)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
 
@@ -311,7 +311,7 @@ namespace pinocchio
     static void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t> & v,
                                    const Eigen::MatrixBase<JacobianOut_t> & J,
-                                   const AssignmentOperatorType op)
+                                   const AssignmentOperatorType op=SETTO)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
       // TODO sparse version
@@ -651,7 +651,7 @@ namespace pinocchio
     static void dIntegrate_dq_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t>  & v,
                                    const Eigen::MatrixBase<JacobianOut_t>& J,
-                                   const AssignmentOperatorType op)
+                                   const AssignmentOperatorType op=SETTO)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
 
@@ -676,7 +676,7 @@ namespace pinocchio
     static void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t>  & v,
                                    const Eigen::MatrixBase<JacobianOut_t>& J,
-                                   const AssignmentOperatorType op)
+                                   const AssignmentOperatorType op=SETTO)
     {
       switch(op)
       {

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -191,7 +191,7 @@ namespace pinocchio
     static void dIntegrate_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t> & /*v*/,
                                    const Eigen::MatrixBase<JacobianOut_t> & J,
-                                   const AssignmentOperatorType op)
+                                   const AssignmentOperatorType op=SETTO)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
       switch(op)
@@ -215,7 +215,7 @@ namespace pinocchio
     static void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t> & /*v*/,
                                    const Eigen::MatrixBase<JacobianOut_t> & J,
-                                   const AssignmentOperatorType op)
+                                   const AssignmentOperatorType op=SETTO)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
       switch(op)
@@ -449,7 +449,7 @@ namespace pinocchio
     static void dIntegrate_dq_impl(const Eigen::MatrixBase<Config_t >  & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t>  & v,
                                    const Eigen::MatrixBase<JacobianOut_t> & J,
-                                   const AssignmentOperatorType op)
+                                   const AssignmentOperatorType op=SETTO)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
       switch(op)
@@ -473,7 +473,7 @@ namespace pinocchio
     static void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t> & v,
                                    const Eigen::MatrixBase<JacobianOut_t> & J,
-                                   const AssignmentOperatorType op)
+                                   const AssignmentOperatorType op=SETTO)
     {
       switch(op)
         {

--- a/src/multibody/liegroup/vector-space.hpp
+++ b/src/multibody/liegroup/vector-space.hpp
@@ -106,7 +106,7 @@ namespace pinocchio
     static void dIntegrate_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t> & /*v*/,
                                    const Eigen::MatrixBase<JacobianOut_t> & J,
-                                   const AssignmentOperatorType op)
+                                   const AssignmentOperatorType op=SETTO)
     {
       Eigen::MatrixBase<JacobianOut_t>& Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
       switch(op)
@@ -130,7 +130,7 @@ namespace pinocchio
     static void dIntegrate_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                    const Eigen::MatrixBase<Tangent_t> & /*v*/,
                                    const Eigen::MatrixBase<JacobianOut_t> & J,
-                                   const AssignmentOperatorType op)
+                                   const AssignmentOperatorType op=SETTO)
     {
       Eigen::MatrixBase<JacobianOut_t>& Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J);
       switch(op)

--- a/unittest/liegroups.cpp
+++ b/unittest/liegroups.cpp
@@ -361,7 +361,7 @@ struct LieGroup_JintegrateJdifference{
     JacobianMatrix_t Jd_qb, Ji_v;
 
     lg.template dDifference<ARG1> (qa, qb, Jd_qb);
-    lg.template dIntegrate <ARG1, SETTO> (qa, v , Ji_v );
+    lg.template dIntegrate <ARG1> (qa, v , Ji_v );
 
     BOOST_CHECK_MESSAGE ((Jd_qb * Ji_v).isIdentity(),
         "Jd_qb\n" <<

--- a/unittest/liegroups.cpp
+++ b/unittest/liegroups.cpp
@@ -316,8 +316,8 @@ struct LieGroup_Jintegrate{
     ConfigVector_t q_v = lg.integrate (q, v);
 
     JacobianMatrix_t Jq, Jv;
-    lg.dIntegrate_dq (q, v, Jq, SETTO);
-    lg.dIntegrate_dv (q, v, Jv, SETTO);
+    lg.dIntegrate_dq (q, v, Jq);
+    lg.dIntegrate_dv (q, v, Jv);
 
     const Scalar eps = 1e-6;
     for (int i = 0; i < v.size(); ++i)


### PR DESCRIPTION
Hi,

hpp-pinocchio doesn't compile on pinocchio 2.4.3, as `dIntegrate_dq` is called with 3 arguments, while 4 are expected.

@proyan : in #1163 you say "The default setting would be SETTO, so it doesn't affect existing code." and yet in #1169, all the methods get their prototype updated by one parameter addition without defaults.

Meaning the API has changed, doesn't it ?

And the [tests](https://github.com/stack-of-tasks/pinocchio/pull/1169/commits/17897a888a949cffad289803764d1cce0458f1e7#diff-4385ca28d5100ad9c49f0f0a6490ba24) have been updated, also meaning the API has changed. Otherwise, we should have kept the old tests with the old API, and added new tests, with the new API, side by side. Ensuring this wouldn't break existing code elsewhere, while the new features are available and working.

This PR fix this, and, in my case, hpp-pinocchio build.