### PR TITLE
Update my email since the robots.ox.ac.uk does not receive buildserver updates

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -6,7 +6,7 @@
   <!-- The maintainer listed here is for the ROS release to receive emails for the buildfarm. 
   Please check the repository URL for full list of authors and maintainers. -->
   <maintainer email="justin.carpentier@inria.fr">Justin Carpentier</maintainer>
-  <maintainer email="wolfgang@robots.ox.ac.uk">Wolfgang Merkt</maintainer>
+  <maintainer email="opensource@wolfgangmerkt.com">Wolfgang Merkt</maintainer>
   <license>BSD</license>
 
   <url type="website">https://github.com/stack-of-tasks/pinocchio</url>


### PR DESCRIPTION
I didn't get any of the recent buildserver emails and we can't track down where they are getting lost... so changing my email for notifications.