### PR TITLE
fix module name

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,6 +4,6 @@
 [submodule ".travis"]
 	path = .travis
 	url = https://github.com/jrl-umi3218/jrl-travis
-[submodule "models/others"]
+[submodule "models/example-robot-data"]
 	path = models/example-robot-data
 	url = https://github.com/Gepetto/example-robot-data.git

--- a/benchmark/timings-geometry.cpp
+++ b/benchmark/timings-geometry.cpp
@@ -30,9 +30,9 @@ int main()
     std::cout << "(the time score in debug mode is not relevant) " << std::endl;
   #endif
   
-  std::string romeo_filename = PINOCCHIO_MODEL_DIR + std::string("/others/robots/romeo_description/urdf/romeo_small.urdf");
+  std::string romeo_filename = PINOCCHIO_MODEL_DIR + std::string("/example-robot-data/robots/romeo_description/urdf/romeo_small.urdf");
   std::vector < std::string > package_dirs;
-  std::string romeo_meshDir  = PINOCCHIO_MODEL_DIR + std::string("/others/robots");
+  std::string romeo_meshDir = PINOCCHIO_MODEL_DIR + std::string("/example-robot-data/robots");
   package_dirs.push_back(romeo_meshDir);
 
   pinocchio::Model model;

--- a/examples/capsule-approximation.py
+++ b/examples/capsule-approximation.py
@@ -150,5 +150,5 @@ if __name__ == "__main__":
     # Example for a whole URDF model
     # This path refers to Pinocchio source code but you can define your own directory here.
     pinocchio_model_dir = join(dirname(dirname(str(abspath(__file__)))), "models")
-    urdf_filename = pinocchio_model_dir + "models/others/robots/ur_description/urdf/ur5_gripper.urdf"
+    urdf_filename = pinocchio_model_dir + "models/example-robot-data/robots/ur_description/urdf/ur5_gripper.urdf"
     parse_urdf(urdf_filename, "ur5_gripper_with_capsules.urdf")

--- a/examples/codegen/codegen-crba.cpp
+++ b/examples/codegen/codegen-crba.cpp
@@ -16,7 +16,7 @@ int main(int argc, const char ** argv)
   using namespace pinocchio;
   using namespace Eigen;
   
-  std::string filename = PINOCCHIO_MODEL_DIR + std::string("/others/robots/ur_description/urdf/ur5_robot.urdf");
+  std::string filename = PINOCCHIO_MODEL_DIR + std::string("/example-robot-data/robots/ur_description/urdf/ur5_robot.urdf");
   if(argc>1) filename = argv[1];
   
   std::cout << "Opening file: " << filename << std::endl;

--- a/examples/panda3d-viewer-play.py
+++ b/examples/panda3d-viewer-play.py
@@ -9,7 +9,7 @@ import sys
 from os.path import dirname, join, abspath
 
 # add path to the example-robot-data package
-path = join(dirname(dirname(abspath(__file__))), 'models', 'others', 'python')
+path = join(dirname(dirname(abspath(__file__))), 'models', 'example-robot-data', 'python')
 sys.path.append(path)
 from example_robot_data import loadTalos
 

--- a/examples/panda3d-viewer.py
+++ b/examples/panda3d-viewer.py
@@ -8,7 +8,7 @@ import sys
 from os.path import dirname, join, abspath
 
 # add path to the example-robot-data package
-path = join(dirname(dirname(abspath(__file__))), 'models', 'others', 'python')
+path = join(dirname(dirname(abspath(__file__))), 'models', 'example-robot-data', 'python')
 sys.path.append(path)
 from example_robot_data import loadTalos, loadRomeo, loadICub, loadTiago
 from example_robot_data import loadSolo, loadHyQ, loadHector


### PR DESCRIPTION
Hi,

Running all tests on a clean repo `clone --recursive` currently fails with:
```cpp
120/147 Test #147: example-cpp-codegen-crba ...........................Child aborted***Exception:   0.16 sec
Opening file: /pinocchio/models/others/robots/ur_description/urdf/ur5_robot.urdf
Error:   File /pinocchio/models/others/robots/ur_description/urdf/ur5_robot.urdf does not exist
         at line 55 in /build/urdfdom-VnCcob/urdfdom-1.0.4+ds/urdf_parser/src/model.cpp
terminate called after throwing an instance of 'std::invalid_argument'
  what():  The file /pinocchio/models/others/robots/ur_description/urdf/ur5_robot.urdf does not contain a valid URDF model.
  ```

It looks like this folder was changed in https://github.com/stack-of-tasks/pinocchio/commit/8b0d1471b1fa5097acde159e9cf3146c45270cdc , but not everywhere.