### PR TITLE
update to pybind11 v2.9.2

### DIFF
--- a/unittest/python/pybind11/CMakeLists.txt
+++ b/unittest/python/pybind11/CMakeLists.txt
@@ -2,7 +2,7 @@ if(CMAKE_VERSION VERSION_GREATER 3.11)
   include(FetchContent)
   FetchContent_Declare(pybind11
     GIT_REPOSITORY https://github.com/pybind/pybind11
-    GIT_TAG v2.8.0)
+    GIT_TAG v2.9.2)
   FetchContent_GetProperties(pybind11)
   if(NOT pybind11_POPULATED)
     FetchContent_Populate(pybind11)


### PR DESCRIPTION
to remove the following warning with CMake 3.22:

```
-- pybind11 v2.8.0
CMake Warning (dev) at /usr/share/cmake/Modules/CMakeDependentOption.cmake:89 (message):
  Policy CMP0127 is not set: cmake_dependent_option() supports full Condition
  Syntax.  Run "cmake --help-policy CMP0127" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.
Call Stack (most recent call first):
  build/_deps/pybind11-src/CMakeLists.txt:101 (cmake_dependent_option)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

PS: I didn't run any build or test, only checked configure is no longer giving the warning. I think the CI checks should be enough.