### PR TITLE
Fix addFrame and getFrameId

### DIFF
--- a/src/algorithm/model.hxx
+++ b/src/algorithm/model.hxx
@@ -364,9 +364,8 @@ namespace pinocchio
                             liMi,
                             FIXED_JOINT);
         
-        int frame_id = reduced_model.addFrame(frame);
-        assert(frame_id >= 0);
-        reduced_model.frames[(size_t)frame_id].previousFrame = (FrameIndex)frame_id; // a bit weird, but this a solution for missing parent frame
+        FrameIndex frame_id = reduced_model.addFrame(frame);
+        reduced_model.frames[frame_id].previousFrame = frame_id; // a bit weird, but this is a solution for missing parent frame
         
         // Add the Inertia of the link supported by joint_id
         reduced_model.appendBodyToJoint(reduced_parent_joint_index,

--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -508,9 +508,8 @@ namespace pinocchio
     /// \param[in] frame The frame to add to the kinematic tree.
     ///
     /// \return Returns the index of the frame if it has been successfully added or if it already exists in the kinematic tree.
-    ///         The function returns -1 when the frame.type did not match with the existing frame in the kinematic having the same name.
     ///
-    int addFrame(const Frame & frame);
+    FrameIndex addFrame(const Frame & frame);
 
     ///
     /// \brief Check the validity of the attributes of Model with respect to the specification of some

--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -442,7 +442,7 @@ namespace pinocchio
     ///
     /// \return Index of the body.
     ///
-    JointIndex getBodyId(const std::string & name) const;
+    FrameIndex getBodyId(const std::string & name) const;
     
     ///
     /// \brief Check if a body given by its name exists.

--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -398,10 +398,10 @@ namespace pinocchio
     /// \param[in] frameIndex Index of the parent frame. If negative,
     ///            the parent frame is the frame of the parent joint.
     ///
-    /// \return The index of the new frame or -1 in case of error.
+    /// \return The index of the new frame
     ///
-    int addJointFrame(const JointIndex & joint_index,
-                      int previous_frame_index = -1);
+    FrameIndex addJointFrame(const JointIndex & joint_index,
+                             int previous_frame_index = -1);
 
     ///
     /// \brief Append a body to a given joint of the kinematic tree.
@@ -424,12 +424,12 @@ namespace pinocchio
     /// \param[in] previousFrame Index of the parent frame. If negative,
     ///            the parent frame is the frame of the parent joint.
     ///
-    /// \return The index of the new frame or -1 in case of error.
+    /// \return The index of the new frame
     ///
-    int addBodyFrame (const std::string & body_name,
-                      const JointIndex  & parentJoint,
-                      const SE3         & body_placement = SE3::Identity(),
-                            int           previousFrame  = -1);
+    FrameIndex addBodyFrame(const std::string & body_name,
+                            const JointIndex  & parentJoint,
+                            const SE3         & body_placement = SE3::Identity(),
+                            int                 previousFrame  = -1);
 
     ///
     /// \brief Return the index of a body given by its name.

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -248,19 +248,19 @@ namespace pinocchio
   }
 
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
-  inline int ModelTpl<Scalar,Options,JointCollectionTpl>::
+  inline typename ModelTpl<Scalar,Options,JointCollectionTpl>::FrameIndex
+  ModelTpl<Scalar,Options,JointCollectionTpl>::
   addFrame(const Frame & frame)
   {
     // Check if the frame.name exists with the same type
     if(existFrame(frame.name,frame.type))
     {
-      FrameIndex frame_id = getFrameId(frame.name,frame.type);
-      return (int)frame_id;
+      return getFrameId(frame.name,frame.type);
     }
     // else: we must add a new frames to the current stack
     frames.push_back(frame);
     nframes++;
-    return nframes - 1;
+    return FrameIndex(nframes - 1);
   }
   
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -194,7 +194,7 @@ namespace pinocchio
   }
   
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
-  inline typename ModelTpl<Scalar,Options,JointCollectionTpl>::JointIndex
+  inline typename ModelTpl<Scalar,Options,JointCollectionTpl>::FrameIndex
   ModelTpl<Scalar,Options,JointCollectionTpl>::
   getBodyId(const std::string & name) const
   {

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -233,8 +233,8 @@ namespace pinocchio
     = std::find_if(frames.begin()
                    ,frames.end()
                    ,details::FilterFrame(name, type));
-    assert(it != frames.end() && "Frame not found");
-    assert((std::find_if( boost::next(it), frames.end(), details::FilterFrame(name, type)) == frames.end())
+    assert(((it == frames.end()) ||
+            (std::find_if( boost::next(it), frames.end(), details::FilterFrame(name, type)) == frames.end()))
         && "Several frames match the filter");
     return FrameIndex(it - frames.begin());
   }

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -146,7 +146,8 @@ namespace pinocchio
   }
   
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
-  inline int ModelTpl<Scalar,Options,JointCollectionTpl>::
+  inline typename ModelTpl<Scalar,Options,JointCollectionTpl>::FrameIndex
+  ModelTpl<Scalar,Options,JointCollectionTpl>::
   addJointFrame(const JointIndex & joint_index,
                 int previous_frame_index)
   {
@@ -176,7 +177,8 @@ namespace pinocchio
   }
 
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
-  inline int ModelTpl<Scalar,Options,JointCollectionTpl>::
+  inline typename ModelTpl<Scalar,Options,JointCollectionTpl>::FrameIndex
+  ModelTpl<Scalar,Options,JointCollectionTpl>::
   addBodyFrame(const std::string & body_name,
                const JointIndex  & parentJoint,
                const SE3         & body_placement,

--- a/src/parsers/urdf/model.hxx
+++ b/src/parsers/urdf/model.hxx
@@ -205,11 +205,9 @@ namespace pinocchio
           {
             const Frame & frame = model.frames[parentFrameId];
 
-            int fid = model.addFrame(Frame(joint_name, frame.parent, parentFrameId,
+            FrameIndex fid = model.addFrame(Frame(joint_name, frame.parent, parentFrameId,
                   frame.placement * joint_placement, FIXED_JOINT)
                 );
-            if (fid < 0)
-              throw std::invalid_argument("Fixed joint " + joint_name + " could not be added.");
 
             appendBodyToJoint((FrameIndex)fid, Y, SE3::Identity(), body_name);
           }

--- a/src/parsers/urdf/model.hxx
+++ b/src/parsers/urdf/model.hxx
@@ -179,20 +179,8 @@ namespace pinocchio
               default:
                 PINOCCHIO_CHECK_INPUT_ARGUMENT(false, "The joint type is not correct.");
             };
-            int res (model.addJointFrame(idx, (int)parentFrameId));
-            if (res == -1) {
-              std::ostringstream oss;
-              oss << joint_name << " already inserted as a frame. Current frames "
-                "are [";
-              for (typename PINOCCHIO_ALIGNED_STD_VECTOR(Frame)::const_iterator it =
-                  model.frames.begin (); it != model.frames.end (); ++it) {
-                oss << '"' << it->name << "\",";
-              }
-              oss << ']';
-              throw std::invalid_argument(oss.str());
-            }
 
-            FrameIndex jointFrameId = (FrameIndex) res; // C-style cast to remove polluting compilation warning. This is Bad practice. See issue #323 (rework indexes)
+            FrameIndex jointFrameId = model.addJointFrame(idx, (int)parentFrameId);
             appendBodyToJoint(jointFrameId, Y, SE3::Identity(), body_name);
           }
 
@@ -347,20 +335,8 @@ namespace pinocchio
                 SE3::Identity(), "root_joint"
                 //TODO ,max_effort,max_velocity,min_config,max_config
                 );
-            int res (model.addJointFrame(idx, 0));
-            if (res == -1) {
-              std::ostringstream oss;
-              oss << "root_joint already inserted as a frame but of different type. Current frames "
-                "are [";
-              for (typename PINOCCHIO_ALIGNED_STD_VECTOR(Frame)::const_iterator it =
-                  model.frames.begin (); it != model.frames.end (); ++it) {
-                oss << '"' << it->name << "\",";
-              }
-              oss << ']';
-              throw std::invalid_argument(oss.str());
-            }
 
-            FrameIndex jointFrameId = (FrameIndex) res; // C-style cast to remove polluting compilation warning. This is Bad practice. See issue #323 (rework indexes)
+            FrameIndex jointFrameId = model.addJointFrame(idx, 0);
             appendBodyToJoint(jointFrameId, Y, SE3::Identity(), body_name);
           }
       };

--- a/unittest/frames.cpp
+++ b/unittest/frames.cpp
@@ -87,8 +87,7 @@ BOOST_AUTO_TEST_CASE ( test_update_placements )
   Model::Index parent_idx = model.existJointName("rarm2_joint")?model.getJointId("rarm2_joint"):(Model::Index)(model.njoints-1);
   const std::string & frame_name = std::string( model.names[parent_idx]+ "_frame");
   const SE3 & framePlacement = SE3::Random();
-  model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
-  Model::FrameIndex frame_idx = model.getFrameId(frame_name);
+  Model::FrameIndex frame_idx = model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
   pinocchio::Data data(model);
   pinocchio::Data data_ref(model);
 
@@ -113,8 +112,7 @@ BOOST_AUTO_TEST_CASE ( test_update_single_placement )
   Model::Index parent_idx = model.existJointName("rarm2_joint")?model.getJointId("rarm2_joint"):(Model::Index)(model.njoints-1);
   const std::string & frame_name = std::string( model.names[parent_idx]+ "_frame");
   const SE3 & framePlacement = SE3::Random();
-  model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
-  Model::FrameIndex frame_idx = model.getFrameId(frame_name);
+  Model::FrameIndex frame_idx = model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
   pinocchio::Data data(model);
   pinocchio::Data data_ref(model);
 
@@ -139,8 +137,7 @@ BOOST_AUTO_TEST_CASE ( test_velocity )
   Model::Index parent_idx = model.existJointName("rarm2_joint")?model.getJointId("rarm2_joint"):(Model::Index)(model.njoints-1);
   const std::string & frame_name = std::string( model.names[parent_idx]+ "_frame");
   const SE3 & framePlacement = SE3::Random();
-  model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
-  Model::FrameIndex frame_idx = model.getFrameId(frame_name);
+  Model::FrameIndex frame_idx = model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
   pinocchio::Data data(model);
 
   VectorXd q = VectorXd::Ones(model.nq);
@@ -173,8 +170,7 @@ BOOST_AUTO_TEST_CASE ( test_acceleration )
   Model::Index parent_idx = model.existJointName("rarm2_joint")?model.getJointId("rarm2_joint"):(Model::Index)(model.njoints-1);
   const std::string & frame_name = std::string( model.names[parent_idx]+ "_frame");
   const SE3 & framePlacement = SE3::Random();
-  model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
-  Model::FrameIndex frame_idx = model.getFrameId(frame_name);
+  Model::FrameIndex frame_idx = model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
   pinocchio::Data data(model);
 
   VectorXd q = VectorXd::Ones(model.nq);
@@ -208,8 +204,7 @@ BOOST_AUTO_TEST_CASE ( test_classic_acceleration )
   Model::Index parent_idx = model.existJointName("rarm2_joint")?model.getJointId("rarm2_joint"):(Model::Index)(model.njoints-1);
   const std::string & frame_name = std::string( model.names[parent_idx]+ "_frame");
   const SE3 & framePlacement = SE3::Random();
-  model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
-  Model::FrameIndex frame_idx = model.getFrameId(frame_name);
+  Model::FrameIndex frame_idx = model.addFrame(Frame (frame_name, parent_idx, 0, framePlacement, OP_FRAME));
   pinocchio::Data data(model);
 
   VectorXd q = VectorXd::Ones(model.nq);
@@ -268,7 +263,7 @@ BOOST_AUTO_TEST_CASE(test_frame_getters)
   // Build a simple 1R planar model
   Model model;
   JointIndex parentId = model.addJoint(0, JointModelRZ(), SE3::Identity(), "Joint1");
-  FrameIndex frameId = (FrameIndex)(model.addFrame(Frame("Frame1", parentId, 0, SE3(Matrix3d::Identity(), Vector3d(1.0, 0.0, 0.0)), OP_FRAME)));
+  FrameIndex frameId = model.addFrame(Frame("Frame1", parentId, 0, SE3(Matrix3d::Identity(), Vector3d(1.0, 0.0, 0.0)), OP_FRAME));
 
   Data data(model);
 

--- a/unittest/model.cpp
+++ b/unittest/model.cpp
@@ -49,6 +49,18 @@ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
     }
   }
 
+  BOOST_AUTO_TEST_CASE(test_model_get_frame_id)
+  {
+    Model model;
+    buildModels::humanoidRandom(model);
+    
+    for(FrameIndex i=0; i<static_cast<FrameIndex>(model.nframes); i++)
+    {
+      BOOST_CHECK_EQUAL(i, model.getFrameId(model.frames[i].name));
+    }
+    BOOST_CHECK_EQUAL(model.nframes, model.getFrameId("NOT_A_FRAME"));
+  }
+
   BOOST_AUTO_TEST_CASE(test_model_support)
   {
     Model model;

--- a/unittest/model.cpp
+++ b/unittest/model.cpp
@@ -164,8 +164,8 @@ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
     // First append a model to the universe frame.
     Model model1;
     GeometryModel geomModel1;
-    int fid = 0;
-    appendModel (humanoid, manipulator, geomHumanoid, geomManipulator, (FrameIndex)fid,
+    FrameIndex fid = 0;
+    appendModel (humanoid, manipulator, geomHumanoid, geomManipulator, fid,
         SE3::Identity(), model1, geomModel1);
 
     Data data1 (model1);
@@ -182,9 +182,7 @@ BOOST_AUTO_TEST_SUITE ( BOOST_TEST_MODULE )
           humanoid.getFrameId("humanoid/chest2_joint"), aMb,
           OP_FRAME));
 
-    BOOST_CHECK(fid >= 0);
-
-    appendModel (humanoid, manipulator, geomHumanoid, geomManipulator, (FrameIndex)fid,
+    appendModel (humanoid, manipulator, geomHumanoid, geomManipulator, fid,
         SE3::Identity(), model, geomModel);
 
     BOOST_TEST_MESSAGE(model);

--- a/unittest/regressor.cpp
+++ b/unittest/regressor.cpp
@@ -99,7 +99,7 @@ BOOST_AUTO_TEST_CASE(test_frame_body_regressor)
   JointIndex JOINT_ID = JointIndex(model.njoints) - 1;
 
   const SE3 & framePlacement = SE3::Random();
-  FrameIndex FRAME_ID = (FrameIndex) model.addBodyFrame ("test_body", JOINT_ID, framePlacement, -1);
+  FrameIndex FRAME_ID = model.addBodyFrame ("test_body", JOINT_ID, framePlacement, -1);
 
   pinocchio::Data data(model);
 


### PR DESCRIPTION
Closes #1199. Closes #1198 for the time being.

For in detail:
- remove assert that frame is found from `getFrameId` and include unit test to check it.
- modify return type of `addFrame`, `addBodyFrame` and `addJointFrame` to `FrameIndex` and remove all related warnings and useless casts
- additionally, change return type of `getBodyId` from `JointIndex` to `FrameIndex`. This has zero impact on the functionality of the code, because they are both typedefs of `size_t`, but it makes more sense from a documentation standpoint.

An observation about `addFrame`: the reason why the return type was `int` is that in the past the function used to return `-1` if there was already a frame with the same name but a different type. This was changed at commit 2f214472b0af1fd2039850b5c2984557073326de : since then, `addFrame` does not care about this possibility and the frame will be added anyways. Thus, the index of a valid frame is _always_ returned.

Consequently, I had to remove some logic related to the possibility that the returned index might be `-1`. Specifically, you might want to check commit 0831335 and see wether the old checks, which I completely removed, should be replaced by something more appropriate