### PR TITLE
python unittest: use context to open files

### DIFF
--- a/unittest/python/bindings_urdf.py
+++ b/unittest/python/bindings_urdf.py
@@ -20,8 +20,9 @@ class TestGeometryObjectUrdfBindings(unittest.TestCase):
         model_ref = pin.buildModelFromUrdf(self.model_path, pin.JointModelFreeFlyer())
 
     def test_xml(self):
-        file_content = open(self.model_path,"r").read()
-        
+        with open(self.model_path) as model:
+            file_content = model.read()
+
         model_ref = pin.buildModelFromUrdf(self.model_path, pin.JointModelFreeFlyer())
         model = pin.buildModelFromXML(file_content,pin.JointModelFreeFlyer())
 


### PR DESCRIPTION
minor fix of:
```
…/pinocchio/unittest/python/bindings_urdf.py:23: ResourceWarning: 
unclosed file <_io.TextIOWrapper name='…/pinocchio/models/others/robots/romeo_description/urdf/romeo.urdf' mode='r' encoding='UTF-8'>
  file_content = open(self.model_path,"r").read()
```