### PR TITLE
package.xml: Add texlive dependency for documentation jobs

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -14,6 +14,7 @@
   <build_depend>git</build_depend>
   <build_depend>doxygen</build_depend>
   <doc_depend>doxygen</doc_depend>
+  <doc_depend>texlive-latex-base</doc_depend>
   <!-- The following tags are recommended by REP-136 -->
   <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
   <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>


### PR DESCRIPTION
While this morning's documentation build job failure was unrelated, going through the logs highlighted a missing dependency: Adding this dependency will correctly render Latex in the future.