### PR TITLE
add Robot wrapper.reduceModel function and extend buildReducedModel for multiple GeometricModel

### DIFF
--- a/bindings/python/algorithm/expose-model.cpp
+++ b/bindings/python/algorithm/expose-model.cpp
@@ -125,7 +125,7 @@ namespace pinocchio
               buildReducedModel<double, 0, JointCollectionDefaultTpl, VectorXd>,
           bp::args("model", "geom_model", "list_of_joints_to_lock",
                    "reference_configuration"),
-          "Build a reduced model and a rededuced geometry model  from a given "
+          "Build a reduced model and a reduced geometry model from a given "
           "input model,"
           "a given input geometry model and a list of joint to lock.\n\n"
           "Parameters:\n"
@@ -143,7 +143,7 @@ namespace pinocchio
               buildReducedModel<double, 0, JointCollectionDefaultTpl, VectorXd>,
           bp::args("model", "list_of_geom_models", "list_of_joints_to_lock",
                    "reference_configuration"),
-          "Build a reduced model and a rededuced geometry model  from a given "
+          "Build a reduced model and a reduced geometry model from a given "
           "input model,"
           "a given input geometry model and a list of joint to lock.\n\n"
           "Parameters:\n"

--- a/bindings/python/algorithm/expose-model.cpp
+++ b/bindings/python/algorithm/expose-model.cpp
@@ -50,17 +50,17 @@ namespace pinocchio
     template <typename Scalar, int Options,
               template <typename, int> class JointCollectionTpl,
               typename ConfigVectorType>
-    bp::tuple buildReducedModel(
-        const ModelTpl<Scalar, Options, JointCollectionTpl> &model,
-        const std::vector<GeometryModel> &list_of_geom_models,
-        const std::vector<JointIndex> &list_of_joints_to_lock,
-        const Eigen::MatrixBase<ConfigVectorType> &reference_configuration) {
+    bp::tuple buildReducedModel(const ModelTpl<Scalar, Options, JointCollectionTpl> &model,
+                                const std::vector<GeometryModel,Eigen::aligned_allocator<GeometryModel> > &list_of_geom_models,
+                                const std::vector<JointIndex> &list_of_joints_to_lock,
+                                const Eigen::MatrixBase<ConfigVectorType> &reference_configuration)
+  {
       typedef ModelTpl<Scalar, Options, JointCollectionTpl> Model;
-      std::vector<GeometryModel> reduced_geom_models;
+      std::vector<GeometryModel,Eigen::aligned_allocator<GeometryModel> > reduced_geom_models;
       Model reduced_model;
       buildReducedModel(model, list_of_geom_models, list_of_joints_to_lock,
-                          reference_configuration, reduced_model,
-                          reduced_geom_models);
+                        reference_configuration, reduced_model,
+                        reduced_geom_models);
       return bp::make_tuple(reduced_model, reduced_geom_models);
     }
 
@@ -68,7 +68,8 @@ namespace pinocchio
     {
       using namespace Eigen;
 
-      StdVectorPythonVisitor<GeometryModel>::expose("StdVec_GeometryModel");
+      typedef std::vector<GeometryModel,Eigen::aligned_allocator<GeometryModel> > GeometryModelVector;
+      StdVectorPythonVisitor<GeometryModel,GeometryModelVector::allocator_type>::expose("StdVec_GeometryModel");
 
       bp::def("appendModel",
               (Model (*)(const Model &, const Model &, const FrameIndex, const SE3 &))&appendModel<double,0,JointCollectionDefaultTpl>,
@@ -105,14 +106,17 @@ namespace pinocchio
               "\treference_configuration: reference configuration to compute the placement of the lock joints\n");
 
       bp::def("buildReducedModel",
-              (bp::tuple (*)(const Model &, const GeometryModel &, const std::vector<JointIndex> &, const Eigen::MatrixBase<VectorXd> &))
+              (bp::tuple (*)(const Model &,
+                             const GeometryModel &,
+                             const std::vector<JointIndex> &,
+                             const Eigen::MatrixBase<VectorXd> &))
               &buildReducedModel<double,0,JointCollectionDefaultTpl,VectorXd>,
               bp::args("model",
                        "geom_model",
                        "list_of_joints_to_lock",
                        "reference_configuration"),
-              "Build a reduced model and a rededuced geometry model  from a given input model,"
-              "a given input geometry model and a list of joint to lock.\n\n"
+              "Build a reduced model and a rededuced geometry model from a given input model,"
+              "an input geometry model and a list of joint to lock.\n\n"
               "Parameters:\n"
               "\tmodel: input kinematic modell to reduce\n"
               "\tgeom_model: input geometry model to reduce\n"
@@ -120,15 +124,16 @@ namespace pinocchio
               "\treference_configuration: reference configuration to compute the placement of the lock joints\n");
 
       bp::def("buildReducedModel",
-              (bp::tuple(*)(const Model &, const std::vector<GeometryModel> &,
+              (bp::tuple(*)(const Model &,
+                            const std::vector<GeometryModel,Eigen::aligned_allocator<GeometryModel> > &,
                             const std::vector<JointIndex> &,
-                            const Eigen::MatrixBase<VectorXd> &)) &
-                  buildReducedModel<double, 0, JointCollectionDefaultTpl, VectorXd>,
+                            const Eigen::MatrixBase<VectorXd> &))
+              buildReducedModel<double, 0, JointCollectionDefaultTpl, VectorXd>,
               bp::args("model", "list_of_geom_models", "list_of_joints_to_lock",
-                      "reference_configuration"),
-              "Build a reduced model and a reduced geometry model from a given "
+                       "reference_configuration"),
+              "Build a reduced model and the related reduced geometry models from a given "
               "input model,"
-              "a given input geometry model and a list of joint to lock.\n\n"
+              "a list of input geometry model and a list of joint to lock.\n\n"
               "Parameters:\n"
               "\tmodel: input kinematic model to reduce\n"
               "\tlist_of_geom_models: input geometry models to reduce\n"

--- a/bindings/python/algorithm/expose-model.cpp
+++ b/bindings/python/algorithm/expose-model.cpp
@@ -42,13 +42,10 @@ namespace pinocchio
         const Eigen::MatrixBase<ConfigVectorType> &reference_configuration) {
       typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
       Model reduced_model;
-      std::vector<GeometryModel> reduced_geom_models(list_of_geom_models.size());
-      std::vector<std::reference_wrapper<GeometryModel>>
-          reduced_geom_models_refs(reduced_geom_models.begin(),
-                                   reduced_geom_models.end());
+      std::vector<GeometryModel> reduced_geom_models;
 
       buildReducedModel(model,list_of_geom_models,list_of_joints_to_lock,
-                        reference_configuration,reduced_model,reduced_geom_models_refs);
+                        reference_configuration,reduced_model,reduced_geom_models);
       
       return bp::make_tuple(reduced_model,reduced_geom_models);
     }
@@ -65,12 +62,8 @@ namespace pinocchio
       Model reduced_model;
       std::vector<GeometryModel> geom_models{ geom_model };
       std::vector<GeometryModel> reduced_geom_models(1); // in this case it's a single element
-      std::vector<std::reference_wrapper<GeometryModel>>
-          reduced_geom_models_refs(reduced_geom_models.begin(),
-                                   reduced_geom_models.end());
-
       buildReducedModel(model,geom_models,list_of_joints_to_lock,
-                        reference_configuration,reduced_model,reduced_geom_models_refs);
+                        reference_configuration,reduced_model,reduced_geom_models);
       
       return bp::make_tuple(reduced_model,reduced_geom_models.front());
     }

--- a/bindings/python/algorithm/expose-model.cpp
+++ b/bindings/python/algorithm/expose-model.cpp
@@ -2,9 +2,11 @@
 // Copyright (c) 2019-2020 INRIA
 //
 
-#include "pinocchio/bindings/python/algorithm/algorithms.hpp"
-#include "pinocchio/bindings/python/utils/list.hpp"
 #include "pinocchio/algorithm/model.hpp"
+#include "pinocchio/bindings/python/algorithm/algorithms.hpp"
+#include "pinocchio/bindings/python/serialization/serializable.hpp"
+#include "pinocchio/bindings/python/utils/list.hpp"
+#include "pinocchio/bindings/python/utils/std-vector.hpp"
 
 namespace pinocchio
 {
@@ -12,7 +14,7 @@ namespace pinocchio
   {
 
     namespace bp = boost::python;
-  
+
     template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
     bp::tuple appendModel_proxy(const ModelTpl<Scalar,Options,JointCollectionTpl> & modelA,
                                 const ModelTpl<Scalar,Options,JointCollectionTpl> & modelB,
@@ -29,27 +31,56 @@ namespace pinocchio
       
       return bp::make_tuple(model,geom_model);
     }
-  
-    template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
-    bp::tuple
-    buildReducedModel(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                      const GeometryModel & geom_model,
-                      const std::vector<JointIndex> & list_of_joints_to_lock,
-                      const Eigen::MatrixBase<ConfigVectorType> & reference_configuration)
-    {
+
+    template <typename Scalar, int Options,
+              template <typename, int> class JointCollectionTpl,
+              typename ConfigVectorType>
+    bp::tuple buildReducedModel(
+        const ModelTpl<Scalar, Options, JointCollectionTpl> &model,
+        const std::vector<GeometryModel> &list_of_geom_models,
+        const std::vector<JointIndex> &list_of_joints_to_lock,
+        const Eigen::MatrixBase<ConfigVectorType> &reference_configuration) {
       typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
-      Model reduced_model; GeometryModel reduced_geom_model;
+      Model reduced_model;
+      std::vector<GeometryModel> reduced_geom_models(list_of_geom_models.size());
+      std::vector<std::reference_wrapper<GeometryModel>>
+          reduced_geom_models_refs(reduced_geom_models.begin(),
+                                   reduced_geom_models.end());
+
+      buildReducedModel(model,list_of_geom_models,list_of_joints_to_lock,
+                        reference_configuration,reduced_model,reduced_geom_models_refs);
       
-      buildReducedModel(model,geom_model,list_of_joints_to_lock,
-                        reference_configuration,reduced_model,reduced_geom_model);
-      
-      return bp::make_tuple(reduced_model,reduced_geom_model);
+      return bp::make_tuple(reduced_model,reduced_geom_models);
     }
-  
+
+    template <typename Scalar, int Options,
+              template <typename, int> class JointCollectionTpl,
+              typename ConfigVectorType>
+    bp::tuple buildReducedModel(
+        const ModelTpl<Scalar, Options, JointCollectionTpl> &model,
+        const GeometryModel &geom_model,
+        const std::vector<JointIndex> &list_of_joints_to_lock,
+        const Eigen::MatrixBase<ConfigVectorType> &reference_configuration) {
+      typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
+      Model reduced_model;
+      std::vector<GeometryModel> geom_models{ geom_model };
+      std::vector<GeometryModel> reduced_geom_models(1); // in this case it's a single element
+      std::vector<std::reference_wrapper<GeometryModel>>
+          reduced_geom_models_refs(reduced_geom_models.begin(),
+                                   reduced_geom_models.end());
+
+      buildReducedModel(model,geom_models,list_of_joints_to_lock,
+                        reference_configuration,reduced_model,reduced_geom_models_refs);
+      
+      return bp::make_tuple(reduced_model,reduced_geom_models.front());
+    }
+
     void exposeModelAlgo()
     {
       using namespace Eigen;
-      
+
+      StdVectorPythonVisitor<GeometryModel>::expose("StdVec_GeometryModel");
+
       bp::def("appendModel",
               (Model (*)(const Model &, const Model &, const FrameIndex, const SE3 &))&appendModel<double,0,JointCollectionDefaultTpl>,
               bp::args("modelA","modelB","frame_in_modelA","aMb"),
@@ -84,21 +115,43 @@ namespace pinocchio
               "\tlist_of_joints_to_lock: list of joint indexes to lock\n"
               "\treference_configuration: reference configuration to compute the placement of the lock joints\n");
 
-      bp::def("buildReducedModel",
-              (bp::tuple (*)(const Model &, const GeometryModel &, const std::vector<JointIndex> &, const Eigen::MatrixBase<VectorXd> &))
-              &buildReducedModel<double,0,JointCollectionDefaultTpl,VectorXd>,
-              bp::args("model",
-                       "geom_model",
-                       "list_of_joints_to_lock",
-                       "reference_configuration"),
-              "Build a reduced model and a rededuced geometry model  from a given input model,"
-              "a given input geometry model and a list of joint to lock.\n\n"
-              "Parameters:\n"
-              "\tmodel: input kinematic modell to reduce\n"
-              "\tgeom_model: input geometry model to reduce\n"
-              "\tlist_of_joints_to_lock: list of joint indexes to lock\n"
-              "\treference_configuration: reference configuration to compute the placement of the lock joints\n");
-      
+      bp::def(
+          "buildReducedModel",
+          (bp::tuple(*)(
+              const Model &,
+              const GeometryModel &,
+              const std::vector<JointIndex> &,
+              const Eigen::MatrixBase<VectorXd> &)) &
+              buildReducedModel<double, 0, JointCollectionDefaultTpl, VectorXd>,
+          bp::args("model", "geom_model", "list_of_joints_to_lock",
+                   "reference_configuration"),
+          "Build a reduced model and a rededuced geometry model  from a given "
+          "input model,"
+          "a given input geometry model and a list of joint to lock.\n\n"
+          "Parameters:\n"
+          "\tmodel: input kinematic modell to reduce\n"
+          "\tgeom_model: input geometry model to reduce\n"
+          "\tlist_of_joints_to_lock: list of joint indexes to lock\n"
+          "\treference_configuration: reference configuration to compute the "
+          "placement of the lock joints\n");
+
+      bp::def(
+          "buildReducedModel",
+          (bp::tuple(*)(const Model &, const std::vector<GeometryModel> &,
+                        const std::vector<JointIndex> &,
+                        const Eigen::MatrixBase<VectorXd> &)) &
+              buildReducedModel<double, 0, JointCollectionDefaultTpl, VectorXd>,
+          bp::args("model", "list_of_geom_models", "list_of_joints_to_lock",
+                   "reference_configuration"),
+          "Build a reduced model and a rededuced geometry model  from a given "
+          "input model,"
+          "a given input geometry model and a list of joint to lock.\n\n"
+          "Parameters:\n"
+          "\tmodel: input kinematic modell to reduce\n"
+          "\tlist_of_geom_models: input geometry models to reduce\n"
+          "\tlist_of_joints_to_lock: list of joint indexes to lock\n"
+          "\treference_configuration: reference configuration to compute the "
+          "placement of the lock joints\n");
     }
     
   } // namespace python

--- a/bindings/python/algorithm/expose-model.cpp
+++ b/bindings/python/algorithm/expose-model.cpp
@@ -115,13 +115,13 @@ namespace pinocchio
                        "geom_model",
                        "list_of_joints_to_lock",
                        "reference_configuration"),
-              "Build a reduced model and a rededuced geometry model from a given input model,"
-              "an input geometry model and a list of joint to lock.\n\n"
+              "Build a reduced model and a reduced geometry model from a given input model,"
+              "an input geometry model and a list of joints to lock.\n\n"
               "Parameters:\n"
-              "\tmodel: input kinematic modell to reduce\n"
+              "\tmodel: input kinematic model to reduce\n"
               "\tgeom_model: input geometry model to reduce\n"
               "\tlist_of_joints_to_lock: list of joint indexes to lock\n"
-              "\treference_configuration: reference configuration to compute the placement of the lock joints\n");
+              "\treference_configuration: reference configuration to compute the placement of the locked joints\n");
 
       bp::def("buildReducedModel",
               (bp::tuple(*)(const Model &,
@@ -133,13 +133,13 @@ namespace pinocchio
                        "reference_configuration"),
               "Build a reduced model and the related reduced geometry models from a given "
               "input model,"
-              "a list of input geometry model and a list of joint to lock.\n\n"
+              "a list of input geometry models and a list of joints to lock.\n\n"
               "Parameters:\n"
               "\tmodel: input kinematic model to reduce\n"
               "\tlist_of_geom_models: input geometry models to reduce\n"
               "\tlist_of_joints_to_lock: list of joint indexes to lock\n"
               "\treference_configuration: reference configuration to compute the "
-              "placement of the lock joints\n");
+              "placement of the locked joints\n");
     }
     
   } // namespace python

--- a/bindings/python/pinocchio/robot_wrapper.py
+++ b/bindings/python/pinocchio/robot_wrapper.py
@@ -175,18 +175,18 @@ class RobotWrapper(object):
     def framesForwardKinematics(self, q):
         pin.framesForwardKinematics(self.model, self.data, q)
 
-    def reduceModel(self,
-                    list_of_joints_to_lock,
-                    reference_configuration=None):
+    def buildReducedRobot(self,
+                          list_of_joints_to_lock,
+                          reference_configuration=None):
         """
-          Reduced the robot model given a list of joints to lock.
+          Build a reduced robot model given a list of joints to lock.
           Parameters:
           \tlist_of_joints_to_lock: list of joint indexes/names to lock.
           \treference_configuration: reference configuration to compute the
           placement of the lock joints. If not provided, reference_configuration
-        defaults to the robot's neutral configuration.
+          defaults to the robot's neutral configuration.
 
-        NOTE: This operation is not reversible, the original model is lost.
+          Returns: a new robot model.
         """
 
         # if joint to lock is a string, try to find its index
@@ -205,9 +205,9 @@ class RobotWrapper(object):
             list_of_geom_models=[self.visual_model, self.collision_model],
             list_of_joints_to_lock=lockjoints_idx,
             reference_configuration=reference_configuration)
-        self.model, self.visual_model, self.collision_model = model, geom_models[
-            0], geom_models[1]
-        self.rebuildData()
+
+        return RobotWrapper(model=model, visual_model=geom_models[0],
+                            collision_model=geom_models[1])
 
     def getFrameJacobian(self, frame_id, rf_frame=pin.ReferenceFrame.LOCAL):
         """

--- a/bindings/python/pinocchio/robot_wrapper.py
+++ b/bindings/python/pinocchio/robot_wrapper.py
@@ -180,11 +180,11 @@ class RobotWrapper(object):
                     reference_configuration=None):
         """
           Reduced the robot model given a list of joints to lock.
-          Parameters:\n
-          \tlist_of_joints_to_lock: list of joint indexes/names to lock\n
+          Parameters:
+          \tlist_of_joints_to_lock: list of joint indexes/names to lock.
           \treference_configuration: reference configuration to compute the
-          placement of the lock joints.\n
-        If not provided, reference_configuration defaults to the robot's neutral configuration.
+          placement of the lock joints. If not provided, reference_configuration
+        defaults to the robot's neutral configuration.
 
         NOTE: This operation is not reversible, the original model is lost.
         """

--- a/bindings/python/pinocchio/robot_wrapper.py
+++ b/bindings/python/pinocchio/robot_wrapper.py
@@ -175,6 +175,40 @@ class RobotWrapper(object):
     def framesForwardKinematics(self, q):
         pin.framesForwardKinematics(self.model, self.data, q)
 
+    def reduceModel(self,
+                    list_of_joints_to_lock,
+                    reference_configuration=None):
+        """
+          Reduced the robot model given a list of joints to lock.
+          Parameters:\n
+          \tlist_of_joints_to_lock: list of joint indexes/names to lock\n
+          \treference_configuration: reference configuration to compute the
+          placement of the lock joints.\n
+        If not provided, reference_configuration defaults to the robot's neutral configuration.
+
+        NOTE: This operation is not reversible, the original model is lost.
+        """
+
+        # if joint to lock is a string, try to find its index
+        lockjoints_idx = []
+        for jnt in list_of_joints_to_lock:
+            idx = jnt
+            if isinstance(jnt, str):
+                idx = self.model.getJointId(jnt)
+            lockjoints_idx.append(idx)
+
+        if reference_configuration is None:
+            reference_configuration = pin.neutral(self.model)
+
+        model, geom_models = pin.buildReducedModel(
+            model=self.model,
+            list_of_geom_models=[self.visual_model, self.collision_model],
+            list_of_joints_to_lock=lockjoints_idx,
+            reference_configuration=reference_configuration)
+        self.model, self.visual_model, self.collision_model = model, geom_models[
+            0], geom_models[1]
+        self.rebuildData()
+
     def getFrameJacobian(self, frame_id, rf_frame=pin.ReferenceFrame.LOCAL):
         """
             It computes the Jacobian of frame given by its id (frame_id) either expressed in the

--- a/examples/build-reduced-model.py
+++ b/examples/build-reduced-model.py
@@ -12,12 +12,14 @@ model_path = pinocchio_model_dir + '/example-robot-data/robots'
 mesh_dir = pinocchio_model_dir
 # You should change here to set up your own URDF file
 urdf_filename = model_path + '/ur_description/urdf/ur5_robot.urdf'
-model, collision_model, visual_model = pin.buildModelsFromUrdf(urdf_filename, mesh_dir)
+model, collision_model, visual_model = pin.buildModelsFromUrdf(
+    urdf_filename, mesh_dir)
 
 # Check dimensions of the original model
 print('standard model: dim=' + str(len(model.joints)))
 for jn in model.joints:
     print(jn)
+print('-' * 30)
 
 # Create a list of joints to lock
 jointsToLock = ['wrist_1_joint', 'wrist_2_joint', 'wrist_3_joint']
@@ -31,16 +33,49 @@ for jn in jointsToLock:
         print('Warning: joint ' + str(jn) + ' does not belong to the model!')
 
 # Set initial position of both fixed and revoulte joints
-initialJointConfig = np.array([0,0,0,   # shoulder and elbow
-                                1,1,1]) # gripper)
+initialJointConfig = np.array([
+    0,
+    0,
+    0,  # shoulder and elbow
+    1,
+    1,
+    1
+])  # gripper)
 
-# Option 1: Build the reduced model including the geometric model for proper displaying of the robot
-model_reduced, visual_model_reduced = pin.buildReducedModel(model, visual_model, jointsToLockIDs, initialJointConfig)
+# Option 1: Only build the reduced model in case no display needed:
+model_reduced = pin.buildReducedModel(model, jointsToLockIDs,
+                                      initialJointConfig)
 
-# Option 2: Only build the reduced model in case no display needed:
-# model_reduced = pin.buildReducedModel(model, jointsToLockIDs, initialJointConfig)
+# Option 2: Build the reduced model including the geometric model for proper displaying of the robot
+model_reduced, visual_model_reduced = pin.buildReducedModel(
+    model, visual_model, jointsToLockIDs, initialJointConfig)
+
+# Option 3: Build the reduced model including multiple geometric models (for example: visuals, collision)
+geom_models = [visual_model, collision_model]
+model_reduced, geometric_models_reduced = pin.buildReducedModel(
+    model,
+    list_of_geom_models=geom_models,
+    list_of_joints_to_lock=jointsToLockIDs,
+    reference_configuration=initialJointConfig)
+# geometric_models_reduced is a list, ordered as the passed variable "geom_models" so:
+visual_model_reduced, collision_model_reduced = geometric_models_reduced[
+    0], geometric_models_reduced[1]
 
 # Check dimensions of the reduced model
+# options 1-3 only take joint ids
+print('joints to lock (only ids):', jointsToLockIDs)
 print('reduced model: dim=' + str(len(model_reduced.joints)))
-for jn in model_reduced.joints:
+
+# Option 4: Build a RobotWrapper and reduce the model using the wrapper
+# reference_configuration is optional: if not provided, neutral configuration used
+# you can even mix joint names and joint ids
+mixed_jointsToLockIDs = [jointsToLockIDs[0], 'wrist_2_joint', 'wrist_3_joint']
+robot = pin.RobotWrapper.BuildFromURDF(urdf_filename, mesh_dir)
+robot.reduceModel(list_of_joints_to_lock=mixed_jointsToLockIDs,
+                  reference_configuration=initialJointConfig)
+
+# Check dimensions of the reduced model and joint info
+print('mixed joints to lock (names and ids):', mixed_jointsToLockIDs)
+print('RobotWrapper reduced model: dim=' + str(len(robot.model.joints)))
+for jn in robot.model.joints:
     print(jn)

--- a/examples/build-reduced-model.py
+++ b/examples/build-reduced-model.py
@@ -65,6 +65,7 @@ visual_model_reduced, collision_model_reduced = geometric_models_reduced[
 # options 1-3 only take joint ids
 print('joints to lock (only ids):', jointsToLockIDs)
 print('reduced model: dim=' + str(len(model_reduced.joints)))
+print('-' * 30)
 
 # Option 4: Build a RobotWrapper and reduce the model using the wrapper
 # reference_configuration is optional: if not provided, neutral configuration used

--- a/examples/build-reduced-model.py
+++ b/examples/build-reduced-model.py
@@ -59,16 +59,16 @@ print('joints to lock (only ids):', jointsToLockIDs)
 print('reduced model: dim=' + str(len(model_reduced.joints)))
 print('-' * 30)
 
-# Option 4: Build a RobotWrapper and reduce the model using the wrapper
+# Option 4: Build a reduced model of a robot using RobotWrapper
 # reference_configuration is optional: if not provided, neutral configuration used
 # you can even mix joint names and joint ids
 mixed_jointsToLockIDs = [jointsToLockIDs[0], 'wrist_2_joint', 'wrist_3_joint']
 robot = pin.RobotWrapper.BuildFromURDF(urdf_filename, mesh_dir)
-robot.reduceModel(list_of_joints_to_lock=mixed_jointsToLockIDs,
-                  reference_configuration=initialJointConfig)
+reduced_robot = robot.buildReducedRobot(list_of_joints_to_lock=mixed_jointsToLockIDs,
+                                        reference_configuration=initialJointConfig)
 
 # Check dimensions of the reduced model and joint info
 print('mixed joints to lock (names and ids):', mixed_jointsToLockIDs)
-print('RobotWrapper reduced model: dim=' + str(len(robot.model.joints)))
+print('RobotWrapper reduced model: dim=' + str(len(reduced_robot.model.joints)))
 for jn in robot.model.joints:
     print(jn)

--- a/examples/build-reduced-model.py
+++ b/examples/build-reduced-model.py
@@ -12,8 +12,7 @@ model_path = pinocchio_model_dir + '/example-robot-data/robots'
 mesh_dir = pinocchio_model_dir
 # You should change here to set up your own URDF file
 urdf_filename = model_path + '/ur_description/urdf/ur5_robot.urdf'
-model, collision_model, visual_model = pin.buildModelsFromUrdf(
-    urdf_filename, mesh_dir)
+model, collision_model, visual_model = pin.buildModelsFromUrdf(urdf_filename, mesh_dir)
 
 # Check dimensions of the original model
 print('standard model: dim=' + str(len(model.joints)))
@@ -33,18 +32,11 @@ for jn in jointsToLock:
         print('Warning: joint ' + str(jn) + ' does not belong to the model!')
 
 # Set initial position of both fixed and revoulte joints
-initialJointConfig = np.array([
-    0,
-    0,
-    0,  # shoulder and elbow
-    1,
-    1,
-    1
-])  # gripper)
+initialJointConfig = np.array([0,0,0,   # shoulder and elbow
+                                1,1,1]) # gripper)
 
 # Option 1: Only build the reduced model in case no display needed:
-model_reduced = pin.buildReducedModel(model, jointsToLockIDs,
-                                      initialJointConfig)
+model_reduced = pin.buildReducedModel(model, jointsToLockIDs, initialJointConfig)
 
 # Option 2: Build the reduced model including the geometric model for proper displaying of the robot
 model_reduced, visual_model_reduced = pin.buildReducedModel(

--- a/src/algorithm/model.hpp
+++ b/src/algorithm/model.hpp
@@ -144,6 +144,31 @@ namespace pinocchio
                     ModelTpl<Scalar,Options,JointCollectionTpl> & reduced_model,
                     GeometryModel & reduced_geom_model);
 
+  /**
+   *
+   *  \brief Build a reduced model and a rededuced geometry model  from a given input model, a given input geometry model and a list of joint to lock.
+   *
+   *  \param[in] model the input model to reduce.
+   *  \param[in] list_of_geom_models the input geometry model to reduce (example: visual_model, collision_model).
+   *  \param[in] list_of_joints_to_lock list of joints to lock in the input model.
+   *  \param[in] reference_configuration reference configuration.
+   *  \param[out] reduced_model the reduced model.
+   *  \param[out] list_of_reduced_geom_model the list of reduced geometry models.
+   *
+   *  \remarks All the joints that have been set to be fixed in the new reduced_model now appear in the kinematic tree as a Frame as FIXED_JOINT.  
+   *
+   */
+  template <typename Scalar, int Options,
+            template <typename, int> class JointCollectionTpl,
+            typename ConfigVectorType>
+  void buildReducedModel(
+      const ModelTpl<Scalar, Options, JointCollectionTpl> &model,
+      const std::vector<GeometryModel> &list_of_geom_models,
+      const std::vector<JointIndex> &list_of_joints_to_lock,
+      const Eigen::MatrixBase<ConfigVectorType> &reference_configuration,
+      ModelTpl<Scalar, Options, JointCollectionTpl> &reduced_model,
+      std::vector<std::reference_wrapper<GeometryModel>> &list_of_reduced_geom_models);
+
 } // namespace pinocchio
 
 #include "pinocchio/algorithm/model.hxx"

--- a/src/algorithm/model.hpp
+++ b/src/algorithm/model.hpp
@@ -167,7 +167,7 @@ namespace pinocchio
       const std::vector<JointIndex> &list_of_joints_to_lock,
       const Eigen::MatrixBase<ConfigVectorType> &reference_configuration,
       ModelTpl<Scalar, Options, JointCollectionTpl> &reduced_model,
-      std::vector<std::reference_wrapper<GeometryModel>> &list_of_reduced_geom_models);
+      std::vector<GeometryModel> &list_of_reduced_geom_models);
 
 } // namespace pinocchio
 

--- a/src/algorithm/model.hpp
+++ b/src/algorithm/model.hpp
@@ -160,14 +160,15 @@ namespace pinocchio
    */
   template <typename Scalar, int Options,
             template <typename, int> class JointCollectionTpl,
+            typename GeometryModelAllocator,
             typename ConfigVectorType>
   void buildReducedModel(
       const ModelTpl<Scalar, Options, JointCollectionTpl> &model,
-      const std::vector<GeometryModel> &list_of_geom_models,
+      const std::vector<GeometryModel,GeometryModelAllocator> &list_of_geom_models,
       const std::vector<JointIndex> &list_of_joints_to_lock,
       const Eigen::MatrixBase<ConfigVectorType> &reference_configuration,
       ModelTpl<Scalar, Options, JointCollectionTpl> &reduced_model,
-      std::vector<GeometryModel> &list_of_reduced_geom_models);
+      std::vector<GeometryModel,GeometryModelAllocator> &list_of_reduced_geom_models);
 
 } // namespace pinocchio
 

--- a/src/algorithm/model.hxx
+++ b/src/algorithm/model.hxx
@@ -502,7 +502,8 @@ namespace pinocchio
     buildReducedModel(input_model, list_of_joints_to_lock, reference_configuration, reduced_model);
 
     // for all GeometryModels
-    for (const GeometryModel &input_geom_model : list_of_geom_models) {
+    for (size_t gmi = 0; gmi < list_of_geom_models.size(); ++gmi) {
+      const GeometryModel &input_geom_model = list_of_geom_models[gmi];
       GeometryModel reduced_geom_model;
 
       // Add all the geometries

--- a/src/algorithm/model.hxx
+++ b/src/algorithm/model.hxx
@@ -480,16 +480,15 @@ namespace pinocchio
       ModelTpl<Scalar, Options, JointCollectionTpl> &reduced_model,
       GeometryModel &reduced_geom_model) {
 
-    // const std::vector<GeometryModel> temp_input_geoms (input_geom_model);
-    // std::vector<std::reference_wrapper<GeometryModel>> temp_reduced_geoms(reduced_geom_model);
-    buildReducedModel(input_model,
-                      // temp_input_geoms,
-                      {input_geom_model},
-                      list_of_joints_to_lock, reference_configuration,
-                      reduced_model,
-                      // temp_reduced_geoms
-                      {reduced_geom_model}
-                      );
+    const std::vector<GeometryModel> temp_input_geoms { input_geom_model };
+    std::vector<GeometryModel> temp_reduced_geom_models { reduced_geom_model };
+    std::vector<std::reference_wrapper<GeometryModel>>
+        temp_reduced_geom_models_refs(temp_reduced_geom_models.begin(),
+                                      temp_reduced_geom_models.end());
+
+    buildReducedModel(input_model, temp_input_geoms, list_of_joints_to_lock,
+                      reference_configuration, reduced_model,
+                      temp_reduced_geom_models_refs);
   }
 
   template <typename Scalar, int Options,
@@ -511,7 +510,7 @@ namespace pinocchio
     // TODO: the check below could only come up from C++,
     // as the python wrapper creates list of the same size
     assert(list_of_reduced_geom_models.size() == list_of_geom_models.size());
-    for (unsigned int i; i < list_of_reduced_geom_models.size(); ++i) {
+    for (unsigned int i=0; i < list_of_reduced_geom_models.size(); ++i) {
       auto &input_geom_model =
         list_of_geom_models[i];
       auto &reduced_geom_model =

--- a/src/algorithm/model.hxx
+++ b/src/algorithm/model.hxx
@@ -489,14 +489,15 @@ namespace pinocchio
 
   template <typename Scalar, int Options,
             template <typename, int> class JointCollectionTpl,
+            typename GeometryModelAllocator,
             typename ConfigVectorType>
   void buildReducedModel(
       const ModelTpl<Scalar, Options, JointCollectionTpl> &input_model,
-      const std::vector<GeometryModel> &list_of_geom_models,
+      const std::vector<GeometryModel,GeometryModelAllocator> &list_of_geom_models,
       const std::vector<JointIndex> &list_of_joints_to_lock,
       const Eigen::MatrixBase<ConfigVectorType> &reference_configuration,
       ModelTpl<Scalar, Options, JointCollectionTpl> &reduced_model,
-      std::vector<GeometryModel> &list_of_reduced_geom_models) {
+      std::vector<GeometryModel,GeometryModelAllocator> &list_of_reduced_geom_models) {
 
     typedef ModelTpl<Scalar, Options, JointCollectionTpl> Model;
     buildReducedModel(input_model, list_of_joints_to_lock, reference_configuration, reduced_model);

--- a/src/algorithm/model.hxx
+++ b/src/algorithm/model.hxx
@@ -468,16 +468,15 @@ namespace pinocchio
     }
   }
 
-  template <typename Scalar, int Options,
-            template <typename, int> class JointCollectionTpl,
-            typename ConfigVectorType>
-  void buildReducedModel(
-      const ModelTpl<Scalar, Options, JointCollectionTpl> &input_model,
-      const GeometryModel &input_geom_model,
-      const std::vector<JointIndex> &list_of_joints_to_lock,
-      const Eigen::MatrixBase<ConfigVectorType> &reference_configuration,
-      ModelTpl<Scalar, Options, JointCollectionTpl> &reduced_model,
-      GeometryModel &reduced_geom_model) {
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
+  void
+  buildReducedModel(const ModelTpl<Scalar,Options,JointCollectionTpl> & input_model,
+                    const GeometryModel & input_geom_model,
+                    const std::vector<JointIndex> & list_of_joints_to_lock,
+                    const Eigen::MatrixBase<ConfigVectorType> & reference_configuration,
+                    ModelTpl<Scalar,Options,JointCollectionTpl> & reduced_model,
+                    GeometryModel & reduced_geom_model)
+  {
 
     const std::vector<GeometryModel> temp_input_geoms { input_geom_model };
     std::vector<GeometryModel> temp_reduced_geom_models;
@@ -498,68 +497,65 @@ namespace pinocchio
       const Eigen::MatrixBase<ConfigVectorType> &reference_configuration,
       ModelTpl<Scalar, Options, JointCollectionTpl> &reduced_model,
       std::vector<GeometryModel> &list_of_reduced_geom_models) {
+
     typedef ModelTpl<Scalar, Options, JointCollectionTpl> Model;
-    buildReducedModel(input_model, list_of_joints_to_lock,
-                      reference_configuration, reduced_model);
+    buildReducedModel(input_model, list_of_joints_to_lock, reference_configuration, reduced_model);
 
     // for all GeometryModels
-    for (auto &input_geom_model : list_of_geom_models) {
+    for (const GeometryModel &input_geom_model : list_of_geom_models) {
       GeometryModel reduced_geom_model;
 
       // Add all the geometries
       typedef GeometryModel::GeometryObject GeometryObject;
       typedef GeometryModel::GeometryObjectVector GeometryObjectVector;
-      for (GeometryObjectVector::const_iterator it =
-               input_geom_model.geometryObjects.begin();
-           it != input_geom_model.geometryObjects.end(); ++it) {
-        const GeometryModel::GeometryObject &geom = *it;
+      for(GeometryObjectVector::const_iterator it = input_geom_model.geometryObjects.begin();
+          it != input_geom_model.geometryObjects.end(); ++it)
+      {
+        const GeometryModel::GeometryObject & geom = *it;
 
         const JointIndex joint_id_in_input_model = geom.parentJoint;
-        _PINOCCHIO_CHECK_INPUT_ARGUMENT_2(
-            (joint_id_in_input_model < (JointIndex)input_model.njoints),
-            "Invalid joint parent index for the geometry with name " +
-                geom.name);
-        const std::string &parent_joint_name =
-            input_model.names[joint_id_in_input_model];
+        _PINOCCHIO_CHECK_INPUT_ARGUMENT_2((joint_id_in_input_model < (JointIndex)input_model.njoints),
+                                          "Invalid joint parent index for the geometry with name " + geom.name);
+        const std::string & parent_joint_name = input_model.names[joint_id_in_input_model];
 
         JointIndex reduced_joint_id = (JointIndex)-1;
         typedef typename Model::SE3 SE3;
         SE3 relative_placement = SE3::Identity();
-        if (reduced_model.existJointName(parent_joint_name)) {
-          reduced_joint_id = reduced_model.getJointId(parent_joint_name);
-        } else // The joint is now a frame
+        if(reduced_model.existJointName(parent_joint_name))
         {
-          const FrameIndex reduced_frame_id =
-              reduced_model.getFrameId(parent_joint_name);
+          reduced_joint_id = reduced_model.getJointId(parent_joint_name);
+        }
+        else // The joint is now a frame
+        {
+          const FrameIndex reduced_frame_id = reduced_model.getFrameId(parent_joint_name);
           reduced_joint_id = reduced_model.frames[reduced_frame_id].parent;
           relative_placement = reduced_model.frames[reduced_frame_id].placement;
         }
 
-
         GeometryObject reduced_geom(geom);
         reduced_geom.parentJoint = reduced_joint_id;
-        reduced_geom.parentFrame =
-            reduced_model.getBodyId(input_model.frames[geom.parentFrame].name);
+        reduced_geom.parentFrame = reduced_model.getBodyId(
+            input_model.frames[geom.parentFrame].name);
         reduced_geom.placement = relative_placement * geom.placement;
         reduced_geom_model.addGeometryObject(reduced_geom);
       }
 
-#ifdef PINOCCHIO_WITH_HPP_FCL
-        // Add all the collision pairs - the index of the geometry objects
-        // should have not changed
+  #ifdef PINOCCHIO_WITH_HPP_FCL
+      // Add all the collision pairs - the index of the geometry objects should have not changed
 
-        typedef GeometryModel::CollisionPairVector CollisionPairVector;
-        for (CollisionPairVector::const_iterator it =
-                 input_geom_model.collisionPairs.begin();
-             it != input_geom_model.collisionPairs.end(); ++it) {
-          const CollisionPair &cp = *it;
-          reduced_geom_model.addCollisionPair(cp);
-        }
-#endif
-      list_of_reduced_geom_models.push_back(reduced_geom_model);
+      typedef GeometryModel::CollisionPairVector CollisionPairVector;
+      for(CollisionPairVector::const_iterator it = input_geom_model.collisionPairs.begin();
+          it != input_geom_model.collisionPairs.end(); ++it)
+      {
+        const CollisionPair & cp = *it;
+        reduced_geom_model.addCollisionPair(cp);
+      }
+  #endif
+
+    list_of_reduced_geom_models.push_back(reduced_geom_model);
     }
   }
 
-  } // namespace pinocchio
+} // namespace pinocchio
 
 #endif // ifndef __pinocchio_algorithm_model_hxx__

--- a/src/algorithm/model.hxx
+++ b/src/algorithm/model.hxx
@@ -6,6 +6,7 @@
 #define __pinocchio_algorithm_model_hxx__
 
 #include <algorithm>
+#include <functional>
 
 namespace pinocchio
 {
@@ -468,67 +469,105 @@ namespace pinocchio
     }
   }
 
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType>
-  void
-  buildReducedModel(const ModelTpl<Scalar,Options,JointCollectionTpl> & input_model,
-                    const GeometryModel & input_geom_model,
-                    const std::vector<JointIndex> & list_of_joints_to_lock,
-                    const Eigen::MatrixBase<ConfigVectorType> & reference_configuration,
-                    ModelTpl<Scalar,Options,JointCollectionTpl> & reduced_model,
-                    GeometryModel & reduced_geom_model)
-  {
-    typedef ModelTpl<Scalar,Options,JointCollectionTpl> Model;
-    buildReducedModel(input_model,list_of_joints_to_lock,reference_configuration,reduced_model);
-    
-    // Add all the geometries
-    typedef GeometryModel::GeometryObject GeometryObject;
-    typedef GeometryModel::GeometryObjectVector GeometryObjectVector;
-    for(GeometryObjectVector::const_iterator it = input_geom_model.geometryObjects.begin();
-        it != input_geom_model.geometryObjects.end(); ++it)
-    {
-      const GeometryModel::GeometryObject & geom = *it;
-      
-      const JointIndex joint_id_in_input_model = geom.parentJoint;
-      _PINOCCHIO_CHECK_INPUT_ARGUMENT_2((joint_id_in_input_model < (JointIndex)input_model.njoints),
-                                        "Invalid joint parent index for the geometry with name " + geom.name);
-      const std::string & parent_joint_name = input_model.names[joint_id_in_input_model];
-      
-      JointIndex reduced_joint_id = (JointIndex)-1;
-      typedef typename Model::SE3 SE3;
-      SE3 relative_placement = SE3::Identity();
-      if(reduced_model.existJointName(parent_joint_name))
-      {
-        reduced_joint_id = reduced_model.getJointId(parent_joint_name);
-      }
-      else // The joint is now a frame
-      {
-        const FrameIndex reduced_frame_id = reduced_model.getFrameId(parent_joint_name);
-        reduced_joint_id = reduced_model.frames[reduced_frame_id].parent;
-        relative_placement = reduced_model.frames[reduced_frame_id].placement;
-      }
-      
-      GeometryObject reduced_geom(geom);
-      reduced_geom.parentJoint = reduced_joint_id;
-      reduced_geom.parentFrame = reduced_model.getBodyId(
-          input_model.frames[geom.parentFrame].name);
-      reduced_geom.placement = relative_placement * geom.placement;
-      reduced_geom_model.addGeometryObject(reduced_geom);
-    }
-    
-#ifdef PINOCCHIO_WITH_HPP_FCL
-    // Add all the collision pairs - the index of the geometry objects should have not changed
-    
-    typedef GeometryModel::CollisionPairVector CollisionPairVector;
-    for(CollisionPairVector::const_iterator it = input_geom_model.collisionPairs.begin();
-        it != input_geom_model.collisionPairs.end(); ++it)
-    {
-      const CollisionPair & cp = *it;
-      reduced_geom_model.addCollisionPair(cp);
-    }
-#endif
-    
+  template <typename Scalar, int Options,
+            template <typename, int> class JointCollectionTpl,
+            typename ConfigVectorType>
+  void buildReducedModel(
+      const ModelTpl<Scalar, Options, JointCollectionTpl> &input_model,
+      const GeometryModel &input_geom_model,
+      const std::vector<JointIndex> &list_of_joints_to_lock,
+      const Eigen::MatrixBase<ConfigVectorType> &reference_configuration,
+      ModelTpl<Scalar, Options, JointCollectionTpl> &reduced_model,
+      GeometryModel &reduced_geom_model) {
+
+    // const std::vector<GeometryModel> temp_input_geoms (input_geom_model);
+    // std::vector<std::reference_wrapper<GeometryModel>> temp_reduced_geoms(reduced_geom_model);
+    buildReducedModel(input_model,
+                      // temp_input_geoms,
+                      {input_geom_model},
+                      list_of_joints_to_lock, reference_configuration,
+                      reduced_model,
+                      // temp_reduced_geoms
+                      {reduced_geom_model}
+                      );
   }
 
-} // namespace pinocchio
+  template <typename Scalar, int Options,
+            template <typename, int> class JointCollectionTpl,
+            typename ConfigVectorType>
+  void buildReducedModel(
+      const ModelTpl<Scalar, Options, JointCollectionTpl> &input_model,
+      const std::vector<GeometryModel> &list_of_geom_models,
+      const std::vector<JointIndex> &list_of_joints_to_lock,
+      const Eigen::MatrixBase<ConfigVectorType> &reference_configuration,
+      ModelTpl<Scalar, Options, JointCollectionTpl> &reduced_model,
+      std::vector<std::reference_wrapper<GeometryModel>>
+          &list_of_reduced_geom_models) {
+    typedef ModelTpl<Scalar, Options, JointCollectionTpl> Model;
+    buildReducedModel(input_model, list_of_joints_to_lock,
+                      reference_configuration, reduced_model);
+
+    // for all GeometryModels
+    // TODO: the check below could only come up from C++,
+    // as the python wrapper creates list of the same size
+    assert(list_of_reduced_geom_models.size() == list_of_geom_models.size());
+    for (unsigned int i; i < list_of_reduced_geom_models.size(); ++i) {
+      auto &input_geom_model =
+        list_of_geom_models[i];
+      auto &reduced_geom_model =
+              list_of_reduced_geom_models[i];
+      // Add all the geometries
+      typedef GeometryModel::GeometryObject GeometryObject;
+      typedef GeometryModel::GeometryObjectVector GeometryObjectVector;
+      for (GeometryObjectVector::const_iterator it =
+               input_geom_model.geometryObjects.begin();
+           it != input_geom_model.geometryObjects.end(); ++it) {
+        const GeometryModel::GeometryObject &geom = *it;
+
+        const JointIndex joint_id_in_input_model = geom.parentJoint;
+        _PINOCCHIO_CHECK_INPUT_ARGUMENT_2(
+            (joint_id_in_input_model < (JointIndex)input_model.njoints),
+            "Invalid joint parent index for the geometry with name " +
+                geom.name);
+        const std::string &parent_joint_name =
+            input_model.names[joint_id_in_input_model];
+
+        JointIndex reduced_joint_id = (JointIndex)-1;
+        typedef typename Model::SE3 SE3;
+        SE3 relative_placement = SE3::Identity();
+        if (reduced_model.existJointName(parent_joint_name)) {
+          reduced_joint_id = reduced_model.getJointId(parent_joint_name);
+        } else // The joint is now a frame
+        {
+          const FrameIndex reduced_frame_id =
+              reduced_model.getFrameId(parent_joint_name);
+          reduced_joint_id = reduced_model.frames[reduced_frame_id].parent;
+          relative_placement = reduced_model.frames[reduced_frame_id].placement;
+        }
+
+        GeometryObject reduced_geom(geom);
+        reduced_geom.parentJoint = reduced_joint_id;
+        reduced_geom.parentFrame =
+            reduced_model.getBodyId(input_model.frames[geom.parentFrame].name);
+        reduced_geom.placement = relative_placement * geom.placement;
+        reduced_geom_model.get().addGeometryObject(reduced_geom);
+      }
+
+#ifdef PINOCCHIO_WITH_HPP_FCL
+      // Add all the collision pairs - the index of the geometry objects should
+      // have not changed
+
+      typedef GeometryModel::CollisionPairVector CollisionPairVector;
+      for (CollisionPairVector::const_iterator it =
+               input_geom_model.collisionPairs.begin();
+           it != input_geom_model.collisionPairs.end(); ++it) {
+        const CollisionPair &cp = *it;
+        reduced_geom_model.get().addCollisionPair(cp);
+      }
+#endif
+    }
+  }
+
+  } // namespace pinocchio
 
 #endif // ifndef __pinocchio_algorithm_model_hxx__

--- a/unittest/model.cpp
+++ b/unittest/model.cpp
@@ -494,6 +494,22 @@ BOOST_AUTO_TEST_CASE(test_buildReducedModel_with_geom)
   {
     BOOST_CHECK(geom_data.oMg[i].isApprox(reduded_geom_data.oMg[i]));
   }
+  
+  // Test other signature
+  std::vector<GeometryModel> full_geometry_models;
+  full_geometry_models.push_back(humanoid_geometry);
+  full_geometry_models.push_back(humanoid_geometry);
+  full_geometry_models.push_back(humanoid_geometry);
+  
+  std::vector<GeometryModel> reduced_geometry_models;
+  
+  Model reduced_humanoid_model_other_sig;
+  buildReducedModel(humanoid_model,full_geometry_models,joints_to_lock,
+                    reference_config_humanoid,reduced_humanoid_model_other_sig,reduced_geometry_models);
+  
+  BOOST_CHECK(reduced_geometry_models[0] == reduced_humanoid_geometry);
+  BOOST_CHECK(reduced_geometry_models[1] == reduced_humanoid_geometry);
+  BOOST_CHECK(reduced_geometry_models[2] == reduced_humanoid_geometry);
 }
 #endif // PINOCCHIO_WITH_HPP_FCL
 


### PR DESCRIPTION
This was referenced in https://github.com/stack-of-tasks/pinocchio/issues/1423.

Summary:
- Extended `buildReducedModel` ([here](https://github.com/ntorresalberto/pinocchio/blob/106ebe56a879d99c1b300318dbea4a027773b132/src/algorithm/model.hxx#L498)) to take multiple GeometricModels (`std::vector<GeometricModel>`) as input. Now the old `buildReducedModel` ([here](https://github.com/ntorresalberto/pinocchio/blob/106ebe56a879d99c1b300318dbea4a027773b132/src/algorithm/model.hxx#L475)) function is redirected to this one to avoid redundant code.
- Exposed the new function as `pinocchio.buildReducedModel` in python (that takes and returns a list of GeometricModel).
- Added `RobotWrapper.reduceModel` function that uses the new `buildReducedModel`. 
I did it so `list_of_joints_to_lock` can take a mix of joint names and indexes ([here](https://github.com/ntorresalberto/pinocchio/blob/106ebe56a879d99c1b300318dbea4a027773b132/bindings/python/pinocchio/robot_wrapper.py#L192)). I'm pointing it out because this could be a source of bugs and it's not as simple to implement in C++.
- Updated the python example `build-reduced-model.py` ([here](https://github.com/ntorresalberto/pinocchio/blob/RobotWrapper.reduceModel/examples/build-reduced-model.py)).

Please let me know if there are any more changes needed.

In particular, there are some things I wasn't sure about:
- Is the `boost::python` wrapping of `std::vector<GeometricModel>` implemented correctly? ([here](https://github.com/ntorresalberto/pinocchio/blob/106ebe56a879d99c1b300318dbea4a027773b132/bindings/python/algorithm/expose-model.cpp#L82))
- Do you use some code formatter (like `clang-format` for C++ or `yapf` for python)?
- 2 tests didn't pass and I'm not sure how to check. I'm running `make test`, is there a way to see the logs?:
```
98% tests passed, 2 tests failed out of 125

Total Test time (real) = 1527.02 sec

The following tests FAILED:
	 36 - test-cpp-model (Timeout)
	 73 - test-py-rpy (Failed)
Errors while running CTest
make: *** [Makefile:130: test] Error 8
```

edit: just fixed `test-cpp-model` but I'm still clueless about `test-py-rpy`, it was failing on my machine even before my modifications and I don't know where to look.


