### PR TITLE
ROS2/Colcon integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -344,3 +344,7 @@ INSTALL(FILES package.xml DESTINATION share/${PROJECT_NAME})
 # Allows Colcon to find non-Ament packages when using workspace underlays
 file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} "")
 install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/ament_index/resource_index/packages/${PROJECT_NAME} DESTINATION share/ament_index/resource_index/packages)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv "prepend-non-duplicate;AMENT_PREFIX_PATH;")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/ament_prefix_path.dsv DESTINATION share/${PROJECT_NAME}/hook)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/python_path.dsv "prepend-non-duplicate;PYTHONPATH;${PYTHON_SITELIB}")
+install(FILES ${CMAKE_CURRENT_BINARY_DIR}/share/${PROJECT_NAME}/hook/python_path.dsv DESTINATION share/${PROJECT_NAME}/hook)

--- a/colcon.pkg
+++ b/colcon.pkg
@@ -1,0 +1,6 @@
+{
+    "hooks": [
+        "share/pinocchio/hook/ament_prefix_path.dsv",
+        "share/pinocchio/hook/python_path.dsv"
+    ]
+}


### PR DESCRIPTION
Analog to EigenPy and HPP-FCL: Correctly sets environment path variables in a colcon workspace. Useful for source builds. Will update the separate PR #1681 for CI later when the required binaries are available.