### PR TITLE
Fix method play() of rviz_visualizer

### DIFF
--- a/bindings/python/pinocchio/visualize/base_visualizer.py
+++ b/bindings/python/pinocchio/visualize/base_visualizer.py
@@ -79,6 +79,9 @@ class BaseVisualizer(object):
         """Captures an image from the viewer and returns an RGB array."""
         pass
 
+    def sleep(self, dt):
+        time.sleep(dt)
+
     def play(self, q_trajectory, dt, capture=False):
         """Play a trajectory with given time step. Optionally capture RGB images and returns them."""
         imgs = []
@@ -91,7 +94,7 @@ class BaseVisualizer(object):
             t1 = time.time()
             elapsed_time = t1 - t0
             if elapsed_time < dt:
-                time.sleep(dt - elapsed_time)
+                self.sleep(dt - elapsed_time)
         if capture:
             return imgs
 

--- a/bindings/python/pinocchio/visualize/rviz_visualizer.py
+++ b/bindings/python/pinocchio/visualize/rviz_visualizer.py
@@ -4,7 +4,8 @@ from ..utils import npToTuple
 from . import BaseVisualizer
 
 import warnings
-import time
+
+from python_qt_binding.QtTest import QTest
 
 try:
     import hppfcl
@@ -243,22 +244,8 @@ class RVizVisualizer(BaseVisualizer):
         """Set whether to display visual objects or not"""
         self.visual_Display.setEnabled(visibility)
 
-    def play(self, q_trajectory, dt, capture=False):
-        """Play a trajectory with given time step. Optionally capture RGB images and returns them."""
-        from python_qt_binding.QtTest import QTest
-        imgs = []
-        for k in range(q_trajectory.shape[1]):
-            t0 = time.time()
-            self.display(q_trajectory[:, k])
-            if capture:
-                img_arr = self.captureImage()
-                imgs.append(img_arr)
-            t1 = time.time()
-            elapsed_time = t1 - t0
-            if elapsed_time < dt:
-                QTest.qWait(1e3*(dt-elapsed_time))
-        if capture:
-            return imgs
+    def sleep(self, dt):
+        QTest.qWait(1e3*dt)
 
 
 __all__ = ['RVizVisualizer']

--- a/bindings/python/pinocchio/visualize/rviz_visualizer.py
+++ b/bindings/python/pinocchio/visualize/rviz_visualizer.py
@@ -5,8 +5,6 @@ from . import BaseVisualizer
 
 import warnings
 
-from python_qt_binding.QtTest import QTest
-
 try:
     import hppfcl
     WITH_HPP_FCL_BINDINGS = True
@@ -245,6 +243,7 @@ class RVizVisualizer(BaseVisualizer):
         self.visual_Display.setEnabled(visibility)
 
     def sleep(self, dt):
+        from python_qt_binding.QtTest import QTest
         QTest.qWait(1e3*dt)
 
 

--- a/bindings/python/pinocchio/visualize/rviz_visualizer.py
+++ b/bindings/python/pinocchio/visualize/rviz_visualizer.py
@@ -4,8 +4,6 @@ from ..utils import npToTuple
 from . import BaseVisualizer
 
 import warnings
-
-from python_qt_binding.QtTest import QTest
 import time
 
 try:
@@ -247,6 +245,7 @@ class RVizVisualizer(BaseVisualizer):
 
     def play(self, q_trajectory, dt, capture=False):
         """Play a trajectory with given time step. Optionally capture RGB images and returns them."""
+        from python_qt_binding.QtTest import QTest
         imgs = []
         for k in range(q_trajectory.shape[1]):
             t0 = time.time()

--- a/bindings/python/pinocchio/visualize/rviz_visualizer.py
+++ b/bindings/python/pinocchio/visualize/rviz_visualizer.py
@@ -5,6 +5,9 @@ from . import BaseVisualizer
 
 import warnings
 
+from python_qt_binding.QtTest import QTest
+import time
+
 try:
     import hppfcl
     WITH_HPP_FCL_BINDINGS = True
@@ -241,5 +244,22 @@ class RVizVisualizer(BaseVisualizer):
     def displayVisuals(self,visibility):
         """Set whether to display visual objects or not"""
         self.visual_Display.setEnabled(visibility)
+
+    def play(self, q_trajectory, dt, capture=False):
+        """Play a trajectory with given time step. Optionally capture RGB images and returns them."""
+        imgs = []
+        for k in range(q_trajectory.shape[1]):
+            t0 = time.time()
+            self.display(q_trajectory[:, k])
+            if capture:
+                img_arr = self.captureImage()
+                imgs.append(img_arr)
+            t1 = time.time()
+            elapsed_time = t1 - t0
+            if elapsed_time < dt:
+                QTest.qWait(1e3*(dt-elapsed_time))
+        if capture:
+            return imgs
+
 
 __all__ = ['RVizVisualizer']


### PR DESCRIPTION
Method `play()` overridden, `Qtest.qWait()` used for the delay between one display to another instead of `time.sleep()`.
In the original implementation method `play()` form base_visualizer was used.