### PR TITLE
[python/visualize] Extend visualizer features and implement them for MeshcatVisualizer

### DIFF
--- a/bindings/python/pinocchio/visualize/base_visualizer.py
+++ b/bindings/python/pinocchio/visualize/base_visualizer.py
@@ -2,6 +2,7 @@ from .. import pinocchio_pywrap as pin
 from ..shortcuts import buildModelsFromUrdf, createDatas
 
 import time
+import numpy as np
 
 class BaseVisualizer(object):
     """Pinocchio visualizers are employed to easily display a model at a given configuration.
@@ -75,9 +76,29 @@ class BaseVisualizer(object):
         """Set whether to display visual objects or not."""
         pass
 
-    def captureImage(self):
+    def setCameraTarget(self, target):
+        raise NotImplementedError()
+
+    def setCameraPosition(self, position: np.ndarray):
+        raise NotImplementedError()
+
+    def setCameraZoom(self, zoom: float):
+        """Set camera zoom value."""
+        raise NotImplementedError()
+
+    def setCameraPose(self, pose: np.ndarray = np.eye(4)):
+        """Set camera pose using a 4x4 matrix."""
+        raise NotImplementedError()
+
+    def captureImage(self, w=None, h=None):
         """Captures an image from the viewer and returns an RGB array."""
         pass
+
+    def disableCameraControl(self):
+        raise NotImplementedError()
+
+    def enableCameraControl(self):
+        raise NotImplementedError()
 
     def sleep(self, dt):
         time.sleep(dt)

--- a/bindings/python/pinocchio/visualize/base_visualizer.py
+++ b/bindings/python/pinocchio/visualize/base_visualizer.py
@@ -6,6 +6,13 @@ import numpy as np
 from pathlib import Path
 
 
+try:
+    import imageio
+    IMAGEIO_SUPPORT = True
+except ImportError:
+    IMAGEIO_SUPPORT = False
+
+
 class BaseVisualizer(object):
     """Pinocchio visualizers are employed to easily display a model at a given configuration.
     BaseVisualizer is not meant to be directly employed, but only to provide a uniform interface and a few common methods.
@@ -99,15 +106,15 @@ class BaseVisualizer(object):
         """Set the camera target."""
         raise NotImplementedError()
 
-    def setCameraPosition(self, position: np.ndarray):
+    def setCameraPosition(self, position):
         """Set the camera's 3D position."""
         raise NotImplementedError()
 
-    def setCameraZoom(self, zoom: float):
+    def setCameraZoom(self, zoom):
         """Set camera zoom value."""
         raise NotImplementedError()
 
-    def setCameraPose(self, pose: np.ndarray = np.eye(4)):
+    def setCameraPose(self, pose=np.eye(4)):
         """Set camera 6D pose using a 4x4 matrix."""
         raise NotImplementedError()
 
@@ -145,7 +152,7 @@ class BaseVisualizer(object):
             if dt is not None and elapsed_time < dt:
                 self.sleep(dt - elapsed_time)
 
-    def create_video_ctx(self, filename: str = None, fps=30, directory=None, **kwargs):
+    def create_video_ctx(self, filename=None, fps=30, directory=None, **kwargs):
         """Create a video recording context, generating the output filename if necessary.
 
         Code inspired from https://github.com/petrikvladimir/RoboMeshCat.
@@ -162,7 +169,7 @@ class BaseVisualizer(object):
 
 
 class VideoContext:
-    def __init__(self, viz: BaseVisualizer, fps: int, filename: str, **kwargs):
+    def __init__(self, viz: BaseVisualizer, fps, filename, **kwargs):
         import imageio
 
         self.viz = viz

--- a/bindings/python/pinocchio/visualize/base_visualizer.py
+++ b/bindings/python/pinocchio/visualize/base_visualizer.py
@@ -63,23 +63,29 @@ class BaseVisualizer(object):
         """ Delete all the objects from the whole scene """
         pass
 
-    def display(self, q = None):
+    def display(self, q=None):
         """Display the robot at configuration q or refresh the rendering
         from the current placements contained in data by placing all the bodies in the viewer."""
         pass
 
-    def displayCollisions(self,visibility):
+    def displayCollisions(self, visibility):
         """Set whether to display collision objects or not."""
         pass
  
-    def displayVisuals(self,visibility):
+    def displayVisuals(self, visibility):
         """Set whether to display visual objects or not."""
-        pass
+        raise NotImplementedError()
+    
+    def setBackgroundColor(self):
+        """Set the visualizer background color."""
+        raise NotImplementedError()
 
     def setCameraTarget(self, target):
+        """Set the camera target."""
         raise NotImplementedError()
 
     def setCameraPosition(self, position: np.ndarray):
+        """Set the camera's 3D position."""
         raise NotImplementedError()
 
     def setCameraZoom(self, zoom: float):
@@ -87,7 +93,7 @@ class BaseVisualizer(object):
         raise NotImplementedError()
 
     def setCameraPose(self, pose: np.ndarray = np.eye(4)):
-        """Set camera pose using a 4x4 matrix."""
+        """Set camera 6D pose using a 4x4 matrix."""
         raise NotImplementedError()
 
     def captureImage(self, w=None, h=None):
@@ -98,6 +104,10 @@ class BaseVisualizer(object):
         raise NotImplementedError()
 
     def enableCameraControl(self):
+        raise NotImplementedError()
+
+    def drawFrameVelocities(self, *args):
+        """Draw current frame velocities."""
         raise NotImplementedError()
 
     def sleep(self, dt):
@@ -118,5 +128,11 @@ class BaseVisualizer(object):
                 self.sleep(dt - elapsed_time)
         if capture:
             return imgs
+
+
+class VideoContext:
+    def __init__(self, viz: BaseVisualizer, fps: int, filename: str, **kwargs):
+        self.viz = viz
+        self.vid_writer
 
 __all__ = ['BaseVisualizer']

--- a/bindings/python/pinocchio/visualize/base_visualizer.py
+++ b/bindings/python/pinocchio/visualize/base_visualizer.py
@@ -3,7 +3,7 @@ from ..shortcuts import buildModelsFromUrdf, createDatas
 
 import time
 import numpy as np
-from pathlib import Path
+import os.path as osp
 
 
 try:
@@ -179,7 +179,8 @@ class BaseVisualizer(object):
                 directory = gettempdir()
             f_fmt = "%Y%m%d_%H%M%S"
             ext = "mp4"
-            filename = Path(directory).joinpath(time.strftime(f"{f_fmt}.{ext}"))
+            filename = time.strftime(f"{f_fmt}.{ext}")
+            filename = osp.join(directory, filename)
         return VideoContext(self, fps, filename)
 
 

--- a/bindings/python/pinocchio/visualize/base_visualizer.py
+++ b/bindings/python/pinocchio/visualize/base_visualizer.py
@@ -138,16 +138,16 @@ class BaseVisualizer(object):
     def has_vid_writer(self):
         return self._video_writer is not None
 
-    def play(self, qs, dt=None, callback=None, capture=False, **kwargs):
+    def play(self, q_trajectory, dt=None, callback=None, capture=False, **kwargs):
         """Play a trajectory with given time step. Optionally capture RGB images and returns them."""
-        nsteps = len(qs)
+        nsteps = len(q_trajectory)
         if not capture:
             capture = self.has_vid_writer()
 
         imgs = []
         for i in range(nsteps):
             t0 = time.time()
-            self.display(qs[i])
+            self.display(q_trajectory[i])
             if callback is not None:
                 callback(i, **kwargs)
             if capture:

--- a/bindings/python/pinocchio/visualize/base_visualizer.py
+++ b/bindings/python/pinocchio/visualize/base_visualizer.py
@@ -179,13 +179,13 @@ class BaseVisualizer(object):
                 directory = gettempdir()
             f_fmt = "%Y%m%d_%H%M%S"
             ext = "mp4"
-            filename = time.strftime(f"{f_fmt}.{ext}")
+            filename = time.strftime("{}.{}".format(f_fmt, ext))
             filename = osp.join(directory, filename)
         return VideoContext(self, fps, filename)
 
 
 class VideoContext:
-    def __init__(self, viz: BaseVisualizer, fps, filename, **kwargs):
+    def __init__(self, viz, fps, filename, **kwargs):
         self.viz = viz
         self.vid_writer = imageio.get_writer(filename, fps=fps, **kwargs)
 

--- a/bindings/python/pinocchio/visualize/base_visualizer.py
+++ b/bindings/python/pinocchio/visualize/base_visualizer.py
@@ -78,7 +78,7 @@ class BaseVisualizer(object):
         """Set whether to display visual objects or not."""
         raise NotImplementedError()
     
-    def setBackgroundColor(self):
+    def setBackgroundColor(self, *args, **kwargs):
         """Set the visualizer background color."""
         raise NotImplementedError()
 
@@ -108,7 +108,7 @@ class BaseVisualizer(object):
     def enableCameraControl(self):
         raise NotImplementedError()
 
-    def drawFrameVelocities(self, *args):
+    def drawFrameVelocities(self, *args, **kwargs):
         """Draw current frame velocities."""
         raise NotImplementedError()
 

--- a/bindings/python/pinocchio/visualize/base_visualizer.py
+++ b/bindings/python/pinocchio/visualize/base_visualizer.py
@@ -186,8 +186,6 @@ class BaseVisualizer(object):
 
 class VideoContext:
     def __init__(self, viz: BaseVisualizer, fps, filename, **kwargs):
-        import imageio
-
         self.viz = viz
         self.vid_writer = imageio.get_writer(filename, fps=fps, **kwargs)
 

--- a/bindings/python/pinocchio/visualize/base_visualizer.py
+++ b/bindings/python/pinocchio/visualize/base_visualizer.py
@@ -5,14 +5,25 @@ import time
 import numpy as np
 from pathlib import Path
 
+
 class BaseVisualizer(object):
     """Pinocchio visualizers are employed to easily display a model at a given configuration.
     BaseVisualizer is not meant to be directly employed, but only to provide a uniform interface and a few common methods.
     New visualizers should extend this class and override its methods as neeeded.
     """
+
     _video_writer = None
 
-    def __init__(self, model = pin.Model(), collision_model = None, visual_model = None, copy_models = False, data = None, collision_data = None, visual_data = None):
+    def __init__(
+        self,
+        model=pin.Model(),
+        collision_model=None,
+        visual_model=None,
+        copy_models=False,
+        data=None,
+        collision_data=None,
+        visual_data=None,
+    ):
         """Construct a display from the given model, collision model, and visual model.
         If copy_models is True, the models are copied. Otherwise, they are simply kept as a reference."""
 
@@ -43,11 +54,13 @@ class BaseVisualizer(object):
     def rebuildData(self):
         """Re-build the data objects. Needed if the models were modified.
         Warning: this will delete any information stored in all data objects."""
-        self.data, self.collision_data, self.visual_data = createDatas(self.model, self.collision_model, self.visual_model)
+        self.data, self.collision_data, self.visual_data = createDatas(
+            self.model, self.collision_model, self.visual_model
+        )
 
     def getViewerNodeName(self, geometry_object, geometry_type):
         """Return the name of the geometry object inside the viewer."""
-        pass 
+        pass
 
     def initViewer(self, *args, **kwargs):
         """Init the viewer by loading the gui and creating a window."""
@@ -57,12 +70,12 @@ class BaseVisualizer(object):
         """Create the scene displaying the robot meshes in the viewer"""
         pass
 
-    def reload(self, new_geometry_object, geometry_type = None):
-        """ Reload a geometry_object given by its type"""
+    def reload(self, new_geometry_object, geometry_type=None):
+        """Reload a geometry_object given by its type"""
         pass
 
     def clean(self):
-        """ Delete all the objects from the whole scene """
+        """Delete all the objects from the whole scene"""
         pass
 
     def display(self, q=None):
@@ -73,11 +86,11 @@ class BaseVisualizer(object):
     def displayCollisions(self, visibility):
         """Set whether to display collision objects or not."""
         pass
- 
+
     def displayVisuals(self, visibility):
         """Set whether to display visual objects or not."""
         raise NotImplementedError()
-    
+
     def setBackgroundColor(self, *args, **kwargs):
         """Set the visualizer background color."""
         raise NotImplementedError()
@@ -140,15 +153,18 @@ class BaseVisualizer(object):
         if filename is None:
             if directory is None:
                 from tempfile import gettempdir
+
                 directory = gettempdir()
             f_fmt = "%Y%m%d_%H%M%S"
             ext = "mp4"
             filename = Path(directory).joinpath(time.strftime(f"{f_fmt}.{ext}"))
         return VideoContext(self, fps, filename)
 
+
 class VideoContext:
     def __init__(self, viz: BaseVisualizer, fps: int, filename: str, **kwargs):
         import imageio
+
         self.viz = viz
         self.vid_writer = imageio.get_writer(filename, fps=fps, **kwargs)
 
@@ -160,4 +176,5 @@ class VideoContext:
         self.vid_writer.close()
         self.viz._video_writer = None
 
-__all__ = ['BaseVisualizer']
+
+__all__ = ["BaseVisualizer"]

--- a/bindings/python/pinocchio/visualize/base_visualizer.py
+++ b/bindings/python/pinocchio/visualize/base_visualizer.py
@@ -135,14 +135,14 @@ class BaseVisualizer(object):
     def sleep(self, dt):
         time.sleep(dt)
 
-    def has_vid_writer(self):
+    def has_video_writer(self):
         return self._video_writer is not None
 
     def play(self, q_trajectory, dt=None, callback=None, capture=False, **kwargs):
         """Play a trajectory with given time step. Optionally capture RGB images and returns them."""
         nsteps = len(q_trajectory)
         if not capture:
-            capture = self.has_vid_writer()
+            capture = self.has_video_writer()
 
         imgs = []
         for i in range(nsteps):
@@ -152,7 +152,7 @@ class BaseVisualizer(object):
                 callback(i, **kwargs)
             if capture:
                 img_arr = self.captureImage()
-                if not self.has_vid_writer():
+                if not self.has_video_writer():
                     imgs.append(img_arr)
                 else:
                     self._video_writer.append_data(img_arr)
@@ -160,7 +160,7 @@ class BaseVisualizer(object):
             elapsed_time = t1 - t0
             if dt is not None and elapsed_time < dt:
                 self.sleep(dt - elapsed_time)
-        if capture and not self.has_vid_writer():
+        if capture and not self.has_video_writer():
             return imgs
 
     def create_video_ctx(self, filename=None, fps=30, directory=None, **kwargs):

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -22,13 +22,6 @@ DEFAULT_COLOR_PROFILES = {
 COLOR_PRESETS = DEFAULT_COLOR_PROFILES.copy()
 
 
-def getColor(color):
-    assert color is not None
-    color = np.asarray(color)
-    assert color.shape == (3,)
-    return color.clip(0., 1.)
-
-
 def isMesh(geometry_object):
     """ Check whether the geometry object contains a Mesh supported by MeshCat """
     if geometry_object.meshPath == "":
@@ -254,7 +247,6 @@ class MeshcatVisualizer(BaseVisualizer):
 
     def setBackgroundColor(self, preset_name: str = "gray"):
         """Set the background."""
-        assert preset_name in COLOR_PRESETS.keys()
         col_top, col_bot = COLOR_PRESETS[preset_name]
         self._node_background.set_property("top_color", col_top)
         self._node_background.set_property("bottom_color", col_bot)
@@ -267,7 +259,6 @@ class MeshcatVisualizer(BaseVisualizer):
 
     def setCameraPreset(self, preset_key: str):
         """Set the camera angle and position using a given preset."""
-        assert preset_key in self.CAMERA_PRESETS
         cam_val = self.CAMERA_PRESETS[preset_key]
         self.setCameraTarget(cam_val[0])
         self.setCameraPosition(cam_val[1])
@@ -276,7 +267,7 @@ class MeshcatVisualizer(BaseVisualizer):
         elt = self._node_default_cam[self._rot_cam_key]
         elt.set_property("zoom", zoom)
 
-    def setCameraPose(self, pose):
+    def setCameraPose(self, pose: np.ndarray = np.eye(4)):
         self._node_default_cam.set_transform(pose)
 
     def disableCameraControl(self):
@@ -527,8 +518,8 @@ class MeshcatVisualizer(BaseVisualizer):
     def _draw_vectors_from_frame(self, vecs: List[np.ndarray], frame_ids: List[int], vec_names: List[str], colors: List[int]):
         """Draw vectors extending from given frames."""
         import meshcat.geometry as mg
-        assert len(vecs) == len(frame_ids), "Different number of vectors and frame_ids"
-        assert len(vecs) == len(vec_names), "Different number of vectors and names"
+        if len(vecs) != len(frame_ids) or len(vecs) != len(vec_names):
+            return ValueError("Number of vectors and frames IDs or names is inconsistent.")
         for i, (fid, v) in enumerate(zip(frame_ids, vecs)):
             frame_pos = self.data.oMf[fid].translation
             vertices = np.array([frame_pos, frame_pos + v]).astype(np.float32).T

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -242,6 +242,7 @@ class MeshcatVisualizer(BaseVisualizer):
         self._node_default_cam = self.viewer["/Cameras/default"]
         self._node_background = self.viewer["/Background"]
         self._rot_cam_key = "rotated/object"
+        self.static_objects = []
 
         self._check_meshcat_has_get_image()
 
@@ -471,9 +472,16 @@ class MeshcatVisualizer(BaseVisualizer):
             # Update viewer configuration.
             self.viewer[visual_name].set_transform(T)
 
+        for visual in self.static_objects:
+            visual_name = self.getViewerNodeName(visual, pin.GeometryType.VISUAL)
+            M: pin.SE3 = visual.placement
+            T = M.homogeneous
+            self.viewer[visual_name].set_transform(T)
+
     def addGeometryObject(self, obj: pin.GeometryObject, color=None):
         """Add a visual GeometryObject to the viewer, with an optional color."""
         self.loadViewerGeometryObject(obj, pin.GeometryType.VISUAL, color)
+        self.static_objects.append(obj)
 
     def _check_meshcat_has_get_image(self):
         if not hasattr(self.viewer, "get_image"):

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -283,7 +283,7 @@ class MeshcatVisualizer(BaseVisualizer):
     def enableCameraControl(self):
         self.setCameraPosition([3, 0, 1])
 
-    def loadPrimitive(self, geometry_object):
+    def loadPrimitive(self, geometry_object: pin.GeometryObject):
 
         import meshcat.geometry as mg
 
@@ -469,6 +469,10 @@ class MeshcatVisualizer(BaseVisualizer):
 
             # Update viewer configuration.
             self.viewer[visual_name].set_transform(T)
+
+    def addGeometryObject(self, obj: pin.GeometryObject, color=None):
+        """Add a visual GeometryObject to the viewer, with an optional color."""
+        self.loadViewerGeometryObject(obj, pin.GeometryType.VISUAL, color)
 
     def _check_meshcat_has_get_image(self):
         if not hasattr(self.viewer, "get_image"):

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -7,7 +7,6 @@ import os
 import warnings
 import numpy as np
 from distutils.version import LooseVersion
-from typing import List
 
 try:
     import hppfcl
@@ -177,7 +176,7 @@ def loadMesh(mesh):
     return mesh
 
 
-def loadPrimitive(geometry_object: pin.GeometryObject):
+def loadPrimitive(geometry_object):
 
     import meshcat.geometry as mg
 
@@ -194,7 +193,7 @@ def loadPrimitive(geometry_object: pin.GeometryObject):
         "RotatedCylinder", (mg.Cylinder,), {"intrinsic_transform": lambda self: R}
     )
 
-    geom: hppfcl.ShapeBase = geometry_object.geometry
+    geom = geometry_object.geometry
     if isinstance(geom, hppfcl.Capsule):
         if hasattr(mg, "TriangularMeshGeometry"):
             obj = createCapsule(2.0 * geom.halfLength, geom.radius)
@@ -549,11 +548,11 @@ class MeshcatVisualizer(BaseVisualizer):
 
         for visual in self.static_objects:
             visual_name = self.getViewerNodeName(visual, pin.GeometryType.VISUAL)
-            M: pin.SE3 = visual.placement
+            M = visual.placement
             T = M.homogeneous
             self.viewer[visual_name].set_transform(T)
 
-    def addGeometryObject(self, obj: pin.GeometryObject, color=None):
+    def addGeometryObject(self, obj, color=None):
         """Add a visual GeometryObject to the viewer, with an optional color."""
         self.loadViewerGeometryObject(obj, pin.GeometryType.VISUAL, color)
         self.static_objects.append(obj)
@@ -594,23 +593,23 @@ class MeshcatVisualizer(BaseVisualizer):
             self.updatePlacements(pin.GeometryType.VISUAL)
 
     def drawFrameVelocities(
-        self, frame_id: int, v_scale=0.2, color=FRAME_VEL_COLOR
+        self, frame_id, v_scale=0.2, color=FRAME_VEL_COLOR
     ):  # pylint: disable=arguments-differ
         pin.updateFramePlacement(self.model, self.data, frame_id)
         vFr = pin.getFrameVelocity(
             self.model, self.data, frame_id, pin.LOCAL_WORLD_ALIGNED
         )
-        line_group_name = f"ee_vel/{frame_id}"
+        line_group_name = "ee_vel/{}".format(frame_id)
         self._draw_vectors_from_frame(
             [v_scale * vFr.linear], [frame_id], [line_group_name], [color]
         )
 
     def _draw_vectors_from_frame(
         self,
-        vecs: List[np.ndarray],
-        frame_ids: List[int],
-        vec_names: List[str],
-        colors: List[int],
+        vecs,
+        frame_ids,
+        vec_names,
+        colors,
     ):
         """Draw vectors extending from given frames."""
         import meshcat.geometry as mg

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -242,6 +242,8 @@ class MeshcatVisualizer(BaseVisualizer):
         self._node_background = self.viewer["/Background"]
         self._rot_cam_key = "rotated/object"
 
+        self._check_meshcat_has_get_image()
+
         if open:
             self.viewer.open()
 
@@ -468,15 +470,16 @@ class MeshcatVisualizer(BaseVisualizer):
             # Update viewer configuration.
             self.viewer[visual_name].set_transform(T)
 
-    def captureImage(self):
-        """Capture an image from the Meshcat viewer and return an RGB array."""
-        try:
-            img = self.viewer.get_image()
-            img_arr = np.asarray(img)
-            return img_arr
-        except AttributeError:
+    def _check_meshcat_has_get_image(self):
+        if not hasattr(self.viewer, "get_image"):
             warnings.warn("meshcat.Visualizer does not have the get_image() method."
                           " You need meshcat >= 0.2.0 to get this feature.")
+
+    def captureImage(self, w=None, h=None):
+        """Capture an image from the Meshcat viewer and return an RGB array."""
+        img = self.viewer.get_image(w, h)
+        img_arr = np.asarray(img)
+        return img_arr
 
     def displayCollisions(self,visibility):
         """Set whether to display collision objects or not."""

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -7,6 +7,7 @@ import os
 import warnings
 import numpy as np
 from distutils.version import LooseVersion
+from typing import List
 
 try:
     import hppfcl
@@ -514,7 +515,7 @@ class MeshcatVisualizer(BaseVisualizer):
         )
         self._draw_vectors_from_frame([v_scale * vFr.linear], [frame_id], [f"ee_v/{frame_id}"], [self.FRAME_VEL_COLOR])
  
-    def _draw_vectors_from_frame(self, vecs: list[np.ndarray], frame_ids: list[int], vec_names: list[str], colors: list[int]):
+    def _draw_vectors_from_frame(self, vecs: List[np.ndarray], frame_ids: List[int], vec_names: List[str], colors: List[int]):
         """Draw vectors extending from given frames."""
         import meshcat.geometry as mg
         assert len(vecs) == len(frame_ids), "Different number of vectors and frame_ids"

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -17,13 +17,13 @@ except ImportError:
 
 DEFAULT_COLOR_PROFILES = {
     "gray": ([0.98, 0.98, 0.98], [0.8, 0.8, 0.8]),
-    "white": (np.ones(3), )
+    "white": (np.ones(3),),
 }
 COLOR_PRESETS = DEFAULT_COLOR_PROFILES.copy()
 
 
 def isMesh(geometry_object):
-    """ Check whether the geometry object contains a Mesh supported by MeshCat """
+    """Check whether the geometry object contains a Mesh supported by MeshCat"""
     if geometry_object.meshPath == "":
         return False
 
@@ -33,105 +33,124 @@ def isMesh(geometry_object):
 
     return False
 
+
 def loadMesh(mesh):
     import meshcat.geometry as mg
 
-    if isinstance(mesh,hppfcl.HeightFieldOBBRSS):
+    if isinstance(mesh, hppfcl.HeightFieldOBBRSS):
         heights = mesh.getHeights()
         x_grid = mesh.getXGrid()
         y_grid = mesh.getYGrid()
         min_height = mesh.getMinHeight()
 
-        X, Y = np.meshgrid(x_grid,y_grid)
+        X, Y = np.meshgrid(x_grid, y_grid)
 
-        nx = len(x_grid)-1
-        ny = len(y_grid)-1
+        nx = len(x_grid) - 1
+        ny = len(y_grid) - 1
 
-        num_cells = (nx) * (ny) * 2 + (nx+ny)*4 + 2
+        num_cells = (nx) * (ny) * 2 + (nx + ny) * 4 + 2
 
         num_vertices = X.size
         num_tris = num_cells
 
-        faces = np.empty((num_tris,3),dtype=int)
-        vertices = np.vstack((np.stack((X.reshape(num_vertices),Y.reshape(num_vertices),heights.reshape(num_vertices)),axis=1),
-                              np.stack((X.reshape(num_vertices),Y.reshape(num_vertices),np.full(num_vertices,min_height)),axis=1)))
+        faces = np.empty((num_tris, 3), dtype=int)
+        vertices = np.vstack(
+            (
+                np.stack(
+                    (
+                        X.reshape(num_vertices),
+                        Y.reshape(num_vertices),
+                        heights.reshape(num_vertices),
+                    ),
+                    axis=1,
+                ),
+                np.stack(
+                    (
+                        X.reshape(num_vertices),
+                        Y.reshape(num_vertices),
+                        np.full(num_vertices, min_height),
+                    ),
+                    axis=1,
+                ),
+            )
+        )
 
         face_id = 0
         for y_id in range(ny):
             for x_id in range(nx):
-                p0 = x_id + y_id * (nx+1)
+                p0 = x_id + y_id * (nx + 1)
                 p1 = p0 + 1
                 p2 = p1 + nx + 1
                 p3 = p2 - 1
 
-                faces[face_id] = np.array([p0,p3,p1])
+                faces[face_id] = np.array([p0, p3, p1])
                 face_id += 1
-                faces[face_id] = np.array([p3,p2,p1])
+                faces[face_id] = np.array([p3, p2, p1])
                 face_id += 1
 
                 if y_id == 0:
                     p0_low = p0 + num_vertices
                     p1_low = p1 + num_vertices
 
-                    faces[face_id] = np.array([p0,p1_low,p0_low])
+                    faces[face_id] = np.array([p0, p1_low, p0_low])
                     face_id += 1
-                    faces[face_id] = np.array([p0,p1,p1_low])
+                    faces[face_id] = np.array([p0, p1, p1_low])
                     face_id += 1
 
-                if y_id == ny-1:
+                if y_id == ny - 1:
                     p2_low = p2 + num_vertices
                     p3_low = p3 + num_vertices
 
-                    faces[face_id] = np.array([p3,p3_low,p2_low])
+                    faces[face_id] = np.array([p3, p3_low, p2_low])
                     face_id += 1
-                    faces[face_id] = np.array([p3,p2_low,p2])
+                    faces[face_id] = np.array([p3, p2_low, p2])
                     face_id += 1
 
                 if x_id == 0:
                     p0_low = p0 + num_vertices
                     p3_low = p3 + num_vertices
 
-                    faces[face_id] = np.array([p0,p3_low,p3])
+                    faces[face_id] = np.array([p0, p3_low, p3])
                     face_id += 1
-                    faces[face_id] = np.array([p0,p0_low,p3_low])
+                    faces[face_id] = np.array([p0, p0_low, p3_low])
                     face_id += 1
 
-                if x_id == nx-1:
+                if x_id == nx - 1:
                     p1_low = p1 + num_vertices
                     p2_low = p2 + num_vertices
 
-                    faces[face_id] = np.array([p1,p2_low,p2])
+                    faces[face_id] = np.array([p1, p2_low, p2])
                     face_id += 1
-                    faces[face_id] = np.array([p1,p1_low,p2_low])
+                    faces[face_id] = np.array([p1, p1_low, p2_low])
                     face_id += 1
 
         # Last face
         p0 = num_vertices
         p1 = p0 + nx
-        p2 = 2*num_vertices-1
+        p2 = 2 * num_vertices - 1
         p3 = p2 - nx
 
-        faces[face_id] = np.array([p0,p1,p2])
+        faces[face_id] = np.array([p0, p1, p2])
         face_id += 1
-        faces[face_id] = np.array([p0,p2,p3])
+        faces[face_id] = np.array([p0, p2, p3])
         face_id += 1
 
-    elif isinstance(mesh,(hppfcl.Convex,hppfcl.BVHModelBase)):
-        if isinstance(mesh,hppfcl.BVHModelBase):
+    elif isinstance(mesh, (hppfcl.Convex, hppfcl.BVHModelBase)):
+        if isinstance(mesh, hppfcl.BVHModelBase):
             num_vertices = mesh.num_vertices
             num_tris = mesh.num_tris
 
             call_triangles = mesh.tri_indices
             call_vertices = mesh.vertices
 
-        elif isinstance(mesh,hppfcl.Convex):
+        elif isinstance(mesh, hppfcl.Convex):
             num_vertices = mesh.num_points
             num_tris = mesh.num_polygons
 
             call_triangles = mesh.polygons
             call_vertices = mesh.points
 
-        faces = np.empty((num_tris,3),dtype=int)
+        faces = np.empty((num_tris, 3), dtype=int)
         for k in range(num_tris):
             tri = call_triangles(k)
             faces[k] = [tri[i] for i in range(3)]
@@ -139,7 +158,7 @@ def loadMesh(mesh):
         if LooseVersion(hppfcl.__version__) >= LooseVersion("1.7.7"):
             vertices = call_vertices()
         else:
-            vertices = np.empty((num_vertices,3))
+            vertices = np.empty((num_vertices, 3))
             for k in range(num_vertices):
                 vertices[k] = call_vertices(k)
 
@@ -149,27 +168,83 @@ def loadMesh(mesh):
         mesh = mg.TriangularMeshGeometry(vertices, faces)
     else:
         mesh = mg.Points(
-                    mg.PointsGeometry(vertices.T, color=np.repeat(np.ones((3,1)),num_vertices,axis=1)),
-                    mg.PointsMaterial(size=0.002))
+            mg.PointsGeometry(
+                vertices.T, color=np.repeat(np.ones((3, 1)), num_vertices, axis=1)
+            ),
+            mg.PointsMaterial(size=0.002),
+        )
 
     return mesh
 
-def createCapsule(length, radius, radial_resolution = 30, cap_resolution = 10):
+
+def loadPrimitive(geometry_object: pin.GeometryObject):
+
+    import meshcat.geometry as mg
+
+    # Cylinders need to be rotated
+    R = np.array(
+        [
+            [1.0, 0.0, 0.0, 0.0],
+            [0.0, 0.0, -1.0, 0.0],
+            [0.0, 1.0, 0.0, 0.0],
+            [0.0, 0.0, 0.0, 1.0],
+        ]
+    )
+    RotatedCylinder = type(
+        "RotatedCylinder", (mg.Cylinder,), {"intrinsic_transform": lambda self: R}
+    )
+
+    geom: hppfcl.ShapeBase = geometry_object.geometry
+    if isinstance(geom, hppfcl.Capsule):
+        if hasattr(mg, "TriangularMeshGeometry"):
+            obj = createCapsule(2.0 * geom.halfLength, geom.radius)
+        else:
+            obj = RotatedCylinder(2.0 * geom.halfLength, geom.radius)
+    elif isinstance(geom, hppfcl.Cylinder):
+        obj = RotatedCylinder(2.0 * geom.halfLength, geom.radius)
+    elif isinstance(geom, hppfcl.Cone):
+        obj = RotatedCylinder(2.0 * geom.halfLength, 0, geom.radius, 0)
+    elif isinstance(geom, hppfcl.Box):
+        obj = mg.Box(npToTuple(2.0 * geom.halfSide))
+    elif isinstance(geom, hppfcl.Sphere):
+        obj = mg.Sphere(geom.radius)
+    elif isinstance(geom, hppfcl.ConvexBase):
+        obj = loadMesh(geom)
+    else:
+        msg = "Unsupported geometry type for %s (%s)" % (
+            geometry_object.name,
+            type(geom),
+        )
+        warnings.warn(msg, category=UserWarning, stacklevel=2)
+        obj = None
+
+    return obj
+
+
+def createCapsule(length, radius, radial_resolution=30, cap_resolution=10):
     nbv = np.array([max(radial_resolution, 4), max(cap_resolution, 4)])
     h = length
     r = radius
     position = 0
     vertices = np.zeros((nbv[0] * (2 * nbv[1]) + 2, 3))
     for j in range(nbv[0]):
-        phi = (( 2 * np.pi * j) / nbv[0])
+        phi = (2 * np.pi * j) / nbv[0]
         for i in range(nbv[1]):
-            theta = ((np.pi / 2 * i) / nbv[1])
-            vertices[position + i, :] = np.array([np.cos(theta) * np.cos(phi) * r,
-                                               np.cos(theta) * np.sin(phi) * r,
-                                               -h / 2 - np.sin(theta) * r])
-            vertices[position + i + nbv[1], :] = np.array([np.cos(theta) * np.cos(phi) * r,
-                                                        np.cos(theta) * np.sin(phi) * r,
-                                                        h / 2 + np.sin(theta) * r])
+            theta = (np.pi / 2 * i) / nbv[1]
+            vertices[position + i, :] = np.array(
+                [
+                    np.cos(theta) * np.cos(phi) * r,
+                    np.cos(theta) * np.sin(phi) * r,
+                    -h / 2 - np.sin(theta) * r,
+                ]
+            )
+            vertices[position + i + nbv[1], :] = np.array(
+                [
+                    np.cos(theta) * np.cos(phi) * r,
+                    np.cos(theta) * np.sin(phi) * r,
+                    h / 2 + np.sin(theta) * r,
+                ]
+            )
         position += nbv[1] * 2
     vertices[-2, :] = np.array([0, 0, -h / 2 - r])
     vertices[-1, :] = np.array([0, 0, h / 2 + r])
@@ -179,18 +254,44 @@ def createCapsule(length, radius, radial_resolution = 30, cap_resolution = 10):
     last = nbv[0] * (2 * nbv[1]) + 1
     for j in range(nbv[0]):
         j_next = (j + 1) % nbv[0]
-        indexes[index + 0] = np.array([j_next * stride + nbv[1], j_next * stride, j * stride])
-        indexes[index + 1] = np.array([j * stride + nbv[1], j_next * stride + nbv[1], j * stride])
-        indexes[index + 2] = np.array([j * stride + nbv[1] - 1, j_next * stride + nbv[1] - 1, last - 1])
-        indexes[index + 3] = np.array([j_next * stride + 2 * nbv[1] - 1, j * stride + 2 * nbv[1] - 1, last])
-        for i in range(nbv[1]-1):
-            indexes[index + 4 + i * 4 + 0] = np.array([j_next * stride + i, j_next * stride + i + 1, j * stride + i])
-            indexes[index + 4 + i * 4 + 1] = np.array([j_next * stride + i + 1, j * stride + i + 1, j * stride + i])
-            indexes[index + 4 + i * 4 + 2] = np.array([j_next * stride + nbv[1] + i + 1, j_next * stride + nbv[1] + i, j * stride + nbv[1] + i])
-            indexes[index + 4 + i * 4 + 3] = np.array([j_next * stride + nbv[1] + i + 1, j * stride + nbv[1] + i, j * stride + nbv[1] + i + 1])
+        indexes[index + 0] = np.array(
+            [j_next * stride + nbv[1], j_next * stride, j * stride]
+        )
+        indexes[index + 1] = np.array(
+            [j * stride + nbv[1], j_next * stride + nbv[1], j * stride]
+        )
+        indexes[index + 2] = np.array(
+            [j * stride + nbv[1] - 1, j_next * stride + nbv[1] - 1, last - 1]
+        )
+        indexes[index + 3] = np.array(
+            [j_next * stride + 2 * nbv[1] - 1, j * stride + 2 * nbv[1] - 1, last]
+        )
+        for i in range(nbv[1] - 1):
+            indexes[index + 4 + i * 4 + 0] = np.array(
+                [j_next * stride + i, j_next * stride + i + 1, j * stride + i]
+            )
+            indexes[index + 4 + i * 4 + 1] = np.array(
+                [j_next * stride + i + 1, j * stride + i + 1, j * stride + i]
+            )
+            indexes[index + 4 + i * 4 + 2] = np.array(
+                [
+                    j_next * stride + nbv[1] + i + 1,
+                    j_next * stride + nbv[1] + i,
+                    j * stride + nbv[1] + i,
+                ]
+            )
+            indexes[index + 4 + i * 4 + 3] = np.array(
+                [
+                    j_next * stride + nbv[1] + i + 1,
+                    j * stride + nbv[1] + i,
+                    j * stride + nbv[1] + i + 1,
+                ]
+            )
         index += 4 * (nbv[1] - 1) + 4
     import meshcat.geometry
+
     return meshcat.geometry.TriangularMeshGeometry(vertices, indexes)
+
 
 class MeshcatVisualizer(BaseVisualizer):
     """A Pinocchio display using Meshcat"""
@@ -214,13 +315,12 @@ class MeshcatVisualizer(BaseVisualizer):
         "talos2": [[0.0, 1.1, 0.0], [1.2, 0.6, 1.5]],
     }
 
-
     def getViewerNodeName(self, geometry_object, geometry_type):
         """Return the name of the geometry object inside the viewer."""
         if geometry_type is pin.GeometryType.VISUAL:
-            return self.viewerVisualGroupName + '/' + geometry_object.name
+            return self.viewerVisualGroupName + "/" + geometry_object.name
         elif geometry_type is pin.GeometryType.COLLISION:
-            return self.viewerCollisionGroupName + '/' + geometry_object.name
+            return self.viewerCollisionGroupName + "/" + geometry_object.name
 
     def initViewer(self, viewer=None, open=False, loadModel=False):
         """Start a new MeshCat server and client.
@@ -245,7 +345,9 @@ class MeshcatVisualizer(BaseVisualizer):
         if loadModel:
             self.loadViewerModel()
 
-    def setBackgroundColor(self, preset_name: str = "gray"):
+    def setBackgroundColor(
+        self, preset_name: str = "gray"
+    ):  # pylint: disable=arguments-differ
         """Set the background."""
         col_top, col_bot = COLOR_PRESETS[preset_name]
         self._node_background.set_property("top_color", col_top)
@@ -275,40 +377,6 @@ class MeshcatVisualizer(BaseVisualizer):
 
     def enableCameraControl(self):
         self.setCameraPosition([3, 0, 1])
-
-    def loadPrimitive(self, geometry_object: pin.GeometryObject):
-
-        import meshcat.geometry as mg
-
-        # Cylinders need to be rotated
-        R = np.array([[1.,  0.,  0.,  0.],
-                      [0.,  0., -1.,  0.],
-                      [0.,  1.,  0.,  0.],
-                      [0.,  0.,  0.,  1.]])
-        RotatedCylinder = type("RotatedCylinder", (mg.Cylinder,), {"intrinsic_transform": lambda self: R })
-
-        geom: hppfcl.ShapeBase = geometry_object.geometry
-        if isinstance(geom, hppfcl.Capsule):
-            if hasattr(mg, 'TriangularMeshGeometry'):
-                obj = createCapsule(2. * geom.halfLength, geom.radius)
-            else:
-                obj = RotatedCylinder(2. * geom.halfLength, geom.radius)
-        elif isinstance(geom, hppfcl.Cylinder):
-            obj = RotatedCylinder(2. * geom.halfLength, geom.radius)
-        elif isinstance(geom, hppfcl.Cone):
-            obj = RotatedCylinder(2. * geom.halfLength, 0, geom.radius, 0)
-        elif isinstance(geom, hppfcl.Box):
-            obj = mg.Box(npToTuple(2. * geom.halfSide))
-        elif isinstance(geom, hppfcl.Sphere):
-            obj = mg.Sphere(geom.radius)
-        elif isinstance(geom, hppfcl.ConvexBase):
-            obj = loadMesh(geom)
-        else:
-            msg = "Unsupported geometry type for %s (%s)" % (geometry_object.name, type(geom) )
-            warnings.warn(msg, category=UserWarning, stacklevel=2)
-            obj = None
-
-        return obj
 
     def loadMesh(self, geometry_object):
 
@@ -343,21 +411,33 @@ class MeshcatVisualizer(BaseVisualizer):
 
         is_mesh = False
         try:
-            if WITH_HPP_FCL_BINDINGS and isinstance(geometry_object.geometry, hppfcl.ShapeBase):
-                obj = self.loadPrimitive(geometry_object)
+            if WITH_HPP_FCL_BINDINGS and isinstance(
+                geometry_object.geometry, hppfcl.ShapeBase
+            ):
+                obj = loadPrimitive(geometry_object)
             elif isMesh(geometry_object):
                 obj = self.loadMesh(geometry_object)
                 is_mesh = True
-            elif WITH_HPP_FCL_BINDINGS and isinstance(geometry_object.geometry, (hppfcl.BVHModelBase,hppfcl.HeightFieldOBBRSS)):
+            elif WITH_HPP_FCL_BINDINGS and isinstance(
+                geometry_object.geometry,
+                (hppfcl.BVHModelBase, hppfcl.HeightFieldOBBRSS),
+            ):
                 obj = loadMesh(geometry_object.geometry)
             else:
-                msg = "The geometry object named " + geometry_object.name + " is not supported by Pinocchio/MeshCat for vizualization."
+                msg = (
+                    "The geometry object named "
+                    + geometry_object.name
+                    + " is not supported by Pinocchio/MeshCat for vizualization."
+                )
                 warnings.warn(msg, category=UserWarning, stacklevel=2)
                 return
             if obj is None:
                 return
         except Exception as e:
-            msg = "Error while loading geometry object: %s\nError message:\n%s" % (geometry_object.name, e)
+            msg = "Error while loading geometry object: %s\nError message:\n%s" % (
+                geometry_object.name,
+                e,
+            )
             warnings.warn(msg, category=UserWarning, stacklevel=2)
             return
 
@@ -370,18 +450,22 @@ class MeshcatVisualizer(BaseVisualizer):
                 meshColor = geometry_object.meshColor
             else:
                 meshColor = color
-            material.color = int(meshColor[0] * 255) * 256**2 + int(meshColor[1] * 255) * 256 + int(meshColor[2] * 255)
+            material.color = (
+                int(meshColor[0] * 255) * 256**2
+                + int(meshColor[1] * 255) * 256
+                + int(meshColor[2] * 255)
+            )
             # Add transparency, if needed.
             if float(meshColor[3]) != 1.0:
                 material.transparent = True
                 material.opacity = float(meshColor[3])
             self.viewer[viewer_name].set_object(obj, material)
 
-        if is_mesh: # Apply the scaling
+        if is_mesh:  # Apply the scaling
             scale = list(np.asarray(geometry_object.meshScale).flatten())
-            self.viewer[viewer_name].set_property("scale",scale)
+            self.viewer[viewer_name].set_property("scale", scale)
 
-    def loadViewerModel(self, rootNodeName="pinocchio", color = None):
+    def loadViewerModel(self, rootNodeName="pinocchio", color=None):
         """Load the robot in a MeshCat viewer.
         Parameters:
             rootNodeName: name to give to the robot in the viewer
@@ -396,18 +480,18 @@ class MeshcatVisualizer(BaseVisualizer):
         self.viewerCollisionGroupName = self.viewerRootNodeName + "/" + "collisions"
 
         for collision in self.collision_model.geometryObjects:
-            self.loadViewerGeometryObject(collision,pin.GeometryType.COLLISION,color)
+            self.loadViewerGeometryObject(collision, pin.GeometryType.COLLISION, color)
         self.displayCollisions(False)
 
         # Visuals
         self.viewerVisualGroupName = self.viewerRootNodeName + "/" + "visuals"
 
         for visual in self.visual_model.geometryObjects:
-            self.loadViewerGeometryObject(visual,pin.GeometryType.VISUAL,color)
+            self.loadViewerGeometryObject(visual, pin.GeometryType.VISUAL, color)
         self.displayVisuals(True)
 
-    def reload(self, new_geometry_object, geometry_type = None):
-        """ Reload a geometry_object given by its name and its type"""
+    def reload(self, new_geometry_object, geometry_type=None):
+        """Reload a geometry_object given by its name and its type"""
         if geometry_type == pin.GeometryType.VISUAL:
             geom_model = self.visual_model
         else:
@@ -419,7 +503,7 @@ class MeshcatVisualizer(BaseVisualizer):
 
         self.delete(new_geometry_object, geometry_type)
         visual = geom_model.geometryObjects[geom_id]
-        self.loadViewerGeometryObject(visual,geometry_type)
+        self.loadViewerGeometryObject(visual, geometry_type)
 
     def clean(self):
         self.viewer.delete()
@@ -428,10 +512,10 @@ class MeshcatVisualizer(BaseVisualizer):
         viewer_name = self.getViewerNodeName(geometry_object, geometry_type)
         self.viewer[viewer_name].delete()
 
-    def display(self, q = None):
+    def display(self, q=None):
         """Display the robot at configuration q in the viewer by placing all the bodies."""
         if q is not None:
-            pin.forwardKinematics(self.model,self.data,q)
+            pin.forwardKinematics(self.model, self.data, q)
 
         if self.display_collisions:
             self.updatePlacements(pin.GeometryType.COLLISION)
@@ -449,13 +533,13 @@ class MeshcatVisualizer(BaseVisualizer):
 
         pin.updateGeometryPlacements(self.model, self.data, geom_model, geom_data)
         for visual in geom_model.geometryObjects:
-            visual_name = self.getViewerNodeName(visual,geometry_type)
+            visual_name = self.getViewerNodeName(visual, geometry_type)
             # Get mesh pose.
             M = geom_data.oMg[geom_model.getGeometryId(visual.name)]
             # Manage scaling: force scaling even if this should be normally handled by MeshCat (but there is a bug here)
             if isMesh(visual):
                 scale = np.asarray(visual.meshScale).flatten()
-                S = np.diag(np.concatenate((scale,[1.0])))
+                S = np.diag(np.concatenate((scale, [1.0])))
                 T = np.array(M.homogeneous).dot(S)
             else:
                 T = M.homogeneous
@@ -476,8 +560,10 @@ class MeshcatVisualizer(BaseVisualizer):
 
     def _check_meshcat_has_get_image(self):
         if not hasattr(self.viewer, "get_image"):
-            warnings.warn("meshcat.Visualizer does not have the get_image() method."
-                          " You need meshcat >= 0.2.0 to get this feature.")
+            warnings.warn(
+                "meshcat.Visualizer does not have the get_image() method."
+                " You need meshcat >= 0.2.0 to get this feature."
+            )
 
     def captureImage(self, w=None, h=None):
         """Capture an image from the Meshcat viewer and return an RGB array."""
@@ -485,7 +571,7 @@ class MeshcatVisualizer(BaseVisualizer):
         img_arr = np.asarray(img)
         return img_arr
 
-    def displayCollisions(self,visibility):
+    def displayCollisions(self, visibility):
         """Set whether to display collision objects or not."""
         if self.collision_model is None:
             self.display_collisions = False
@@ -496,7 +582,7 @@ class MeshcatVisualizer(BaseVisualizer):
         if visibility:
             self.updatePlacements(pin.GeometryType.COLLISION)
 
-    def displayVisuals(self,visibility):
+    def displayVisuals(self, visibility):
         """Set whether to display visual objects or not."""
         if self.visual_model is None:
             self.display_visuals = False
@@ -507,27 +593,42 @@ class MeshcatVisualizer(BaseVisualizer):
         if visibility:
             self.updatePlacements(pin.GeometryType.VISUAL)
 
-    def drawFrameVelocities(self, frame_id: int, v_scale=0.2, color=FRAME_VEL_COLOR):
+    def drawFrameVelocities(
+        self, frame_id: int, v_scale=0.2, color=FRAME_VEL_COLOR
+    ):  # pylint: disable=arguments-differ
         pin.updateFramePlacement(self.model, self.data, frame_id)
         vFr = pin.getFrameVelocity(
             self.model, self.data, frame_id, pin.LOCAL_WORLD_ALIGNED
         )
         line_group_name = f"ee_vel/{frame_id}"
-        self._draw_vectors_from_frame([v_scale * vFr.linear], [frame_id], [line_group_name], [color])
- 
-    def _draw_vectors_from_frame(self, vecs: List[np.ndarray], frame_ids: List[int], vec_names: List[str], colors: List[int]):
+        self._draw_vectors_from_frame(
+            [v_scale * vFr.linear], [frame_id], [line_group_name], [color]
+        )
+
+    def _draw_vectors_from_frame(
+        self,
+        vecs: List[np.ndarray],
+        frame_ids: List[int],
+        vec_names: List[str],
+        colors: List[int],
+    ):
         """Draw vectors extending from given frames."""
         import meshcat.geometry as mg
+
         if len(vecs) != len(frame_ids) or len(vecs) != len(vec_names):
-            return ValueError("Number of vectors and frames IDs or names is inconsistent.")
+            return ValueError(
+                "Number of vectors and frames IDs or names is inconsistent."
+            )
         for i, (fid, v) in enumerate(zip(frame_ids, vecs)):
             frame_pos = self.data.oMf[fid].translation
             vertices = np.array([frame_pos, frame_pos + v]).astype(np.float32).T
             name = vec_names[i]
             geometry = mg.PointsGeometry(position=vertices)
-            geom_object = mg.LineSegments(geometry, mg.LineBasicMaterial(color=colors[i]))
-            prefix = self.viewerVisualGroupName + '/lines/' + name
+            geom_object = mg.LineSegments(
+                geometry, mg.LineBasicMaterial(color=colors[i])
+            )
+            prefix = self.viewerVisualGroupName + "/lines/" + name
             self.viewer[prefix].set_object(geom_object)
-            
 
-__all__ = ['MeshcatVisualizer']
+
+__all__ = ["MeshcatVisualizer"]

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -346,30 +346,30 @@ class MeshcatVisualizer(BaseVisualizer):
             self.loadViewerModel()
 
     def setBackgroundColor(
-        self, preset_name: str = "gray"
+        self, preset_name="gray"
     ):  # pylint: disable=arguments-differ
         """Set the background."""
         col_top, col_bot = COLOR_PRESETS[preset_name]
         self._node_background.set_property("top_color", col_top)
         self._node_background.set_property("bottom_color", col_bot)
 
-    def setCameraTarget(self, target: np.ndarray):
+    def setCameraTarget(self, target):
         self.viewer.set_cam_target(target)
 
-    def setCameraPosition(self, position: np.ndarray):
+    def setCameraPosition(self, position):
         self.viewer.set_cam_pos(position)
 
-    def setCameraPreset(self, preset_key: str):
+    def setCameraPreset(self, preset_key):
         """Set the camera angle and position using a given preset."""
         cam_val = self.CAMERA_PRESETS[preset_key]
         self.setCameraTarget(cam_val[0])
         self.setCameraPosition(cam_val[1])
 
-    def setCameraZoom(self, zoom: float):
+    def setCameraZoom(self, zoom):
         elt = self._node_default_cam[self._rot_cam_key]
         elt.set_property("zoom", zoom)
 
-    def setCameraPose(self, pose: np.ndarray = np.eye(4)):
+    def setCameraPose(self, pose=np.eye(4)):
         self._node_default_cam.set_transform(pose)
 
     def disableCameraControl(self):

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -508,12 +508,13 @@ class MeshcatVisualizer(BaseVisualizer):
         if visibility:
             self.updatePlacements(pin.GeometryType.VISUAL)
 
-    def drawFrameVelocities(self, frame_id: int, v_scale=0.2):
+    def drawFrameVelocities(self, frame_id: int, v_scale=0.2, color=FRAME_VEL_COLOR):
         pin.updateFramePlacement(self.model, self.data, frame_id)
         vFr = pin.getFrameVelocity(
             self.model, self.data, frame_id, pin.LOCAL_WORLD_ALIGNED
         )
-        self._draw_vectors_from_frame([v_scale * vFr.linear], [frame_id], [f"ee_v/{frame_id}"], [self.FRAME_VEL_COLOR])
+        line_group_name = f"ee_vel/{frame_id}"
+        self._draw_vectors_from_frame([v_scale * vFr.linear], [frame_id], [line_group_name], [color])
  
     def _draw_vectors_from_frame(self, vecs: List[np.ndarray], frame_ids: List[int], vec_names: List[str], colors: List[int]):
         """Draw vectors extending from given frames."""
@@ -526,7 +527,7 @@ class MeshcatVisualizer(BaseVisualizer):
             name = vec_names[i]
             geometry = mg.PointsGeometry(position=vertices)
             geom_object = mg.LineSegments(geometry, mg.LineBasicMaterial(color=colors[i]))
-            prefix = f"lines/{name!r}"
+            prefix = self.viewerVisualGroupName + '/lines/' + name
             self.viewer[prefix].set_object(geom_object)
             
 

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -566,7 +566,11 @@ class MeshcatVisualizer(BaseVisualizer):
 
     def captureImage(self, w=None, h=None):
         """Capture an image from the Meshcat viewer and return an RGB array."""
-        img = self.viewer.get_image(w, h)
+        if w is not None or h is not None:
+            # pass arguments when either is not None
+            img = self.viewer.get_image(w, h)
+        else:
+            img = self.viewer.get_image()
         img_arr = np.asarray(img)
         return img_arr
 

--- a/examples/meshcat-viewer.py
+++ b/examples/meshcat-viewer.py
@@ -104,6 +104,6 @@ fid2 = model.getFrameId("FL_FOOT")
 def my_callback(i, *args):
     viz.drawFrameVelocities(frame_id)
     viz.drawFrameVelocities(fid2)
-    
+
 with viz.create_video_ctx("../leap.mp4"):
     viz.play(qs, dt, callback=my_callback)

--- a/examples/meshcat-viewer.py
+++ b/examples/meshcat-viewer.py
@@ -78,12 +78,12 @@ viz.display()
 viz.drawFrameVelocities(frame_id=frame_id)
 
 model.gravity.linear[:] = 0.
+dt = 0.01
 
 def sim_loop():
-    dt = 0.01
+    tau0 = np.zeros(model.nv)
     qs = [q1]
     vs = [v0]
-    tau0 = np.zeros(model.nv)
     nsteps = 100
     for i in range(nsteps):
         q = qs[i]
@@ -95,5 +95,15 @@ def sim_loop():
         vs.append(vnext)
         viz.display(qnext)
         viz.drawFrameVelocities(frame_id=frame_id)
+    return qs, vs
 
-sim_loop()
+qs, vs = sim_loop()
+
+fid2 = model.getFrameId("FL_FOOT")
+
+def my_callback(i, *args):
+    viz.drawFrameVelocities(frame_id)
+    viz.drawFrameVelocities(fid2)
+    
+with viz.create_video_ctx("../leap.mp4"):
+    viz.play(qs, dt, callback=my_callback)

--- a/examples/meshcat-viewer.py
+++ b/examples/meshcat-viewer.py
@@ -12,16 +12,18 @@ from pinocchio.visualize import MeshcatVisualizer
 
 # Load the URDF model.
 # Conversion with str seems to be necessary when executing this file with ipython
-pinocchio_model_dir = join(dirname(dirname(str(abspath(__file__)))),"models")
+pinocchio_model_dir = join(dirname(dirname(str(abspath(__file__)))), "models")
 
-model_path = join(pinocchio_model_dir,"example-robot-data/robots")
+model_path = join(pinocchio_model_dir, "example-robot-data/robots")
 mesh_dir = pinocchio_model_dir
 # urdf_filename = "talos_reduced.urdf"
 # urdf_model_path = join(join(model_path,"talos_data/robots"),urdf_filename)
 urdf_filename = "solo.urdf"
-urdf_model_path = join(join(model_path,"solo_description/robots"),urdf_filename)
+urdf_model_path = join(join(model_path, "solo_description/robots"), urdf_filename)
 
-model, collision_model, visual_model = pin.buildModelsFromUrdf(urdf_model_path, mesh_dir, pin.JointModelFreeFlyer())
+model, collision_model, visual_model = pin.buildModelsFromUrdf(
+    urdf_model_path, mesh_dir, pin.JointModelFreeFlyer()
+)
 
 viz = MeshcatVisualizer(model, collision_model, visual_model)
 
@@ -34,7 +36,9 @@ viz = MeshcatVisualizer(model, collision_model, visual_model)
 try:
     viz.initViewer(open=True)
 except ImportError as err:
-    print("Error while initializing the viewer. It seems you should install Python meshcat")
+    print(
+        "Error while initializing the viewer. It seems you should install Python meshcat"
+    )
     print(err)
     sys.exit(0)
 
@@ -53,22 +57,23 @@ convex = mesh.convex
 
 if convex is not None:
     placement = pin.SE3.Identity()
-    placement.translation[0] = 2.
-    geometry = pin.GeometryObject("convex",0,convex,placement)
+    placement.translation[0] = 2.0
+    geometry = pin.GeometryObject("convex", 0, convex, placement)
     geometry.meshColor = np.ones((4))
     visual_model.addGeometryObject(geometry)
 
 # Display another robot.
 viz2 = MeshcatVisualizer(model, collision_model, visual_model)
 viz2.initViewer(viz.viewer)
-viz2.loadViewerModel(rootNodeName = "pinocchio2")
+viz2.loadViewerModel(rootNodeName="pinocchio2")
 q = q0.copy()
 q[1] = 1.0
 viz2.display(q)
 
 # standing config
-q1 = np.array([ 0.   ,  0.   ,  0.235,  0.   ,  0.   ,  0.   ,  1.   ,  0.8  ,
-       -1.6  ,  0.8  , -1.6  , -0.8  ,  1.6  , -0.8  ,  1.6  ])
+q1 = np.array(
+    [0.0, 0.0, 0.235, 0.0, 0.0, 0.0, 1.0, 0.8, -1.6, 0.8, -1.6, -0.8, 1.6, -0.8, 1.6]
+)
 
 v0 = np.random.randn(model.nv) * 2
 data = viz.data
@@ -77,8 +82,9 @@ frame_id = model.getFrameId("HR_FOOT")
 viz.display()
 viz.drawFrameVelocities(frame_id=frame_id)
 
-model.gravity.linear[:] = 0.
+model.gravity.linear[:] = 0.0
 dt = 0.01
+
 
 def sim_loop():
     tau0 = np.zeros(model.nv)
@@ -97,13 +103,16 @@ def sim_loop():
         viz.drawFrameVelocities(frame_id=frame_id)
     return qs, vs
 
+
 qs, vs = sim_loop()
 
 fid2 = model.getFrameId("FL_FOOT")
 
+
 def my_callback(i, *args):
     viz.drawFrameVelocities(frame_id)
     viz.drawFrameVelocities(fid2)
+
 
 with viz.create_video_ctx("../leap.mp4"):
     viz.play(qs, dt, callback=my_callback)

--- a/examples/meshcat-viewer.py
+++ b/examples/meshcat-viewer.py
@@ -16,8 +16,10 @@ pinocchio_model_dir = join(dirname(dirname(str(abspath(__file__)))),"models")
 
 model_path = join(pinocchio_model_dir,"example-robot-data/robots")
 mesh_dir = pinocchio_model_dir
-urdf_filename = "talos_reduced.urdf"
-urdf_model_path = join(join(model_path,"talos_data/robots"),urdf_filename)
+# urdf_filename = "talos_reduced.urdf"
+# urdf_model_path = join(join(model_path,"talos_data/robots"),urdf_filename)
+urdf_filename = "solo.urdf"
+urdf_model_path = join(join(model_path,"solo_description/robots"),urdf_filename)
 
 model, collision_model, visual_model = pin.buildModelsFromUrdf(urdf_model_path, mesh_dir, pin.JointModelFreeFlyer())
 
@@ -64,3 +66,34 @@ q = q0.copy()
 q[1] = 1.0
 viz2.display(q)
 
+# standing config
+q1 = np.array([ 0.   ,  0.   ,  0.235,  0.   ,  0.   ,  0.   ,  1.   ,  0.8  ,
+       -1.6  ,  0.8  , -1.6  , -0.8  ,  1.6  , -0.8  ,  1.6  ])
+
+v0 = np.random.randn(model.nv) * 2
+data = viz.data
+pin.forwardKinematics(model, data, q1, v0)
+frame_id = model.getFrameId("HR_FOOT")
+viz.display()
+viz.drawFrameVelocities(frame_id=frame_id)
+
+model.gravity.linear[:] = 0.
+
+def sim_loop():
+    dt = 0.01
+    qs = [q1]
+    vs = [v0]
+    tau0 = np.zeros(model.nv)
+    nsteps = 100
+    for i in range(nsteps):
+        q = qs[i]
+        v = vs[i]
+        a1 = pin.aba(model, data, q, v, tau0)
+        vnext = v + dt * a1
+        qnext = pin.integrate(model, q, dt * vnext)
+        qs.append(qnext)
+        vs.append(vnext)
+        viz.display(qnext)
+        viz.drawFrameVelocities(frame_id=frame_id)
+
+sim_loop()


### PR DESCRIPTION
This PR adds new features to the Python visualization API, and implements them for MeshcatVisualizer

+ add visualizer methods for setting the camera target, position,
  environment background color
+ base class raises NotImplementedError when there is no implementation

- [x] set background color
- [x] video recording
- [x] captureImage : allow specifying output image dimensions (for meshcat, requires rdeits/meshcat-python#109)
- [x] enable/disable user camera control
- [x] set camera zoom
- [x] draw frame velocities
- [x] set camera targets
- [x] meshcat: can add objects of type `pin.GeometryObject` outside of the Pinocchio visual model, on-the-fly
- [x] adds an example showcasing a pose of Solo-12 onto a `hppfcl.HeightField`

*Note* This PR is a backport from changes added to Pinocchio 3.