### PR TITLE
Skip collision pairs between geom on same joint in appendGeometryModel

### DIFF
--- a/src/algorithm/geometry.hxx
+++ b/src/algorithm/geometry.hxx
@@ -297,8 +297,10 @@ namespace pinocchio
 
     /// 2. add the collision pairs between geom_model1 and geom_model2.
     for (Index i = 0; i < nGeom1; ++i) {
-      for (Index j = 0; j < nGeom2; ++j) {
-        geom_model1.collisionPairs.push_back(CollisionPair(i, nGeom1 + j));
+      Index parent_i = geom_model1.geometryObjects[i].parentJoint;
+      for (Index j = nGeom1; j < nGeom1 + nGeom2; ++j) {
+        if (parent_i != geom_model1.geometryObjects[j].parentJoint)
+          geom_model1.collisionPairs.push_back(CollisionPair(i, j));
       }
     }
   }

--- a/unittest/geom.cpp
+++ b/unittest/geom.cpp
@@ -434,6 +434,15 @@ BOOST_AUTO_TEST_CASE ( test_append_geom_models )
   
   appendGeometryModel(geom_model2,geom_model1);
   BOOST_CHECK(geom_model2.ngeoms == 2*geom_model1.ngeoms);
+
+  // Check that collision pairs between geoms on the same joint are discarded.
+  for (pinocchio::Index i = 0; i < geom_model2.collisionPairs.size(); ++i) {
+    pinocchio::CollisionPair cp = geom_model2.collisionPairs[i];
+    BOOST_CHECK_NE(
+        geom_model2.geometryObjects[cp.first].parentJoint,
+        geom_model2.geometryObjects[cp.second].parentJoint
+    );
+  }
   
   {
     GeometryModel geom_model_empty;


### PR DESCRIPTION
The change comes with a unit test which was failing before and which is self-explanatory.