### PR TITLE
Update documentation of `JointModel.shortname` in python bindings

### DIFF
--- a/bindings/python/multibody/joint/joint-derived.hpp
+++ b/bindings/python/multibody/joint/joint-derived.hpp
@@ -46,7 +46,21 @@ namespace pinocchio
              &JointModelDerived::template hasSameIndexes<JointModelDerived>,
              bp::args("self","other"),
              "Check if this has same indexes than other.")
-        .def("shortname",&JointModelDerived::shortname,bp::arg("self"))
+        .def("shortname",
+             &JointModelDerived::shortname,
+             bp::arg("self"),
+             "Returns string indicating the joint type (class name):" 
+                "\n\t- JointModelR[*]: Revolute Joint, with rotation axis [*] ∈ [X,Y,Z]"
+                "\n\t- JointModelRevoluteUnaligned: Revolute Joint, with rotation axis not aligned with X, Y, nor Z"
+                "\n\t- JointModelRUB[*]: Unbounded revolute Joint (without position limits), with rotation axis [*] ∈ [X,Y,Z]"
+                "\n\t- JointModelRevoluteUnboundedUnaligned: Unbounded revolute Joint, with rotation axis not aligned with X, Y, nor Z"
+                "\n\t- JointModelP[*]: Prismatic Joint, with rotation axis [*] ∈ [X,Y,Z]"
+                "\n\t- JointModelPlanar: Planar joint"
+                "\n\t- JointModelPrismaticUnaligned: Prismatic joint, with translation axis not aligned with X, Y, nor Z"
+                "\n\t- JointModelSphericalZYX: Spherical joint (3D rotation)"
+                "\n\t- JointModelTranslation: Translation joint (3D translation)"
+                "\n\t- JointModelFreeFlyer: Joint enabling 3D rotation and translations." 
+                )
         
         .def(bp::self == bp::self)
         .def(bp::self != bp::self)

--- a/bindings/python/multibody/joint/joint.hpp
+++ b/bindings/python/multibody/joint/joint.hpp
@@ -42,7 +42,21 @@ namespace pinocchio
              &JointModel::hasSameIndexes<JointModel>,
              bp::args("self","other"),
              "Check if this has same indexes than other.")
-        .def("shortname",&JointModel::shortname,bp::arg("self"))
+        .def("shortname",
+             &JointModel::shortname,
+             bp::arg("self"),
+             "Returns string indicating the joint type (class name):" 
+                "\n\t- JointModelR[*]: Revolute Joint, with rotation axis [*] ∈ [X,Y,Z]"
+                "\n\t- JointModelRevoluteUnaligned: Revolute Joint, with rotation axis not aligned with X, Y, nor Z"
+                "\n\t- JointModelRUB[*]: Unbounded revolute Joint (without position limits), with rotation axis [*] ∈ [X,Y,Z]"
+                "\n\t- JointModelRevoluteUnboundedUnaligned: Unbounded revolute Joint, with rotation axis not aligned with X, Y, nor Z"
+                "\n\t- JointModelP[*]: Prismatic Joint, with rotation axis [*] ∈ [X,Y,Z]"
+                "\n\t- JointModelPlanar: Planar joint"
+                "\n\t- JointModelPrismaticUnaligned: Prismatic joint, with translation axis not aligned with X, Y, nor Z"
+                "\n\t- JointModelSphericalZYX: Spherical joint (3D rotation)"
+                "\n\t- JointModelTranslation: Translation joint (3D translation)"
+                "\n\t- JointModelFreeFlyer: Joint enabling 3D rotation and translations." 
+                )
         
         .def(bp::self == bp::self)
         .def(bp::self != bp::self)


### PR DESCRIPTION
Following the discussion of issue #802, this PR presents an update to the documentation of the `shortname` function for the python class `JointModel` exposed by Boost.python.

This function is the only way to determine the joint type in python and was previously left undocumented.

The new function documentation describes the following possible cases:
>>>
                - JointModelR[*]: Revolute Joint, with rotation axis [*] ∈ [X,Y,Z]
                - JointModelRevoluteUnaligned: Revolute Joint, with rotation axis not aligned with X, Y, nor Z
                - JointModelRUB[*]: Unbounded revolute Joint (without position limits), with rotation axis [*] ∈ [X,Y,Z]
                - JointModelRevoluteUnboundedUnaligned: Unbounded revolute Joint, with rotation axis not aligned with X, Y, nor Z
                - JointModelP[*]: Prismatic Joint, with rotation axis [*] ∈ [X,Y,Z]
                - JointModelPlanar: Planar joint
                - JointModelPrismaticUnaligned: Prismatic joint, with translation axis not aligned with X, Y, nor Z
                - JointModelSphericalZYX: Spherical joint (3D rotation)
                - JointModelTranslation: Translation joint (3D translation)
                - JointModelFreeFlyer: Joint enabling 3D rotation and translations.

If there are any other possible outputs of JointModel.shortname please let me know to update the docstring.

Some questions emerge after understanding the `shortname` method: After a robot is loaded in Pinocchio, all of its joints are exposed to python as `JointModel` class instances. However, there are also specific joint-type classes exposed to python (e.g., JointModelFreeFlyer, JointModelRUBY) which led me to think that a more elegant and pythonic way of identifying the joint type is by use of `isinstanceof` method (e.g., `isinstanceof(joint, JointModelRUBY)`). This if, the robot joints were instantiated as specific joint type classes instead of the generic `JointModel`.

- Why are joints instantiated after robot load as JointModel and not as instances of the joint-type specific class? 
