### PR TITLE
Add signatures for loading geometry models, add support in robot_wrapper, and fix issues in sdf parsing

### DIFF
--- a/bindings/python/parsers/sdf/geometry.cpp
+++ b/bindings/python/parsers/sdf/geometry.cpp
@@ -44,11 +44,9 @@ namespace pinocchio
       pinocchio::sdf::buildGeom(model,contact_models,filename,type,geometry_model);
       return geometry_model;
     }
-    
 
-    
     GeometryModel
-    buildGeomFromSdf(Model & model,
+    buildGeomFromSdf(const Model & model,
                      PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)& contact_models,
                      const std::string & filename,
                      const GeometryType type,

--- a/bindings/python/parsers/sdf/geometry.cpp
+++ b/bindings/python/parsers/sdf/geometry.cpp
@@ -22,6 +22,30 @@ namespace pinocchio
 
 #ifdef PINOCCHIO_WITH_SDF
 #ifdef PINOCCHIO_WITH_HPP_FCL
+
+    GeometryModel
+    buildGeomFromSdf(const Model & model,
+		     PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)& contact_models,
+		     const std::string & filename,
+		     const GeometryType type)
+    {
+      GeometryModel geometry_model;
+      pinocchio::sdf::buildGeom(model,contact_models,filename,type,geometry_model);
+      return geometry_model;
+    }
+
+    GeometryModel &
+    buildGeomFromSdf(const Model & model,
+		     PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)& contact_models,
+		     const std::string & filename,
+		     const GeometryType type,
+		     GeometryModel & geometry_model)
+    {
+      pinocchio::sdf::buildGeom(model,contact_models,filename,type,geometry_model);
+      return geometry_model;
+    }
+    
+
     
     GeometryModel
     buildGeomFromSdf(Model & model,
@@ -37,6 +61,124 @@ namespace pinocchio
       
       return geometry_model;
     }
+
+    GeometryModel
+    buildGeomFromSdf(const Model & model,
+		     PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)& contact_models,
+		     const std::string & filename,
+		     const GeometryType type,
+		     const std::vector<std::string> & package_dirs)
+    {
+      GeometryModel geometry_model;
+      pinocchio::sdf::buildGeom(model,contact_models,filename,type,geometry_model,package_dirs);
+      return geometry_model;
+    }    
+
+    GeometryModel &
+    buildGeomFromSdf(const Model & model,
+		     PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)& contact_models,
+		     const std::string & filename,
+		     const GeometryType type,
+		     GeometryModel & geometry_model,
+		     const std::vector<std::string> & package_dirs)
+    {
+      pinocchio::sdf::buildGeom(model,contact_models,filename,type,geometry_model,package_dirs);
+      return geometry_model;
+
+    }
+
+    GeometryModel &
+    buildGeomFromSdf(const Model & model,
+		     PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)& contact_models,
+		     const std::string & filename,
+		     const GeometryType type,
+		     GeometryModel & geometry_model,
+		     const std::string & package_dir)
+    {
+      pinocchio::sdf::buildGeom(model,contact_models,filename,type,geometry_model,package_dir);
+      return geometry_model;
+    }
+
+    GeometryModel
+    buildGeomFromSdf(const Model & model,
+		     PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)& contact_models,
+                      const std::string & filename,
+                      const GeometryType type,
+                      const fcl::MeshLoaderPtr & meshLoader)
+    {
+      std::vector<std::string> hints;
+      GeometryModel geometry_model;
+      pinocchio::sdf::buildGeom(model,contact_models,filename,
+				type,geometry_model,hints,meshLoader);
+      
+      return geometry_model;
+    }
+        
+    GeometryModel &
+    buildGeomFromSdf(const Model & model,
+		     PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)& contact_models,
+		     const std::string & filename,
+		     const GeometryType type,
+		     GeometryModel & geometry_model,
+		     const fcl::MeshLoaderPtr & meshLoader)
+    {
+      std::vector<std::string> hints;
+      pinocchio::sdf::buildGeom(model,contact_models,filename,type,geometry_model,hints,meshLoader);
+      return geometry_model;
+    }
+
+    GeometryModel
+    buildGeomFromSdf(const Model & model,
+		     PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)& contact_models,
+		     const std::string & filename,
+		     const GeometryType type,
+		     const std::vector<std::string> & package_dirs,
+		     const fcl::MeshLoaderPtr & meshLoader)
+    {
+      GeometryModel geometry_model;
+      pinocchio::sdf::buildGeom(model,contact_models,filename,type,geometry_model,package_dirs,meshLoader);
+      return geometry_model;
+    }
+
+    GeometryModel &
+    buildGeomFromSdf(const Model & model,
+		     PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)& contact_models,
+		     const std::string & filename,
+		     const GeometryType type,
+		     GeometryModel & geometry_model,
+		     const std::vector<std::string> & package_dirs,
+		     const fcl::MeshLoaderPtr & meshLoader)
+    {
+      pinocchio::sdf::buildGeom(model,contact_models,filename,type,geometry_model,package_dirs,meshLoader);
+      return geometry_model;
+    }
+
+    GeometryModel
+    buildGeomFromSdf(const Model & model,
+		     PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)& contact_models,
+		     const std::string & filename,
+		     const GeometryType type,
+		     const std::string & package_dir,
+		     const fcl::MeshLoaderPtr & meshLoader)
+    {
+      GeometryModel geometry_model;
+      pinocchio::sdf::buildGeom(model,contact_models,filename,type,geometry_model,package_dir,meshLoader);
+      return geometry_model;
+    }
+
+    GeometryModel &
+    buildGeomFromSdf(const Model & model,
+		     PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)& contact_models,
+		     const std::string & filename,
+		     const GeometryType type,
+		     GeometryModel & geometry_model,
+		     const std::string & package_dir,
+		     const fcl::MeshLoaderPtr & meshLoader)
+    {
+      pinocchio::sdf::buildGeom(model,contact_models,filename,type,geometry_model,package_dir,meshLoader);
+      return geometry_model;
+    }
+    
 #endif // #ifdef PINOCCHIO_WITH_HPP_FCL
 #endif // #ifdef PINOCCHIO_WITH_SDF
 
@@ -46,15 +188,170 @@ namespace pinocchio
 #ifdef PINOCCHIO_WITH_HPP_FCL
       bp::def("buildGeomFromSdf",
               static_cast <GeometryModel (*) (Model &, PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)&, const std::string &, const GeometryType, const std::string &)> (pinocchio::python::buildGeomFromSdf),
-              bp::args("model","contact_models","urdf_filename","geom_type","package_dir"  ),
-              "Parse the URDF file given as input looking for the geometry of the given input model and\n"
+              bp::args("model","contact_models","sdf_filename","geom_type","package_dir"  ),
+              "Parse the SDF file given as input looking for the geometry of the given input model and\n"
               "return a GeometryModel containing either the collision geometries (GeometryType.COLLISION) or the visual geometries (GeometryType.VISUAL).\n"
               "Parameters:\n"
               "\tmodel: model of the robot\n"
-              "\turdf_filename: path to the URDF file containing the model of the robot\n"
-              "\tgeom_type: type of geometry to extract from the URDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
+              "\tsdf_filename: path to the SDF file containing the model of the robot\n"
+              "\tgeom_type: type of geometry to extract from the SDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
               "\tpackage_dir: path pointing to the folder containing the meshes of the robot\n"
               );
+
+      bp::def("buildGeomFromSdf",
+              static_cast <GeometryModel (*) (const Model &,PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)&, const std::string &, const GeometryType, const std::vector<std::string> &)> (pinocchio::python::buildGeomFromSdf),
+              bp::args("model","sdf_filename","geom_type","package_dirs"),
+              "Parse the SDF file given as input looking for the geometry of the given input model and\n"
+              "return a GeometryModel containing either the collision geometries (GeometryType.COLLISION) or the visual geometries (GeometryType.VISUAL).\n"
+              "Parameters:\n"
+              "\tmodel: model of the robot\n"
+              "\tsdf_filename: path to the SDF file containing the model of the robot\n"
+              "\tgeom_type: type of geometry to extract from the SDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
+              "\tpackage_dirs: vector of paths pointing to the folders containing the model of the robot\n"
+              );
+      
+      bp::def("buildGeomFromSdf",
+              static_cast <GeometryModel & (*) (const Model &,PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)&, const std::string &, const GeometryType, GeometryModel &, const std::vector<std::string> &)> (pinocchio::python::buildGeomFromSdf),
+              bp::args("model","sdf_filename","geom_type","geom_model","package_dirs"),
+              "Parse the SDF file given as input looking for the geometry of the given input model and\n"
+              "and store either the collision geometries (GeometryType.COLLISION) or the visual geometries (GeometryType.VISUAL) in the geom_model given as input.\n"
+              "Parameters:\n"
+              "\tmodel: model of the robot\n"
+              "\tsdf_filename: path to the SDF file containing the model of the robot\n"
+              "\tgeom_type: type of geometry to extract from the SDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
+              "\tgeom_model: reference where to store the parsed information\n"
+              "\tpackage_dirs: vector of paths pointing to the folders containing the model of the robot\n",
+              bp::return_internal_reference<4>()
+              );
+      
+      bp::def("buildGeomFromSdf",
+              static_cast <GeometryModel (*) (const Model &,PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)&, const std::string &, const GeometryType)> (pinocchio::python::buildGeomFromSdf),
+              bp::args("model","sdf_filename","geom_type"),
+              "Parse the SDF file given as input looking for the geometry of the given input model and\n"
+              "return a GeometryModel containing either the collision geometries (GeometryType.COLLISION) or the visual geometries (GeometryType.VISUAL).\n"
+              "Parameters:\n"
+              "\tmodel: model of the robot\n"
+              "\tsdf_filename: path to the SDF file containing the model of the robot\n"
+              "\tgeom_type: type of geometry to extract from the SDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
+              "Note:\n"
+              "This function does not take any hint concerning the location of the meshes of the robot."
+              );
+      
+      bp::def("buildGeomFromSdf",
+              static_cast <GeometryModel & (*) (const Model &,PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)&, const std::string &, const GeometryType, GeometryModel &)> (pinocchio::python::buildGeomFromSdf),
+              bp::args("model","sdf_filename","geom_type","geom_model"),
+              "Parse the SDF file given as input looking for the geometry of the given input model and\n"
+              "and store either the collision geometries (GeometryType.COLLISION) or the visual geometries (GeometryType.VISUAL) in the geom_model given as input.\n"
+              "Parameters:\n"
+              "\tmodel: model of the robot\n"
+              "\tsdf_filename: path to the SDF file containing the model of the robot\n"
+              "\tgeom_type: type of geometry to extract from the SDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
+              "\tgeom_model: reference where to store the parsed information\n"
+              "Note:\n"
+              "This function does not take any hint concerning the location of the meshes of the robot.",
+              bp::return_internal_reference<4>()
+              );
+
+      bp::def("buildGeomFromSdf",
+              static_cast <GeometryModel & (*) (const Model &,PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)&, const std::string &, const GeometryType, GeometryModel &, const std::string &)> (pinocchio::python::buildGeomFromSdf),
+              bp::args("model","sdf_filename","geom_type","geom_model","package_dir"),
+              "Parse the SDF file given as input looking for the geometry of the given input model and\n"
+              "and store either the collision geometries (GeometryType.COLLISION) or the visual geometries (GeometryType.VISUAL) in the geom_model given as input.\n"
+              "Parameters:\n"
+              "\tmodel: model of the robot\n"
+              "\tsdf_filename: path to the SDF file containing the model of the robot\n"
+              "\tgeom_type: type of geometry to extract from the SDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
+              "\tgeom_model: reference where to store the parsed information\n"
+              "\tpackage_dir: path pointing to the folder containing the meshes of the robot\n",
+              bp::return_internal_reference<4>()
+              );
+      
+      bp::def("buildGeomFromSdf",
+              static_cast <GeometryModel (*) (const Model &,PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)&, const std::string &, const GeometryType, const std::vector<std::string> &, const fcl::MeshLoaderPtr&)> (pinocchio::python::buildGeomFromSdf),
+              bp::args("model","sdf_filename","geom_type","package_dirs","mesh_loader"),
+              "Parse the SDF file given as input looking for the geometry of the given input model and\n"
+              "return a GeometryModel containing either the collision geometries (GeometryType.COLLISION) or the visual geometries (GeometryType.VISUAL).\n"
+              "Parameters:\n"
+              "\tmodel: model of the robot\n"
+              "\tsdf_filename: path to the SDF file containing the model of the robot\n"
+              "\tgeom_type: type of geometry to extract from the SDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
+              "\tpackage_dirs: vector of paths pointing to the folders containing the model of the robot\n"
+              "\tmesh_loader: an hpp-fcl mesh loader (to load only once the related geometries)."
+              );
+      
+      bp::def("buildGeomFromSdf",
+              static_cast <GeometryModel & (*) (const Model &,PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)&, const std::string &, const GeometryType, GeometryModel &, const std::vector<std::string> &, const fcl::MeshLoaderPtr&)> (pinocchio::python::buildGeomFromSdf),
+              bp::args("model","sdf_filename","geom_type","geom_model","package_dirs","mesh_loader"),
+              "Parse the SDF file given as input looking for the geometry of the given input model and\n"
+              "and store either the collision geometries (GeometryType.COLLISION) or the visual geometries (GeometryType.VISUAL) in the geom_model given as input.\n"
+              "Parameters:\n"
+              "\tmodel: model of the robot\n"
+              "\tsdf_filename: path to the SDF file containing the model of the robot\n"
+              "\tgeom_type: type of geometry to extract from the SDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
+              "\tgeom_model: reference where to store the parsed information\n"
+              "\tpackage_dirs: vector of paths pointing to the folders containing the model of the robot\n"
+              "\tmesh_loader: an hpp-fcl mesh loader (to load only once the related geometries).",
+              bp::return_internal_reference<4>()
+              );
+
+      bp::def("buildGeomFromSdf",
+              static_cast <GeometryModel (*) (const Model &,PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)&, const std::string &, const GeometryType, const std::string &, const fcl::MeshLoaderPtr&)> (pinocchio::python::buildGeomFromSdf),
+              bp::args("model","sdf_filename","geom_type","package_dir","mesh_loader"),
+              "Parse the SDF file given as input looking for the geometry of the given input model and\n"
+              "return a GeometryModel containing either the collision geometries (GeometryType.COLLISION) or the visual geometries (GeometryType.VISUAL).\n"
+              "Parameters:\n"
+              "\tmodel: model of the robot\n"
+              "\tsdf_filename: path to the SDF file containing the model of the robot\n"
+              "\tgeom_type: type of geometry to extract from the SDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
+              "\tpackage_dir: path pointing to the folder containing the meshes of the robot\n"
+              "\tmesh_loader: an hpp-fcl mesh loader (to load only once the related geometries)."
+              );
+
+      bp::def("buildGeomFromSdf",
+              static_cast <GeometryModel & (*) (const Model &,PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)&, const std::string &, const GeometryType, GeometryModel &, const std::string &, const fcl::MeshLoaderPtr&)> (pinocchio::python::buildGeomFromSdf),
+              bp::args("model","sdf_filename","geom_type","geom_model","package_dir","mesh_loader"),
+              "Parse the SDF file given as input looking for the geometry of the given input model and\n"
+              "and store either the collision geometries (GeometryType.COLLISION) or the visual geometries (GeometryType.VISUAL) in the geom_model given as input.\n"
+              "Parameters:\n"
+              "\tmodel: model of the robot\n"
+              "\tsdf_filename: path to the SDF file containing the model of the robot\n"
+              "\tgeom_type: type of geometry to extract from the SDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
+              "\tgeom_model: reference where to store the parsed information\n"
+              "\tpackage_dir: path pointing to the folder containing the meshes of the robot\n"
+              "\tmesh_loader: an hpp-fcl mesh loader (to load only once the related geometries).",
+              bp::return_internal_reference<4>()
+              );
+      
+      bp::def("buildGeomFromSdf",
+              static_cast <GeometryModel (*) (const Model &,PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)&, const std::string &, const GeometryType, const fcl::MeshLoaderPtr&)> (pinocchio::python::buildGeomFromSdf),
+              bp::args("model","sdf_filename","geom_type","mesh_loader"),
+              "Parse the SDF file given as input looking for the geometry of the given input model and\n"
+              "return a GeometryModel containing either the collision geometries (GeometryType.COLLISION) or the visual geometries (GeometryType.VISUAL).\n"
+              "Parameters:\n"
+              "\tmodel: model of the robot\n"
+              "\tsdf_filename: path to the SDF file containing the model of the robot\n"
+              "\tgeom_type: type of geometry to extract from the SDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
+              "\tmesh_loader: an hpp-fcl mesh loader (to load only once the related geometries).\n"
+              "Note:\n"
+              "This function does not take any hint concerning the location of the meshes of the robot."
+              );
+      
+      bp::def("buildGeomFromSdf",
+              static_cast <GeometryModel & (*) (const Model &,PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)&, const std::string &, const GeometryType, GeometryModel &, const fcl::MeshLoaderPtr&)> (pinocchio::python::buildGeomFromSdf),
+              bp::args("model","sdf_filename","geom_type","geom_model","mesh_loader"),
+              "Parse the SDF file given as input looking for the geometry of the given input model and\n"
+              "and store either the collision geometries (GeometryType.COLLISION) or the visual geometries (GeometryType.VISUAL) in the geom_model given as input.\n"
+              "Parameters:\n"
+              "\tmodel: model of the robot\n"
+              "\tsdf_filename: path to the SDF file containing the model of the robot\n"
+              "\tgeom_type: type of geometry to extract from the SDF file (either the VISUAL for display or the COLLISION for collision detection).\n"
+              "\tgeom_model: reference where to store the parsed information\n"
+              "\tmesh_loader: an hpp-fcl mesh loader (to load only once the related geometries).\n"
+              "Note:\n"
+              "This function does not take any hint concerning the location of the meshes of the robot.",
+              bp::return_internal_reference<4>()
+              );
+      
 #endif // #ifdef PINOCCHIO_WITH_HPP_FCL
 #endif
     }

--- a/bindings/python/parsers/sdf/geometry.cpp
+++ b/bindings/python/parsers/sdf/geometry.cpp
@@ -185,7 +185,7 @@ namespace pinocchio
 #ifdef PINOCCHIO_WITH_SDF
 #ifdef PINOCCHIO_WITH_HPP_FCL
       bp::def("buildGeomFromSdf",
-              static_cast <GeometryModel (*) (Model &, PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)&, const std::string &, const GeometryType, const std::string &)> (pinocchio::python::buildGeomFromSdf),
+              static_cast <GeometryModel (*) (const Model &, PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)&, const std::string &, const GeometryType, const std::string &)> (pinocchio::python::buildGeomFromSdf),
               bp::args("model","contact_models","sdf_filename","geom_type","package_dir"  ),
               "Parse the SDF file given as input looking for the geometry of the given input model and\n"
               "return a GeometryModel containing either the collision geometries (GeometryType.COLLISION) or the visual geometries (GeometryType.VISUAL).\n"

--- a/bindings/python/parsers/sdf/model.cpp
+++ b/bindings/python/parsers/sdf/model.cpp
@@ -29,9 +29,8 @@ namespace pinocchio
     }
 
     bp::tuple buildModelFromSdf(const std::string & filename,
-                                const bp::object & root_joint_object)
+				const JointModel & root_joint)
     {
-      JointModelVariant root_joint = bp::extract<JointModelVariant>(root_joint_object)();
       Model model;
       PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel) contact_models;
       pinocchio::sdf::buildModel(filename, root_joint, model, contact_models);
@@ -48,13 +47,13 @@ namespace pinocchio
       bp::def("buildModelFromSdf",
               static_cast <bp::tuple (*) (const std::string &)> (pinocchio::python::buildModelFromSdf),
               bp::args("sdf_filename"),
-              "Parse the SDF file given in input and return a pinocchio Model."
+              "Parse the SDF file given in input and return a pinocchio Model and constraint models."
               );
 
       bp::def("buildModelFromSdf",
-              static_cast <bp::tuple (*) (const std::string &, const bp::object &)> (pinocchio::python::buildModelFromSdf),
+              static_cast <bp::tuple (*) (const std::string &, const JointModel &)> (pinocchio::python::buildModelFromSdf),
               bp::args("sdf_filename","root_joint"),
-              "Append to a given model a SDF structure given by its filename and the root joint."
+              "Parse the SDF file given in input and return a pinocchio Model and constraint models starting with the given root joint."
               );
 #endif // #ifdef PINOCCHIO_WITH_HPP_FCL
 #endif

--- a/bindings/python/pinocchio/robot_wrapper.py
+++ b/bindings/python/pinocchio/robot_wrapper.py
@@ -21,6 +21,16 @@ class RobotWrapper(object):
         model, collision_model, visual_model = buildModelsFromUrdf(filename, package_dirs, root_joint, verbose, meshLoader)
         RobotWrapper.__init__(self,model=model,collision_model=collision_model,visual_model=visual_model)
 
+    def BuildFromSDF(filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None):
+        robot = RobotWrapper()
+        robot.initFromSDF(filename, package_dirs, root_joint, verbose, meshLoader)
+        return robot
+
+    def initFromSDF(self,filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None):
+        model, constraint_models, collision_model, visual_model = buildModelsFromSDF(filename, package_dirs, root_joint, verbose, meshLoader)
+        RobotWrapper.__init__(self,model=model,collision_model=collision_model,visual_model=visual_model)
+        self.constraint_models = constraint_models
+        
     def __init__(self, model = pin.Model(), collision_model = None, visual_model = None, verbose=False):
 
         self.model = model

--- a/bindings/python/pinocchio/robot_wrapper.py
+++ b/bindings/python/pinocchio/robot_wrapper.py
@@ -21,6 +21,7 @@ class RobotWrapper(object):
         model, collision_model, visual_model = buildModelsFromUrdf(filename, package_dirs, root_joint, verbose, meshLoader)
         RobotWrapper.__init__(self,model=model,collision_model=collision_model,visual_model=visual_model)
 
+    @staticmethod
     def BuildFromSDF(filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None):
         robot = RobotWrapper()
         robot.initFromSDF(filename, package_dirs, root_joint, verbose, meshLoader)

--- a/bindings/python/pinocchio/robot_wrapper.py
+++ b/bindings/python/pinocchio/robot_wrapper.py
@@ -5,7 +5,7 @@
 from . import pinocchio_pywrap_default as pin
 from . import utils
 from .deprecation import deprecated
-from .shortcuts import buildModelsFromUrdf, createDatas
+from .shortcuts import buildModelsFromUrdf, createDatas, buildModelsFromSdf
 
 import numpy as np
 
@@ -27,7 +27,7 @@ class RobotWrapper(object):
         return robot
 
     def initFromSDF(self,filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None):
-        model, constraint_models, collision_model, visual_model = buildModelsFromSDF(filename, package_dirs, root_joint, verbose, meshLoader)
+        model, constraint_models, collision_model, visual_model = buildModelsFromSdf(filename, package_dirs, root_joint, verbose, meshLoader)
         RobotWrapper.__init__(self,model=model,collision_model=collision_model,visual_model=visual_model)
         self.constraint_models = constraint_models
         

--- a/bindings/python/pinocchio/shortcuts.py
+++ b/bindings/python/pinocchio/shortcuts.py
@@ -9,7 +9,7 @@ from . import WITH_HPP_FCL, WITH_HPP_FCL_BINDINGS
 
 nle = pin.nonLinearEffects
 
-def buildModelsFromUrdf(filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None, geometry_types=[pin.GeometryType.COLLISION,pin.GeometryType.VISUAL]):
+def buildModelsFromUrdf(filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None, geometry_types=None):
     """Parse the URDF file given in input and return a Pinocchio Model followed by corresponding GeometryModels of types specified by geometry_types, in the same order as listed.
     Examples of usage:
         # load model, collision model, and visual model, in this order (default)
@@ -22,7 +22,8 @@ def buildModelsFromUrdf(filename, package_dirs=None, root_joint=None, verbose=Fa
         
         model = buildModelsFromUrdf(filename[, ...], geometry_types=[])  # equivalent to buildModelFromUrdf(filename[, root_joint])
     """
-
+    if geometry_types is None:
+        geometry_types = [pin.GeometryType.COLLISION,pin.GeometryType.VISUAL]
     if root_joint is None:
         model = pin.buildModelFromUrdf(filename)
     else:
@@ -56,7 +57,7 @@ def createDatas(*models):
     return tuple([None if model is None else model.createData() for model in models])
 
 
-def buildModelsFromSdf(filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None, geometry_types=[pin.GeometryType.COLLISION,pin.GeometryType.VISUAL]):
+def buildModelsFromSdf(filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None, geometry_types=None):
     """Parse the SDF file given in input and return a Pinocchio Model and a list of Constraint Models, followed by corresponding GeometryModels of types specified by geometry_types, in the same order as listed.
     Examples of usage:
         # load model, constraint models, collision model, and visual model, in this order (default)
@@ -69,7 +70,8 @@ def buildModelsFromSdf(filename, package_dirs=None, root_joint=None, verbose=Fal
         
         model, constraint_models = buildModelsFromSdf(filename[, ...], geometry_types=[])  # equivalent to buildModelFromSdf(filename[, root_joint])
     """
-
+    if geometry_types is None:
+        geometry_types = [pin.GeometryType.COLLISION,pin.GeometryType.VISUAL]
     if root_joint is None:
         model, constraint_models = pin.buildModelFromSdf(filename)
     else:

--- a/bindings/python/pinocchio/shortcuts.py
+++ b/bindings/python/pinocchio/shortcuts.py
@@ -54,3 +54,44 @@ def createDatas(*models):
     If one of the models is None, the corresponding data object in the result is also None.
     """
     return tuple([None if model is None else model.createData() for model in models])
+
+
+def buildModelsFromSdf(filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None, geometry_types=[pin.GeometryType.COLLISION,pin.GeometryType.VISUAL]):
+    """Parse the SDF file given in input and return a Pinocchio Model and a list of Constraint Models, followed by corresponding GeometryModels of types specified by geometry_types, in the same order as listed.
+    Examples of usage:
+        # load model, constraint models, collision model, and visual model, in this order (default)
+        model, constraint_models, collision_model, visual_model = buildModelsFromSdf(filename[, ...], geometry_types=[pin.GeometryType.COLLISION,pin.GeometryType.VISUAL])
+        model, constraint_models, collision_model, visual_model = buildModelsFromSdf(filename[, ...]) # same as above
+        
+        model, constraint_models, collision_model = buildModelsFromSdf(filename[, ...], geometry_types=[pin.GeometryType.COLLISION]) # only load the model, constraint models and the collision model
+        model, constraint_models, collision_model = buildModelsFromSdf(filename[, ...], geometry_types=pin.GeometryType.COLLISION)   # same as above
+        model, constraint_models, visual_model    = buildModelsFromSdf(filename[, ...], geometry_types=pin.GeometryType.VISUAL)      # only load the model and the visual model
+        
+        model, constraint_models = buildModelsFromSdf(filename[, ...], geometry_types=[])  # equivalent to buildModelFromSdf(filename[, root_joint])
+    """
+
+    if root_joint is None:
+        model, constraint_models = pin.buildModelFromSdf(filename)
+    else:
+        model, constraint_models = pin.buildModelFromSdf(filename, root_joint)
+
+    if verbose and not WITH_HPP_FCL and meshLoader is not None:
+        print('Info: MeshLoader is ignored. Pinocchio has not been compiled with HPP-FCL.')
+    if verbose and not WITH_HPP_FCL_BINDINGS and meshLoader is not None:
+        print('Info: MeshLoader is ignored. The HPP-FCL Python bindings have not been installed.')
+    if package_dirs is None:
+        package_dirs = []
+
+    lst = [model, constraint_models]
+
+    if not hasattr(geometry_types, '__iter__'):
+        geometry_types = [geometry_types]
+
+    for geometry_type in geometry_types:
+        if meshLoader is None or (not WITH_HPP_FCL and not WITH_HPP_FCL_BINDINGS):
+            geom_model = pin.buildGeomFromSdf(model, constraint_models, filename, geometry_type, package_dirs)
+        else:
+            geom_model = pin.buildGeomFromSdf(model, constraint_models, filename, geometry_type, package_dirs, meshLoader)
+        lst.append(geom_model)
+
+    return tuple(lst)

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -273,7 +273,7 @@ class MeshcatVisualizer(BaseVisualizer):
                 T = np.array(M.homogeneous).dot(S)
             else:
                 T = M.homogeneous
-            
+
             # Update viewer configuration.
             self.viewer[visual_name].set_transform(T)
 

--- a/bindings/python/utils/pickle-vector.hpp
+++ b/bindings/python/utils/pickle-vector.hpp
@@ -20,7 +20,7 @@ namespace pinocchio
     ///
     template<typename VecType>
     struct PickleVector : boost::python::pickle_suite
-    { 
+    {
       static boost::python::tuple getinitargs(const VecType&)
       { return boost::python::make_tuple(); }
       

--- a/src/algorithm/centroidal-derivatives.hxx
+++ b/src/algorithm/centroidal-derivatives.hxx
@@ -291,8 +291,16 @@ namespace pinocchio
     data.Ig.inertia() = Ytot.inertia();
     
     // Compute the partial derivatives
-    translateForceSet(data.dHdq,com,PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike0,dh_dq));
-    translateForceSet(data.dFdq,com,PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike1,dhdot_dq));
+    translateForceSet(data.dHdq,com,dh_dq.const_cast_derived());
+    Matrix6xLike0 & dh_dq_ = dh_dq.const_cast_derived();
+    for(Eigen::DenseIndex k = 0; k < model.nv; ++k)
+      dh_dq_.col(k).template segment<3>(Force::ANGULAR) += data.hg.linear().cross(data.dFda.col(k).template segment<3>(Force::LINEAR))/Ytot.mass();
+    
+    translateForceSet(data.dFdq,com,dhdot_dq.const_cast_derived());
+    Matrix6xLike1 & dhdot_dq_ = dhdot_dq.const_cast_derived();
+    for(Eigen::DenseIndex k = 0; k < model.nv; ++k)
+      dhdot_dq_.col(k).template segment<3>(Force::ANGULAR) += data.dhg.linear().cross(data.dFda.col(k).template segment<3>(Force::LINEAR))/Ytot.mass();
+    
     translateForceSet(data.dFdv,com,PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike2,dhdot_dv));
     translateForceSet(data.dFda,com,data.Ag);
     PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike3,dhdot_da) = data.Ag;
@@ -410,8 +418,16 @@ namespace pinocchio
     data.Ig.inertia() = Ytot.inertia();
     
     // Retrieve the partial derivatives from RNEA derivatives
-    translateForceSet(data.dHdq,com,PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike0,dh_dq));
-    translateForceSet(Ftmp,com,PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike1,dhdot_dq));
+    translateForceSet(data.dHdq,com,dh_dq.const_cast_derived());
+    Matrix6xLike0 & dh_dq_ = dh_dq.const_cast_derived();
+    for(Eigen::DenseIndex k = 0; k < model.nv; ++k)
+      dh_dq_.col(k).template segment<3>(Force::ANGULAR) += data.hg.linear().cross(data.dFda.col(k).template segment<3>(Force::LINEAR))/Ytot.mass();
+    
+    translateForceSet(Ftmp,com,dhdot_dq.const_cast_derived());
+    Matrix6xLike1 & dhdot_dq_ = dhdot_dq.const_cast_derived();
+    for(Eigen::DenseIndex k = 0; k < model.nv; ++k)
+      dhdot_dq_.col(k).template segment<3>(Force::ANGULAR) += data.dhg.linear().cross(data.dFda.col(k).template segment<3>(Force::LINEAR))/Ytot.mass();
+    
     translateForceSet(data.dFdv,com,PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike2,dhdot_dv));
     translateForceSet(data.dFda,com,data.Ag);
     PINOCCHIO_EIGEN_CONST_CAST(Matrix6xLike3,dhdot_da) = data.Ag;

--- a/src/parsers/sdf.hpp
+++ b/src/parsers/sdf.hpp
@@ -18,13 +18,13 @@ namespace pinocchio
 #ifdef PINOCCHIO_WITH_HPP_FCL
 #ifdef PINOCCHIO_WITH_SDF
     /**
-     * @brief      Build The GeometryModel from a URDF file. Search for meshes
+     * @brief      Build The GeometryModel from a SDF file. Search for meshes
      *             in the directories specified by the user first and then in
      *             the environment variable ROS_PACKAGE_PATH
      *
      * @param[in]  model         The model of the robot, built with
-     *                           urdf::buildModel
-     * @param[in]  filename      The URDF complete (absolute) file path
+     *                           sdf::buildModel
+     * @param[in]  filename      The SDF complete (absolute) file path
      * @param[in]  packageDirs   A vector containing the different directories
      *                           where to search for models and meshes, typically 
      *                           obtained from calling pinocchio::rosPaths()
@@ -46,13 +46,48 @@ namespace pinocchio
                               GeometryModel & geomModel,
                               const std::vector<std::string> & packageDirs = std::vector<std::string> (),
                               ::hpp::fcl::MeshLoaderPtr meshLoader = ::hpp::fcl::MeshLoaderPtr());
+
+
+    /**
+     * @brief      Build The GeometryModel from a SDF file. Search for meshes
+     *             in the directories specified by the user first and then in
+     *             the environment variable ROS_PACKAGE_PATH
+     *
+     * @param[in]  model         The model of the robot, built with
+     *                           sdf::buildModel
+     * @param[in]  filename      The SDF complete (absolute) file path
+     * @param[in]  package_path    A string containing the path to the directories of the meshes,
+     *                           typically obtained from calling pinocchio::rosPaths().
+     *
+     * @param[in]   type         The type of objects that must be loaded (must be VISUAL or COLLISION)
+     * @param[in]   meshLoader   object used to load meshes: hpp::fcl::MeshLoader [default] or hpp::fcl::CachedMeshLoader.
+     * @param[out]  geomModel    Reference where to put the parsed information.
+     *
+     * @return      Returns the reference on geom model for convenience.
+     *
+     * \warning     If hpp-fcl has not been found during compilation, COLLISION objects can not be loaded
+     *
+     */
+    template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+    GeometryModel & buildGeom(ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                              PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)& contact_models,
+                              const std::string & filename,
+                              const GeometryType type,
+                              GeometryModel & geomModel,
+                              const std::string & packagePath,
+                              ::hpp::fcl::MeshLoaderPtr meshLoader = ::hpp::fcl::MeshLoaderPtr())
+    {
+      const std::vector<std::string> dirs(1,packagePath);
+      return buildGeom(model,contact_models,filename,type,geomModel,dirs,meshLoader);
+    };
+
     
 
     ///
-    /// \brief Build the model from a URDF file with a particular joint as root of the model tree inside
+    /// \brief Build the model from a SDF file with a particular joint as root of the model tree inside
     /// the model given as reference argument.
     ///
-    /// \param[in] filename The URDF complete file path.
+    /// \param[in] filename The SDF complete file path.
     /// \param[in] rootJoint The joint at the root of the model tree.
     /// \param[in] verbose Print parsing info.
     /// \param[out] model Reference model where to put the parsed information.
@@ -68,9 +103,9 @@ namespace pinocchio
 
 
     ///
-    /// \brief Build the model from a URDF file with a fixed joint as root of the model tree.
+    /// \brief Build the model from a SDF file with a fixed joint as root of the model tree.
     ///
-    /// \param[in] filename The URDF complete file path.
+    /// \param[in] filename The SDF complete file path.
     /// \param[in] verbose Print parsing info.
     /// \param[out] model Reference model where to put the parsed information.
     /// \return Return the reference on argument model for convenience.

--- a/src/parsers/sdf.hpp
+++ b/src/parsers/sdf.hpp
@@ -39,7 +39,7 @@ namespace pinocchio
      *
      */
     template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
-    GeometryModel & buildGeom(ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+    GeometryModel & buildGeom(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                               PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)& contact_models,
                               const std::string & filename,
                               const GeometryType type,
@@ -69,7 +69,7 @@ namespace pinocchio
      *
      */
     template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
-    GeometryModel & buildGeom(ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+    GeometryModel & buildGeom(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                               PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)& contact_models,
                               const std::string & filename,
                               const GeometryType type,

--- a/src/parsers/sdf/geometry.hxx
+++ b/src/parsers/sdf/geometry.hxx
@@ -65,10 +65,12 @@ namespace pinocchio
         std::vector< ::sdf::ElementPtr> geometry_array;
         ::sdf::ElementPtr geomElement = link->GetElement("collision");
         while (geomElement)
-        {
-          //Inserting data in std::map
-          geometry_array.push_back(geomElement);
-          geomElement = link->GetNextElement("collision");
+        { 
+	  //Inserting data in std::map
+	  if (geomElement->Get<std::string>("name") != "__default__") {
+	    geometry_array.push_back(geomElement);
+	  }
+	    geomElement = link->GetNextElement("collision");
         }
         return geometry_array;
       }
@@ -82,7 +84,9 @@ namespace pinocchio
         while (geomElement)
         {
           //Inserting data in std::map
-          geometry_array.push_back(geomElement);
+	  if (geomElement->Get<std::string>("name") != "__default__") {
+	    geometry_array.push_back(geomElement);
+	  }
           geomElement = link->GetNextElement("visual");
         }
         return geometry_array;

--- a/src/parsers/sdf/geometry.hxx
+++ b/src/parsers/sdf/geometry.hxx
@@ -326,7 +326,7 @@ namespace pinocchio
     } // namespace details
 
     template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
-    GeometryModel& buildGeom(ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+    GeometryModel& buildGeom(const ModelTpl<Scalar,Options,JointCollectionTpl> & const_model,
                              PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel)& contact_models,
                              const std::string & filename,
                              const GeometryType type,
@@ -335,6 +335,7 @@ namespace pinocchio
                              ::hpp::fcl::MeshLoaderPtr meshLoader)
       
     {
+      Model& model = const_cast<Model &>(const_model); //TODO: buildGeom should not need to parse model again.
       ::pinocchio::urdf::details::UrdfVisitor<Scalar, Options, JointCollectionTpl> visitor (model);
       ::pinocchio::sdf::details::SdfGraph graph (visitor, contact_models);
       //if (verbose) visitor.log = &std::cout;

--- a/src/parsers/urdf/geometry.hxx
+++ b/src/parsers/urdf/geometry.hxx
@@ -63,11 +63,11 @@ namespace pinocchio
        *
        */
       PINOCCHIO_DLLAPI void parseTreeForGeom(UrdfGeomVisitorBase& visitor,
-                            const std::istream& xmlStream,
-                            const GeometryType type,
-                            GeometryModel & geomModel,
-                            const std::vector<std::string> & package_dirs,
-                            ::hpp::fcl::MeshLoaderPtr meshLoader);
+                                             const std::istream& xmlStream,
+                                             const GeometryType type,
+                                             GeometryModel & geomModel,
+                                             const std::vector<std::string> & package_dirs,
+                                             ::hpp::fcl::MeshLoaderPtr meshLoader);
       
       } // namespace details
       

--- a/unittest/centroidal-derivatives.cpp
+++ b/unittest/centroidal-derivatives.cpp
@@ -108,8 +108,7 @@ BOOST_AUTO_TEST_CASE(test_centroidal_derivatives)
   const pinocchio::Force dhg = pinocchio::computeCentroidalMomentumTimeVariation(model,data_fd,q,v,a);
   const pinocchio::Force hg = data_fd.hg;
   BOOST_CHECK(data.hg.isApprox(data_ref.hg));
-  const pinocchio::Force::Vector3 com = data_fd.com[0];
-  
+
   // Check dhdot_dq and dh_dq with finite differences
   Eigen::VectorXd q_plus(model.nq,1);
   Eigen::VectorXd v_eps(model.nv,1); v_eps.setZero();

--- a/unittest/centroidal-derivatives.cpp
+++ b/unittest/centroidal-derivatives.cpp
@@ -124,13 +124,9 @@ BOOST_AUTO_TEST_CASE(test_centroidal_derivatives)
     const pinocchio::Force & dhg_plus
     = pinocchio::computeCentroidalMomentumTimeVariation(model,data_fd,q_plus,v,a);
     const pinocchio::Force hg_plus = data_fd.hg;
-    const pinocchio::Force::Vector3 com_plus = data_fd.com[0];
-    
-    pinocchio::SE3 transform(pinocchio::SE3::Identity());
-    transform.translation() = com_plus - com;
-    
-    dhdot_dq_fd.col(k) = (transform.act(dhg_plus) - dhg).toVector()/eps;
-    dh_dq_fd.col(k) = (transform.act(hg_plus) - hg).toVector()/eps;
+
+    dhdot_dq_fd.col(k) = (dhg_plus - dhg).toVector()/eps;
+    dh_dq_fd.col(k) = (hg_plus - hg).toVector()/eps;
     v_eps[k] = 0.;
   }
   


### PR DESCRIPTION
This PR fixes some issues in sdf parsing related to non-existent geometry models, and adds signatures in python and c++ for loading geometry models. Also it links with https://github.com/Gepetto/example-robot-data/pull/100 to support easy loading of cassie model through robot_wrapper.

In addition, this PR adds the bug fix in centroidal-dynamics-derivatives from 2.6.3, and the rest of the commits from 2.6.3, and thus sits on top of 2.6.3.