### PR TITLE
Prefer not to use collisionObjects

### DIFF
--- a/src/algorithm/geometry.hxx
+++ b/src/algorithm/geometry.hxx
@@ -58,13 +58,17 @@ namespace pinocchio
     const CollisionPair & pair = geom_model.collisionPairs[pairId];
 
     PINOCCHIO_CHECK_INPUT_ARGUMENT( pairId      < geom_data.collisionResults.size() );
-    PINOCCHIO_CHECK_INPUT_ARGUMENT( pair.first  < geom_data.collisionObjects.size() );
-    PINOCCHIO_CHECK_INPUT_ARGUMENT( pair.second < geom_data.collisionObjects.size() );
+    PINOCCHIO_CHECK_INPUT_ARGUMENT( pair.first  < geom_model.ngeoms );
+    PINOCCHIO_CHECK_INPUT_ARGUMENT( pair.second < geom_model.ngeoms );
 
     fcl::CollisionResult& collisionResult = geom_data.collisionResults[pairId];
     collisionResult.clear();
-    fcl::collide (&geom_data.collisionObjects[pair.first],
-                  &geom_data.collisionObjects[pair.second],
+
+    fcl::Transform3f oM1 (toFclTransform3f(geom_data.oMg[pair.first ])),
+                     oM2 (toFclTransform3f(geom_data.oMg[pair.second]));
+
+    fcl::collide (geom_model.geometryObjects[pair.first ].geometry.get(), oM1,
+                  geom_model.geometryObjects[pair.second].geometry.get(), oM2,
                   geom_data.collisionRequest,
                   collisionResult);
 
@@ -123,12 +127,14 @@ namespace pinocchio
     const CollisionPair & pair = geom_model.collisionPairs[pairId];
 
     PINOCCHIO_CHECK_INPUT_ARGUMENT( pairId      < geom_data.distanceResults.size() );
-    PINOCCHIO_CHECK_INPUT_ARGUMENT( pair.first  < geom_data.collisionObjects.size() );
-    PINOCCHIO_CHECK_INPUT_ARGUMENT( pair.second < geom_data.collisionObjects.size() );
+    PINOCCHIO_CHECK_INPUT_ARGUMENT( pair.first  < geom_model.ngeoms );
+    PINOCCHIO_CHECK_INPUT_ARGUMENT( pair.second < geom_model.ngeoms );
 
     geom_data.distanceResults[pairId].clear();
-    fcl::distance ( &geom_data.collisionObjects[pair.first],
-                    &geom_data.collisionObjects[pair.second],
+    fcl::Transform3f oM1 (toFclTransform3f(geom_data.oMg[pair.first ])),
+                     oM2 (toFclTransform3f(geom_data.oMg[pair.second]));
+    fcl::distance ( geom_model.geometryObjects[pair.first ].geometry.get(), oM1,
+                    geom_model.geometryObjects[pair.second].geometry.get(), oM2,
                     geom_data.distanceRequest,
                     geom_data.distanceResults[pairId]);
 

--- a/src/algorithm/geometry.hxx
+++ b/src/algorithm/geometry.hxx
@@ -40,7 +40,10 @@ namespace pinocchio
       if (joint>0) geom_data.oMg[i] =  (data.oMi[joint] * geom_model.geometryObjects[i].placement);
       else         geom_data.oMg[i] =  geom_model.geometryObjects[i].placement;
 #ifdef PINOCCHIO_WITH_HPP_FCL  
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
       geom_data.collisionObjects[i].setTransform( toFclTransform3f(geom_data.oMg[i]) );
+#pragma GCC diagnostic pop
 #endif // PINOCCHIO_WITH_HPP_FCL
     }
   }

--- a/src/multibody/geometry.hpp
+++ b/src/multibody/geometry.hpp
@@ -195,7 +195,7 @@ namespace pinocchio
     /// The object contains a pointer on the collision geometries contained in geomModel.geometryObjects.
     /// \sa GeometryModel::geometryObjects and GeometryObjects
     ///
-    std::vector<fcl::CollisionObject> collisionObjects;
+    std::vector<fcl::CollisionObject> collisionObjects PINOCCHIO_DEPRECATED;
 
     ///
     /// \brief Defines what information should be computed by distance computation.
@@ -245,7 +245,8 @@ namespace pinocchio
     std::map<JointIndex,GeomIndexList>  outerObjects;
 
     GeometryData(const GeometryModel & geomModel);
-    ~GeometryData() {};
+    GeometryData(const GeometryData & other);
+    ~GeometryData();
 
     /// Fill both innerObjects and outerObjects maps, from vectors collisionObjects and 
     /// collisionPairs. 

--- a/src/multibody/geometry.hxx
+++ b/src/multibody/geometry.hxx
@@ -11,6 +11,9 @@
 
 namespace pinocchio
 {
+// Avoid deprecated warning of collisionObjects
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
   inline GeometryData::GeometryData(const GeometryModel & geom_model)
   : oMg(geom_model.ngeoms)
   , activeCollisionPairs(geom_model.collisionPairs.size(), true)
@@ -34,6 +37,25 @@ namespace pinocchio
 #endif
     fillInnerOuterObjectMaps(geom_model);
   }
+
+  inline GeometryData::GeometryData(const GeometryData & other)
+  : oMg (other.oMg)
+  , activeCollisionPairs (other.activeCollisionPairs)
+#ifdef PINOCCHIO_WITH_HPP_FCL
+  , collisionObjects (other.collisionObjects)
+  , distanceRequest (other.distanceRequest)
+  , distanceResults (other.distanceResults)
+  , collisionRequest (other.collisionRequest)
+  , collisionResults (other.collisionResults)
+  , radius (other.radius)
+  , collisionPairIndex (other.collisionPairIndex)
+#endif // PINOCCHIO_WITH_HPP_FCL
+  , innerObjects (other.innerObjects)
+  , outerObjects (other.outerObjects)
+  {}
+
+  inline GeometryData::~GeometryData() {}
+#pragma GCC diagnostic pop
 
   template<typename S2, int O2, template<typename,int> class JointCollectionTpl>
   GeomIndex GeometryModel::addGeometryObject(const GeometryObject & object,


### PR DESCRIPTION
After playing around with hpp-fcl and pinocchio, I spent quite some time trying to figure out why collision checking was not working.

It was due to the fact the I modified a collision geometry in the model, with create a new geometry data. Thus the pointer stored in the collision object of geometry data was not pointing to the same object as the collision geometry in geometry model. I don't know if I was clear...

Anyway, the API of hppfcl allow to bypass completely the collision object class. As it avoids duplicating a pointer, I believe it is better not to use it. I don't think removing it completely is a good idea neither. So I open the debate.