### PR TITLE
pinocchio/visualize: Add support for cone shape in meshcat dispaly

### DIFF
--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -229,6 +229,8 @@ class MeshcatVisualizer(BaseVisualizer):
                 obj = RotatedCylinder(2. * geom.halfLength, geom.radius)
         elif isinstance(geom, hppfcl.Cylinder):
             obj = RotatedCylinder(2. * geom.halfLength, geom.radius)
+        elif isinstance(geom, hppfcl.Cone):
+            obj = RotatedCylinder(2. * geom.halfLength, 0, 0, geom.radius)
         elif isinstance(geom, hppfcl.Box):
             obj = meshcat.geometry.Box(npToTuple(2. * geom.halfSide))
         elif isinstance(geom, hppfcl.Sphere):

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -230,7 +230,7 @@ class MeshcatVisualizer(BaseVisualizer):
         elif isinstance(geom, hppfcl.Cylinder):
             obj = RotatedCylinder(2. * geom.halfLength, geom.radius)
         elif isinstance(geom, hppfcl.Cone):
-            obj = RotatedCylinder(2. * geom.halfLength, 0, 0, geom.radius)
+            obj = RotatedCylinder(2. * geom.halfLength, 0, geom.radius, 0)
         elif isinstance(geom, hppfcl.Box):
             obj = meshcat.geometry.Box(npToTuple(2. * geom.halfSide))
         elif isinstance(geom, hppfcl.Sphere):

--- a/examples/display-shapes-meshcat.py
+++ b/examples/display-shapes-meshcat.py
@@ -1,0 +1,45 @@
+import sys
+import numpy as np
+import pinocchio as pin
+try:
+    import hppfcl
+except ImportError:
+    print("This example requires hppfcl")
+    sys.exit(0)
+from pinocchio.visualize import MeshcatVisualizer
+
+model = pin.Model()
+
+geom_model = pin.GeometryModel()
+geometries = [
+    hppfcl.Capsule(0.1, 0.8),
+    hppfcl.Sphere(0.5),
+    hppfcl.Box(1, 1, 1),
+    hppfcl.Cylinder(0.1, 1.0),
+    hppfcl.Cone(0.5, 1.0),
+]
+for i, geom in enumerate(geometries):
+    placement = pin.SE3(np.eye(3), np.array([i, 0, 0]))
+    geom_obj = pin.GeometryObject("obj{}".format(i), 0, 0, geom, placement)
+    color = np.random.uniform(0, 1, 4)
+    color[3] = 1
+    geom_obj.meshColor = color
+    geom_model.addGeometryObject(geom_obj)
+
+viz = MeshcatVisualizer(model, geom_model, geom_model)
+
+# Initialize the viewer.
+try:
+    viz.initViewer(open=True)
+except ImportError as error:
+    print(error)
+    sys.exit(0)
+
+try:
+    viz.loadViewerModel("shapes")
+except AttributeError as error:
+    print(error)
+    sys.exit(0)
+
+viz.display(np.zeros(0))
+input("press enter to continue")


### PR DESCRIPTION
Add support for cone shape in Meshcat dispaly, which is discussed in #1768 .