### PR TITLE
meshcat: fix loading of BVH model

### DIFF
--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -261,17 +261,19 @@ class MeshcatVisualizer(BaseVisualizer):
 
         pin.updateGeometryPlacements(self.model, self.data, self.visual_model, self.visual_data)
         for visual in self.visual_model.geometryObjects:
+            visual_name = self.getViewerNodeName(visual,pin.GeometryType.VISUAL)
             # Get mesh pose.
             M = self.visual_data.oMg[self.visual_model.getGeometryId(visual.name)]
-            # Manage scaling
-            if self.isMesh(visual):
+            # Manage scaling: force scaling even if this should be normally handled by MeshCat (but there is a bug here)
+            if isMesh(visual):
                 scale = np.asarray(visual.meshScale).flatten()
                 S = np.diag(np.concatenate((scale,[1.0])))
                 T = np.array(M.homogeneous).dot(S)
             else:
                 T = M.homogeneous
+            
             # Update viewer configuration.
-            self.viewer[self.getViewerNodeName(visual,pin.GeometryType.VISUAL)].set_transform(T)
+            self.viewer[visual_name].set_transform(T)
 
     def displayCollisions(self,visibility):
         """Set whether to display collision objects or not.

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -259,9 +259,12 @@ class MeshcatVisualizer(BaseVisualizer):
             # Get mesh pose.
             M = self.visual_data.oMg[self.visual_model.getGeometryId(visual.name)]
             # Manage scaling
-            scale = np.asarray(visual.meshScale).flatten()
-            S = np.diag(np.concatenate((scale,[1.0])))
-            T = np.array(M.homogeneous).dot(S)
+            if self.isMesh(visual):
+                scale = np.asarray(visual.meshScale).flatten()
+                S = np.diag(np.concatenate((scale,[1.0])))
+                T = np.array(M.homogeneous).dot(S)
+            else:
+                T = M.homogeneous
             # Update viewer configuration.
             self.viewer[self.getViewerNodeName(visual,pin.GeometryType.VISUAL)].set_transform(T)
 

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -13,6 +13,16 @@ try:
 except:
     WITH_HPP_FCL_BINDINGS = False
 
+def isMesh(geometry_object):
+    """ Check whether the geometry object contains a Mesh supported by MeshCat """
+    if geometry_object.meshPath == "":
+        return False
+
+    _, file_extension = os.path.splitext(geometry_object.meshPath)
+    if file_extension.lower() in [".dae", ".obj", ".stl"]:
+        return True
+
+    return False
 
 def loadBVH(bvh):
     import meshcat.geometry as mg
@@ -134,17 +144,6 @@ class MeshcatVisualizer(BaseVisualizer):
 
         return obj
 
-    def isMesh(self, geometry_object):
-        """ Check whether the geometry object contains a Mesh supported by MeshCat """
-        if geometry_object.meshPath == "":
-            return False
-
-        _, file_extension = os.path.splitext(geometry_object.meshPath)
-        if file_extension.lower() in [".dae", ".obj", ".stl"]:
-            return True
-
-        return False
-
     def loadMesh(self, geometry_object):
 
         import meshcat.geometry
@@ -179,7 +178,7 @@ class MeshcatVisualizer(BaseVisualizer):
         try:
             if WITH_HPP_FCL_BINDINGS and isinstance(geometry_object.geometry, hppfcl.ShapeBase):
                 obj = self.loadPrimitive(geometry_object)
-            elif self.isMesh(geometry_object):
+            elif isMesh(geometry_object):
                 obj = self.loadMesh(geometry_object)
             elif WITH_HPP_FCL_BINDINGS and isinstance(geometry_object.geometry, hppfcl.BVHModelBase):
                 obj = loadBVH(geometry_object.geometry)

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -134,6 +134,17 @@ class MeshcatVisualizer(BaseVisualizer):
 
         return obj
 
+    def isMesh(self, geometry_object):
+        """ Check whether the geometry object contains a Mesh supported by MeshCat """
+        if geometry_object.meshPath == "":
+            return False
+
+        _, file_extension = os.path.splitext(geometry_object.meshPath)
+        if file_extension.lower() in [".dae", ".obj", ".stl"]:
+            return True
+
+        return False
+
     def loadMesh(self, geometry_object):
 
         import meshcat.geometry
@@ -168,10 +179,14 @@ class MeshcatVisualizer(BaseVisualizer):
         try:
             if WITH_HPP_FCL_BINDINGS and isinstance(geometry_object.geometry, hppfcl.ShapeBase):
                 obj = self.loadPrimitive(geometry_object)
+            elif self.isMesh(geometry_object):
+                obj = self.loadMesh(geometry_object)
             elif WITH_HPP_FCL_BINDINGS and isinstance(geometry_object.geometry, hppfcl.BVHModelBase):
                 obj = loadBVH(geometry_object.geometry)
             else:
-                obj = self.loadMesh(geometry_object)
+                msg = "The geometry object named " + geometry_object.name + " is not supported by Pinocchio/MeshCat for vizualization."
+                warnings.warn(msg, category=UserWarning, stacklevel=2)
+                return
             if obj is None:
                 return
         except Exception as e:

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -175,11 +175,13 @@ class MeshcatVisualizer(BaseVisualizer):
 
         viewer_name = self.getViewerNodeName(geometry_object, geometry_type)
 
+        is_mesh = False
         try:
             if WITH_HPP_FCL_BINDINGS and isinstance(geometry_object.geometry, hppfcl.ShapeBase):
                 obj = self.loadPrimitive(geometry_object)
             elif isMesh(geometry_object):
                 obj = self.loadMesh(geometry_object)
+                is_mesh = True
             elif WITH_HPP_FCL_BINDINGS and isinstance(geometry_object.geometry, hppfcl.BVHModelBase):
                 obj = loadBVH(geometry_object.geometry)
             else:
@@ -208,6 +210,10 @@ class MeshcatVisualizer(BaseVisualizer):
                 material.transparent = True
                 material.opacity = float(meshColor[3])
             self.viewer[viewer_name].set_object(obj, material)
+
+        if is_mesh: # Apply the scaling
+            scale = list(np.asarray(geometry_object.meshScale).flatten())
+            self.viewer[viewer_name].set_property("scale",scale)
 
     def loadViewerModel(self, rootNodeName="pinocchio", color = None):
         """Load the robot in a MeshCat viewer.

--- a/src/parsers/urdf/geometry.cpp
+++ b/src/parsers/urdf/geometry.cpp
@@ -360,7 +360,7 @@ namespace pinocchio
 
           FrameIndex frame_id;
           UrdfGeomVisitorBase::Frame frame = visitor.getBodyFrame (link_name, frame_id);
-          SE3 body_placement = frame.placement;
+          const SE3 & body_placement = frame.placement;
 
           std::size_t objectId = 0;
           for (typename VectorSharedT::const_iterator i = geometries_array.begin();i != geometries_array.end(); ++i)
@@ -391,7 +391,7 @@ namespace pinocchio
             std::string meshTexturePath;
             bool overrideMaterial = getVisualMaterial<GeometryType>((*i), meshTexturePath, meshColor, package_dirs);
 
-            SE3 geomPlacement = body_placement * convertFromUrdf((*i)->origin);
+            const SE3 geomPlacement = body_placement * convertFromUrdf((*i)->origin);
             std::ostringstream geometry_object_suffix;
             geometry_object_suffix << "_" << objectId;
             const std::string & geometry_object_name = std::string(link_name + geometry_object_suffix.str());


### PR DESCRIPTION
BVH models should be loaded in a raw manner after checking if they are not related to a specific file