### PR TITLE
Change 'typedef' to 'using', add curly braces

### DIFF
--- a/examples/inverse-kinematics.cpp
+++ b/examples/inverse-kinematics.cpp
@@ -23,7 +23,7 @@ int main(int /* argc */, char ** /* argv */)
   J.setZero();
 
   bool success = false;
-  using Vector6d = Eigen::Matrix<double, 6, 1>;
+  typedef Eigen::Matrix<double, 6, 1> Vector6d;
   Vector6d err;
   Eigen::VectorXd v(model.nv);
   for (int i=0;;i++)

--- a/examples/inverse-kinematics.cpp
+++ b/examples/inverse-kinematics.cpp
@@ -23,7 +23,7 @@ int main(int /* argc */, char ** /* argv */)
   J.setZero();
 
   bool success = false;
-  typedef Eigen::Matrix<double, 6, 1> Vector6d;
+  using Vector6d = Eigen::Matrix<double, 6, 1>;
   Vector6d err;
   Eigen::VectorXd v(model.nv);
   for (int i=0;;i++)
@@ -51,11 +51,15 @@ int main(int /* argc */, char ** /* argv */)
       std::cout << i << ": error = " << err.transpose() << std::endl;
   }
 
-  if(success)
+  if(success) 
+  {
     std::cout << "Convergence achieved!" << std::endl;
-  else
+  }
+  else 
+  {
     std::cout << "\nWarning: the iterative algorithm has not reached convergence to the desired precision" << std::endl;
-
+  }
+    
   std::cout << "\nresult: " << q.transpose() << std::endl;
   std::cout << "\nfinal error: " << err.transpose() << std::endl;
 }


### PR DESCRIPTION
Simple PR to change:
- `typedef` to `using` when defining the Vector6d, as there are advantages to the `using` syntax: https://stackoverflow.com/a/32959200
- Add some curly braces to the success/failure scenarios, as adding further statements after these tripped me up in the same way as: https://stackoverflow.com/a/2125078