### PR TITLE
Append "/share" to AMENT_PREFIX_PATH

### DIFF
--- a/src/utils/file-explorer.cpp
+++ b/src/utils/file-explorer.cpp
@@ -43,12 +43,26 @@ namespace pinocchio
     return list_of_paths;
   }
 
+  void appendSuffixToPaths(std::vector<std::string> & list_of_paths,
+                           const std::string & suffix)
+  {
+    for (size_t i = 0; i < list_of_paths.size(); ++i)
+    {
+      list_of_paths[i] += suffix;
+    }
+  }
+  
   std::vector<std::string> rosPaths()
   {
     std::vector<std::string> raw_list_of_paths;
+    std::vector<std::string> raw_list_of_prefixes;
     extractPathFromEnvVar("ROS_PACKAGE_PATH", raw_list_of_paths);
-    extractPathFromEnvVar("AMENT_PREFIX_PATH", raw_list_of_paths);
+    extractPathFromEnvVar("AMENT_PREFIX_PATH", raw_list_of_prefixes);
 
+    appendSuffixToPaths(raw_list_of_prefixes, "/share");
+    raw_list_of_paths.insert(raw_list_of_paths.end(), raw_list_of_prefixes.begin(),
+                             raw_list_of_prefixes.end());
+    
     // Work-around for https://github.com/stack-of-tasks/pinocchio/issues/1463
     // To support ROS devel/isolated spaces, we also need to look one package above the package.xml:
     fs::path path;

--- a/src/utils/file-explorer.hpp
+++ b/src/utils/file-explorer.hpp
@@ -30,6 +30,15 @@ namespace pinocchio
 #endif
                         );
 
+  /**
+   * @brief      For a given vector of paths, add a suffix inplace to each path and return the vector inplace.
+   *
+   * @param[in,out]  list_of_paths The vector of path names.
+   * @param[in] suffix Suffix to be added to each element of the path names.
+   */
+  PINOCCHIO_DLLAPI void
+  appendSuffixToPaths(std::vector<std::string> & list_of_paths,
+                      const std::string & suffix);
 
   /**
    * @brief      Parse an environment variable if exists and extract paths according to the delimiter.


### PR DESCRIPTION
This PR appends the suffix "/share" to the list of directories loaded by AMENT_PREFIX_PATH. It fixes https://github.com/stack-of-tasks/pinocchio/issues/1520