### PR TITLE
Fix buildReducedModel

### DIFF
--- a/src/algorithm/model.hpp
+++ b/src/algorithm/model.hpp
@@ -83,6 +83,9 @@ namespace pinocchio
    *
    *  \remarks All the joints that have been set to be fixed in the new reduced_model now appear in the kinematic tree as a Frame as FIXED_JOINT.
    *
+   *  \todo At the moment, the joint and geometry order is kept while the frames
+   *  are re-ordered in a hard to predict way. Their order could be kept.
+   *
    */
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
   void

--- a/src/algorithm/model.hxx
+++ b/src/algorithm/model.hxx
@@ -509,6 +509,8 @@ namespace pinocchio
       
       GeometryObject reduced_geom(geom);
       reduced_geom.parentJoint = reduced_joint_id;
+      reduced_geom.parentFrame = reduced_model.getBodyId(
+          input_model.frames[geom.parentFrame].name);
       reduced_geom.placement = relative_placement * geom.placement;
       reduced_geom_model.addGeometryObject(reduced_geom);
     }

--- a/unittest/model.cpp
+++ b/unittest/model.cpp
@@ -422,13 +422,15 @@ BOOST_AUTO_TEST_CASE(test_buildReducedModel_with_geom)
   {
     const GeometryObject & go1 = humanoid_geometry.geometryObjects[i];
     const GeometryObject & go2 = reduced_humanoid_geometry.geometryObjects[i];
-    BOOST_CHECK(go1.name == go2.name);
-    BOOST_CHECK(go1.geometry == go2.geometry);
-    BOOST_CHECK(go1.meshPath == go2.meshPath);
-    BOOST_CHECK(go1.meshScale == go2.meshScale);
-    BOOST_CHECK(go1.overrideMaterial == go2.overrideMaterial);
-    BOOST_CHECK(go1.meshColor == go2.meshColor);
-    BOOST_CHECK(go1.meshTexturePath == go2.meshTexturePath);
+    BOOST_CHECK_EQUAL(go1.name, go2.name);
+    BOOST_CHECK_EQUAL(go1.geometry, go2.geometry);
+    BOOST_CHECK_EQUAL(go1.meshPath, go2.meshPath);
+    BOOST_CHECK_EQUAL(go1.meshScale, go2.meshScale);
+    BOOST_CHECK_EQUAL(go1.overrideMaterial, go2.overrideMaterial);
+    BOOST_CHECK_EQUAL(go1.meshColor, go2.meshColor);
+    BOOST_CHECK_EQUAL(go1.meshTexturePath, go2.meshTexturePath);
+    BOOST_CHECK_EQUAL(humanoid_model.frames[go1.parentFrame].name,
+                      reduced_humanoid_model.frames[go2.parentFrame].name);
   }
   
   Data data(humanoid_model), reduced_data(reduced_humanoid_model);


### PR DESCRIPTION
The parent frame of the geometry objects was copied from the input model. As the frame order is not kept, they were erroneous.

As a side note, I think the frame order could be kept. I won't have time to dig into this.
