### PR TITLE
Add contact state in constrained dynamics

### DIFF
--- a/src/algorithm/constrained-dynamics.hpp
+++ b/src/algorithm/constrained-dynamics.hpp
@@ -12,7 +12,6 @@
 
 namespace pinocchio
 {
-
   ///
   /// \brief Init the forward dynamics data according to the contact information contained in contact_models.
   ///
@@ -31,6 +30,26 @@ namespace pinocchio
   initConstraintDynamics(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                       DataTpl<Scalar,Options,JointCollectionTpl> & data,
                       const std::vector<RigidConstraintModelTpl<Scalar,Options>,Allocator> & contact_models);
+
+  ///
+  /// \brief Init the forward dynamics data according to the contact information contained in contact_models.
+  ///
+  /// \tparam JointCollection Collection of Joint types.
+  /// \tparam ConfigVectorType Type of the joint configuration vector.
+  /// \tparam TangentVectorType1 Type of the joint velocity vector.
+  /// \tparam TangentVectorType2 Type of the joint torque vector.
+  /// \tparam Allocator Allocator class for the std::vector.
+  ///
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  /// \param[in] contact_models Vector of contact information related to the problem.
+  ///
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, class ContactModelAllocator, class ContactDataAllocator>
+  inline void
+  initConstraintDynamics(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                      DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                      const std::vector<RigidConstraintModelTpl<Scalar,Options>,ContactModelAllocator> & contact_models,
+                      const std::vector<RigidConstraintDataTpl<Scalar,Options>,ContactDataAllocator> & contact_datas);
   
   ///
   /// \brief Computes the forward dynamics with contact constraints according to a given list of Contact information.

--- a/src/algorithm/constrained-dynamics.hxx
+++ b/src/algorithm/constrained-dynamics.hxx
@@ -16,13 +16,10 @@
 
 namespace pinocchio
 {
-
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, class Allocator>
-  inline void initConstraintDynamics(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                                  DataTpl<Scalar,Options,JointCollectionTpl> & data,
-                                  const std::vector<RigidConstraintModelTpl<Scalar,Options>,Allocator> & contact_models)
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  inline void resizeConstraintDynamicsData(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                                           DataTpl<Scalar,Options,JointCollectionTpl> & data)
   {
-    data.contact_chol.allocate(model,contact_models);
     data.primal_dual_contact_solution.resize(data.contact_chol.size());
     data.primal_rhs_contact.resize(data.contact_chol.constraintDim());
 
@@ -50,6 +47,25 @@ namespace pinocchio
     data.dac_dv.setZero();
     data.dac_da.setZero();
     data.osim.setZero();
+  }
+
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, class Allocator>
+  inline void initConstraintDynamics(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                                  DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                                  const std::vector<RigidConstraintModelTpl<Scalar,Options>,Allocator> & contact_models)
+  {
+    data.contact_chol.allocate(model,contact_models);
+    resizeConstraintDynamicsData(model,data);
+  }
+
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, class ContactModelAllocator, class ContactDataAllocator>
+  inline void initConstraintDynamics(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                                  DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                                  const std::vector<RigidConstraintModelTpl<Scalar,Options>,ContactModelAllocator> & contact_models,
+                                  const std::vector<RigidConstraintDataTpl<Scalar,Options>,ContactDataAllocator> & contact_datas)
+  {
+    data.contact_chol.allocate(model,contact_models,contact_datas);
+    resizeConstraintDynamicsData(model,data);
   }
   
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl, typename ConfigVectorType, typename TangentVectorType, bool ContactMode>
@@ -250,140 +266,144 @@ namespace pinocchio
     {
       const RigidConstraintModel & contact_model = contact_models[contact_id];
       RigidConstraintData & contact_data = contact_datas[contact_id];
-      const int contact_dim = contact_model.size();
-      
-      const typename RigidConstraintModel::BaumgarteCorrectorParameters & corrector = contact_model.corrector;
-      const typename RigidConstraintData::Motion & contact_acceleration_desired = contact_data.contact_acceleration_desired;
-      typename RigidConstraintData::Motion & contact_acceleration_error = contact_data.contact_acceleration_error;
+
+      if (contact_data.is_active) 
+      {
+        const int contact_dim = contact_model.size();
         
-      const typename Model::JointIndex joint1_id = contact_model.joint1_id;
-      typename RigidConstraintData::SE3 & oMc1 = contact_data.oMc1;
-      typename RigidConstraintData::Motion & vc1 = contact_data.contact1_velocity;
-      typename RigidConstraintData::Motion & coriolis_centrifugal_acc1 = contact_data.contact1_acceleration_drift;
-      
-      const typename Model::JointIndex joint2_id = contact_model.joint2_id;
-      typename RigidConstraintData::SE3 & oMc2 = contact_data.oMc2;
-      typename RigidConstraintData::Motion & vc2 = contact_data.contact2_velocity;
-      typename RigidConstraintData::Motion & coriolis_centrifugal_acc2 = contact_data.contact2_acceleration_drift;
-      
-      const typename RigidConstraintData::SE3 & c1Mc2 = contact_data.c1Mc2;
-      
-      // Compute contact placement and velocities
-      if(joint1_id > 0)
-        vc1 = oMc1.actInv(data.ov[joint1_id]);
-      else
-        vc1.setZero();
-      if(joint2_id > 0)
-        vc2 = oMc2.actInv(data.ov[joint2_id]);
-      else
-        vc2.setZero();
-      
-      // Compute placement and velocity errors
-      if(contact_model.type == CONTACT_6D)
-      {
-        contact_data.contact_placement_error = -log6(c1Mc2);
-        contact_data.contact_velocity_error.toVector() = (vc1 - c1Mc2.act(vc2)).toVector();
-      }
-      else
-      {
-        contact_data.contact_placement_error.linear() = -c1Mc2.translation();
-        contact_data.contact_placement_error.angular().setZero();
+        const typename RigidConstraintModel::BaumgarteCorrectorParameters & corrector = contact_model.corrector;
+        const typename RigidConstraintData::Motion & contact_acceleration_desired = contact_data.contact_acceleration_desired;
+        typename RigidConstraintData::Motion & contact_acceleration_error = contact_data.contact_acceleration_error;
+          
+        const typename Model::JointIndex joint1_id = contact_model.joint1_id;
+        typename RigidConstraintData::SE3 & oMc1 = contact_data.oMc1;
+        typename RigidConstraintData::Motion & vc1 = contact_data.contact1_velocity;
+        typename RigidConstraintData::Motion & coriolis_centrifugal_acc1 = contact_data.contact1_acceleration_drift;
         
-        contact_data.contact_velocity_error.linear() = vc1.linear() - c1Mc2.rotation()*vc2.linear();
-        contact_data.contact_velocity_error.angular().setZero();
-      }
-      
-      if(check_expression_if_real<Scalar,false>(corrector.Kp == Scalar(0) && corrector.Kd == Scalar(0)))
-      {
-        contact_acceleration_error.setZero();
-      }
-      else
-      {
+        const typename Model::JointIndex joint2_id = contact_model.joint2_id;
+        typename RigidConstraintData::SE3 & oMc2 = contact_data.oMc2;
+        typename RigidConstraintData::Motion & vc2 = contact_data.contact2_velocity;
+        typename RigidConstraintData::Motion & coriolis_centrifugal_acc2 = contact_data.contact2_acceleration_drift;
+        
+        const typename RigidConstraintData::SE3 & c1Mc2 = contact_data.c1Mc2;
+        
+        // Compute contact placement and velocities
+        if(joint1_id > 0)
+          vc1 = oMc1.actInv(data.ov[joint1_id]);
+        else
+          vc1.setZero();
+        if(joint2_id > 0)
+          vc2 = oMc2.actInv(data.ov[joint2_id]);
+        else
+          vc2.setZero();
+        
+        // Compute placement and velocity errors
         if(contact_model.type == CONTACT_6D)
-          contact_acceleration_error.toVector().noalias() =
-          - corrector.Kp /* * Jexp6(contact_data.contact_placement_error) */ * contact_data.contact_placement_error.toVector()
-          - corrector.Kd * contact_data.contact_velocity_error.toVector();
+        {
+          contact_data.contact_placement_error = -log6(c1Mc2);
+          contact_data.contact_velocity_error.toVector() = (vc1 - c1Mc2.act(vc2)).toVector();
+        }
         else
         {
-          contact_acceleration_error.linear().noalias() =
-          - corrector.Kp * contact_data.contact_placement_error.linear()
-          - corrector.Kd * contact_data.contact_velocity_error.linear();
-          contact_acceleration_error.angular().setZero();
-        }
-      }
-      
-      switch(contact_model.reference_frame)
-      {
-        case LOCAL_WORLD_ALIGNED:
-        {
-          // LINEAR
-          coriolis_centrifugal_acc1.linear().noalias()
-          = data.oa[joint1_id].linear() + data.oa[joint1_id].angular().cross(oMc1.translation());
-          if(contact_model.type == CONTACT_3D)
-            coriolis_centrifugal_acc1.linear() += data.ov[joint1_id].angular().cross(data.ov[joint1_id].linear() + data.ov[joint1_id].angular().cross(oMc1.translation()));
-          // ANGULAR
-          coriolis_centrifugal_acc1.angular() = data.oa[joint1_id].angular();
+          contact_data.contact_placement_error.linear() = -c1Mc2.translation();
+          contact_data.contact_placement_error.angular().setZero();
           
-          // LINEAR
-          if(contact_model.type == CONTACT_3D)
-          {
-            coriolis_centrifugal_acc2.linear().noalias()
-            = data.oa[joint2_id].linear() + data.oa[joint2_id].angular().cross(oMc2.translation())
-            + data.ov[joint2_id].angular().cross(data.ov[joint2_id].linear() + data.ov[joint2_id].angular().cross(oMc2.translation()));
-            coriolis_centrifugal_acc2.angular().setZero();
-          }
+          contact_data.contact_velocity_error.linear() = vc1.linear() - c1Mc2.rotation()*vc2.linear();
+          contact_data.contact_velocity_error.angular().setZero();
+        }
+        
+        if(check_expression_if_real<Scalar,false>(corrector.Kp == Scalar(0) && corrector.Kd == Scalar(0)))
+        {
+          contact_acceleration_error.setZero();
+        }
+        else
+        {
+          if(contact_model.type == CONTACT_6D)
+            contact_acceleration_error.toVector().noalias() =
+            - corrector.Kp /* * Jexp6(contact_data.contact_placement_error) */ * contact_data.contact_placement_error.toVector()
+            - corrector.Kd * contact_data.contact_velocity_error.toVector();
           else
           {
-            coriolis_centrifugal_acc2.linear() = data.oa[joint2_id].linear() + data.oa[joint2_id].angular().cross(oMc1.translation());
-            coriolis_centrifugal_acc2.angular() = data.oa[joint2_id].angular();
+            contact_acceleration_error.linear().noalias() =
+            - corrector.Kp * contact_data.contact_placement_error.linear()
+            - corrector.Kd * contact_data.contact_velocity_error.linear();
+            contact_acceleration_error.angular().setZero();
           }
-          
-          contact_acceleration_error.linear() = oMc1.rotation() * contact_acceleration_error.linear();
-          contact_acceleration_error.angular() = oMc1.rotation() * contact_acceleration_error.angular();
-          break;
         }
-        case LOCAL:
+        
+        switch(contact_model.reference_frame)
         {
-          coriolis_centrifugal_acc1 = oMc1.actInv(data.oa[joint1_id]);
-          if(contact_model.type == CONTACT_3D)
+          case LOCAL_WORLD_ALIGNED:
           {
-            coriolis_centrifugal_acc1.linear() += vc1.angular().cross(vc1.linear());
-            coriolis_centrifugal_acc1.angular().setZero();
+            // LINEAR
+            coriolis_centrifugal_acc1.linear().noalias()
+            = data.oa[joint1_id].linear() + data.oa[joint1_id].angular().cross(oMc1.translation());
+            if(contact_model.type == CONTACT_3D)
+              coriolis_centrifugal_acc1.linear() += data.ov[joint1_id].angular().cross(data.ov[joint1_id].linear() + data.ov[joint1_id].angular().cross(oMc1.translation()));
+            // ANGULAR
+            coriolis_centrifugal_acc1.angular() = data.oa[joint1_id].angular();
+            
+            // LINEAR
+            if(contact_model.type == CONTACT_3D)
+            {
+              coriolis_centrifugal_acc2.linear().noalias()
+              = data.oa[joint2_id].linear() + data.oa[joint2_id].angular().cross(oMc2.translation())
+              + data.ov[joint2_id].angular().cross(data.ov[joint2_id].linear() + data.ov[joint2_id].angular().cross(oMc2.translation()));
+              coriolis_centrifugal_acc2.angular().setZero();
+            }
+            else
+            {
+              coriolis_centrifugal_acc2.linear() = data.oa[joint2_id].linear() + data.oa[joint2_id].angular().cross(oMc1.translation());
+              coriolis_centrifugal_acc2.angular() = data.oa[joint2_id].angular();
+            }
+            
+            contact_acceleration_error.linear() = oMc1.rotation() * contact_acceleration_error.linear();
+            contact_acceleration_error.angular() = oMc1.rotation() * contact_acceleration_error.angular();
+            break;
           }
-          
-          if(contact_model.type == CONTACT_3D)
+          case LOCAL:
           {
-            coriolis_centrifugal_acc2.linear().noalias()
-            = oMc1.rotation().transpose()*(data.oa[joint2_id].linear() + data.oa[joint2_id].angular().cross(oMc2.translation())
-            + data.ov[joint2_id].angular().cross(data.ov[joint2_id].linear() + data.ov[joint2_id].angular().cross(oMc2.translation())));
-            coriolis_centrifugal_acc2.angular().setZero();
+            coriolis_centrifugal_acc1 = oMc1.actInv(data.oa[joint1_id]);
+            if(contact_model.type == CONTACT_3D)
+            {
+              coriolis_centrifugal_acc1.linear() += vc1.angular().cross(vc1.linear());
+              coriolis_centrifugal_acc1.angular().setZero();
+            }
+            
+            if(contact_model.type == CONTACT_3D)
+            {
+              coriolis_centrifugal_acc2.linear().noalias()
+              = oMc1.rotation().transpose()*(data.oa[joint2_id].linear() + data.oa[joint2_id].angular().cross(oMc2.translation())
+              + data.ov[joint2_id].angular().cross(data.ov[joint2_id].linear() + data.ov[joint2_id].angular().cross(oMc2.translation())));
+              coriolis_centrifugal_acc2.angular().setZero();
+            }
+            else
+              coriolis_centrifugal_acc2 = oMc1.actInv(data.oa[joint2_id]);
+            break;
           }
-          else
-            coriolis_centrifugal_acc2 = oMc1.actInv(data.oa[joint2_id]);
-          break;
+          default:
+            assert(false && "must never happened");
+            break;
         }
-        default:
-          assert(false && "must never happened");
-          break;
-      }
-      
-      contact_data.contact_acceleration = coriolis_centrifugal_acc2;
-      switch(contact_model.type)
-      {
-        case CONTACT_3D:
-          primal_rhs_contact.segment(current_row_id,contact_dim)
-          = -coriolis_centrifugal_acc1.linear() + coriolis_centrifugal_acc2.linear() + contact_acceleration_error.linear() + contact_acceleration_desired.linear();
-          break;
-        case CONTACT_6D:
-          primal_rhs_contact.segment(current_row_id,contact_dim)
-          = -coriolis_centrifugal_acc1.toVector() + coriolis_centrifugal_acc2.toVector() + contact_acceleration_error.toVector() + contact_acceleration_desired.toVector();
-          break;
-        default:
-          assert(false && "must never happened");
-          break;
-      }
+        
+        contact_data.contact_acceleration = coriolis_centrifugal_acc2;
+        switch(contact_model.type)
+        {
+          case CONTACT_3D:
+            primal_rhs_contact.segment(current_row_id,contact_dim)
+            = -coriolis_centrifugal_acc1.linear() + coriolis_centrifugal_acc2.linear() + contact_acceleration_error.linear() + contact_acceleration_desired.linear();
+            break;
+          case CONTACT_6D:
+            primal_rhs_contact.segment(current_row_id,contact_dim)
+            = -coriolis_centrifugal_acc1.toVector() + coriolis_centrifugal_acc2.toVector() + contact_acceleration_error.toVector() + contact_acceleration_desired.toVector();
+            break;
+          default:
+            assert(false && "must never happened");
+            break;
+        }
 
-      current_row_id += contact_dim;
+        current_row_id += contact_dim;
+      } // if (contact_data.is_active) 
     }
     
     // Solve the system
@@ -412,30 +432,33 @@ namespace pinocchio
     {
       const RigidConstraintModel & contact_model = contact_models[contact_id];
       RigidConstraintData & contact_data = contact_datas[contact_id];
-      typename RigidConstraintData::Force & fext = contact_data.contact_force;
-      const int contact_dim = contact_model.size();
-      
-      switch(contact_model.type)
+      if(contact_data.is_active) 
       {
-        case CONTACT_3D:
+        typename RigidConstraintData::Force & fext = contact_data.contact_force;
+        const int contact_dim = contact_model.size();
+        
+        switch(contact_model.type)
         {
-          fext.linear() = -primal_dual_contact_solution.template segment<3>(current_row_sol_id);
-          fext.angular().setZero();
-          break;
+          case CONTACT_3D:
+          {
+            fext.linear() = -primal_dual_contact_solution.template segment<3>(current_row_sol_id);
+            fext.angular().setZero();
+            break;
+          }
+          case CONTACT_6D:
+          {
+            typedef typename Data::VectorXs::template FixedSegmentReturnType<6>::Type Segment6d;
+            const ForceRef<Segment6d> f_sol(primal_dual_contact_solution.template segment<6>(current_row_sol_id));
+            fext = -f_sol;
+            break;
+          }
+          default:
+            assert(false && "must never happened");
+            break;
         }
-        case CONTACT_6D:
-        {
-          typedef typename Data::VectorXs::template FixedSegmentReturnType<6>::Type Segment6d;
-          const ForceRef<Segment6d> f_sol(primal_dual_contact_solution.template segment<6>(current_row_sol_id));
-          fext = -f_sol;
-          break;
-        }
-        default:
-          assert(false && "must never happened");
-          break;
-      }
-      
-      current_row_sol_id += contact_dim;
+        
+        current_row_sol_id += contact_dim;
+      } // if(contact_data.is_active) 
     }
     
     return a;

--- a/src/algorithm/contact-info.hpp
+++ b/src/algorithm/contact-info.hpp
@@ -380,6 +380,9 @@ namespace pinocchio
     
     /// \brief Contact deviation from the reference acceleration (a.k.a the error)
     Motion contact_acceleration_deviation;
+
+    /// \brief If this contact is active or not.
+    bool is_active;
     
     RigidConstraintDataTpl(const ContactModel & /*contact_model*/)
     : contact_force(Force::Zero())
@@ -393,6 +396,7 @@ namespace pinocchio
     , contact1_acceleration_drift(Motion::Zero())
     , contact2_acceleration_drift(Motion::Zero())
     , contact_acceleration_deviation(Motion::Zero())
+    , is_active(true)
     {}
     
     bool operator==(const RigidConstraintDataTpl & other) const
@@ -412,6 +416,7 @@ namespace pinocchio
       && contact1_acceleration_drift == other.contact1_acceleration_drift
       && contact2_acceleration_drift == other.contact2_acceleration_drift
       && contact_acceleration_deviation == other.contact_acceleration_deviation
+      && is_active == other.is_active
       ;
     }
     

--- a/unittest/contact-cholesky.cpp
+++ b/unittest/contact-cholesky.cpp
@@ -1363,8 +1363,8 @@ BOOST_AUTO_TEST_CASE(contact_cholesky_with_inactive_contacts)
   contact_datas.push_back(RigidConstraintData(ci_LA));
 
   // contacts in RF and LA are inactive
-  contact_datas[0] = false;
-  contact_datas[3] = false;
+  contact_datas[0].is_active = false;
+  contact_datas[3].is_active = false;
   
   Data data(model); crba(model,data,q);
   ContactCholeskyDecomposition contact_chol_decomposition;


### PR DESCRIPTION
Dear all,

Thank you for continuing to provide a wonderful tool.

Regarding the new constrained-dynamics feature, I personally think that it may be useful if I can set the contact status.
That is, `std::vector<RigidConstraintModel>` is a collection of contact candidates and we describe which contacts are actually active through `RigidConstraintData::is_active`. 
The idea is also summarized in `test_with_inactive_contacts` in `unittest/constrained-dynamics.cpp`.
This is just my personal idea and I do not have confidence that others also agree with it.
This draft pull request is just a question of how the developers think about this.

Thank you 