### PR TITLE
Stored Data object as shared pointer to fix data alignment #1201

### DIFF
--- a/bindings/python/multibody/data.hpp
+++ b/bindings/python/multibody/data.hpp
@@ -173,7 +173,7 @@ namespace pinocchio
       /* --- Expose --------------------------------------------------------- */
       static void expose()
       {
-        bp::class_<Data>("Data",
+        bp::class_<Data, boost::shared_ptr<Data> >("Data",
                          "Articulated rigid body data related to a Model.\n"
                          "It contains all the data that can be modified by the Pinocchio algorithms.",
                          bp::no_init)


### PR DESCRIPTION
Hi @jcarpent 

Let me tell you the story behind this. I though that storing the object by value might create issues with data alignment at Boost Python level. As you might know, Eigen instructs us to do not pass objects by value. Then I did a quick research on google and I found the following article: https://stackoverflow.com/questions/13177573/how-to-expose-aligned-class-with-boost-python

With this, I started to believe that makes sense my hypothesis. I decided to quickly implement it and *voila*, it is working.

I hope this solution meets Pinocchio standards.

Carlos

PD: this fixes the issue #1201.