### PR TITLE
Make Pinocchio v2 compatible with HPP-FCL v2

### DIFF
--- a/src/multibody/geometry.hpp
+++ b/src/multibody/geometry.hpp
@@ -285,6 +285,13 @@ namespace pinocchio
     /// \param[in] other GeometryData to copy
     ///
     GeometryData(const GeometryData & other);
+
+    ///
+    /// \brief Copy operator
+    ///
+    /// \param[in] other GeometryData to copy
+    ///
+    GeometryData& operator=(const GeometryData & other);
     
     /// \brief Empty constructor
     GeometryData() {};

--- a/src/multibody/geometry.hxx
+++ b/src/multibody/geometry.hxx
@@ -81,6 +81,28 @@ namespace pinocchio
   , outerObjects (other.outerObjects)
   {}
 
+  inline GeometryData& GeometryData::operator=(const GeometryData & other)
+  {
+    if (this != &other)
+    {
+      oMg = other.oMg;
+      activeCollisionPairs = other.activeCollisionPairs;
+#ifdef PINOCCHIO_WITH_HPP_FCL
+      distanceRequests = other.distanceRequests;
+      distanceResults = other.distanceResults;
+      collisionRequests = other.collisionRequests;
+      collisionResults = other.collisionResults;
+      radius = other.radius;
+      collisionPairIndex = other.collisionPairIndex;
+      collision_functors = other.collision_functors;
+      distance_functors = other.distance_functors;
+#endif // PINOCCHIO_WITH_HPP_FCL
+      innerObjects = other.innerObjects;
+      outerObjects = other.outerObjects;
+    }
+    return *this;
+  }
+
   inline GeometryData::~GeometryData() {}
 
   template<typename S2, int O2, template<typename,int> class JointCollectionTpl>

--- a/src/parsers/urdf/geometry.cpp
+++ b/src/parsers/urdf/geometry.cpp
@@ -165,9 +165,18 @@ namespace pinocchio
           bool convex = tree.isMeshConvex (linkName, geomName);
           if (convex) {
             bvh->buildConvexRepresentation (false);
+#if HPP_FCL_MAJOR_VERSION < 2
             geometry = bvh->convex;
-          } else
+#else
+            geometry = boost::shared_ptr<fcl::CollisionGeometry>(bvh->convex.get(), [bvh](...) mutable { bvh->convex.reset(); });
+#endif  // HPP_FCL_MAJOR_VERSION
+          } else {
+#if HPP_FCL_MAJOR_VERSION < 2
             geometry = bvh;
+#else
+            geometry = boost::shared_ptr<fcl::CollisionGeometry>(bvh.get(), [bvh](...) mutable { bvh.reset(); });
+#endif  // HPP_FCL_MAJOR_VERSION
+          }
 #else
           geometry = meshLoader->load (meshPath, scale);
 #endif

--- a/src/parsers/urdf/geometry.cpp
+++ b/src/parsers/urdf/geometry.cpp
@@ -221,7 +221,7 @@ namespace pinocchio
         
         if (!geometry)
         {
-          throw std::invalid_argument("The polyhedron retrived is empty");
+          throw std::invalid_argument("The polyhedron retrieved is empty");
         }
 
         return geometry;
@@ -408,7 +408,7 @@ namespace pinocchio
 
       /**
        * @brief      Recursive procedure for reading the URDF tree, looking for geometries
-       *             This function fill the geometric model whith geometry objects retrieved from the URDF tree
+       *             This function fill the geometric model with geometry objects retrieved from the URDF tree
        *
        * @param[in]  tree           The URDF kinematic tree
        * @param[in]  meshLoader     The FCL mesh loader to avoid duplications of already loaded geometries


### PR DESCRIPTION
While I am aware behind the rationale of twinning HPP-FCL v2 with Pinocchio v3 for C++11 reasons in binary builds, there does not appear to be anything holding back using the latest HPP-FCL v2 in source builds with the Pinocchio devel branch. This PR fixes the one pointer issue and enables Pinocchio v2/devel to be compatible with either HPP-FCL v1 or v2.