### PR TITLE
[visualize] captureImage() method

### DIFF
--- a/bindings/python/pinocchio/visualize/base_visualizer.py
+++ b/bindings/python/pinocchio/visualize/base_visualizer.py
@@ -75,14 +75,24 @@ class BaseVisualizer(object):
         """Set whether to display visual objects or not."""
         pass
 
-    def play(self, q_trajectory, dt):
-        """Play a trajectory with given time step."""
+    def captureImage(self):
+        """Captures an image from the viewer and returns an RGB array."""
+        pass
+
+    def play(self, q_trajectory, dt, capture=False):
+        """Play a trajectory with given time step. Optionally capture RGB images and returns them."""
+        imgs = []
         for k in range(q_trajectory.shape[1]):
             t0 = time.time()
             self.display(q_trajectory[:, k])
+            if capture:
+                img_arr = self.captureImage()
+                imgs.append(img_arr)
             t1 = time.time()
             elapsed_time = t1 - t0
             if elapsed_time < dt:
                 time.sleep(dt - elapsed_time)
+        if capture:
+            return imgs
 
 __all__ = ['BaseVisualizer']

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -283,7 +283,7 @@ class MeshcatVisualizer(BaseVisualizer):
             return img_arr
         except AttributeError:
             warnings.warn("meshcat.Visualizer does not have the get_image() method."
-                          " Check your version of meshcat.")
+                          " You need meschat >= 0.2.0 to get this feature.")
 
 
     def displayCollisions(self,visibility):

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -275,6 +275,18 @@ class MeshcatVisualizer(BaseVisualizer):
             # Update viewer configuration.
             self.viewer[visual_name].set_transform(T)
 
+    def captureImage(self):
+        """Capture an image from the Meshcat viewer and return an RGB array."""
+        try:
+            img = self.viewer.get_image()
+            img_arr = np.asarray(img)
+            return img_arr
+        except AttributeError:
+            import warnings
+            warnings.warn("meshcat.Visualizer does not have the get_image() method."
+                          " Check your version of meshcat.")
+
+
     def displayCollisions(self,visibility):
         """Set whether to display collision objects or not.
         WARNING: Plotting collision meshes is not yet available for MeshcatVisualizer."""

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -283,7 +283,7 @@ class MeshcatVisualizer(BaseVisualizer):
             return img_arr
         except AttributeError:
             warnings.warn("meshcat.Visualizer does not have the get_image() method."
-                          " You need meschat >= 0.2.0 to get this feature.")
+                          " You need meshcat >= 0.2.0 to get this feature.")
 
 
     def displayCollisions(self,visibility):

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -282,7 +282,6 @@ class MeshcatVisualizer(BaseVisualizer):
             img_arr = np.asarray(img)
             return img_arr
         except AttributeError:
-            import warnings
             warnings.warn("meshcat.Visualizer does not have the get_image() method."
                           " Check your version of meshcat.")
 


### PR DESCRIPTION
This commit adds a `captureImage()` method for visualizers. It returns an RGB array. A minimal example:

```python
import matplotlib.pyplot as plt

visualizer.display(q)
img: np.ndarray = visualizer.captureImage()

# display with matplotlib
plt.imshow(img)
plt.axis('off')
plt.show()
```

For now, it is only implemented for `MeshcatVisualizer`. This requires that rdeits/meshcat-python#93 be merged first. To work, this requires the visualizer window be already opened in the browser.

I also added an optional argument `capture` to the `play()` method. It makes the method return a list of ndarrays containing each captured image, which can be fed to something like `imageio` to produce an MP4 video.