### PR TITLE
Add helper functions for computing supported inertia and force by frames

### DIFF
--- a/bindings/python/algorithm/expose-frames.cpp
+++ b/bindings/python/algorithm/expose-frames.cpp
@@ -145,21 +145,15 @@ namespace pinocchio
               "Returns the Jacobian time variation of the frame given by its frame_id either in the reference frame provided by reference_frame.\n"
               "You have to call computeJointJacobiansTimeVariation(model,data,q,v) and updateFramePlacements(model,data) first.");
 
-      bp::def("computeFrameSupportedInertiaInBody",
-              &computeFrameSupportedInertiaInBody<double,0,JointCollectionDefaultTpl>,
-              bp::args("model","frame_id"),
-              "Computes the supported inertia in the current rigid body of the frame (given by frame_id) and returns it.\n"
-              "The supported inertia in the body corresponds to the sum of the inertias of all the frames that belongs to the same parent joint, and that come after the given frame.\n");
-
-        bp::def("computeFrameSupportedInertiaWithSubtree",
-              &computeFrameSupportedInertiaWithSubtree<double,0,JointCollectionDefaultTpl>,
-              bp::args("model", "data", "frame_id"),
-              "Computes the total supported inertia in the current rigid body of the frame (given by frame_id) and returns it.\n"
-              "The supported inertia corresponds to the sum of the supported inertia in body plus all the inertias of the child joints.\n"
+      bp::def("computeSupportedInertiaByFrame",
+              &computeSupportedInertiaByFrame<double,0,JointCollectionDefaultTpl>,
+              bp::args("model", "data", "frame_id", "with_subtree"),
+              "Computes the supported inertia by the frame (given by frame_id) and returns it.\n"
+              "The supported inertia corresponds to the sum of the inertias of all the child frames (that belongs to the same joint body) and the child joints, if with_subtree=True.\n"
               "You must first call pinocchio::forwardKinematics to update placement values in data structure.");
 
-      bp::def("computeFrameSupportedForce",
-              &computeFrameSupportedForce<double,0,JointCollectionDefaultTpl>,
+      bp::def("computeSupportedForceByFrame",
+              &computeSupportedForceByFrame<double,0,JointCollectionDefaultTpl>,
               bp::args("model","data","frame_id"),
               "Computes the supported force of the frame (given by frame_id) and returns it.\n"
               "The supported force corresponds to the sum of all the forces experienced after the given frame.\n"

--- a/bindings/python/algorithm/expose-frames.cpp
+++ b/bindings/python/algorithm/expose-frames.cpp
@@ -67,7 +67,7 @@ namespace pinocchio
   
       return get_frame_jacobian_time_variation_proxy(model, data, frame_id, rf);
     }
-    
+
     BOOST_PYTHON_FUNCTION_OVERLOADS(getFrameVelocity_overload, (getFrameVelocity<double,0,JointCollectionDefaultTpl>), 3, 4)
     BOOST_PYTHON_FUNCTION_OVERLOADS(getFrameAcceleration_overload, (getFrameAcceleration<double,0,JointCollectionDefaultTpl>), 3, 4)
     BOOST_PYTHON_FUNCTION_OVERLOADS(getFrameClassicalAcceleration_overload, (getFrameClassicalAcceleration<double,0,JointCollectionDefaultTpl>), 3, 4)
@@ -145,8 +145,27 @@ namespace pinocchio
               "Returns the Jacobian time variation of the frame given by its frame_id either in the reference frame provided by reference_frame.\n"
               "You have to call computeJointJacobiansTimeVariation(model,data,q,v) and updateFramePlacements(model,data) first.");
 
+      bp::def("computeFrameSupportedInertiaInBody",
+              &computeFrameSupportedInertiaInBody<double,0,JointCollectionDefaultTpl>,
+              bp::args("model","frame_id"),
+              "Computes the supported inertia in the current rigid body of the frame (given by frame_id) and returns it.\n"
+              "The supported inertia in the body corresponds to the sum of the inertias of all the frames that belongs to the same parent joint, and that come after the given frame.\n");
+
+        bp::def("computeFrameSupportedInertiaWithSubtree",
+              &computeFrameSupportedInertiaWithSubtree<double,0,JointCollectionDefaultTpl>,
+              bp::args("model", "data", "frame_id"),
+              "Computes the total supported inertia in the current rigid body of the frame (given by frame_id) and returns it.\n"
+              "The supported inertia corresponds to the sum of the supported inertia in body plus all the inertias of the child joints.\n"
+              "You must first call pinocchio::forwardKinematics to update placement values in data structure.");
+
+      bp::def("computeFrameSupportedForce",
+              &computeFrameSupportedForce<double,0,JointCollectionDefaultTpl>,
+              bp::args("model","data","frame_id"),
+              "Computes the supported force of the frame (given by frame_id) and returns it.\n"
+              "The supported force corresponds to the sum of all the forces experienced after the given frame.\n"
+              "You must first call pinocchio::rnea to update placement values in data structure.");
+
     }
-  
   } // namespace python
 
 } // namespace pinocchio

--- a/src/algorithm/frames.hpp
+++ b/src/algorithm/frames.hpp
@@ -291,7 +291,7 @@ namespace pinocchio
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
   InertiaTpl<Scalar, Options>
   computeSupportedInertiaByFrame(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                                 DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                                 const DataTpl<Scalar,Options,JointCollectionTpl> & data,
                                  const FrameIndex frame_id,
                                  bool with_subtree);
 
@@ -324,8 +324,8 @@ namespace pinocchio
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
   ForceTpl<Scalar, Options>
   computeSupportedForceByFrame(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                             DataTpl<Scalar,Options,JointCollectionTpl> & data,
-                             const FrameIndex frame_id);
+                               const DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                               const FrameIndex frame_id);
 
 } // namespace pinocchio
 

--- a/src/algorithm/frames.hpp
+++ b/src/algorithm/frames.hpp
@@ -299,7 +299,7 @@ namespace pinocchio
   * @brief Computes the force supported by a specific frame (given by frame_id) expressed in the LOCAL frame.
   *        The supported force corresponds to the sum of all the forces experienced after the given frame, i.e :
   *         * The inertial forces and gravity (applied on the supported inertia in body)
-  *         * The forces applied by child joint
+  *         * The forces applied by child joints
   *         * (The external forces)
   *        You must first call pinocchio::rnea to update placements, velocities and efforts values in data structure.
   *

--- a/src/algorithm/frames.hpp
+++ b/src/algorithm/frames.hpp
@@ -263,43 +263,26 @@ namespace pinocchio
                                      const Eigen::MatrixBase<Matrix6xLike> & dJ);
 
 /**
-  * @brief Get the inertia supported by a specific frame (given by frame_id), inside of the frame rigid body, expressed in the LOCAL frame.
-  *        The supported inertia in body corresponds to the sum of :
-  *         * The frame inertia
-  *         * The 'child frames' inertia. ('Child frames' refers to frames that share the same parent joint and are placed after the given frame)
-  *
-  * @note Physically speaking, if the body contaning the current frame were to be cut in two parts at that frame, the FrameSupportedInertiaInBody would be the inertia of the part of the body that was after the frame.
-  *
-  * @note The equivalent function for a joint would be to read `model.inertia[joint_id]`.
-  *
-  * @tparam JointCollection Collection of Joint types.
-  *
-  * @param[in] model The model structure of the rigid body system.
-  * @param[in] frameId The index of the frame.
-  *
-  * @return The computed inertia.
-  */
-  template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
-  InertiaTpl<Scalar, Options>
-  computeFrameSupportedInertiaInBody(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                                     const FrameIndex frame_id);
-
-/**
-  * @brief Get the total inertia supported by a specific frame (given by frame_id) expressed in the LOCAL frame.
+  * @brief Compute the inertia supported by a specific frame (given by frame_id) expressed in the LOCAL frame.
   *        The total supported inertia corresponds to the sum of all the inertia after the given frame, i.e :
-  *         * The frame supported inertia in body (see computeFrameSupportedInertiaInBody)
-  *         * The child joints inertia
+  *         * The frame inertia
+  *         * The child frames inertia ('Child frames' refers to frames that share the same parent joint and are placed after the given frame)
+  *         * The child joints inertia (if with_subtree == true)
   *        You must first call pinocchio::forwardKinematics to update placement values in data structure.
   *
   * @note Physically speaking, if the robot were to be cut in two parts at that given frame, this supported inertia would represents the inertia of the part that was after the frame.
+  *       with_subtree determines if the childs joints must be taken into consideration (if true) or only the current joint (if false).
   *
-  * @note The equivalent function for a joint would be to read `data.Ycrb[joint_id]`, after having called pinocchio::crba.
+  * @note The equivalent function for a joint would be :
+  *       * to read `data.Ycrb[joint_id]`, after having called pinocchio::crba (if with_subtree == true).
+  *       * to read `model.inertia[joint_id]` (if with_subtree == false).
   *
   * @tparam JointCollection Collection of Joint types.
   *
   * @param[in] model The model structure of the rigid body system.
   * @param[in] data The data structure of the rigid body system.
   * @param[in] frameId The index of the frame.
+  * @param[in] with_subtree If false, compute the inertia only inside the frame parent joint if false. If true, include child joints inertia.
   *
   * @return The computed inertia.
   *
@@ -307,9 +290,10 @@ namespace pinocchio
   */
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
   InertiaTpl<Scalar, Options>
-  computeFrameSupportedInertiaWithSubtree(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
-                                        DataTpl<Scalar,Options,JointCollectionTpl> & data,
-                                        const FrameIndex frame_id);
+  computeSupportedInertiaByFrame(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+                                 DataTpl<Scalar,Options,JointCollectionTpl> & data,
+                                 const FrameIndex frame_id,
+                                 bool with_subtree);
 
 /**
   * @brief Computes the force supported by a specific frame (given by frame_id) expressed in the LOCAL frame.
@@ -339,7 +323,7 @@ namespace pinocchio
   */
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
   ForceTpl<Scalar, Options>
-  computeFrameSupportedForce(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
+  computeSupportedForceByFrame(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                              DataTpl<Scalar,Options,JointCollectionTpl> & data,
                              const FrameIndex frame_id);
 

--- a/src/algorithm/frames.hxx
+++ b/src/algorithm/frames.hxx
@@ -329,7 +329,7 @@ namespace pinocchio
     const pinocchio::SE3 oMf = data.oMi[joint_id]*frame.placement;
     const Motion v = getFrameVelocity(model, data, frame_id, LOCAL);
     const Motion a = getFrameAcceleration(model, data, frame_id, LOCAL);
-    Force f = fI.vxiv(v) + fI * a - fI * oMf.actInv(model.gravity);
+    Force f = fI.vxiv(v) + fI * (a - oMf.actInv(model.gravity));
 
     // Add child joints forces
     f = frame.placement.act(f); // Express force in parent joint frame

--- a/unittest/frames.cpp
+++ b/unittest/frames.cpp
@@ -635,9 +635,9 @@ BOOST_AUTO_TEST_CASE(test_supported_inertia_and_force)
   VectorXd a_ff(VectorXd::Random(model_ff.nv));
 
   // Set free-flyer joint to q, v, a = 0 to mimic fixed joint
-  q_ff.segment(head_q, 7) <<  Vector<double, 6>::Constant(0), 1; // Unit quaternion
-  v_ff.segment(head_v, 6) <<  Vector<double, 6>::Constant(0);
-  a_ff.segment(head_v, 6) <<  Vector<double, 6>::Constant(0);
+  q_ff.segment(head_q, 7) <<  Eigen::Matrix<double, 6, 1, 0>::Constant(0), 1; // Unit quaternion
+  v_ff.segment(head_v, 6) <<  Eigen::Matrix<double, 6, 1, 0>::Constant(0);
+  a_ff.segment(head_v, 6) <<  Eigen::Matrix<double, 6, 1, 0>::Constant(0);
 
   // Adapt configuration for fixed joint model
   VectorXd q_fix(model_fix.nq);

--- a/unittest/frames.cpp
+++ b/unittest/frames.cpp
@@ -7,13 +7,16 @@
 #include "pinocchio/algorithm/jacobian.hpp"
 #include "pinocchio/algorithm/frames.hpp"
 #include "pinocchio/algorithm/rnea.hpp"
+#include "pinocchio/algorithm/crba.hpp"
 #include "pinocchio/spatial/act-on-set.hpp"
 #include "pinocchio/parsers/sample-models.hpp"
 #include "pinocchio/utils/timer.hpp"
+#include "pinocchio/parsers/urdf.hpp"
 #include "pinocchio/algorithm/joint-configuration.hpp"
 
 #include <iostream>
 
+#include <urdf_parser/urdf_parser.h>
 #include <boost/test/unit_test.hpp>
 #include <boost/utility/binary.hpp>
 
@@ -587,6 +590,80 @@ BOOST_AUTO_TEST_CASE ( test_frame_jacobian_time_variation )
     BOOST_CHECK(dJ_local_world_aligned.isApprox(dJ_ref_local_world_aligned,sqrt(alpha)));
   }
 }
-             
-BOOST_AUTO_TEST_SUITE_END ()
 
+BOOST_AUTO_TEST_CASE(test_supported_inertia_and_force)
+{
+  using namespace Eigen;
+  using namespace pinocchio;
+
+  const std::string filename = PINOCCHIO_MODEL_DIR + std::string("/example-robot-data/robots/talos_data/robots/talos_full_v2.urdf");
+  ::urdf::ModelInterfaceSharedPtr urdfTree = ::urdf::parseURDFFile(filename);
+
+  // Working frame
+  const std::string joint_name = "wrist_left_ft_joint";
+
+  // Create a model containing a fixed joint
+  pinocchio::Model model_fix;
+  pinocchio::urdf::buildModel(urdfTree, model_fix);
+  Data data_fix(model_fix);
+  const FrameIndex frame_id = model_fix.getFrameId(joint_name);
+
+  // Modify the urdf to have a floating joint instead
+  std::shared_ptr<::urdf::Joint> p_joint = urdfTree->joints_.find(joint_name)->second;
+  BOOST_CHECK(p_joint);
+  p_joint->type = ::urdf::Joint::FLOATING;
+
+  // Create a model with the floating joint
+  pinocchio::Model model_ff;
+  pinocchio::urdf::buildModel(urdfTree, model_ff);
+  Data data_ff(model_ff);
+
+  // Const variable to convert q, v from model to another
+  const JointIndex joint_id = model_ff.getJointId(joint_name);
+  const int head_q(model_ff.joints[joint_id].idx_q());
+  const int head_v(model_ff.joints[joint_id].idx_v());
+  const int tail_q(model_ff.nq - model_ff.joints[joint_id].nq() - head_q);
+  const int tail_v(model_ff.nv - model_ff.joints[joint_id].nv() - head_v);
+
+  // Joint value will be kept to 0. Limits are set to allow for randomConfiguration
+  model_ff.lowerPositionLimit.segment(head_q, 3) << Vector3d::Constant(-1);
+  model_ff.upperPositionLimit.segment(head_q, 3) << Vector3d::Constant( 1);
+
+  // Pick random q, v, a
+  VectorXd q_ff = randomConfiguration(model_ff);
+  VectorXd v_ff(VectorXd::Random(model_ff.nv));
+  VectorXd a_ff(VectorXd::Random(model_ff.nv));
+
+  // Set free-flyer joint to q, v, a = 0 to mimic fixed joint
+  q_ff.segment(head_q, 7) <<  Vector<double, 6>::Constant(0), 1; // Unit quaternion
+  v_ff.segment(head_v, 6) <<  Vector<double, 6>::Constant(0);
+  a_ff.segment(head_v, 6) <<  Vector<double, 6>::Constant(0);
+
+  // Adapt configuration for fixed joint model
+  VectorXd q_fix(model_fix.nq);
+  q_fix << q_ff.head(head_q), q_ff.tail(tail_q);
+  VectorXd v_fix(model_fix.nv);
+  v_fix << v_ff.head(head_v), v_ff.tail(tail_v);
+  VectorXd a_fix(model_fix.nv);
+  a_fix << a_ff.head(head_v), a_ff.tail(tail_v);
+
+  // Compute inertia/force for both models differently
+  forwardKinematics(model_fix, data_fix, q_fix, v_fix, a_fix);
+  crba(model_ff, data_ff, q_ff);
+
+  Inertia inertia_fix = computeFrameSupportedInertiaInBody(model_fix, frame_id);
+  Inertia inertia_ff(model_ff.inertias[joint_id]);
+  BOOST_CHECK(inertia_fix.isApprox(inertia_ff));
+
+  inertia_fix = computeFrameSupportedInertiaWithSubtree(model_fix, data_fix, frame_id);
+  inertia_ff = data_ff.Ycrb[joint_id];
+  BOOST_CHECK(inertia_fix.isApprox(inertia_ff));
+
+                       rnea(model_fix, data_fix, q_fix, v_fix, a_fix);
+  const VectorXd tau = rnea(model_ff,  data_ff,  q_ff,  v_ff,  a_ff);
+
+  Force force_fix = computeFrameSupportedForce(model_fix, data_fix, frame_id);
+  Force force_ff(tau.segment(head_v, 6));
+  BOOST_CHECK(force_fix.isApprox(force_ff));
+}
+BOOST_AUTO_TEST_SUITE_END ()

--- a/unittest/frames.cpp
+++ b/unittest/frames.cpp
@@ -651,18 +651,18 @@ BOOST_AUTO_TEST_CASE(test_supported_inertia_and_force)
   forwardKinematics(model_fix, data_fix, q_fix, v_fix, a_fix);
   crba(model_ff, data_ff, q_ff);
 
-  Inertia inertia_fix = computeFrameSupportedInertiaInBody(model_fix, frame_id);
+  Inertia inertia_fix = computeSupportedInertiaByFrame(model_fix, data_fix, frame_id, false);
   Inertia inertia_ff(model_ff.inertias[joint_id]);
   BOOST_CHECK(inertia_fix.isApprox(inertia_ff));
 
-  inertia_fix = computeFrameSupportedInertiaWithSubtree(model_fix, data_fix, frame_id);
+  inertia_fix = computeSupportedInertiaByFrame(model_fix, data_fix, frame_id, true);
   inertia_ff = data_ff.Ycrb[joint_id];
   BOOST_CHECK(inertia_fix.isApprox(inertia_ff));
 
                        rnea(model_fix, data_fix, q_fix, v_fix, a_fix);
   const VectorXd tau = rnea(model_ff,  data_ff,  q_ff,  v_ff,  a_ff);
 
-  Force force_fix = computeFrameSupportedForce(model_fix, data_fix, frame_id);
+  Force force_fix = computeSupportedForceByFrame(model_fix, data_fix, frame_id);
   Force force_ff(tau.segment(head_v, 6));
   BOOST_CHECK(force_fix.isApprox(force_ff));
 }


### PR DESCRIPTION
Hello,
Following my discussion with @jcarpent, I propose the implementation of 3 new helper functions that compute supported inertia and force by frames.

Motivation : 
In our current robot setup, we have a force-torque sensor mounted in the arm. We would like to compute the forces that this sensor is supposed to measure.

Problem : 
This sensor is represented by a FIXED_JOINT in the urdf, thus it is not represented in the pinocchio model, and retrieving such info is not straightforward. 

Solution :
The method `pinocchio::computeFrameSupportedForce` compute this force. It takes into account inertial forces, gravity and external forces.
Computing supported inertias is an intermediary step in that process. I choose to expose it, as it may be useful for other uses.