### PR TITLE
[Python][gepetto-viewer] Enable display of convex object.

### DIFF
--- a/bindings/python/multibody/geometry-object.hpp
+++ b/bindings/python/multibody/geometry-object.hpp
@@ -40,6 +40,11 @@ namespace pinocchio
                        "placement", "mesh_path", "mesh_scale", "override_material", "mesh_color", "mesh_texture_path"),
               "Reduced constructor of a GeometryObject. This constructor does not require to specify the parent frame index."
               ))
+        .def(bp::init<const GeometryObject&>
+             (
+              bp::args("self","otherGeometryObject"),
+              "Copy constructor"
+              ))
         .add_property("meshScale",
                       bp::make_getter(&GeometryObject::meshScale,
                                       bp::return_value_policy<bp::return_by_value>()),

--- a/bindings/python/pinocchio/visualize/gepetto_visualizer.py
+++ b/bindings/python/pinocchio/visualize/gepetto_visualizer.py
@@ -71,6 +71,19 @@ class GepettoVisualizer(BaseVisualizer):
             return gui.addSphere(meshName, geom.radius, npToTuple(meshColor))
         elif isinstance(geom, hppfcl.Cone):
             return gui.addCone(meshName, geom.radius, 2. * geom.halfLength, npToTuple(meshColor))
+        elif isinstance(geom, hppfcl.Convex):
+            pts = [ npToTuple(geom.points(geom.polygons(f)[i])) for f in range(geom.num_polygons) for i in range(3) ]
+            gui.addCurve(meshName, pts, npToTuple(meshColor))
+            gui.setCurveMode(meshName, "TRIANGLES")
+            gui.setLightingMode(meshName, "ON")
+            gui.setBoolProperty(meshName, "BackfaceDrawing", True)
+            return True
+        elif isinstance(geom, hppfcl.ConvexBase):
+            pts = [ npToTuple(geom.points(i)) for i in range(geom.num_points) ]
+            gui.addCurve(meshName, pts, npToTuple(meshColor))
+            gui.setCurveMode(meshName, "POINTS")
+            gui.setLightingMode(meshName, "OFF")
+            return True
         else:
             msg = "Unsupported geometry type for %s (%s)" % (geometry_object.name, type(geom) )
             warnings.warn(msg, category=UserWarning, stacklevel=2)


### PR DESCRIPTION
With https://github.com/humanoid-path-planner/hpp-fcl/pull/167, compiled with qhull, and this PR, building a convex hull for a geometry in Pinocchio is as simple as:
```python
# cmodel is a instance of pinocchio.GeometryModel
go = cmodel.geometryObjects[0]
# Set the boolean to True to store the triangles.
# It is not required for collision checking but it is for nice visualization
go.geometry.buildConvexHull(False, None)
cgo = pinocchio.GeometryObject(go)
cgo.name = cgo.name + "_convex_hull"
cgo.geometry = go.geometry.convex
cmodel.addGeometryObject(cgo)
```

One can replace the current geometry with
```python
# cmodel is a instance of pinocchio.GeometryModel
go = cmodel.geometryObjects[0]
# Set the boolean to True to store the triangles.
# It is not required for collision checking but it is for nice visualization
go.geometry.buildConvexHull(False, None)
go.geometry = go.geometry.convex
```