### PR TITLE
Configuration limits for joints and model

### DIFF
--- a/bindings/python/multibody/joint/joint-derived.hpp
+++ b/bindings/python/multibody/joint/joint-derived.hpp
@@ -33,7 +33,7 @@ namespace pinocchio
         .add_property("idx_v",&get_idx_v)
         .add_property("nq",&get_nq)
         .add_property("nv",&get_nv)
-        .add_property("has_configuration_limit", &JointModelDerived::hasConfigurationLimit,
+        .add_property("hasConfigurationLimit", &JointModelDerived::hasConfigurationLimit,
              "Return vector of boolean if joint has configuration limits.")
         .def("setIndexes",
              &JointModelDerived::setIndexes,

--- a/bindings/python/multibody/joint/joint-derived.hpp
+++ b/bindings/python/multibody/joint/joint-derived.hpp
@@ -33,7 +33,7 @@ namespace pinocchio
         .add_property("idx_v",&get_idx_v)
         .add_property("nq",&get_nq)
         .add_property("nv",&get_nv)
-        .add_property("configuration_limit", &JointModelDerived::hasConfigurationLimit,
+        .add_property("has_configuration_limit", &JointModelDerived::hasConfigurationLimit,
              "Return vector of boolean if joint has configuration limits.")
         .def("setIndexes",
              &JointModelDerived::setIndexes,

--- a/bindings/python/multibody/joint/joint-derived.hpp
+++ b/bindings/python/multibody/joint/joint-derived.hpp
@@ -33,8 +33,12 @@ namespace pinocchio
         .add_property("idx_v",&get_idx_v)
         .add_property("nq",&get_nq)
         .add_property("nv",&get_nv)
-        .add_property("hasConfigurationLimit", &JointModelDerived::hasConfigurationLimit,
-             "Return vector of boolean if joint has configuration limits.")
+        .add_property("hasConfigurationLimit", 
+                      &JointModelDerived::hasConfigurationLimit,
+                      "Return vector of boolean if joint has configuration limits.")
+        .add_property("hasConfigurationLimitInTangent",
+                      &JointModelDerived::hasConfigurationLimitInTangent,
+                      "Return vector of boolean if joint has configuration limits in tangent space.")
         .def("setIndexes",
              &JointModelDerived::setIndexes,
              bp::args("self","id","idx_q","idx_v"))

--- a/bindings/python/multibody/joint/joint-derived.hpp
+++ b/bindings/python/multibody/joint/joint-derived.hpp
@@ -33,6 +33,8 @@ namespace pinocchio
         .add_property("idx_v",&get_idx_v)
         .add_property("nq",&get_nq)
         .add_property("nv",&get_nv)
+        .add_property("configuration_limit", &JointModelDerived::hasConfigurationLimit,
+             "Return vector of boolean if joint has configuration limits.")
         .def("setIndexes",
              &JointModelDerived::setIndexes,
              bp::args("self","id","idx_q","idx_v"))

--- a/bindings/python/multibody/joint/joint.hpp
+++ b/bindings/python/multibody/joint/joint.hpp
@@ -33,6 +33,8 @@ namespace pinocchio
         .add_property("nv",&getNv)
         .def("hasConfigurationLimit", &JointModel::hasConfigurationLimit,
              "Return vector of boolean if joint has configuration limits.")
+        .def("hasConfigurationLimitInTangent", &JointModel::hasConfigurationLimitInTangent,
+             "Return vector of boolean if joint has configuration limits in tangent space.")
         .def("setIndexes",
              &JointModel::setIndexes,
              bp::args("self","id","idx_q","idx_v"))

--- a/bindings/python/multibody/joint/joint.hpp
+++ b/bindings/python/multibody/joint/joint.hpp
@@ -31,6 +31,8 @@ namespace pinocchio
         .add_property("idx_v",&getIdx_v)
         .add_property("nq",&getNq)
         .add_property("nv",&getNv)
+        .def("configuration_limit", &JointModel::hasConfigurationLimit,
+             "Return vector of boolean if joint has configuration limits.")
         .def("setIndexes",
              &JointModel::setIndexes,
              bp::args("self","id","idx_q","idx_v"))

--- a/bindings/python/multibody/joint/joint.hpp
+++ b/bindings/python/multibody/joint/joint.hpp
@@ -31,7 +31,7 @@ namespace pinocchio
         .add_property("idx_v",&getIdx_v)
         .add_property("nq",&getNq)
         .add_property("nv",&getNv)
-        .def("configuration_limit", &JointModel::hasConfigurationLimit,
+        .def("has_configuration_limit", &JointModel::hasConfigurationLimit,
              "Return vector of boolean if joint has configuration limits.")
         .def("setIndexes",
              &JointModel::setIndexes,

--- a/bindings/python/multibody/joint/joint.hpp
+++ b/bindings/python/multibody/joint/joint.hpp
@@ -31,7 +31,7 @@ namespace pinocchio
         .add_property("idx_v",&getIdx_v)
         .add_property("nq",&getNq)
         .add_property("nv",&getNv)
-        .def("has_configuration_limit", &JointModel::hasConfigurationLimit,
+        .def("hasConfigurationLimit", &JointModel::hasConfigurationLimit,
              "Return vector of boolean if joint has configuration limits.")
         .def("setIndexes",
              &JointModel::setIndexes,

--- a/bindings/python/multibody/model.hpp
+++ b/bindings/python/multibody/model.hpp
@@ -125,6 +125,7 @@ namespace pinocchio
         .add_property("nvs",&Model::nvs)          
         .add_property("parents",&Model::parents)
         .add_property("names",&Model::names)
+        .add_property("configurationLimit",&Model::configurationLimit)
         .def_readwrite("name",&Model::name)
         .def_readwrite("referenceConfigurations", &Model::referenceConfigurations)
         

--- a/bindings/python/multibody/model.hpp
+++ b/bindings/python/multibody/model.hpp
@@ -125,7 +125,7 @@ namespace pinocchio
         .add_property("nvs",&Model::nvs)          
         .add_property("parents",&Model::parents)
         .add_property("names",&Model::names)
-        .add_property("configurationLimit",&Model::configurationLimit)
+        .add_property("hasConfigurationLimit",&Model::hasConfigurationLimit)
         .def_readwrite("name",&Model::name)
         .def_readwrite("referenceConfigurations", &Model::referenceConfigurations)
         

--- a/bindings/python/multibody/model.hpp
+++ b/bindings/python/multibody/model.hpp
@@ -125,7 +125,6 @@ namespace pinocchio
         .add_property("nvs",&Model::nvs)          
         .add_property("parents",&Model::parents)
         .add_property("names",&Model::names)
-        .add_property("hasConfigurationLimit",&Model::hasConfigurationLimit)
         .def_readwrite("name",&Model::name)
         .def_readwrite("referenceConfigurations", &Model::referenceConfigurations)
         
@@ -206,6 +205,8 @@ namespace pinocchio
         
         .def("check",(bool (Model::*)(const Data &) const) &Model::check,bp::args("self","data"),
              "Check consistency of data wrt model.")
+        .def("hasConfigurationLimit",&Model::hasConfigurationLimit, bp::args("self"), "Returns list of boolean if joints have configuration limit.")
+        .def("hasConfigurationLimitInTangent",&Model::hasConfigurationLimitInTangent, bp::args("self"), "Returns list of boolean if joints have configuration limit in tangent space  .")
         
         .def(bp::self == bp::self)
         .def(bp::self != bp::self)

--- a/src/multibody/joint/joint-basic-visitors.hpp
+++ b/src/multibody/joint/joint-basic-visitors.hpp
@@ -103,6 +103,18 @@ namespace pinocchio
 
   
   /**
+   * @brief      Visit a JointModelTpl through JointconfigurationLimitVisitor
+   *             to get the configurations limits
+   *
+   * @param[in]  jmodel  The JointModelVariant
+   *
+   * @return     The bool with configurations limits of the joint
+   */
+  template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
+  inline const std::vector<bool> hasConfigurationLimit(const JointModelTpl<Scalar,Options,JointCollectionTpl> & jmodel);
+
+
+  /**
    * @brief      Visit a JointModelTpl through JointIdxQVisitor to get the index in the full model configuration
    *             space corresponding to the first degree of freedom of the Joint
    *

--- a/src/multibody/joint/joint-basic-visitors.hpp
+++ b/src/multibody/joint/joint-basic-visitors.hpp
@@ -103,7 +103,7 @@ namespace pinocchio
 
   
   /**
-   * @brief      Visit a JointModelTpl through JointconfigurationLimitVisitor
+   * @brief      Visit a JointModelTpl through JointConfigurationLimitVisitor
    *             to get the configurations limits
    *
    * @param[in]  jmodel  The JointModelVariant
@@ -112,6 +112,18 @@ namespace pinocchio
    */
   template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
   inline const std::vector<bool> hasConfigurationLimit(const JointModelTpl<Scalar,Options,JointCollectionTpl> & jmodel);
+
+  
+  /**
+   * @brief      Visit a JointModelTpl through JointConfigurationLimitInTangentVisitor
+   *             to get the configurations limits in tangent space
+   *
+   * @param[in]  jmodel  The JointModelVariant
+   *
+   * @return     The bool with configurations limits in tangent space of the joint
+   */
+  template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
+  inline const std::vector<bool> hasConfigurationLimitInTangent(const JointModelTpl<Scalar,Options,JointCollectionTpl> & jmodel);
 
 
   /**

--- a/src/multibody/joint/joint-basic-visitors.hxx
+++ b/src/multibody/joint/joint-basic-visitors.hxx
@@ -179,9 +179,9 @@ namespace pinocchio
   { return JointNqVisitor::run(jmodel); }
 
   /**
-   * @brief      JointconfigurationLimitVisitor visitor
+   * @brief      JointConfigurationLimitVisitor visitor
    */
-  struct JointconfigurationLimitVisitor
+  struct JointConfigurationLimitVisitor
   : boost::static_visitor<std::vector<bool>>
   {
     template<typename JointModelDerived>
@@ -190,12 +190,31 @@ namespace pinocchio
     
     template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
     static const std::vector<bool> run( const JointModelTpl<Scalar,Options,JointCollectionTpl> & jmodel)
-    { return boost::apply_visitor(JointconfigurationLimitVisitor(),jmodel); }
+    { return boost::apply_visitor(JointConfigurationLimitVisitor(),jmodel); }
   };
   
   template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
   inline const std::vector<bool> hasConfigurationLimit(const JointModelTpl<Scalar,Options,JointCollectionTpl> & jmodel)
-  { return JointconfigurationLimitVisitor::run(jmodel); }
+  { return JointConfigurationLimitVisitor::run(jmodel); }
+
+  /**
+   * @brief      JointConfigurationLimitInTangentVisitor visitor
+   */
+  struct JointConfigurationLimitInTangentVisitor
+  : boost::static_visitor<std::vector<bool>>
+  {
+    template<typename JointModelDerived>
+    const std::vector<bool> operator()(const JointModelBase<JointModelDerived> & jmodel) const
+    { return jmodel.hasConfigurationLimitInTangent(); }
+    
+    template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
+    static const std::vector<bool> run( const JointModelTpl<Scalar,Options,JointCollectionTpl> & jmodel)
+    { return boost::apply_visitor(JointConfigurationLimitInTangentVisitor(),jmodel); }
+  };
+  
+  template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
+  inline const std::vector<bool> hasConfigurationLimitInTangent(const JointModelTpl<Scalar,Options,JointCollectionTpl> & jmodel)
+  { return JointConfigurationLimitInTangentVisitor::run(jmodel); }
 
   /**
    * @brief      JointIdxQVisitor visitor

--- a/src/multibody/joint/joint-basic-visitors.hxx
+++ b/src/multibody/joint/joint-basic-visitors.hxx
@@ -179,6 +179,25 @@ namespace pinocchio
   { return JointNqVisitor::run(jmodel); }
 
   /**
+   * @brief      JointconfigurationLimitVisitor visitor
+   */
+  struct JointconfigurationLimitVisitor
+  : boost::static_visitor<std::vector<bool>>
+  {
+    template<typename JointModelDerived>
+    const std::vector<bool> operator()(const JointModelBase<JointModelDerived> & jmodel) const
+    { return jmodel.hasConfigurationLimit(); }
+    
+    template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
+    static const std::vector<bool> run( const JointModelTpl<Scalar,Options,JointCollectionTpl> & jmodel)
+    { return boost::apply_visitor(JointconfigurationLimitVisitor(),jmodel); }
+  };
+  
+  template<typename Scalar, int Options, template<typename S, int O> class JointCollectionTpl>
+  inline const std::vector<bool> hasConfigurationLimit(const JointModelTpl<Scalar,Options,JointCollectionTpl> & jmodel)
+  { return JointconfigurationLimitVisitor::run(jmodel); }
+
+  /**
    * @brief      JointIdxQVisitor visitor
    */
   struct JointIdxQVisitor

--- a/src/multibody/joint/joint-composite.hpp
+++ b/src/multibody/joint/joint-composite.hpp
@@ -260,6 +260,19 @@ namespace pinocchio
       return JointDataDerived(jdata,nq(),nv());
     }
 
+    const std::vector<bool> hasConfigurationLimit() const
+    {
+      std::vector<bool> vec;
+      for (size_t i = 0; i < joints.size(); ++i)
+        {
+          const std::vector<bool> & joint_cf_limit = joints[i].hasConfigurationLimit();
+          vec.insert(vec.end(),
+                    joint_cf_limit.begin(),
+                    joint_cf_limit.end());
+        }
+      return vec;
+    }
+
     template<typename, int, template<typename S, int O> class, typename>
     friend struct JointCompositeCalcZeroOrderStep;
     

--- a/src/multibody/joint/joint-composite.hpp
+++ b/src/multibody/joint/joint-composite.hpp
@@ -273,6 +273,19 @@ namespace pinocchio
       return vec;
     }
 
+    const std::vector<bool> hasConfigurationLimitInTangent() const
+    {
+      std::vector<bool> vec;
+      for (size_t i = 0; i < joints.size(); ++i)
+        {
+          const std::vector<bool> & joint_cf_limit = joints[i].hasConfigurationLimitInTangent();
+          vec.insert(vec.end(),
+                    joint_cf_limit.begin(),
+                    joint_cf_limit.end());
+        }
+      return vec;
+    }
+
     template<typename, int, template<typename S, int O> class, typename>
     friend struct JointCompositeCalcZeroOrderStep;
     

--- a/src/multibody/joint/joint-free-flyer.hpp
+++ b/src/multibody/joint/joint-free-flyer.hpp
@@ -218,6 +218,11 @@ namespace pinocchio
 
     JointDataDerived createData() const { return JointDataDerived(); }
     
+    const std::vector<bool> hasConfigurationLimit() const
+    {
+      return {true, true, true, false, false, false, false};
+    }
+
     template<typename ConfigVectorLike>
     inline void forwardKinematics(Transformation_t & M, const Eigen::MatrixBase<ConfigVectorLike> & q_joint) const
     {

--- a/src/multibody/joint/joint-free-flyer.hpp
+++ b/src/multibody/joint/joint-free-flyer.hpp
@@ -223,6 +223,11 @@ namespace pinocchio
       return {true, true, true, false, false, false, false};
     }
 
+    const std::vector<bool> hasConfigurationLimitInTangent() const
+    {
+      return {true, true, true, false, false, false};
+    }
+
     template<typename ConfigVectorLike>
     inline void forwardKinematics(Transformation_t & M, const Eigen::MatrixBase<ConfigVectorLike> & q_joint) const
     {

--- a/src/multibody/joint/joint-generic.hpp
+++ b/src/multibody/joint/joint-generic.hpp
@@ -185,6 +185,11 @@ namespace pinocchio
     {
     }
     
+    const std::vector<bool> hasConfigurationLimit() const
+    {
+      return ::pinocchio::hasConfigurationLimit(*this);
+    }
+
     template<typename JointModelDerived>
     JointModelTpl(const JointModelBase<JointModelDerived> & jmodel)
     : JointModelVariant((JointModelVariant)jmodel.derived())

--- a/src/multibody/joint/joint-generic.hpp
+++ b/src/multibody/joint/joint-generic.hpp
@@ -190,6 +190,11 @@ namespace pinocchio
       return ::pinocchio::hasConfigurationLimit(*this);
     }
 
+    const std::vector<bool> hasConfigurationLimitInTangent() const
+    {
+      return ::pinocchio::hasConfigurationLimitInTangent(*this);
+    }
+
     template<typename JointModelDerived>
     JointModelTpl(const JointModelBase<JointModelDerived> & jmodel)
     : JointModelVariant((JointModelVariant)jmodel.derived())

--- a/src/multibody/joint/joint-mimic.hpp
+++ b/src/multibody/joint/joint-mimic.hpp
@@ -448,6 +448,11 @@ namespace pinocchio
       return JointDataDerived(m_jmodel_ref.createData(),scaling());
     }
     
+    const std::vector<bool> hasConfigurationLimit() const
+    {
+      return m_jmodel_ref.hasConfigurationLimit();
+    }
+
     template<typename ConfigVector>
     EIGEN_DONT_INLINE
     void calc(JointDataDerived & jdata,

--- a/src/multibody/joint/joint-mimic.hpp
+++ b/src/multibody/joint/joint-mimic.hpp
@@ -453,6 +453,11 @@ namespace pinocchio
       return m_jmodel_ref.hasConfigurationLimit();
     }
 
+    const std::vector<bool> hasConfigurationLimitInTangent() const
+    {
+      return m_jmodel_ref.hasConfigurationLimitInTangent();
+    }
+
     template<typename ConfigVector>
     EIGEN_DONT_INLINE
     void calc(JointDataDerived & jdata,

--- a/src/multibody/joint/joint-model-base.hpp
+++ b/src/multibody/joint/joint-model-base.hpp
@@ -81,6 +81,11 @@ namespace pinocchio
       return derived().hasConfigurationLimit();
     }
 
+    const std::vector<bool> hasConfigurationLimitInTangent() const
+    {
+      return derived().hasConfigurationLimitInTangent();
+    }
+
     template<typename ConfigVectorType>
     void calc(JointDataDerived & data,
               const Eigen::MatrixBase<ConfigVectorType> & qs) const

--- a/src/multibody/joint/joint-model-base.hpp
+++ b/src/multibody/joint/joint-model-base.hpp
@@ -76,6 +76,11 @@ namespace pinocchio
 
     JointDataDerived createData() const { return derived().createData(); }
     
+    const std::vector<bool> hasConfigurationLimit() const
+    {
+      return derived().hasConfigurationLimit();
+    }
+
     template<typename ConfigVectorType>
     void calc(JointDataDerived & data,
               const Eigen::MatrixBase<ConfigVectorType> & qs) const

--- a/src/multibody/joint/joint-planar.hpp
+++ b/src/multibody/joint/joint-planar.hpp
@@ -483,6 +483,11 @@ namespace pinocchio
       return {true, true, false, false};
     }
 
+    const std::vector<bool> hasConfigurationLimitInTangent() const
+    {
+      return {true, true, false};
+    }
+
     template<typename ConfigVector>
     inline void forwardKinematics(Transformation_t & M, const Eigen::MatrixBase<ConfigVector> & q_joint) const
     {

--- a/src/multibody/joint/joint-planar.hpp
+++ b/src/multibody/joint/joint-planar.hpp
@@ -478,6 +478,11 @@ namespace pinocchio
 
     JointDataDerived createData() const { return JointDataDerived(); }
     
+    const std::vector<bool> hasConfigurationLimit() const
+    {
+      return {true, true, false, false};
+    }
+
     template<typename ConfigVector>
     inline void forwardKinematics(Transformation_t & M, const Eigen::MatrixBase<ConfigVector> & q_joint) const
     {

--- a/src/multibody/joint/joint-prismatic-unaligned.hpp
+++ b/src/multibody/joint/joint-prismatic-unaligned.hpp
@@ -514,6 +514,11 @@ namespace pinocchio
 
     JointDataDerived createData() const { return JointDataDerived(axis); }
     
+    const std::vector<bool> hasConfigurationLimit() const
+    {
+      return {true};
+    }
+
     using Base::isEqual;
     bool isEqual(const JointModelPrismaticUnalignedTpl & other) const
     {

--- a/src/multibody/joint/joint-prismatic-unaligned.hpp
+++ b/src/multibody/joint/joint-prismatic-unaligned.hpp
@@ -518,6 +518,11 @@ namespace pinocchio
     {
       return {true};
     }
+    
+    const std::vector<bool> hasConfigurationLimitInTangent() const
+    {
+      return {true};
+    }
 
     using Base::isEqual;
     bool isEqual(const JointModelPrismaticUnalignedTpl & other) const

--- a/src/multibody/joint/joint-prismatic.hpp
+++ b/src/multibody/joint/joint-prismatic.hpp
@@ -586,6 +586,11 @@ namespace pinocchio
     
     JointDataDerived createData() const { return JointDataDerived(); }
     
+    const std::vector<bool> hasConfigurationLimit() const
+    {
+      return {true};
+    }
+
     template<typename ConfigVector>
     void calc(JointDataDerived & data,
               const typename Eigen::MatrixBase<ConfigVector> & qs) const

--- a/src/multibody/joint/joint-prismatic.hpp
+++ b/src/multibody/joint/joint-prismatic.hpp
@@ -590,6 +590,11 @@ namespace pinocchio
     {
       return {true};
     }
+    
+    const std::vector<bool> hasConfigurationLimitInTangent() const
+    {
+      return {true};
+    }
 
     template<typename ConfigVector>
     void calc(JointDataDerived & data,

--- a/src/multibody/joint/joint-revolute-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unaligned.hpp
@@ -549,6 +549,11 @@ namespace pinocchio
       return {true};
     }
 
+    const std::vector<bool> hasConfigurationLimitInTangent() const
+    {
+      return {true};
+    }
+
     template<typename ConfigVector>
     void calc(JointDataDerived & data,
               const typename Eigen::MatrixBase<ConfigVector> & qs) const

--- a/src/multibody/joint/joint-revolute-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unaligned.hpp
@@ -543,7 +543,12 @@ namespace pinocchio
     {
       return Base::isEqual(other) && axis == other.axis;
     }
-    
+
+    const std::vector<bool> hasConfigurationLimit() const
+    {
+      return {true};
+    }
+
     template<typename ConfigVector>
     void calc(JointDataDerived & data,
               const typename Eigen::MatrixBase<ConfigVector> & qs) const

--- a/src/multibody/joint/joint-revolute-unbounded-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unbounded-unaligned.hpp
@@ -140,6 +140,11 @@ namespace pinocchio
       return {false, false};
     }
 
+    const std::vector<bool> hasConfigurationLimitInTangent() const
+    {
+      return {false};
+    }
+
     using Base::isEqual;
     bool isEqual(const JointModelRevoluteUnboundedUnalignedTpl & other) const
     {

--- a/src/multibody/joint/joint-revolute-unbounded-unaligned.hpp
+++ b/src/multibody/joint/joint-revolute-unbounded-unaligned.hpp
@@ -135,6 +135,11 @@ namespace pinocchio
 
     JointDataDerived createData() const { return JointDataDerived(axis); }
     
+    const std::vector<bool> hasConfigurationLimit() const
+    {
+      return {false, false};
+    }
+
     using Base::isEqual;
     bool isEqual(const JointModelRevoluteUnboundedUnalignedTpl & other) const
     {

--- a/src/multibody/joint/joint-revolute-unbounded.hpp
+++ b/src/multibody/joint/joint-revolute-unbounded.hpp
@@ -112,7 +112,12 @@ namespace pinocchio
     {
       return {false, false};
     }
-    
+
+    const std::vector<bool> hasConfigurationLimitInTangent() const
+    {
+      return {false};
+    }
+
     template<typename ConfigVector>
     void calc(JointDataDerived & data,
               const typename Eigen::MatrixBase<ConfigVector> & qs) const

--- a/src/multibody/joint/joint-revolute-unbounded.hpp
+++ b/src/multibody/joint/joint-revolute-unbounded.hpp
@@ -107,6 +107,11 @@ namespace pinocchio
     using Base::setIndexes;
     
     JointDataDerived createData() const { return JointDataDerived(); }
+
+    const std::vector<bool> hasConfigurationLimit() const
+    {
+      return {false, false};
+    }
     
     template<typename ConfigVector>
     void calc(JointDataDerived & data,

--- a/src/multibody/joint/joint-revolute.hpp
+++ b/src/multibody/joint/joint-revolute.hpp
@@ -684,6 +684,11 @@ namespace pinocchio
     JointDataDerived createData() const { return JointDataDerived(); }
     
     JointModelRevoluteTpl() {}
+
+    const std::vector<bool> hasConfigurationLimit() const
+    {
+      return {true};
+    }
     
     template<typename ConfigVector>
     EIGEN_DONT_INLINE

--- a/src/multibody/joint/joint-revolute.hpp
+++ b/src/multibody/joint/joint-revolute.hpp
@@ -689,7 +689,12 @@ namespace pinocchio
     {
       return {true};
     }
-    
+
+    const std::vector<bool> hasConfigurationLimitInTangent() const
+    {
+      return {true};
+    }
+
     template<typename ConfigVector>
     EIGEN_DONT_INLINE
     void calc(JointDataDerived & data,

--- a/src/multibody/joint/joint-spherical-ZYX.hpp
+++ b/src/multibody/joint/joint-spherical-ZYX.hpp
@@ -311,6 +311,11 @@ namespace pinocchio
 
     JointDataDerived createData() const { return JointDataDerived(); }
 
+    const std::vector<bool> hasConfigurationLimit() const
+    {
+      return {true, true, true};
+    }
+
     template<typename ConfigVector>
     void calc(JointDataDerived & data,
               const typename Eigen::MatrixBase<ConfigVector> & qs) const

--- a/src/multibody/joint/joint-spherical-ZYX.hpp
+++ b/src/multibody/joint/joint-spherical-ZYX.hpp
@@ -316,6 +316,11 @@ namespace pinocchio
       return {true, true, true};
     }
 
+    const std::vector<bool> hasConfigurationLimitInTangent() const
+    {
+      return {true, true, true};
+    }
+
     template<typename ConfigVector>
     void calc(JointDataDerived & data,
               const typename Eigen::MatrixBase<ConfigVector> & qs) const

--- a/src/multibody/joint/joint-spherical.hpp
+++ b/src/multibody/joint/joint-spherical.hpp
@@ -414,6 +414,10 @@ namespace pinocchio
 
     JointDataDerived createData() const { return JointDataDerived(); }
 
+    const std::vector<bool> hasConfigurationLimit() const
+    {
+      return {false, false, false, false};
+    }
     template<typename ConfigVectorLike>
     inline void forwardKinematics(Transformation_t & M, const Eigen::MatrixBase<ConfigVectorLike> & q_joint) const
     {

--- a/src/multibody/joint/joint-spherical.hpp
+++ b/src/multibody/joint/joint-spherical.hpp
@@ -418,6 +418,12 @@ namespace pinocchio
     {
       return {false, false, false, false};
     }
+
+    const std::vector<bool> hasConfigurationLimitInTangent() const
+    {
+      return {false, false, false};
+    }
+
     template<typename ConfigVectorLike>
     inline void forwardKinematics(Transformation_t & M, const Eigen::MatrixBase<ConfigVectorLike> & q_joint) const
     {

--- a/src/multibody/joint/joint-translation.hpp
+++ b/src/multibody/joint/joint-translation.hpp
@@ -497,6 +497,11 @@ namespace pinocchio
       return {true, true, true};
     }
 
+    const std::vector<bool> hasConfigurationLimitInTangent() const
+    {
+      return {true, true, true};
+    }
+
     template<typename ConfigVector>
     void calc(JointDataDerived & data,
               const typename Eigen::MatrixBase<ConfigVector> & qs) const

--- a/src/multibody/joint/joint-translation.hpp
+++ b/src/multibody/joint/joint-translation.hpp
@@ -492,6 +492,11 @@ namespace pinocchio
 
     JointDataDerived createData() const { return JointDataDerived(); }
 
+    const std::vector<bool> hasConfigurationLimit() const
+    {
+      return {true, true, true};
+    }
+
     template<typename ConfigVector>
     void calc(JointDataDerived & data,
               const typename Eigen::MatrixBase<ConfigVector> & qs) const

--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -141,9 +141,6 @@ namespace pinocchio
     /// \brief Upper joint configuration limit
     ConfigVectorType upperPositionLimit;
 
-    /// \brief Bool if joint has configuration limit
-    std::vector<bool> hasConfigurationLimit;
-
     /// \brief Vector of operational frames registered on the model.
     FrameVector frames;
     
@@ -182,7 +179,6 @@ namespace pinocchio
     , nvs(1,0)
     , parents(1, 0)
     , names(1)
-    , hasConfigurationLimit()
     , supports(1,IndexVector(1,0))
     , subtrees(1)
     , gravity(gravity981,Vector3::Zero())
@@ -216,7 +212,6 @@ namespace pinocchio
       res.nqs = nqs;
       res.idx_vs = idx_vs;
       res.nvs = nvs;
-      res.hasConfigurationLimit = hasConfigurationLimit;
       
       // Eigen Vectors
       res.rotorInertia = rotorInertia.template cast<NewScalar>();
@@ -554,6 +549,20 @@ namespace pinocchio
     template<typename D>
     inline bool check(const AlgorithmCheckerBase<D> & checker = AlgorithmCheckerBase<D>()) const
     { return checker.checkModel(*this); }
+
+    ///
+    /// \brief Check if joints have configuration limits
+    ///
+    /// \return Returns list of boolean of size model.nq.
+    ///
+    std::vector<bool> hasConfigurationLimit();
+
+    ///
+    /// \brief Check if joints have configuration limits
+    ///
+    /// \return Returns list of boolean of size model.nq.
+    ///
+    std::vector<bool> hasConfigurationLimitInTangent();
 
     /// Run check(fusion::list) with DEFAULT_CHECKERS as argument.
     inline bool check() const;

--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -141,6 +141,9 @@ namespace pinocchio
     /// \brief Upper joint configuration limit
     ConfigVectorType upperPositionLimit;
 
+    /// \brief Bool if joint has configuration limit
+    std::vector<bool> configurationLimit;
+
     /// \brief Vector of operational frames registered on the model.
     FrameVector frames;
     
@@ -179,6 +182,7 @@ namespace pinocchio
     , nvs(1,0)
     , parents(1, 0)
     , names(1)
+    , configurationLimit()
     , supports(1,IndexVector(1,0))
     , subtrees(1)
     , gravity(gravity981,Vector3::Zero())
@@ -212,6 +216,7 @@ namespace pinocchio
       res.nqs = nqs;
       res.idx_vs = idx_vs;
       res.nvs = nvs;
+      res.configurationLimit = configurationLimit;
       
       // Eigen Vectors
       res.rotorInertia = rotorInertia.template cast<NewScalar>();

--- a/src/multibody/model.hpp
+++ b/src/multibody/model.hpp
@@ -142,7 +142,7 @@ namespace pinocchio
     ConfigVectorType upperPositionLimit;
 
     /// \brief Bool if joint has configuration limit
-    std::vector<bool> configurationLimit;
+    std::vector<bool> hasConfigurationLimit;
 
     /// \brief Vector of operational frames registered on the model.
     FrameVector frames;
@@ -182,7 +182,7 @@ namespace pinocchio
     , nvs(1,0)
     , parents(1, 0)
     , names(1)
-    , configurationLimit()
+    , hasConfigurationLimit()
     , supports(1,IndexVector(1,0))
     , subtrees(1)
     , gravity(gravity981,Vector3::Zero())
@@ -216,7 +216,7 @@ namespace pinocchio
       res.nqs = nqs;
       res.idx_vs = idx_vs;
       res.nvs = nvs;
-      res.configurationLimit = configurationLimit;
+      res.hasConfigurationLimit = hasConfigurationLimit;
       
       // Eigen Vectors
       res.rotorInertia = rotorInertia.template cast<NewScalar>();

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -97,6 +97,11 @@ namespace pinocchio
     parents        .push_back(parent);
     jointPlacements.push_back(joint_placement);
     names          .push_back(joint_name);
+
+    const std::vector<bool> & cf_limits = jmodel.hasConfigurationLimit();
+    configurationLimit.insert(configurationLimit.end(),
+                               cf_limits.begin(),
+                               cf_limits.end());
     
     nq += joint_nq; nqs.push_back(joint_nq); idx_qs.push_back(joint_idx_q);
     nv += joint_nv; nvs.push_back(joint_nv); idx_vs.push_back(joint_idx_v);

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -99,9 +99,9 @@ namespace pinocchio
     names          .push_back(joint_name);
 
     const std::vector<bool> & cf_limits = jmodel.hasConfigurationLimit();
-    configurationLimit.insert(configurationLimit.end(),
-                               cf_limits.begin(),
-                               cf_limits.end());
+    hasConfigurationLimit.insert(hasConfigurationLimit.end(),
+                                 cf_limits.begin(),
+                                 cf_limits.end());
     
     nq += joint_nq; nqs.push_back(joint_nq); idx_qs.push_back(joint_idx_q);
     nv += joint_nv; nvs.push_back(joint_nv); idx_vs.push_back(joint_idx_v);

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -98,10 +98,6 @@ namespace pinocchio
     jointPlacements.push_back(joint_placement);
     names          .push_back(joint_name);
 
-    const std::vector<bool> & cf_limits = jmodel.hasConfigurationLimit();
-    hasConfigurationLimit.insert(hasConfigurationLimit.end(),
-                                 cf_limits.begin(),
-                                 cf_limits.end());
     
     nq += joint_nq; nqs.push_back(joint_nq); idx_qs.push_back(joint_idx_q);
     nv += joint_nv; nvs.push_back(joint_nv); idx_vs.push_back(joint_idx_v);
@@ -311,6 +307,34 @@ namespace pinocchio
     
     // Also add joint_id to the universe
     subtrees[0].push_back(joint_id);
+  }
+
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  std::vector<bool> ModelTpl<Scalar,Options,JointCollectionTpl>::hasConfigurationLimit()
+  {
+    std::vector<bool> vec;
+    for(Index i=1;i<(Index)(njoints);++i)
+    {
+      const std::vector<bool> & cf_limits = joints[i].hasConfigurationLimit();
+      vec.insert(vec.end(),
+                 cf_limits.begin(),
+                 cf_limits.end());
+    }    
+    return vec;
+  }
+
+  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
+  std::vector<bool> ModelTpl<Scalar,Options,JointCollectionTpl>::hasConfigurationLimitInTangent()
+  {
+    std::vector<bool> vec;
+    for(Index i=1;i<(Index)(njoints);++i)
+    {
+      const std::vector<bool> & cf_limits = joints[i].hasConfigurationLimitInTangent();
+      vec.insert(vec.end(),
+                 cf_limits.begin(),
+                 cf_limits.end());
+    }    
+    return vec;
   }
 
 } // namespace pinocchio

--- a/src/serialization/model.hpp
+++ b/src/serialization/model.hpp
@@ -50,7 +50,6 @@ namespace boost
       ar & make_nvp("velocityLimit",model.velocityLimit);
       ar & make_nvp("lowerPositionLimit",model.lowerPositionLimit);
       ar & make_nvp("upperPositionLimit",model.upperPositionLimit);
-      ar & make_nvp("hasConfigurationLimit",model.hasConfigurationLimit);
       
       ar & make_nvp("inertias",model.inertias);
       ar & make_nvp("jointPlacements",model.jointPlacements);

--- a/src/serialization/model.hpp
+++ b/src/serialization/model.hpp
@@ -50,7 +50,7 @@ namespace boost
       ar & make_nvp("velocityLimit",model.velocityLimit);
       ar & make_nvp("lowerPositionLimit",model.lowerPositionLimit);
       ar & make_nvp("upperPositionLimit",model.upperPositionLimit);
-      ar & make_nvp("configurationLimit",model.configurationLimit);
+      ar & make_nvp("hasConfigurationLimit",model.hasConfigurationLimit);
       
       ar & make_nvp("inertias",model.inertias);
       ar & make_nvp("jointPlacements",model.jointPlacements);

--- a/src/serialization/model.hpp
+++ b/src/serialization/model.hpp
@@ -50,6 +50,7 @@ namespace boost
       ar & make_nvp("velocityLimit",model.velocityLimit);
       ar & make_nvp("lowerPositionLimit",model.lowerPositionLimit);
       ar & make_nvp("upperPositionLimit",model.upperPositionLimit);
+      ar & make_nvp("configurationLimit",model.configurationLimit);
       
       ar & make_nvp("inertias",model.inertias);
       ar & make_nvp("jointPlacements",model.jointPlacements);

--- a/unittest/model.cpp
+++ b/unittest/model.cpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016-2019 CNRS INRIA
+// Copyright (c) 2016-2022 CNRS INRIA
 //
 
 #include "pinocchio/multibody/data.hpp"
@@ -545,5 +545,41 @@ BOOST_AUTO_TEST_CASE(test_buildReducedModel_with_geom)
   BOOST_CHECK(reduced_geometry_models[2] == reduced_humanoid_geometry);
 }
 #endif // PINOCCHIO_WITH_HPP_FCL
+
+BOOST_AUTO_TEST_CASE(test_has_configuration_limit)
+{
+  using namespace Eigen;
+
+  // Test joint specific function hasConfigurationLimit
+  JointModelFreeFlyer test_joint_ff = JointModelFreeFlyer();
+  std::vector<bool> cf_limits_ff = test_joint_ff.hasConfigurationLimit();
+  std::vector<bool> expected_cf_limits_ff({true, true, true, false, false, false, false});
+  BOOST_CHECK(cf_limits_ff == expected_cf_limits_ff);
+
+  JointModelPlanar test_joint_planar = JointModelPlanar();
+  std::vector<bool> cf_limits_planar = test_joint_planar.hasConfigurationLimit();
+  std::vector<bool> expected_cf_limits_planar({true, true, false, false});
+  BOOST_CHECK(cf_limits_planar == expected_cf_limits_planar);
+
+  JointModelPX test_joint_p = JointModelPX();
+  std::vector<bool> cf_limits_prismatic = test_joint_p.hasConfigurationLimit();
+  std::vector<bool> expected_cf_limits_prismatic({true});
+  BOOST_CHECK(cf_limits_prismatic == expected_cf_limits_prismatic);
+
+  // Test model.configurationLimit vector
+  Model model;
+  JointIndex jointId = 0;
+
+  jointId = model.addJoint(jointId, JointModelFreeFlyer(), SE3::Identity(), "Joint0");
+  jointId = model.addJoint(jointId, JointModelRZ(), SE3::Identity(), "Joint1");
+  jointId = model.addJoint(jointId, JointModelRUBZ(), SE3(Matrix3d::Identity(), Vector3d(1.0, 0.0, 0.0)), "Joint2");
+  
+  std::vector<bool> expected_cf_limits_model({true, true, true, // translation of FF
+                                              false, false, false, false,  // rotation of FF
+                                              true,  // roational joint
+                                              false, false});  // unbounded rotational joint
+  BOOST_CHECK((model.configurationLimit == expected_cf_limits_model));
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/model.cpp
+++ b/unittest/model.cpp
@@ -575,7 +575,7 @@ BOOST_AUTO_TEST_CASE(test_has_configuration_limit)
   BOOST_CHECK(cf_limits_prismatic == expected_cf_limits_prismatic);
   BOOST_CHECK(cf_limits_tangent_prismatic == expected_cf_limits_tangent_prismatic);
 
-  // Test model.hasConfigurationLimit vector
+  // Test model.hasConfigurationLimit() function
   Model model;
   JointIndex jointId = 0;
 
@@ -587,7 +587,16 @@ BOOST_AUTO_TEST_CASE(test_has_configuration_limit)
                                               false, false, false, false,  // rotation of FF
                                               true,  // roational joint
                                               false, false});  // unbounded rotational joint
-  BOOST_CHECK((model.hasConfigurationLimit == expected_cf_limits_model));
+  std::vector<bool> model_cf_limits =  model.hasConfigurationLimit();
+  BOOST_CHECK((model_cf_limits == expected_cf_limits_model));
+
+// Test model.hasConfigurationLimitInTangent() function
+  std::vector<bool> expected_cf_limits_tangent_model({true, true, true, // translation of FF
+                                                      false, false, false, // rotation of FF
+                                                      true,  // roational joint
+                                                      false });  // unbounded rotational joint
+  std::vector<bool> model_cf_limits_tangent =  model.hasConfigurationLimitInTangent();
+  BOOST_CHECK((model_cf_limits_tangent == expected_cf_limits_tangent_model));
 }
 
 

--- a/unittest/model.cpp
+++ b/unittest/model.cpp
@@ -553,18 +553,27 @@ BOOST_AUTO_TEST_CASE(test_has_configuration_limit)
   // Test joint specific function hasConfigurationLimit
   JointModelFreeFlyer test_joint_ff = JointModelFreeFlyer();
   std::vector<bool> cf_limits_ff = test_joint_ff.hasConfigurationLimit();
+  std::vector<bool> cf_limits_tangent_ff = test_joint_ff.hasConfigurationLimitInTangent();
   std::vector<bool> expected_cf_limits_ff({true, true, true, false, false, false, false});
+  std::vector<bool> expected_cf_limits_tangent_ff({true, true, true, false, false, false});
   BOOST_CHECK(cf_limits_ff == expected_cf_limits_ff);
+  BOOST_CHECK(cf_limits_tangent_ff == expected_cf_limits_tangent_ff);
 
   JointModelPlanar test_joint_planar = JointModelPlanar();
   std::vector<bool> cf_limits_planar = test_joint_planar.hasConfigurationLimit();
+  std::vector<bool> cf_limits_tangent_planar = test_joint_planar.hasConfigurationLimitInTangent();
   std::vector<bool> expected_cf_limits_planar({true, true, false, false});
+  std::vector<bool> expected_cf_limits_tangent_planar({true, true, false});
   BOOST_CHECK(cf_limits_planar == expected_cf_limits_planar);
+  BOOST_CHECK(cf_limits_tangent_planar == expected_cf_limits_tangent_planar);
 
   JointModelPX test_joint_p = JointModelPX();
   std::vector<bool> cf_limits_prismatic = test_joint_p.hasConfigurationLimit();
+  std::vector<bool> cf_limits_tangent_prismatic = test_joint_p.hasConfigurationLimitInTangent();
   std::vector<bool> expected_cf_limits_prismatic({true});
+  std::vector<bool> expected_cf_limits_tangent_prismatic({true});
   BOOST_CHECK(cf_limits_prismatic == expected_cf_limits_prismatic);
+  BOOST_CHECK(cf_limits_tangent_prismatic == expected_cf_limits_tangent_prismatic);
 
   // Test model.hasConfigurationLimit vector
   Model model;

--- a/unittest/model.cpp
+++ b/unittest/model.cpp
@@ -566,7 +566,7 @@ BOOST_AUTO_TEST_CASE(test_has_configuration_limit)
   std::vector<bool> expected_cf_limits_prismatic({true});
   BOOST_CHECK(cf_limits_prismatic == expected_cf_limits_prismatic);
 
-  // Test model.configurationLimit vector
+  // Test model.hasConfigurationLimit vector
   Model model;
   JointIndex jointId = 0;
 
@@ -578,7 +578,7 @@ BOOST_AUTO_TEST_CASE(test_has_configuration_limit)
                                               false, false, false, false,  // rotation of FF
                                               true,  // roational joint
                                               false, false});  // unbounded rotational joint
-  BOOST_CHECK((model.configurationLimit == expected_cf_limits_model));
+  BOOST_CHECK((model.hasConfigurationLimit == expected_cf_limits_model));
 }
 
 


### PR DESCRIPTION
- every joint returns a vector of boolean of size nq describing if each of the DOF has bounds or not
- model: vector stacking the boolean vector of configurations limits of each joint in the model

now we can do:
```
In [1]: import pinocchio as pin
   ...: model = pin.Model()
   ...: model.addJoint(0, pin.JointModelFreeFlyer(), pin.SE3.Identity(), "root_joint")
   ...: model.addJoint(0, pin.JointModelRZ(), pin.SE3.Identity(), "joint1")
   ...: model.addJoint(0, pin.JointModelRUBZ(), pin.SE3.Identity(), "joint2")
   ...: model.configurationLimit.tolist()
Out[1]: [True, True, True, False, False, False, False, True, False, False]
```

which can be used to see where bounds are expected or not using e.g. `model.upperPositionLimit[model.configurationLimit.tolist()]` and check if these are meaningful joint bounds, as suggested in #1752 .
