### PR TITLE
Expose dIntegrateTransport

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ The following people have been involved in the development of **Pinocchio** and 
 -   [Aamr El Kazdadi](https://github.com/aelkazdadi) (Inria): multiprecision arithmetic support
 -   [Nicolas Torres Alberto](https://scholar.google.com/citations?user=gYNLhEIAAAAJ&hl=en) (Inria): features extension
 -   [Etienne Arlaud](https://github.com/EtienneAr) (Inria): RViz viewer support
+-   [Wilson Jallet](https://github.com/ManifoldFR) (LAAS-CNRS/Inria): extension of Python bindings
 
 If you have taken part to the development of **Pinocchio**, feel free to add your name and contribution in this list.
 

--- a/bindings/python/algorithm/expose-joints.cpp
+++ b/bindings/python/algorithm/expose-joints.cpp
@@ -50,6 +50,18 @@ namespace pinocchio
       return J;
     }
 
+    Eigen::MatrixXd dIntegrateTransport_proxy(const Model & model,
+                                              const Eigen::VectorXd & q,
+                                              const Eigen::VectorXd & v,
+                                              const Eigen::MatrixXd & Jin,
+                                              const ArgumentPosition arg)
+    {
+      int ncols = Jin.cols();
+      Eigen::MatrixXd Jout(Eigen::MatrixXd::Zero(model.nv,ncols));
+      dIntegrateTransport(model, q, v, Jin, Jout, arg);
+      return Jout;
+    }
+
     bp::tuple dDifference_proxy(const Model & model,
                                 const Eigen::VectorXd & q1,
                                 const Eigen::VectorXd & q2)
@@ -109,6 +121,18 @@ namespace pinocchio
               "\tq: the joint configuration vector (size model.nq)\n"
               "\tv: the joint velocity vector (size model.nv)\n"
               "\targument_position: either pinocchio.ArgumentPosition.ARG0 or pinocchio.ArgumentPosition.ARG1, depending on the desired Jacobian value.\n");
+
+      bp::def("dIntegrateTransport",
+              &dIntegrateTransport_proxy,
+              bp::args("model","q","v","Jin","argument_position"),
+              "Takes a matrix expressed at q (+) v and uses parallel transport to express it in the tangent space at q."
+              "\tThis operation does the product of the matrix by the Jacobian of the integration operation, but more efficiently."
+              "Parameters:\n"
+              "\tmodel: model of the kinematic tree\n"
+              "\tq: the joint configuration vector (size model.nq)\n"
+              "\tv: the joint velocity vector (size model.nv)\n"
+              "\tJin: the input matrix (row size model.nv)"
+              "\targument_position: either pinocchio.ArgumentPosition.ARG0 (q) or pinocchio.ArgumentPosition.ARG1 (v), depending on the desired Jacobian value.\n");
 
       bp::def("interpolate",
               &interpolate<double,0,JointCollectionDefaultTpl,VectorXd,VectorXd>,

--- a/unittest/python/bindings_joint_algorithms.py
+++ b/unittest/python/bindings_joint_algorithms.py
@@ -62,8 +62,8 @@ class TestJointsAlgo(TestCase):
         v = self.v
 
         J0, J1 = pin.dIntegrate(model,q,v)
-        res_0 = pin.dIntegrate(model,q,v,pin.ARG0)
-        res_1 = pin.dIntegrate(model,q,v,pin.ARG1)
+        res_0 = pin.dIntegrate(model,q,v,pin.ArgumentPosition.ARG0)
+        res_1 = pin.dIntegrate(model,q,v,pin.ArgumentPosition.ARG1)
 
         self.assertApprox(J0,res_0)
         self.assertApprox(J1,res_1)

--- a/unittest/python/bindings_joint_algorithms.py
+++ b/unittest/python/bindings_joint_algorithms.py
@@ -77,5 +77,16 @@ class TestJointsAlgo(TestCase):
         self.assertApprox(J0,res_0)
         self.assertApprox(J1,res_1)
 
+    def test_transport(self):
+        model = self.model
+        Jq, Jv = pin.dIntegrate(model, self.q, self.v)
+        mat = np.random.randn(model.nv, 2)
+
+        mat_transported_q = pin.dIntegrateTransport(model, self.q, self.v, mat, pin.ARG0)
+        mat_transported_v = pin.dIntegrateTransport(model, self.q, self.v, mat, pin.ARG1)
+
+        self.assertApprox(mat_transported_q, np.dot(Jq, mat))
+        self.assertApprox(mat_transported_v, np.dot(Jv, mat))
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
As mentioned in #1571, this PR exposes the `dIntegrateTransport` function from the `pinocchio` namespace to the Python bindings.

I also added a unittest for good measure.