### PR TITLE
Elevate check for ambiguous input argument to an exception

### DIFF
--- a/.github/workflows/macos-linux-conda.yml
+++ b/.github/workflows/macos-linux-conda.yml
@@ -38,6 +38,7 @@ jobs:
         conda activate pinocchio
         conda install cmake -c main
         mamba install llvm-openmp compilers -c conda-forge
+        conda list
 
     - name: Build Pinocchio
       shell: bash -l {0}

--- a/.github/workflows/macos-linux-conda.yml
+++ b/.github/workflows/macos-linux-conda.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         conda activate pinocchio
         conda install cmake -c main
-        mamba install llvm-openmp compilers -c conda-forge
+        mamba install llvm-openmp compilers=1.4.2 -c conda-forge
         conda list
 
     - name: Build Pinocchio

--- a/.github/workflows/macos-linux-conda.yml
+++ b/.github/workflows/macos-linux-conda.yml
@@ -37,7 +37,7 @@ jobs:
       run: |
         conda activate pinocchio
         conda install cmake -c main
-        mamba install llvm-openmp -c conda-forge
+        mamba install llvm-openmp compilers -c conda-forge
 
     - name: Build Pinocchio
       shell: bash -l {0}

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -261,9 +261,8 @@ namespace pinocchio
     = std::find_if(frames.begin()
                    ,frames.end()
                    ,details::FilterFrame(name, type));
-    PINOCCHIO_CHECK_INPUT_ARGUMENT(((it == frames.end()) ||
-            (std::find_if( boost::next(it), frames.end(), details::FilterFrame(name, type)) == frames.end()))
-        && "Several frames match the filter - please specify the FrameType");
+    PINOCCHIO_CHECK_INPUT_ARGUMENT(((it == frames.end() || (std::find_if(boost::next(it), frames.end(), details::FilterFrame(name, type)) == frames.end()))),
+                                   "Several frames match the filter - please specify the FrameType");
     return FrameIndex(it - frames.begin());
   }
   

--- a/src/multibody/model.hxx
+++ b/src/multibody/model.hxx
@@ -186,7 +186,7 @@ namespace pinocchio
       previous_frame_index = (int)getFrameId(names[parents[joint_index]], (FrameType)(JOINT | FIXED_JOINT));
     }
     assert((size_t)previous_frame_index < frames.size() && "Frame index out of bound");
-    
+
     // Add a the joint frame attached to itself to the frame vector - redundant information but useful.
     return addFrame(Frame(names[joint_index],joint_index,(FrameIndex)previous_frame_index,SE3::Identity(),JOINT));
   }
@@ -261,9 +261,9 @@ namespace pinocchio
     = std::find_if(frames.begin()
                    ,frames.end()
                    ,details::FilterFrame(name, type));
-    assert(((it == frames.end()) ||
+    PINOCCHIO_CHECK_INPUT_ARGUMENT(((it == frames.end()) ||
             (std::find_if( boost::next(it), frames.end(), details::FilterFrame(name, type)) == frames.end()))
-        && "Several frames match the filter");
+        && "Several frames match the filter - please specify the FrameType");
     return FrameIndex(it - frames.begin());
   }
   

--- a/unittest/models/link_and_joint_identical_name.urdf
+++ b/unittest/models/link_and_joint_identical_name.urdf
@@ -1,0 +1,15 @@
+<?xml version="1.0" ?>
+<!--
+This URDF reproduces a test case which previously triggered an assertion when
+performing `getFrameId()` due to a joint and a link having the same name. This
+results in two frames with the same name - one from the body and one from the
+joint.
+-->
+<robot name="test_link_and_joint_with_identical_name">
+  <link name="base"/>
+  <joint name="base" type="fixed">
+    <parent link="base"/>
+    <child link="trunk"/>
+  </joint>
+  <link name="trunk"/>
+</robot>

--- a/unittest/urdf.cpp
+++ b/unittest/urdf.cpp
@@ -257,4 +257,19 @@ BOOST_AUTO_TEST_CASE(check_specific_models)
   pinocchio::urdf::buildModel(filename, model);
 }
 
+BOOST_AUTO_TEST_CASE(test_getFrameId_identical_link_and_joint_name)
+{
+    // This test checks whether the input argument of getFrameId raises an exception when multiple frames with identical names are found.
+    // Note, a model that contains a link and a joint with the same name is valid, but the look-up for e.g. getFrameId requires the explicit
+    // specification of the FrameType in order to be valid.
+    // It resolved https://github.com/stack-of-tasks/pinocchio/issues/1771
+    pinocchio::Model model;
+    const std::string filename = PINOCCHIO_MODEL_DIR + std::string("/../unittest/models/link_and_joint_identical_name.urdf");
+    pinocchio::urdf::buildModel(filename,model);
+
+    BOOST_CHECK_THROW(model.getFrameId("base"), std::invalid_argument);
+    BOOST_CHECK(model.getFrameId("base", pinocchio::FrameType::BODY) == 2);
+    BOOST_CHECK(model.getFrameId("base", pinocchio::FrameType::FIXED_JOINT) == 3);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
A sufficient solution is to elevate the assertion to an exception 

Fixes #1771 