### PR TITLE
Work-around for finding meshes of URDFs in ROS devel spaces #1463

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
   <name>pinocchio</name>
-  <version>2.6.1</version>
+  <version>2.6.3</version>
   <description>A fast and flexible implementation of Rigid Body Dynamics algorithms and their analytical derivatives.</description>
   <!-- The maintainer listed here is for the ROS release to receive emails for the buildfarm. 
   Please check the repository URL for full list of authors and maintainers. -->

--- a/src/utils/file-explorer.cpp
+++ b/src/utils/file-explorer.cpp
@@ -57,9 +57,9 @@ namespace pinocchio
     // To support ROS devel/isolated spaces, we also need to look one package above the package.xml:
     fs::path path;
     std::vector<std::string> list_of_paths;
-    for (const auto& path_string : raw_list_of_paths) {
-      list_of_paths.push_back(path_string);
-      path = fs::path(path_string);
+    for (std::vector<std::string>::iterator it = raw_list_of_paths.begin(); it != raw_list_of_paths.end(); ++it) {
+      list_of_paths.push_back(*it);
+      path = fs::path(*it);
       if (fs::exists(path / "package.xml")) {
         list_of_paths.push_back(fs::path(path / "..").string());
       }

--- a/src/utils/file-explorer.cpp
+++ b/src/utils/file-explorer.cpp
@@ -6,18 +6,13 @@
 #include <boost/filesystem.hpp>
 #include "pinocchio/utils/file-explorer.hpp"
 
-#ifdef _WIN32
-const char delimiter = ';';
-#else
-const char delimiter = ':';
-#endif
-
 namespace fs = boost::filesystem;
 namespace pinocchio
 {
 
   void extractPathFromEnvVar(const std::string & env_var_name,
-                             std::vector<std::string> & list_of_paths)
+                             std::vector<std::string> & list_of_paths,
+                             const std::string & delimiter)
   {
     const char * env_var_value = std::getenv(env_var_name.c_str());
     
@@ -40,10 +35,11 @@ namespace pinocchio
     }
   }
 
-  std::vector<std::string> extractPathFromEnvVar(const std::string & env_var_name)
+  std::vector<std::string> extractPathFromEnvVar(const std::string & env_var_name,
+                                                 const std::string & delimiter)
   {
     std::vector<std::string> list_of_paths;
-    extractPathFromEnvVar(env_var_name,list_of_paths);
+    extractPathFromEnvVar(env_var_name,list_of_paths,delimiter);
     return list_of_paths;
   }
 

--- a/src/utils/file-explorer.cpp
+++ b/src/utils/file-explorer.cpp
@@ -24,8 +24,12 @@ namespace pinocchio
       while(true)
       {
         size_t offset = policyStr.find_first_of(delimiter, lastOffset);
-        if (offset < policyStr.size())
+        if (offset < policyStr.size()) {
           list_of_paths.push_back(policyStr.substr(lastOffset, offset - lastOffset));
+          // Support for devel spaces: We also need to look one package above:
+          // Work-around for https://github.com/stack-of-tasks/pinocchio/issues/1463
+          list_of_paths.push_back(policyStr.substr(lastOffset, offset - lastOffset) + "/..");
+        }
         if (offset == std::string::npos)
           break;
         else

--- a/src/utils/file-explorer.cpp
+++ b/src/utils/file-explorer.cpp
@@ -6,13 +6,18 @@
 #include <boost/filesystem.hpp>
 #include "pinocchio/utils/file-explorer.hpp"
 
+#ifdef _WIN32
+const char delimiter = ';';
+#else
+const char delimiter = ':';
+#endif
+
 namespace fs = boost::filesystem;
 namespace pinocchio
 {
 
   void extractPathFromEnvVar(const std::string & env_var_name,
-                             std::vector<std::string> & list_of_paths,
-                             const std::string & delimiter)
+                             std::vector<std::string> & list_of_paths)
   {
     const char * env_var_value = std::getenv(env_var_name.c_str());
     
@@ -20,25 +25,13 @@ namespace pinocchio
     {
       std::string policyStr(env_var_value);
       // Add a separator at the end so that last path is also retrieved
-      policyStr += std::string(":");
+      policyStr += delimiter;
       size_t lastOffset = 0;
-      std::string path_string;
-      path_string.reserve(500);
-      fs::path path;
-      
       while(true)
       {
         size_t offset = policyStr.find_first_of(delimiter, lastOffset);
-        if (offset < policyStr.size()) {
-          path_string = policyStr.substr(lastOffset, offset - lastOffset);
-          path = fs::path(path_string);
-          list_of_paths.push_back(path_string);
-          // Work-around for https://github.com/stack-of-tasks/pinocchio/issues/1463
-          // To support ROS devel/isolated spaces, we also need to look one package above the package.xml:
-          if (fs::exists(path / "package.xml")) {
-            list_of_paths.push_back(fs::path(path / "..").string());
-          }
-        }
+        if (offset < policyStr.size())
+          list_of_paths.push_back(policyStr.substr(lastOffset, offset - lastOffset));
         if (offset == std::string::npos)
           break;
         else
@@ -47,20 +40,30 @@ namespace pinocchio
     }
   }
 
-  std::vector<std::string> extractPathFromEnvVar(const std::string & env_var_name,
-                                                 const std::string & delimiter)
+  std::vector<std::string> extractPathFromEnvVar(const std::string & env_var_name)
   {
     std::vector<std::string> list_of_paths;
-    extractPathFromEnvVar(env_var_name,list_of_paths,delimiter);
+    extractPathFromEnvVar(env_var_name,list_of_paths);
     return list_of_paths;
   }
 
   std::vector<std::string> rosPaths()
   {
+    std::vector<std::string> raw_list_of_paths;
+    extractPathFromEnvVar("ROS_PACKAGE_PATH", raw_list_of_paths);
+    extractPathFromEnvVar("AMENT_PREFIX_PATH", raw_list_of_paths);
+
+    // Work-around for https://github.com/stack-of-tasks/pinocchio/issues/1463
+    // To support ROS devel/isolated spaces, we also need to look one package above the package.xml:
+    fs::path path;
     std::vector<std::string> list_of_paths;
-    extractPathFromEnvVar("ROS_PACKAGE_PATH",list_of_paths);
-    extractPathFromEnvVar("AMENT_PREFIX_PATH",list_of_paths);
-    
+    for (const auto& path_string : raw_list_of_paths) {
+      list_of_paths.push_back(path_string);
+      path = fs::path(path_string);
+      if (fs::exists(path / "package.xml")) {
+        list_of_paths.push_back(fs::path(path / "..").string());
+      }
+    }
     return list_of_paths;
   }
 

--- a/src/utils/file-explorer.cpp
+++ b/src/utils/file-explorer.cpp
@@ -3,8 +3,10 @@
 //
 
 #include <cstdlib>
+#include <boost/filesystem.hpp>
 #include "pinocchio/utils/file-explorer.hpp"
 
+namespace fs = boost::filesystem;
 namespace pinocchio
 {
 
@@ -20,15 +22,22 @@ namespace pinocchio
       // Add a separator at the end so that last path is also retrieved
       policyStr += std::string(":");
       size_t lastOffset = 0;
+      std::string path_string;
+      path_string.reserve(500);
+      fs::path path;
       
       while(true)
       {
         size_t offset = policyStr.find_first_of(delimiter, lastOffset);
         if (offset < policyStr.size()) {
-          list_of_paths.push_back(policyStr.substr(lastOffset, offset - lastOffset));
-          // Support for devel spaces: We also need to look one package above:
+          path_string = policyStr.substr(lastOffset, offset - lastOffset);
+          path = fs::path(path_string);
+          list_of_paths.push_back(path_string);
           // Work-around for https://github.com/stack-of-tasks/pinocchio/issues/1463
-          list_of_paths.push_back(policyStr.substr(lastOffset, offset - lastOffset) + "/..");
+          // To support ROS devel/isolated spaces, we also need to look one package above the package.xml:
+          if (fs::exists(path / "package.xml")) {
+            list_of_paths.push_back(fs::path(path / "..").string());
+          }
         }
         if (offset == std::string::npos)
           break;

--- a/src/utils/file-explorer.hpp
+++ b/src/utils/file-explorer.hpp
@@ -17,13 +17,11 @@ namespace pinocchio
    * @brief      Parse an environment variable if exists and extract paths according to the delimiter.
    *
    * @param[in]  env_var_name The name of the environment variable.
-   * @param[in]  delimiter The delimiter between two consecutive paths.
    *
    * @return The vector of paths extracted from the environment variable value.
    */
   PINOCCHIO_DLLAPI std::vector<std::string>
-  extractPathFromEnvVar(const std::string & env_var_name,
-                        const std::string & delimiter = ":");
+  extractPathFromEnvVar(const std::string & env_var_name);
 
 
   /**
@@ -31,12 +29,10 @@ namespace pinocchio
    *
    * @param[in]  env_var_name The name of the environment variable.
    * @param[out] list_of_paths List of path to fill with the paths extracted from the environment variable value.
-   * @param[in]  delimiter The delimiter between two consecutive paths.
    */
   PINOCCHIO_DLLAPI void
   extractPathFromEnvVar(const std::string & env_var_name,
-                        std::vector<std::string> & list_of_paths,
-                        const std::string & delimiter = ":");
+                        std::vector<std::string> & list_of_paths);
 
 
   /**

--- a/src/utils/file-explorer.hpp
+++ b/src/utils/file-explorer.hpp
@@ -17,11 +17,18 @@ namespace pinocchio
    * @brief      Parse an environment variable if exists and extract paths according to the delimiter.
    *
    * @param[in]  env_var_name The name of the environment variable.
+   * @param[in]  delimiter The delimiter between two consecutive paths.
    *
    * @return The vector of paths extracted from the environment variable value.
    */
   PINOCCHIO_DLLAPI std::vector<std::string>
-  extractPathFromEnvVar(const std::string & env_var_name);
+  extractPathFromEnvVar(const std::string & env_var_name,
+#ifdef _WIN32
+                        const std::string & delimiter = ";"
+#else
+                        const std::string & delimiter = ":"
+#endif
+                        );
 
 
   /**
@@ -29,16 +36,23 @@ namespace pinocchio
    *
    * @param[in]  env_var_name The name of the environment variable.
    * @param[out] list_of_paths List of path to fill with the paths extracted from the environment variable value.
+   * @param[in] delimiter The delimiter between two consecutive paths.
    */
   PINOCCHIO_DLLAPI void
   extractPathFromEnvVar(const std::string & env_var_name,
-                        std::vector<std::string> & list_of_paths);
+                        std::vector<std::string> & list_of_paths,
+#ifdef _WIN32
+                        const std::string & delimiter = ";"
+#else
+                        const std::string & delimiter = ":"
+#endif
+                        );
 
 
   /**
-   * @brief      Parse the environment variable ROS_PACKAGE_PATH and extract paths
+   * @brief      Parse the environment variables ROS_PACKAGE_PATH / AMENT_PREFIX_PATH and extract paths
    *
-   * @return     The vector of paths extracted from the environment variable ROS_PACKAGE_PATH
+   * @return     The vector of paths extracted from the environment variables ROS_PACKAGE_PATH / AMENT_PREFIX_PATH
    */
   PINOCCHIO_DLLAPI std::vector<std::string> rosPaths();
 


### PR DESCRIPTION
I've also run into the issue described by @jmirabel in #1463. The following work-around resolves this issue (as postulated at in https://github.com/stack-of-tasks/pinocchio/issues/1463#issuecomment-872225739). 

Note, this is likely not Windows-compatible due to the forward slash "/". I'd love to hear some thoughts/discussion on a better solution for this issue

@jmirabel - would this PR solve your issue as well?