### PR TITLE
follow up on hpp-fcl v2

### DIFF
--- a/.github/workflows/conda/conda-env.yml
+++ b/.github/workflows/conda/conda-env.yml
@@ -4,7 +4,7 @@ channels:
   - nodefaults
 dependencies:
   - eigen
-  - hpp-fcl=1.8.0
+  - hpp-fcl
   - numpy
   - boost
   - eigenpy

--- a/bindings/python/multibody/geometry-object.hpp
+++ b/bindings/python/multibody/geometry-object.hpp
@@ -83,6 +83,7 @@ namespace pinocchio
           .staticmethod("CreateCapsule")
 #endif // PINOCCHIO_WITH_HPP_FCL
         ;
+        bp::register_ptr_to_python<CollisionGeometryPtr>();
       }
 
 #ifdef PINOCCHIO_WITH_HPP_FCL


### PR DESCRIPTION
Hi,


Following #1631, we should be able to use hpp-fcl v2, but this raise the following issue on various linux:
```python 
133/134 Test #133: example-py-collision-with-point-clouds .............***Failed    1.27 sec
Traceback (most recent call last):
  File "…/pinocchio/examples/collision-with-point-clouds.py", line 70, in <module>
    go_panda_hand.geometry.buildConvexRepresentation(False)
TypeError: No to_python (by-value) converter found for C++ type: boost::shared_ptr<hpp::fcl::CollisionGeometry>
```

The CI can reproduce it, as shown in this PR.