### PR TITLE
make copy of supports during model cast

### DIFF
--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -203,6 +203,7 @@ namespace pinocchio
       res.nframes = nframes;
       res.parents = parents;
       res.names = names;
+      res.supports = supports;      
       res.subtrees = subtrees;
       res.gravity = gravity.template cast<NewScalar>();
       res.name = name;


### PR DESCRIPTION
It seems that the coping of the member "supports" was forgotten in the cast of a model.