### PR TITLE
[timings] Reduce allocations in finite-difference baselines

### DIFF
--- a/benchmark/timings-cholesky.cpp
+++ b/benchmark/timings-cholesky.cpp
@@ -18,8 +18,6 @@
 
 #include "pinocchio/utils/timer.hpp"
 
-#include <Eigen/StdVector>
-EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(Eigen::VectorXd)
 
 int main(int argc, const char ** argv)
 {
@@ -50,9 +48,9 @@ int main(int argc, const char ** argv)
   MatrixXd A(model.nv,model.nv), B(model.nv,model.nv);
   A.setZero(); B.setRandom();
 
-  std::vector<VectorXd> qs     (NBT);
-  std::vector<VectorXd> lhs  (NBT);
-  std::vector<VectorXd> rhs (NBT);
+  PINOCCHIO_ALIGNED_STD_VECTOR(VectorXd) qs  (NBT);
+  PINOCCHIO_ALIGNED_STD_VECTOR(VectorXd) lhs (NBT);
+  PINOCCHIO_ALIGNED_STD_VECTOR(VectorXd) rhs (NBT);
   for(size_t i=0;i<NBT;++i)
   {
     qs[i] = randomConfiguration(model,-qmax,qmax);

--- a/benchmark/timings-derivatives.cpp
+++ b/benchmark/timings-derivatives.cpp
@@ -44,7 +44,7 @@ void rnea_fd(const pinocchio::Model & model, pinocchio::Data & data_fd,
   for(int k = 0; k < model.nv; ++k)
   {
     v_eps[k] += alpha;
-    q_plus = integrate(model,q,v_eps);
+    integrate(model,q,v_eps,q_plus);
     tau_plus = rnea(model,data_fd,q_plus,v,a);
     
     drnea_dq.col(k) = (tau_plus - tau0)/alpha;
@@ -89,7 +89,7 @@ void aba_fd(const pinocchio::Model & model, pinocchio::Data & data_fd,
   for(int k = 0; k < model.nv; ++k)
   {
     v_eps[k] += alpha;
-    q_plus = integrate(model,q,v_eps);
+    integrate(model,q,v_eps,q_plus);
     a_plus = aba(model,data_fd,q_plus,v,tau);
     
     daba_dq.col(k) = (a_plus - a0)/alpha;

--- a/benchmark/timings-geometry.cpp
+++ b/benchmark/timings-geometry.cpp
@@ -11,9 +11,7 @@
 #include "pinocchio/utils/timer.hpp"
 
 #include <iostream>
-#include <Eigen/StdVector>
 
-EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(Eigen::VectorXd)
 
 int main()
 {
@@ -47,9 +45,9 @@ int main()
   VectorXd qmax = Eigen::VectorXd::Ones(model.nq);
 
 
-  std::vector<VectorXd> qs_romeo     (NBT);
-  std::vector<VectorXd> qdots_romeo  (NBT);
-  std::vector<VectorXd> qddots_romeo (NBT);
+  PINOCCHIO_ALIGNED_STD_VECTOR(VectorXd) qs_romeo     (NBT);
+  PINOCCHIO_ALIGNED_STD_VECTOR(VectorXd) qdots_romeo  (NBT);
+  PINOCCHIO_ALIGNED_STD_VECTOR(VectorXd) qddots_romeo (NBT);
   for(size_t i=0;i<NBT;++i)
   {
     qs_romeo[i]     = randomConfiguration(model,-qmax,qmax);

--- a/benchmark/timings-jacobian.cpp
+++ b/benchmark/timings-jacobian.cpp
@@ -14,8 +14,6 @@
 
 #include "pinocchio/utils/timer.hpp"
 
-#include <Eigen/StdVector>
-EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(Eigen::VectorXd)
 
 int main(int argc, const char ** argv)
 {
@@ -54,13 +52,12 @@ int main(int argc, const char ** argv)
 
   pinocchio::Data data(model);
   VectorXd qmax = Eigen::VectorXd::Ones(model.nq);
-  //VectorXd q = randomConfiguration(model);
 
   pinocchio::Data::Matrix6x J(6,model.nv);
   J.setZero();
   pinocchio::Model::JointIndex JOINT_ID = (Model::JointIndex)(model.njoints-1);
 
-  std::vector<VectorXd> qs(NBT);
+  PINOCCHIO_ALIGNED_STD_VECTOR(VectorXd) qs(NBT);
   for(size_t i=0;i<NBT;++i)
   {
     qs[i] = randomConfiguration(model,-qmax,qmax);

--- a/benchmark/timings-parallel.cpp
+++ b/benchmark/timings-parallel.cpp
@@ -19,8 +19,6 @@
 
 #include "pinocchio/utils/timer.hpp"
 
-#include <Eigen/StdVector>
-EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(Eigen::VectorXd)
 
 int main(int /*argc*/, const char ** /*argv*/)
 {
@@ -87,8 +85,6 @@ int main(int /*argc*/, const char ** /*argv*/)
   MatrixXd as(model.nv,BATCH_SIZE);
   MatrixXd taus(model.nv,BATCH_SIZE);
   MatrixXd res(model.nv,BATCH_SIZE);
-  
-//  VectorXb cols()
   
   PINOCCHIO_ALIGNED_STD_VECTOR(VectorXd) q_vec(NBT);
   for(size_t i=0; i < NBT; ++i)

--- a/benchmark/timings.cpp
+++ b/benchmark/timings.cpp
@@ -24,8 +24,6 @@
 
 #include "pinocchio/utils/timer.hpp"
 
-#include <Eigen/StdVector>
-EIGEN_DEFINE_STL_VECTOR_SPECIALIZATION(Eigen::VectorXd)
 
 namespace pinocchio
 {


### PR DESCRIPTION
Reduces the allocations in the finite-difference baselines by passing the output argument to `pinocchio::integrate`. Also uses the `PINOCCHIO_ALIGNED_STD_VECTOR` macro in the benchmarks.