### PR TITLE
SO3 diff impl use quaternion instead of rotation matrix

### DIFF
--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -383,7 +383,7 @@ namespace pinocchio
       assert(quaternion::isNormalized(quat1,RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
       
       PINOCCHIO_EIGEN_CONST_CAST(Tangent_t,d)
-        = log3((quat0.conjugate() * quat1).matrix().eval());
+        = quaternion::log3(Quaternion_t(quat0.conjugate() * quat1));
     }
 
     template <ArgumentPosition arg, class ConfigL_t, class ConfigR_t, class JacobianOut_t>
@@ -398,15 +398,16 @@ namespace pinocchio
       ConstQuaternionMap_t quat1 (q1.derived().data());
       assert(quaternion::isNormalized(quat1,RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
       
-      const Matrix3 R = (quat0.conjugate() * quat1).matrix();
+      const Quaternion_t quat_diff = quat0.conjugate() * quat1;
 
       if (arg == ARG0) {
         JacobianMatrix_t J1;
-        Jlog3 (R, J1);
+        quaternion::Jlog3(quat_diff, J1);
+        const Matrix3 R = (quat_diff).matrix();
 
         PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J).noalias() = - J1 * R.transpose();
       } else if (arg == ARG1) {
-        Jlog3 (R, J);
+        quaternion::Jlog3(quat_diff, J);
       }
     }
 

--- a/src/multibody/liegroup/special-orthogonal.hpp
+++ b/src/multibody/liegroup/special-orthogonal.hpp
@@ -383,7 +383,7 @@ namespace pinocchio
       assert(quaternion::isNormalized(quat1,RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
       
       PINOCCHIO_EIGEN_CONST_CAST(Tangent_t,d)
-        = log3((quat0.matrix().transpose() * quat1.matrix()).eval());
+        = log3((quat0.conjugate() * quat1).matrix().eval());
     }
 
     template <ArgumentPosition arg, class ConfigL_t, class ConfigR_t, class JacobianOut_t>
@@ -398,7 +398,7 @@ namespace pinocchio
       ConstQuaternionMap_t quat1 (q1.derived().data());
       assert(quaternion::isNormalized(quat1,RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
       
-      const Matrix3 R = quat0.matrix().transpose() * quat1.matrix(); // TODO: perform first the Quaternion multiplications and then return a Rotation Matrix
+      const Matrix3 R = (quat0.conjugate() * quat1).matrix();
 
       if (arg == ARG0) {
         JacobianMatrix_t J1;

--- a/unittest/joint-configurations.cpp
+++ b/unittest/joint-configurations.cpp
@@ -282,7 +282,7 @@ BOOST_AUTO_TEST_CASE ( integrate_difference_test )
  Eigen::VectorXd q1(randomConfiguration(model, -1 * Eigen::VectorXd::Ones(model.nq), Eigen::VectorXd::Ones(model.nq) ));
  Eigen::VectorXd qdot(Eigen::VectorXd::Random(model.nv));
 
- BOOST_CHECK_MESSAGE(isSameConfiguration(model, integrate(model, q0, difference(model, q0,q1)), q1, 1.5e-12), "Integrate (difference) - wrong results");
+ BOOST_CHECK_MESSAGE(isSameConfiguration(model, integrate(model, q0, difference(model, q0,q1)), q1), "Integrate (difference) - wrong results");
 
  BOOST_CHECK_MESSAGE(difference(model, q0, integrate(model,q0, qdot)).isApprox(qdot),"difference (integrate) - wrong results");
 }

--- a/unittest/joint-configurations.cpp
+++ b/unittest/joint-configurations.cpp
@@ -282,7 +282,7 @@ BOOST_AUTO_TEST_CASE ( integrate_difference_test )
  Eigen::VectorXd q1(randomConfiguration(model, -1 * Eigen::VectorXd::Ones(model.nq), Eigen::VectorXd::Ones(model.nq) ));
  Eigen::VectorXd qdot(Eigen::VectorXd::Random(model.nv));
 
- BOOST_CHECK_MESSAGE(isSameConfiguration(model, integrate(model, q0, difference(model, q0,q1)), q1), "Integrate (difference) - wrong results");
+ BOOST_CHECK_MESSAGE(isSameConfiguration(model, integrate(model, q0, difference(model, q0,q1)), q1, 1.5e-12), "Integrate (difference) - wrong results");
 
  BOOST_CHECK_MESSAGE(difference(model, q0, integrate(model,q0, qdot)).isApprox(qdot),"difference (integrate) - wrong results");
 }

--- a/unittest/liegroups.cpp
+++ b/unittest/liegroups.cpp
@@ -685,6 +685,18 @@ BOOST_AUTO_TEST_CASE(test_dim_computation)
   BOOST_CHECK(dim == Eigen::Dynamic);
 }
 
+BOOST_AUTO_TEST_CASE (small_distance_test)
+{
+  SpecialOrthogonalOperationTpl <3,double> so3;
+  Eigen::VectorXd q1(so3.nq());
+  Eigen::VectorXd q2(so3.nq());
+  q1 << 0,0,-0.1953711450011105244,0.9807293794421349169;
+  q2 << 0,0,-0.19537114500111049664,0.98072937944213492244;
+
+  BOOST_CHECK_MESSAGE (so3.distance(q1,q2) > 0.,
+                       "SO3 small distance - wrong results");
+}
+
 template<typename LieGroupCollection>
 struct TestLieGroupVariantVisitor
 {


### PR DESCRIPTION
It seems that using quaternion multiplication (`q0.conjugate()*q1`) then converting to matrix is actually more accurate than using matrix multiplication (`q0.matrix().transpose()*q1.matrix()`) in calculating the difference between `q1` and `q0`. 

When two SO3 configurations are very similar, with coordinates differing approximately by the smallest floating point division for `double` (I checked this using `numpy.spacing(value)` for the `numpy.float64` value of the quaternion coordinate), quaternion multiplication followed by converting to matrix gives a non-identity result (non-zero distance) while the matrix conversion followed by matrix multiplication gives an identity matrix. 