### PR TITLE
Support HPP-FCL for ROS binaries & introduce ROS2 ament integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -332,3 +332,6 @@ ENDFOREACH(cflags ${CFLAGS_DEPENDENCIES})
 
 # Install catkin package.xml
 INSTALL(FILES package.xml DESTINATION share/${PROJECT_NAME})
+# Allows Colcon to find non-Ament packages when using workspace underlays
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} "")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} DESTINATION share/ament_index/resource_index/packages)

--- a/package.xml
+++ b/package.xml
@@ -17,7 +17,6 @@
   <doc_depend>texlive-latex-base</doc_depend>
   <!-- The following tags are recommended by REP-136 -->
   <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
-  <exec_depend condition="$ROS_VERSION == 2">ament_cmake</exec_depend>
   <depend condition="$ROS_PYTHON_VERSION == 2">python</depend>
   <depend condition="$ROS_PYTHON_VERSION == 3">python3</depend>
   <depend condition="$ROS_PYTHON_VERSION == 2">python-numpy</depend>

--- a/package.xml
+++ b/package.xml
@@ -26,9 +26,7 @@
   <depend>eigen</depend>
   <depend>boost</depend>
   <depend>eigenpy</depend>
-  <!-- The ROS-released HPP-FCL is not yet ready for use with Pinocchio out of the box (old version).
-  Additionally, as BUILD_WITH_COLLISION_SUPPORT is default OFF, the ROS buildfarm would not configure it proper either way. -->
-  <!-- <depend>hpp-fcl</depend> -->
+  <depend>hpp-fcl</depend>
 
   <buildtool_depend>cmake</buildtool_depend>
   <export>

--- a/package.xml
+++ b/package.xml
@@ -27,6 +27,9 @@
   <depend>eigenpy</depend>
   <depend>hpp-fcl</depend>
 
+  <!-- Compiling Pinocchio with clang reduces build time, required memory, and results in faster runtime. Note: This only specifies the build dependency, it does not auto-select the compiler - this needs to be specified manually -->
+  <buildtool_depend>clang</buildtool_depend>
+
   <buildtool_depend>cmake</buildtool_depend>
   <export>
     <build_type>cmake</build_type>


### PR DESCRIPTION
HPP-FCL is now available on `testing` for ROS Noetic, with a release to Melodic pending. We can now start targeting Pinocchio binaries with HPP-FCL included.

This PR also introduces an ament integration for ROS2 releases.