### PR TITLE
Topic/cppad support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -216,6 +216,7 @@ MAKE_DIRECTORY("${${PROJECT_NAME}_BINARY_DIR}/include/pinocchio/autodiff/casadi/
 MAKE_DIRECTORY("${${PROJECT_NAME}_BINARY_DIR}/include/pinocchio/autodiff/cppad")
 MAKE_DIRECTORY("${${PROJECT_NAME}_BINARY_DIR}/include/pinocchio/autodiff/cppad/spatial")
 MAKE_DIRECTORY("${${PROJECT_NAME}_BINARY_DIR}/include/pinocchio/autodiff/cppad/math")
+MAKE_DIRECTORY("${${PROJECT_NAME}_BINARY_DIR}/include/pinocchio/autodiff/cppad/algorithm")
 MAKE_DIRECTORY("${${PROJECT_NAME}_BINARY_DIR}/include/pinocchio/autodiff/cppad/utils")
 
 SET(HEADERS_)

--- a/src/algorithm/aba.hxx
+++ b/src/algorithm/aba.hxx
@@ -115,30 +115,6 @@ namespace pinocchio
       }
     };
     
-#ifdef PINOCCHIO_WITH_CPPAD_SUPPORT
-    /// \brief Partial specialization for CppAD::AGtypes
-    template<typename _Scalar>
-    struct SE3actOn< CppAD::AD<_Scalar> >
-    {
-      typedef CppAD::AD<_Scalar> Scalar;
-      
-      template<int Options, typename Matrix6Type>
-      static typename PINOCCHIO_EIGEN_PLAIN_TYPE(Matrix6Type)
-      run(const SE3Tpl<Scalar,Options> & M,
-          const Eigen::MatrixBase<Matrix6Type> & I)
-      {
-        typedef SE3Tpl<Scalar,Options> SE3;
-        
-        typedef typename PINOCCHIO_EIGEN_PLAIN_TYPE(Matrix6Type) ReturnType;
-        
-        typename SE3::ActionMatrixType dual_action_matrix(M.toDualActionMatrix());
-        typename SE3::ActionMatrixType action_matrix(M.toActionMatrixInverse());
-        ReturnType intermediate_result = dual_action_matrix*I;
-        ReturnType res = intermediate_result*action_matrix;
-        return res;
-      }
-    };
-#endif
   }
   
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>

--- a/src/autodiff/cppad.hpp
+++ b/src/autodiff/cppad.hpp
@@ -176,5 +176,7 @@ namespace pinocchio
 #include "pinocchio/autodiff/cppad/spatial/log.hxx"
 #include "pinocchio/autodiff/cppad/utils/static-if.hpp"
 #include "pinocchio/autodiff/cppad/math/quaternion.hpp"
+#include "pinocchio/autodiff/cppad/algorithm/aba.hpp"
+
 
 #endif // #ifndef __pinocchio_autodiff_cppad_hpp__

--- a/src/autodiff/cppad/algorithm/aba.hpp
+++ b/src/autodiff/cppad/algorithm/aba.hpp
@@ -1,0 +1,41 @@
+//
+// Copyright (c) 2019-2020 INRIA CNRS
+//
+
+#ifndef __pinocchio_autodiff_cppad_algorithm_aba_hpp__
+#define __pinocchio_autodiff_cppad_algorithm_aba_hpp__
+
+namespace pinocchio
+{
+  namespace internal
+  {
+
+    //Fwd def
+    template<typename _Scalar>  struct SE3actOn;
+    
+    /// \brief Partial specialization for CppAD::AGtypes
+    template<typename _Scalar>
+    struct SE3actOn< CppAD::AD<_Scalar> >
+    {
+      typedef CppAD::AD<_Scalar> Scalar;
+      
+      template<int Options, typename Matrix6Type>
+      static typename PINOCCHIO_EIGEN_PLAIN_TYPE(Matrix6Type)
+      run(const SE3Tpl<Scalar,Options> & M,
+          const Eigen::MatrixBase<Matrix6Type> & I)
+      {
+        typedef SE3Tpl<Scalar,Options> SE3;
+        
+        typedef typename PINOCCHIO_EIGEN_PLAIN_TYPE(Matrix6Type) ReturnType;
+        
+        typename SE3::ActionMatrixType dual_action_matrix(M.toDualActionMatrix());
+        typename SE3::ActionMatrixType action_matrix(M.toActionMatrixInverse());
+        ReturnType intermediate_result = dual_action_matrix*I;
+        ReturnType res = intermediate_result*action_matrix;
+        return res;
+      }
+    };
+  }
+}
+
+#endif // __pinocchio_autodiff_cppad_algorithm_aba_hpp__


### PR DESCRIPTION
Move cppad specialization from `aba.hxx` to `cppad/algorithm/aba`.

This PR removes any need for a inclusion of cppadcg if code-gen is not being used.