### PR TITLE
URDF: fix loading relative mesh path in urdf

### DIFF
--- a/src/parsers/utils.hpp
+++ b/src/parsers/utils.hpp
@@ -105,9 +105,9 @@ namespace pinocchio
       // handle the case where a relative mesh path is specified without using //package
       for (std::size_t i = 0; i < package_dirs.size(); ++i)
         {
-          if ( bf::exists( bf::path(package_dirs[i] + "/" + string.substr(2))))
+          if ( bf::exists( bf::path(package_dirs[i] + "/" + string)))
           {
-            result_path = std::string( package_dirs[i] + "/" + string.substr(2));
+            result_path = std::string( package_dirs[i] + "/" + string);
             break;
           }
         }

--- a/unittest/urdf.cpp
+++ b/unittest/urdf.cpp
@@ -95,8 +95,7 @@ BOOST_AUTO_TEST_CASE ( check_mesh_relative_path )
   pinocchio::urdf::buildGeom(model1, filename, pinocchio::COLLISION, geomModel1, dir);
   BOOST_CHECK_EQUAL(geomModel1.ngeoms, 2);
 
-  // check that both models point to the same mesh on the disk
-  BOOST_CHECK_EQUAL(geomModel0.geometryObjects[1].meshPath.compare(geomModel1.geometryObjects[1].meshPath), 0);
+  BOOST_CHECK_EQUAL(geomModel0.geometryObjects[1].name.compare(geomModel1.geometryObjects[1].name), 0);
 }
     
 BOOST_AUTO_TEST_CASE ( build_model_from_XML )


### PR DESCRIPTION
this solves #1747.

We are now handling not only `./rel-mesh-path` but also `rel-mesh-path` and `../rel-mesh-path`.