### PR TITLE
[Tests] add missing include

### DIFF
--- a/unittest/liegroups.cpp
+++ b/unittest/liegroups.cpp
@@ -12,6 +12,7 @@
 #include <boost/test/unit_test.hpp>
 #include <boost/utility/binary.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/mpl/vector.hpp>
 
 #define EIGEN_VECTOR_IS_APPROX(Va, Vb, precision)                              \
   BOOST_CHECK_MESSAGE((Va).isApprox(Vb, precision),                            \


### PR DESCRIPTION
fix on Boost 1.76:

```
/src/pinocchio/unittest/liegroups.cpp:455:23: error: no template named 'vector' in namespace 'boost::mpl'
  typedef boost::mpl::vector<  VectorSpaceOperationTpl<1,Scalar,Options>
          ~~~~~~~~~~~~^
/src/pinocchio/unittest/liegroups.cpp:479:23: error: no template named 'vector' in namespace 'boost::mpl'
  typedef boost::mpl::vector<  VectorSpaceOperationTpl<1,Scalar,Options>
          ~~~~~~~~~~~~^
/src/pinocchio/unittest/liegroups.cpp:506:23: error: no template named 'vector' in namespace 'boost::mpl'
  typedef boost::mpl::vector<  VectorSpaceOperationTpl<1,Scalar,Options>
          ~~~~~~~~~~~~^
/src/pinocchio/unittest/liegroups.cpp:530:23: error: no template named 'vector' in namespace 'boost::mpl'
  typedef boost::mpl::vector<  VectorSpaceOperationTpl<1,Scalar,Options>
          ~~~~~~~~~~~~^
```