### PR TITLE
Add codegen/autodiff support for eigen coeff-wise min and max operations

### DIFF
--- a/src/autodiff/casadi.hpp
+++ b/src/autodiff/casadi.hpp
@@ -5,6 +5,7 @@
 #ifndef __pinocchio_autodiff_casadi_hpp__
 #define __pinocchio_autodiff_casadi_hpp__
 
+#include "pinocchio/fwd.hpp"
 #include "pinocchio/math/fwd.hpp"
 
 #include <casadi/casadi.hpp>

--- a/src/autodiff/cppad.hpp
+++ b/src/autodiff/cppad.hpp
@@ -61,6 +61,27 @@ namespace Eigen
       }
     };
   }
+  
+  namespace numext
+  {
+    template<typename Scalar>
+    EIGEN_DEVICE_FUNC
+    EIGEN_ALWAYS_INLINE CppAD::AD<Scalar> mini(const CppAD::AD<Scalar>& x, const CppAD::AD<Scalar>& y)
+    {
+      using ::pinocchio::internal::if_then_else;
+      using ::pinocchio::internal::LT;
+      return if_then_else(LT, y, x, y, x);
+    }
+
+    template<typename Scalar>
+    EIGEN_DEVICE_FUNC
+    EIGEN_ALWAYS_INLINE CppAD::AD<Scalar> maxi(const CppAD::AD<Scalar>& x, const CppAD::AD<Scalar>& y)
+    {
+      using ::pinocchio::internal::if_then_else;
+      using ::pinocchio::internal::LT;
+      return if_then_else(LT, x, y, y, x);
+    }
+  }
 } //namespace Eigen
 
 // Source from #include <cppad/example/cppad_eigen.hpp>

--- a/src/autodiff/cppad.hpp
+++ b/src/autodiff/cppad.hpp
@@ -5,6 +5,7 @@
 #ifndef __pinocchio_autodiff_ccpad_hpp__
 #define __pinocchio_autodiff_ccpad_hpp__
 
+#include "pinocchio/container/boost-container-limits.hpp"
 #include "pinocchio/math/fwd.hpp"
 
 // Do not include this file directly.
@@ -134,20 +135,6 @@ namespace CppAD
 } // namespace CppAD
 
 #include "pinocchio/utils/static-if.hpp"
-
-namespace Eigen
-{
-  namespace internal
-  {
-    template<typename Scalar> EIGEN_DEVICE_FUNC inline CppAD::AD<Scalar>
-    pmin(const CppAD::AD<Scalar>& a, const CppAD::AD<Scalar>& b)
-    { return numext::mini(a, b); }
-
-    template<typename Scalar> EIGEN_DEVICE_FUNC inline CppAD::AD<Scalar>
-    pmax(const CppAD::AD<Scalar>& a, const CppAD::AD<Scalar>& b)
-    { return numext::maxi(a, b); }
-  }
-}
 
 namespace pinocchio
 {

--- a/src/autodiff/cppad.hpp
+++ b/src/autodiff/cppad.hpp
@@ -15,7 +15,7 @@
 #ifdef PINOCCHIO_CPPAD_REQUIRES_MATRIX_BASE_PLUGIN
   #define EIGEN_MATRIXBASE_PLUGIN <cppad/example/eigen_plugin.hpp>
 #endif
-
+#include "pinocchio/autodiff/cppad/minmax.hpp"
 #include <cppad/cppad.hpp>
 #include <Eigen/Dense>
 
@@ -146,27 +146,6 @@ namespace Eigen
     template<typename Scalar> EIGEN_DEVICE_FUNC inline CppAD::AD<Scalar>
     pmax(const CppAD::AD<Scalar>& a, const CppAD::AD<Scalar>& b)
     { return numext::maxi(a, b); }
-  }
-  
-  namespace numext
-  {
-    template<typename Scalar>
-    EIGEN_DEVICE_FUNC
-    EIGEN_ALWAYS_INLINE CppAD::AD<Scalar> mini(const CppAD::AD<Scalar>& x, const CppAD::AD<Scalar>& y)
-    {
-      using ::pinocchio::internal::if_then_else;
-      using ::pinocchio::internal::LT;
-      return if_then_else(LT, y, x, y, x);
-    }
-
-    template<typename Scalar>
-    EIGEN_DEVICE_FUNC
-    EIGEN_ALWAYS_INLINE CppAD::AD<Scalar> maxi(const CppAD::AD<Scalar>& x, const CppAD::AD<Scalar>& y)
-    {
-      using ::pinocchio::internal::if_then_else;
-      using ::pinocchio::internal::LT;
-      return if_then_else(LT, x, y, y, x);
-    }
   }
 }
 

--- a/src/autodiff/cppad.hpp
+++ b/src/autodiff/cppad.hpp
@@ -61,27 +61,6 @@ namespace Eigen
       }
     };
   }
-  
-  namespace numext
-  {
-    template<typename Scalar>
-    EIGEN_DEVICE_FUNC
-    EIGEN_ALWAYS_INLINE CppAD::AD<Scalar> mini(const CppAD::AD<Scalar>& x, const CppAD::AD<Scalar>& y)
-    {
-      using ::pinocchio::internal::if_then_else;
-      using ::pinocchio::internal::LT;
-      return if_then_else(LT, y, x, y, x);
-    }
-
-    template<typename Scalar>
-    EIGEN_DEVICE_FUNC
-    EIGEN_ALWAYS_INLINE CppAD::AD<Scalar> maxi(const CppAD::AD<Scalar>& x, const CppAD::AD<Scalar>& y)
-    {
-      using ::pinocchio::internal::if_then_else;
-      using ::pinocchio::internal::LT;
-      return if_then_else(LT, x, y, y, x);
-    }
-  }
 } //namespace Eigen
 
 // Source from #include <cppad/example/cppad_eigen.hpp>
@@ -155,6 +134,41 @@ namespace CppAD
 } // namespace CppAD
 
 #include "pinocchio/utils/static-if.hpp"
+
+namespace Eigen
+{
+  namespace internal
+  {
+    template<typename Scalar> EIGEN_DEVICE_FUNC inline CppAD::AD<Scalar>
+    pmin(const CppAD::AD<Scalar>& a, const CppAD::AD<Scalar>& b)
+    { return numext::mini(a, b); }
+
+    template<typename Scalar> EIGEN_DEVICE_FUNC inline CppAD::AD<Scalar>
+    pmax(const CppAD::AD<Scalar>& a, const CppAD::AD<Scalar>& b)
+    { return numext::maxi(a, b); }
+  }
+  
+  namespace numext
+  {
+    template<typename Scalar>
+    EIGEN_DEVICE_FUNC
+    EIGEN_ALWAYS_INLINE CppAD::AD<Scalar> mini(const CppAD::AD<Scalar>& x, const CppAD::AD<Scalar>& y)
+    {
+      using ::pinocchio::internal::if_then_else;
+      using ::pinocchio::internal::LT;
+      return if_then_else(LT, y, x, y, x);
+    }
+
+    template<typename Scalar>
+    EIGEN_DEVICE_FUNC
+    EIGEN_ALWAYS_INLINE CppAD::AD<Scalar> maxi(const CppAD::AD<Scalar>& x, const CppAD::AD<Scalar>& y)
+    {
+      using ::pinocchio::internal::if_then_else;
+      using ::pinocchio::internal::LT;
+      return if_then_else(LT, x, y, y, x);
+    }
+  }
+}
 
 namespace pinocchio
 {

--- a/src/autodiff/cppad/minmax.hpp
+++ b/src/autodiff/cppad/minmax.hpp
@@ -1,3 +1,7 @@
+//
+// Copyright (c) 2020 CNRS INRIA
+//
+
 #ifndef __pinocchio_autodiff_cppad_minmax_hpp__
 #define __pinocchio_autodiff_cppad_minmax_hpp__
 

--- a/src/autodiff/cppad/minmax.hpp
+++ b/src/autodiff/cppad/minmax.hpp
@@ -1,0 +1,61 @@
+#ifndef __pinocchio_autodiff_cppad_minmax_hpp__
+#define __pinocchio_autodiff_cppad_minmax_hpp__
+
+#include "pinocchio/utils/static-if.hpp"
+
+#ifdef __CUDACC__
+#define EIGEN_DEVICE_FUNC __host__ __device__
+// We need cuda_runtime.h to ensure that that EIGEN_USING_STD_MATH macro
+// works properly on the device side
+#include <cuda_runtime.h>
+#else
+#define EIGEN_DEVICE_FUNC
+#endif
+
+#ifndef EIGEN_STRONG_INLINE
+#if EIGEN_COMP_MSVC || EIGEN_COMP_ICC
+#define EIGEN_STRONG_INLINE __forceinline
+#else
+#define EIGEN_STRONG_INLINE inline
+#endif
+#endif
+
+#if (__GNUC__ > 4) || ((__GNUC__ == 4) && (__GNUC_MINOR__ >= 2))
+#define EIGEN_ALWAYS_INLINE __attribute__((always_inline)) inline
+#else
+#define EIGEN_ALWAYS_INLINE EIGEN_STRONG_INLINE
+#endif
+
+
+namespace CppAD
+{
+  template<typename Scalar> struct AD;
+}
+
+namespace Eigen
+{
+  namespace numext
+  {
+    template<typename Scalar>
+    EIGEN_DEVICE_FUNC
+    EIGEN_ALWAYS_INLINE ::CppAD::AD<Scalar> mini(const ::CppAD::AD<Scalar>& x,
+                                                 const ::CppAD::AD<Scalar>& y)
+    {
+      using ::pinocchio::internal::if_then_else;
+      using ::pinocchio::internal::LT;
+      return if_then_else(LT, y, x, y, x);
+    }
+    
+    template<typename Scalar>
+    EIGEN_DEVICE_FUNC
+    EIGEN_ALWAYS_INLINE ::CppAD::AD<Scalar> maxi(const ::CppAD::AD<Scalar>& x,
+                                                 const ::CppAD::AD<Scalar>& y)
+    {
+      using ::pinocchio::internal::if_then_else;
+      using ::pinocchio::internal::LT;
+      return if_then_else(LT, x, y, y, x);
+    }
+  }
+}
+
+#endif

--- a/src/codegen/cppadcg.hpp
+++ b/src/codegen/cppadcg.hpp
@@ -57,6 +57,27 @@ namespace Eigen
       }
     };
   }
+  namespace numext
+  {
+    template<typename Scalar>
+    EIGEN_DEVICE_FUNC
+    EIGEN_ALWAYS_INLINE CppAD::cg::CG<Scalar> mini(const CppAD::cg::CG<Scalar>& x, const CppAD::cg::CG<Scalar>& y)
+    {
+      using ::pinocchio::internal::if_then_else;
+      using ::pinocchio::internal::LT;
+      return if_then_else(LT, y, x, y, x);
+    }
+
+    template<typename Scalar>
+    EIGEN_DEVICE_FUNC
+    EIGEN_ALWAYS_INLINE CppAD::cg::CG<Scalar> maxi(const CppAD::cg::CG<Scalar>& x, const CppAD::cg::CG<Scalar>& y)
+    {
+      using ::pinocchio::internal::if_then_else;
+      using ::pinocchio::internal::LT;
+      return if_then_else(LT, x, y, y, x);
+    }
+  }
+  
 } // namespace Eigen
 
 namespace CppAD

--- a/src/codegen/cppadcg.hpp
+++ b/src/codegen/cppadcg.hpp
@@ -5,6 +5,7 @@
 #ifndef __pinocchio_codegen_ccpadcg_hpp__
 #define __pinocchio_codegen_ccpadcg_hpp__
 
+#include "pinocchio/container/boost-container-limits.hpp"
 #include "pinocchio/math/fwd.hpp"
 
 #include <cmath>

--- a/src/codegen/cppadcg.hpp
+++ b/src/codegen/cppadcg.hpp
@@ -8,6 +8,7 @@
 #include "pinocchio/math/fwd.hpp"
 
 #include <cmath>
+#include "pinocchio/autodiff/cppad/minmax.hpp"
 #include <cppad/cg/support/cppadcg_eigen.hpp>
 
 #include "pinocchio/autodiff/cppad.hpp"
@@ -67,10 +68,11 @@ namespace Eigen
     
   }
   namespace numext
-  {
+  { 
     template<typename Scalar>
     EIGEN_DEVICE_FUNC
-    EIGEN_ALWAYS_INLINE CppAD::cg::CG<Scalar> mini(const CppAD::cg::CG<Scalar>& x, const CppAD::cg::CG<Scalar>& y)
+    EIGEN_ALWAYS_INLINE CppAD::cg::CG<Scalar> mini(const CppAD::cg::CG<Scalar>& x,
+                                                   const CppAD::cg::CG<Scalar>& y)
     {
       using ::pinocchio::internal::if_then_else;
       using ::pinocchio::internal::LT;
@@ -79,7 +81,8 @@ namespace Eigen
 
     template<typename Scalar>
     EIGEN_DEVICE_FUNC
-    EIGEN_ALWAYS_INLINE CppAD::cg::CG<Scalar> maxi(const CppAD::cg::CG<Scalar>& x, const CppAD::cg::CG<Scalar>& y)
+    EIGEN_ALWAYS_INLINE CppAD::cg::CG<Scalar> maxi(const CppAD::cg::CG<Scalar>& x,
+                                                   const CppAD::cg::CG<Scalar>& y)
     {
       using ::pinocchio::internal::if_then_else;
       using ::pinocchio::internal::LT;

--- a/src/codegen/cppadcg.hpp
+++ b/src/codegen/cppadcg.hpp
@@ -56,6 +56,15 @@ namespace Eigen
         return x.getValue();
       }
     };
+
+    template<typename Scalar> EIGEN_DEVICE_FUNC inline CppAD::cg::CG<Scalar>
+    pmin(const CppAD::cg::CG<Scalar>& a, const CppAD::cg::CG<Scalar>& b)
+    { return numext::mini(a, b); }
+    
+    template<typename Scalar> EIGEN_DEVICE_FUNC inline CppAD::cg::CG<Scalar>
+    pmax(const CppAD::cg::CG<Scalar>& a, const CppAD::cg::CG<Scalar>& b)
+    { return numext::maxi(a, b); }
+    
   }
   namespace numext
   {

--- a/src/fwd.hpp
+++ b/src/fwd.hpp
@@ -6,7 +6,26 @@
 #define __pinocchio_fwd_hpp__
 
 // Forward declaration of the main pinocchio namespace
-namespace pinocchio {}
+namespace pinocchio {
+
+  /// \brief Argument position.
+  ///        Used as template parameter to refer to an argument.
+  enum ArgumentPosition
+  {
+    ARG0 = 0,
+    ARG1 = 1,
+    ARG2 = 2,
+    ARG3 = 3,
+    ARG4 = 4
+  };
+  
+  enum AssignmentOperatorType
+  {
+    SETTO,
+    ADDTO,
+    RMTO
+  };
+}
 
 #include "pinocchio/macros.hpp"
 #include "pinocchio/deprecation.hpp"

--- a/src/fwd.hpp
+++ b/src/fwd.hpp
@@ -27,47 +27,6 @@ namespace pinocchio {}
 
 #include <cstddef> // std::size_t
 
-namespace pinocchio
-{
-  ///
-  /// \brief Common traits structure to fully define base classes for CRTP.
-  ///
-  template<class C> struct traits {};
-  
-  namespace internal
-  {
-    template<typename T> struct traits {};
-  }
-  
-  ///
-  /// \brief Type of the cast of a class C templated by Scalar and Options, to a new NewScalar type.
-  ///        This class should be specialized for each types.
-  ///
-  template<typename NewScalar, class C> struct CastType;
-
-  /// \brief Argument position.
-  ///        Used as template parameter to refer to an argument.
-  enum ArgumentPosition
-  {
-    ARG0 = 0,
-    ARG1 = 1,
-    ARG2 = 2,
-    ARG3 = 3,
-    ARG4 = 4
-  };
-
-  enum AssignmentOperatorType
-  {
-    SETTO,
-    ADDTO,
-    RMTO
-  };
-
-  
-  
-  /// \brief Return type undefined
-  ///        This is an helper structure to help internal diagnosis.
-  struct ReturnTypeNotDefined;
-}
+#include "pinocchio/traits.hpp"
 
 #endif // #ifndef __pinocchio_fwd_hpp__

--- a/src/math/fwd.hpp
+++ b/src/math/fwd.hpp
@@ -5,7 +5,7 @@
 #ifndef __pinocchio_math_fwd_hpp__
 #define __pinocchio_math_fwd_hpp__
 
-#include "pinocchio/fwd.hpp"
+#include "pinocchio/traits.hpp"
 #include <math.h>
 #include <boost/math/constants/constants.hpp>
 

--- a/src/math/matrix.hpp
+++ b/src/math/matrix.hpp
@@ -5,7 +5,7 @@
 #ifndef __pinocchio_math_matrix_hpp__
 #define __pinocchio_math_matrix_hpp__
 
-#include "pinocchio/macros.hpp"
+#include "pinocchio/fwd.hpp"
 #include "pinocchio/math/fwd.hpp"
 
 #include <Eigen/Core>

--- a/src/math/quaternion.hpp
+++ b/src/math/quaternion.hpp
@@ -9,6 +9,7 @@
   #define PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE 1e-8
 #endif
 
+#include "pinocchio/fwd.hpp"
 #include "pinocchio/math/fwd.hpp"
 #include "pinocchio/math/comparison-operators.hpp"
 #include "pinocchio/math/matrix.hpp"

--- a/src/math/rpy.hpp
+++ b/src/math/rpy.hpp
@@ -5,6 +5,7 @@
 #ifndef __pinocchio_math_rpy_hpp__
 #define __pinocchio_math_rpy_hpp__
 
+#include "pinocchio/fwd.hpp"
 #include "pinocchio/math/fwd.hpp"
 #include "pinocchio/math/comparison-operators.hpp"
 

--- a/src/multibody/joint/joint-free-flyer.hpp
+++ b/src/multibody/joint/joint-free-flyer.hpp
@@ -11,6 +11,8 @@
 #include "pinocchio/spatial/explog.hpp"
 #include "pinocchio/multibody/joint/joint-base.hpp"
 #include "pinocchio/multibody/constraint.hpp"
+
+#include "pinocchio/fwd.hpp"
 #include "pinocchio/math/fwd.hpp"
 #include "pinocchio/math/quaternion.hpp"
 

--- a/src/multibody/joint/joint-revolute-unbounded.hpp
+++ b/src/multibody/joint/joint-revolute-unbounded.hpp
@@ -5,6 +5,7 @@
 #ifndef __pinocchio_joint_revolute_unbounded_hpp__
 #define __pinocchio_joint_revolute_unbounded_hpp__
 
+#include "pinocchio/fwd.hpp"
 #include "pinocchio/math/fwd.hpp"
 #include "pinocchio/math/sincos.hpp"
 #include "pinocchio/spatial/inertia.hpp"

--- a/src/spatial/inertia.hpp
+++ b/src/spatial/inertia.hpp
@@ -8,6 +8,7 @@
 
 #include <iostream>
 
+#include "pinocchio/fwd.hpp"
 #include "pinocchio/math/fwd.hpp"
 #include "pinocchio/spatial/symmetric3.hpp"
 #include "pinocchio/spatial/force.hpp"

--- a/src/traits.hpp
+++ b/src/traits.hpp
@@ -1,3 +1,7 @@
+//
+// Copyright (c) 2018-2020 INRIA CNRS
+//
+
 #ifndef __pinocchio_traits_hpp__
 #define __pinocchio_traits_hpp__
 
@@ -18,25 +22,6 @@ namespace pinocchio
   ///        This class should be specialized for each types.
   ///
   template<typename NewScalar, class C> struct CastType;
-
-  /// \brief Argument position.
-  ///        Used as template parameter to refer to an argument.
-  enum ArgumentPosition
-  {
-    ARG0 = 0,
-    ARG1 = 1,
-    ARG2 = 2,
-    ARG3 = 3,
-    ARG4 = 4
-  };
-
-  enum AssignmentOperatorType
-  {
-    SETTO,
-    ADDTO,
-    RMTO
-  };
-
   
   
   /// \brief Return type undefined

--- a/src/traits.hpp
+++ b/src/traits.hpp
@@ -1,0 +1,47 @@
+#ifndef __pinocchio_traits_hpp__
+#define __pinocchio_traits_hpp__
+
+namespace pinocchio
+{
+  ///
+  /// \brief Common traits structure to fully define base classes for CRTP.
+  ///
+  template<class C> struct traits {};
+  
+  namespace internal
+  {
+    template<typename T> struct traits {};
+  }
+  
+  ///
+  /// \brief Type of the cast of a class C templated by Scalar and Options, to a new NewScalar type.
+  ///        This class should be specialized for each types.
+  ///
+  template<typename NewScalar, class C> struct CastType;
+
+  /// \brief Argument position.
+  ///        Used as template parameter to refer to an argument.
+  enum ArgumentPosition
+  {
+    ARG0 = 0,
+    ARG1 = 1,
+    ARG2 = 2,
+    ARG3 = 3,
+    ARG4 = 4
+  };
+
+  enum AssignmentOperatorType
+  {
+    SETTO,
+    ADDTO,
+    RMTO
+  };
+
+  
+  
+  /// \brief Return type undefined
+  ///        This is an helper structure to help internal diagnosis.
+  struct ReturnTypeNotDefined;
+}
+
+#endif

--- a/src/utils/static-if.hpp
+++ b/src/utils/static-if.hpp
@@ -5,7 +5,7 @@
 #ifndef __pinocchio_utils_static_if_hpp__
 #define __pinocchio_utils_static_if_hpp__
 
-#include "pinocchio/fwd.hpp"
+#include "pinocchio/traits.hpp"
 
 namespace pinocchio
 {

--- a/unittest/all-joints.cpp
+++ b/unittest/all-joints.cpp
@@ -3,6 +3,7 @@
 // Copyright(c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 
+#include "pinocchio/fwd.hpp"
 #include "pinocchio/math/fwd.hpp"
 #include "pinocchio/multibody/joint/joints.hpp"
 #include "pinocchio/algorithm/rnea.hpp"

--- a/unittest/cppad-basic.cpp
+++ b/unittest/cppad-basic.cpp
@@ -171,6 +171,61 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
     BOOST_CHECK(NearEqual(dz[0],std::cos(x0),eps99,eps99));
   }
 
+  BOOST_AUTO_TEST_CASE(test_eigen_min)
+  {
+    using CppAD::AD;
+    
+    typedef double Scalar;
+    typedef AD<double> ADScalar;
+    Eigen::Matrix<ADScalar, Eigen::Dynamic, 1> ad_X;
+    Eigen::Matrix<ADScalar, Eigen::Dynamic, 1> ad_Y;
+    ad_X.resize(2);
+    ad_Y.resize(2);
+
+    Eigen::Matrix2d x_test(-1,1);
+    Eigen::Matrix2d y_test = x_test.array().min(Scalar(0.));
+    
+    CppAD::Independent(ad_X);
+    //Function
+    ad_Y = ad_X.array().min(Scalar(0.));
+    CppAD::ADFun<Scalar> ad_fun(ad_X,ad_Y);
+
+    CPPAD_TESTVECTOR(Scalar) x((size_t)2);
+    Eigen::Map<Eigen::Matrix2d>(x.data(),2,1) = x_test;
+
+    CPPAD_TESTVECTOR(Scalar) y = ad_fun.Forward(0,x);
+
+    BOOST_CHECK(Eigen::Map<Eigen::Matrix2d>(y.data(),2,1).isApprox(y_test));
+  }
+
+  BOOST_AUTO_TEST_CASE(test_eigen_max)
+  {
+    using CppAD::AD;
+    
+    typedef double Scalar;
+    typedef AD<double> ADScalar;
+    Eigen::Matrix<ADScalar, Eigen::Dynamic, 1> ad_X;
+    Eigen::Matrix<ADScalar, Eigen::Dynamic, 1> ad_Y;
+    ad_X.resize(2);
+    ad_Y.resize(2);
+
+    Eigen::Matrix2d x_test(-1,1);
+    Eigen::Matrix2d y_test = x_test.array().max(Scalar(0.));
+    
+    CppAD::Independent(ad_X);
+    //Function
+    ad_Y = ad_X.array().max(Scalar(0.));
+    CppAD::ADFun<Scalar> ad_fun(ad_X,ad_Y);
+
+    CPPAD_TESTVECTOR(Scalar) x((size_t)2);
+    Eigen::Map<Eigen::Matrix2d>(x.data(),2,1) = x_test;
+
+    CPPAD_TESTVECTOR(Scalar) y = ad_fun.Forward(0,x);
+
+    BOOST_CHECK(Eigen::Map<Eigen::Matrix2d>(y.data(),2,1).isApprox(y_test));
+  }
+
+
   BOOST_AUTO_TEST_CASE(test_eigen_support)
   {
     using namespace CppAD;

--- a/unittest/joint-free-flyer.cpp
+++ b/unittest/joint-free-flyer.cpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 
+#include "pinocchio/fwd.hpp"
 #include "pinocchio/math/fwd.hpp"
 #include "pinocchio/multibody/joint/joints.hpp"
 #include "pinocchio/algorithm/rnea.hpp"

--- a/unittest/joint-planar.cpp
+++ b/unittest/joint-planar.cpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 
+#include "pinocchio/fwd.hpp"
 #include "pinocchio/math/fwd.hpp"
 #include "pinocchio/multibody/joint/joints.hpp"
 #include "pinocchio/algorithm/rnea.hpp"

--- a/unittest/joint-prismatic.cpp
+++ b/unittest/joint-prismatic.cpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 
+#include "pinocchio/fwd.hpp"
 #include "pinocchio/math/fwd.hpp"
 #include "pinocchio/multibody/joint/joints.hpp"
 #include "pinocchio/algorithm/rnea.hpp"

--- a/unittest/joint-revolute.cpp
+++ b/unittest/joint-revolute.cpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 
+#include "pinocchio/fwd.hpp"
 #include "pinocchio/math/fwd.hpp"
 #include "pinocchio/multibody/joint/joints.hpp"
 #include "pinocchio/algorithm/rnea.hpp"

--- a/unittest/joint-spherical.cpp
+++ b/unittest/joint-spherical.cpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 
+#include "pinocchio/fwd.hpp"
 #include "pinocchio/math/fwd.hpp"
 #include "pinocchio/multibody/joint/joints.hpp"
 #include "pinocchio/algorithm/rnea.hpp"

--- a/unittest/joint-translation.cpp
+++ b/unittest/joint-translation.cpp
@@ -3,6 +3,7 @@
 // Copyright (c) 2015 Wandercraft, 86 rue de Paris 91400 Orsay, France.
 //
 
+#include "pinocchio/fwd.hpp"
 #include "pinocchio/math/fwd.hpp"
 #include "pinocchio/multibody/joint/joints.hpp"
 #include "pinocchio/algorithm/rnea.hpp"


### PR DESCRIPTION
This PR creates codegen/autodiff support for the Eigen `min`/`max` operations.

For that purpose, the min/max specialization needs to be loaded before Eigen/Core is loaded. Else, the eigen implementation defaults to `std::max/min`.

1. I had to separate the traits from the `fwd.hpp` so it could be loaded before `Eigen/Core`
2. The `minmax.hpp` file has to be loaded before Eigen/Core is loaded. This means loading it before `math/fwd.hpp`.
3. Since `minmax.hpp` needs to be included before `Eigen`, I had to redefine the eigen inline macros.
4. I had to refactor the header `math/fwd.hpp`, since it was loading `Eigen/Core` module, and `pinocchio/math/fwd.hpp` did not require `Eigen`. With this PR, Eigen/Core is not loaded with `pinocchio/math/fwd.hpp`.
5. I've added a unittest to check the min/max support

Point 3 might affect downstream repositories, if they only include `math/fwd.hpp` and not `fwd.hpp`.  

1. Any downstream user that is doing that would need to include `fwd.hpp` as well.
2. On the other hand, this refactoring is needed for inequality cost support in `crocoddyl`.

