### PR TITLE
existJointName/existFrame: Handle case of empty name

### DIFF
--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -223,7 +223,7 @@ namespace pinocchio
   inline bool ModelTpl<Scalar,Options,JointCollectionTpl>::
   existJointName(const std::string & name) const
   {
-    return (names.end() != std::find(names.begin(),names.end(),name));
+    return !name.empty() && (names.end() != std::find(names.begin(),names.end(),name));
   }
 
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
@@ -245,7 +245,7 @@ namespace pinocchio
   inline bool ModelTpl<Scalar,Options,JointCollectionTpl>::
   existFrame(const std::string & name, const FrameType & type) const
   {
-    return std::find_if(frames.begin(), frames.end(),
+    return !name.empty() && std::find_if(frames.begin(), frames.end(),
                         details::FilterFrame(name, type)) != frames.end();
   }
 

--- a/src/parsers/urdf/geometry.hxx
+++ b/src/parsers/urdf/geometry.hxx
@@ -42,7 +42,7 @@ namespace pinocchio
         {
           if (!model.existFrame(link_name, BODY))
           {
-            throw std::invalid_argument("No link " + link_name + " in model");
+            throw std::invalid_argument("No link '" + link_name + "' in model");
           }
           fid = model.getFrameId(link_name, BODY);
           PINOCCHIO_CHECK_INPUT_ARGUMENT(model.frames[fid].type == BODY);


### PR DESCRIPTION
Noticed when we got a segmentation fault due to a wrong name (empty string). We probably don't want to allow empty strings as names...