### PR TITLE
[parser] Compute Local AABB when loading a geometry.

### DIFF
--- a/src/parsers/urdf/geometry.cpp
+++ b/src/parsers/urdf/geometry.cpp
@@ -224,6 +224,7 @@ namespace pinocchio
           throw std::invalid_argument("The polyhedron retrived is empty");
         }
 
+        geometry->computeLocalAABB();
         return geometry;
       }
 #endif // PINOCCHIO_WITH_HPP_FCL


### PR DESCRIPTION
It seems that the method was not called for all the geometry types. Since the AABB is now initialized to infinity, the missing
call has visible effects.