### PR TITLE
Enabled copy and deepcopy

### DIFF
--- a/.github/workflows/macos-linux-conda.yml
+++ b/.github/workflows/macos-linux-conda.yml
@@ -8,6 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     env:
       CCACHE_DIR: ${{ matrix.CCACHE_DIR }}
+      BUILD_ADVANCED_TESTING: ${{ matrix.BUILD_ADVANCED_TESTING }}
 
     strategy:
       fail-fast: false
@@ -18,8 +19,10 @@ jobs:
         include:
           - os: ubuntu-latest
             CCACHE_DIR: /home/runner/.ccache
+            BUILD_ADVANCED_TESTING: OFF
           - os: macos-latest
             CCACHE_DIR: /Users/runner/.ccache
+            BUILD_ADVANCED_TESTING: ON
 
     steps:
     - uses: actions/checkout@v3
@@ -54,7 +57,7 @@ jobs:
         mkdir build
         cd build
 
-        cmake .. -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_WITH_COLLISION_SUPPORT=ON -DBUILD_ADVANCED_TESTING=ON -DBUILD_WITH_CASADI_SUPPORT=OFF -DPYTHON_EXECUTABLE=$(which python3) -DBUILD_WITH_OPENMP_SUPPORT=ON -DINSTALL_DOCUMENTATION=ON -DOpenMP_ROOT=$CONDA_PREFIX
+        cmake .. -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} -DBUILD_WITH_COLLISION_SUPPORT=ON -DBUILD_ADVANCED_TESTING=${{ env.BUILD_ADVANCED_TESTING }}  -DBUILD_WITH_CASADI_SUPPORT=OFF -DPYTHON_EXECUTABLE=$(which python3) -DBUILD_WITH_OPENMP_SUPPORT=ON -DINSTALL_DOCUMENTATION=ON -DOpenMP_ROOT=$CONDA_PREFIX
         make
         make build_tests
         CTEST_OUTPUT_ON_FAILURE=1 make test

--- a/bindings/python/utils/copyable.hpp
+++ b/bindings/python/utils/copyable.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016-2021 CNRS INRIA
+// Copyright (c) 2016-2023 CNRS INRIA, Heriot-Watt University
 //
 
 #ifndef __pinocchio_python_utils_copyable_hpp__
@@ -13,7 +13,42 @@ namespace pinocchio
   {
     
     namespace bp = boost::python;
-    
+
+    template <class T>
+    inline PyObject* managingPyObject(T* p)
+    {
+      return typename bp::manage_new_object::apply<T*>::type()(p);
+    }
+
+    template <class Copyable>
+    bp::object generic__copy__(bp::object copyable)
+    {
+      Copyable* newCopyable(new Copyable(bp::extract<const Copyable&>(copyable)));
+      bp::object result(bp::detail::new_reference(managingPyObject(newCopyable)));
+
+      bp::extract<bp::dict>(result.attr("__dict__"))().update(copyable.attr("__dict__"));
+
+      return result;
+    }
+
+    template <class Copyable>
+    bp::object generic__deepcopy__(bp::object copyable, bp::dict memo)
+    {
+      bp::object copyMod = bp::import("copy");
+      bp::object deepcopy = copyMod.attr("deepcopy");
+
+      Copyable* newCopyable(new Copyable(bp::extract<const Copyable&>(copyable)));
+      bp::object result(bp::detail::new_reference(managingPyObject(newCopyable)));
+
+      int copyableId = (long long)(copyable.ptr());
+      memo[copyableId] = result;
+
+      bp::extract<bp::dict>(result.attr("__dict__"))().update(
+          deepcopy(bp::extract<bp::dict>(copyable.attr("__dict__"))(), memo));
+      return result;
+    }
+
+
     ///
     /// \brief Add the Python method copy to allow a copy of this by calling the copy constructor.
     ///
@@ -23,7 +58,11 @@ namespace pinocchio
     {
       template<class PyClass>
       void visit(PyClass & cl) const
-      { cl.def("copy",&copy,bp::arg("self"),"Returns a copy of *this."); }
+      {
+        cl.def("copy",&copy,bp::arg("self"),"Returns a copy of *this.");
+        cl.def("__copy__", &generic__copy__<C>);
+        cl.def("__deepcopy__", &generic__deepcopy__<C>);
+      }
       
     private:
       static C copy(const C & self) { return C(self); }

--- a/bindings/python/utils/copyable.hpp
+++ b/bindings/python/utils/copyable.hpp
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2016-2023 CNRS INRIA, Heriot-Watt University
+// Copyright (c) 2016-2023 CNRS INRIA
 //
 
 #ifndef __pinocchio_python_utils_copyable_hpp__
@@ -14,41 +14,6 @@ namespace pinocchio
     
     namespace bp = boost::python;
 
-    template <class T>
-    inline PyObject* managingPyObject(T* p)
-    {
-      return typename bp::manage_new_object::apply<T*>::type()(p);
-    }
-
-    template <class Copyable>
-    bp::object generic__copy__(bp::object copyable)
-    {
-      Copyable* newCopyable(new Copyable(bp::extract<const Copyable&>(copyable)));
-      bp::object result(bp::detail::new_reference(managingPyObject(newCopyable)));
-
-      bp::extract<bp::dict>(result.attr("__dict__"))().update(copyable.attr("__dict__"));
-
-      return result;
-    }
-
-    template <class Copyable>
-    bp::object generic__deepcopy__(bp::object copyable, bp::dict memo)
-    {
-      bp::object copyMod = bp::import("copy");
-      bp::object deepcopy = copyMod.attr("deepcopy");
-
-      Copyable* newCopyable(new Copyable(bp::extract<const Copyable&>(copyable)));
-      bp::object result(bp::detail::new_reference(managingPyObject(newCopyable)));
-
-      int copyableId = (long long)(copyable.ptr());
-      memo[copyableId] = result;
-
-      bp::extract<bp::dict>(result.attr("__dict__"))().update(
-          deepcopy(bp::extract<bp::dict>(copyable.attr("__dict__"))(), memo));
-      return result;
-    }
-
-
     ///
     /// \brief Add the Python method copy to allow a copy of this by calling the copy constructor.
     ///
@@ -60,12 +25,13 @@ namespace pinocchio
       void visit(PyClass & cl) const
       {
         cl.def("copy",&copy,bp::arg("self"),"Returns a copy of *this.");
-        cl.def("__copy__", &generic__copy__<C>);
-        cl.def("__deepcopy__", &generic__deepcopy__<C>);
+        cl.def("__copy__", &copy,bp::arg("self"),"Returns a copy of *this.");
+        cl.def("__deepcopy__", &deepcopy,bp::args("self","memo"),"Returns a deep copy of *this.");
       }
       
     private:
       static C copy(const C & self) { return C(self); }
+      static C deepcopy(const C & self, bp::dict) { return C(self); }
     };
   } // namespace python
 } // namespace pinocchio

--- a/unittest/python/bindings_SE3.py
+++ b/unittest/python/bindings_SE3.py
@@ -2,6 +2,7 @@ import unittest
 import pinocchio as pin
 import numpy as np
 from pinocchio.utils import eye,zero,rand
+from copy import deepcopy, copy
 
 ones = lambda n: np.ones([n, 1] if isinstance(n, int) else n)
 
@@ -157,6 +158,18 @@ class TestSE3Bindings(unittest.TestCase):
             r = pin.SE3.Random() * pin.SE3.Random()
             s = r.__str__()
             self.assertTrue(s != '')
+
+    def test_copy(self):
+        M = pin.SE3.Random()
+        Mc = copy(M)
+        Mdc = deepcopy(M)
+        self.assertTrue(M == Mc)
+        self.assertTrue(M == Mdc)
+
+        Mc.setRandom()
+        self.assertFalse(M == Mc)
+        Mdc.setRandom()
+        self.assertFalse(M == Mc)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Pickable is the worst solution for enabling an object to be copyable. Instead, the purpose solution is better while still keeping the pickability of the Pinocchio objects.

Additionally, the pickable solution creates segfaul in my Apple M1 chip. But, if I remember correctly, this doesn't happen in Ubuntu.

In short this PR enables us to do the following:
```python
import pinocchio
import copy

model = pinochio.Model()

m1 = copy.copy(model)
m2 = copy.deepcopy(model)
```