### PR TITLE
Address remaining warnings + speed-up build for BUILD_TESTING=OFF

### DIFF
--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -145,8 +145,9 @@ IF(BUILD_PYTHON_INTERFACE)
   # Do not report:
   #  -Wconversion as the BOOST_PYTHON_FUNCTION_OVERLOADS implicitly converts.
   #  -Wcomment as latex equations have multi-line comments.
+  #  -Wself-assign-overloaded as bp::self operations trigger this
   IF(NOT WIN32)
-    TARGET_COMPILE_OPTIONS(${PYWRAP} PRIVATE -Wno-conversion -Wno-comment)
+    TARGET_COMPILE_OPTIONS(${PYWRAP} PRIVATE -Wno-conversion -Wno-comment -Wno-self-assign-overloaded)
   ENDIF(NOT WIN32)
 
   SET_TARGET_PROPERTIES(${PYWRAP} PROPERTIES VERSION ${PROJECT_VERSION})

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -634,6 +634,11 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
     ///
     /// Prevent the copy of derived class.
     LieGroupBase( const LieGroupBase & /*clone*/) {}
+    void operator=(const LieGroupBase & /*x*/) {}
+
+    // C++11
+    // LieGroupBase(const LieGroupBase &) = delete;
+    // void operator=(const LieGroupBase & /*x*/) = delete;
   }; // struct LieGroupBase
 
 } // namespace pinocchio

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -634,11 +634,11 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
     ///
     /// Prevent the copy of derived class.
     LieGroupBase( const LieGroupBase & /*clone*/) {}
-    void operator=(const LieGroupBase & /*x*/) {}
+    LieGroupBase& operator=(const LieGroupBase & /*x*/) {}
 
     // C++11
     // LieGroupBase(const LieGroupBase &) = delete;
-    // void operator=(const LieGroupBase & /*x*/) = delete;
+    // LieGroupBase& operator=(const LieGroupBase & /*x*/) = delete;
   }; // struct LieGroupBase
 
 } // namespace pinocchio

--- a/src/multibody/liegroup/liegroup-base.hpp
+++ b/src/multibody/liegroup/liegroup-base.hpp
@@ -634,7 +634,7 @@ PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived,typename)
     ///
     /// Prevent the copy of derived class.
     LieGroupBase( const LieGroupBase & /*clone*/) {}
-    LieGroupBase& operator=(const LieGroupBase & /*x*/) {}
+    LieGroupBase& operator=(const LieGroupBase & /*x*/) { return *this; }
 
     // C++11
     // LieGroupBase(const LieGroupBase &) = delete;

--- a/src/multibody/liegroup/liegroup-generic.hpp
+++ b/src/multibody/liegroup/liegroup-generic.hpp
@@ -43,6 +43,10 @@ namespace pinocchio
     : Base(lg_variant)
     {}
     
+    LieGroupGenericTpl(const LieGroupGenericTpl & lg_generic)
+    : Base(lg_generic)
+    {}
+
     LieGroupGenericTpl & operator=(const LieGroupGenericTpl & other)
     {
       static_cast<Base&>(*this) = other.toVariant();

--- a/src/multibody/liegroup/vector-space.hpp
+++ b/src/multibody/liegroup/vector-space.hpp
@@ -48,6 +48,13 @@ namespace pinocchio
       assert(size_.value() >= 0);
     }
 
+    VectorSpaceOperationTpl& operator=(const VectorSpaceOperationTpl& other)
+    {
+      size_.setValue(other.size_.value());
+      assert(size_.value() >= 0);
+      return *this;
+    }
+
     Index nq () const
     {
       return size_.value();

--- a/unittest/python/pybind11/CMakeLists.txt
+++ b/unittest/python/pybind11/CMakeLists.txt
@@ -9,7 +9,11 @@ if(CMAKE_VERSION VERSION_GREATER 3.11)
     add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
 
     #pybind11_add_module(cpp2pybind11 cpp2pybind11.cpp) # BUG: might not work out of the box on OSX with conda: https://github.com/pybind/pybind11/issues/3081
-    add_library(cpp2pybind11 MODULE cpp2pybind11.cpp)
+    if(NOT BUILD_TESTING)
+      add_library(cpp2pybind11 EXCLUDE_FROM_ALL MODULE cpp2pybind11.cpp)
+    else(NOT BUILD_TESTING)
+      add_library(cpp2pybind11 MODULE cpp2pybind11.cpp)
+    endif(NOT BUILD_TESTING)
     target_link_libraries(cpp2pybind11 PRIVATE pinocchio_pywrap pybind11::module)
 
     SET_TARGET_PROPERTIES(cpp2pybind11


### PR DESCRIPTION
Speed-up when not building tests should be ~30% by conditionally compiling `cpp2pybind11` following the same logic as `add_unit_test`