### PR TITLE
Bug fix in quaterion::normalize and quaternion::log3

### DIFF
--- a/src/math/quaternion.hpp
+++ b/src/math/quaternion.hpp
@@ -237,7 +237,7 @@ namespace pinocchio
     template<typename Quaternion>
     inline void normalize(const Eigen::QuaternionBase<Quaternion> & quat)
     {
-      return pinocchio::normalize(quat.const_cast_derived().coeffs());
+      return pinocchio::normalize(PINOCCHIO_EIGEN_CONST_CAST(Quaternion, quat).coeffs());
     }
   
     ///

--- a/unittest/casadi/spatial.cpp
+++ b/unittest/casadi/spatial.cpp
@@ -7,6 +7,7 @@
 #include <pinocchio/math/quaternion.hpp>
 #include <pinocchio/spatial/se3.hpp>
 #include <pinocchio/spatial/motion.hpp>
+#include <pinocchio/spatial/explog-quaternion.hpp>
 
 #include <boost/variant.hpp> // to avoid C99 warnings
 
@@ -87,6 +88,54 @@ BOOST_AUTO_TEST_CASE(test_quaternion)
   }
   
   
+}
+
+BOOST_AUTO_TEST_CASE(test_quaternion_normalize)
+{
+  Eigen::Quaternion<double> quat_double(1, 2, 3, 4);
+  quat_double.normalize();
+
+  Eigen::Quaternion<casadi::SX> quat_casadi(1, 2, 3, 4);
+  pinocchio::quaternion::normalize(quat_casadi);
+
+  for (int i = 0; i < 4; ++i) {
+    BOOST_CHECK_CLOSE(double(quat_casadi.coeffs()[i]), quat_double.coeffs()[i], 1e-6);
+  }
+}
+
+
+BOOST_AUTO_TEST_CASE(test_log3_autodiff_degenerative_case)
+{
+  auto quat_casadi = casadi::SX::sym("quat", 4);  // qx, qy, qz, qw
+
+  // eigen quaternion eats scalar first
+  Eigen::Quaternion<casadi::SX> quat(quat_casadi(3), quat_casadi(0),
+                                     quat_casadi(1), quat_casadi(2));
+  auto so3 = pinocchio::quaternion::log3(quat);
+  auto so3_casadi = casadi::SX::sym("so3", 3);
+  pinocchio::casadi::copy(so3, so3_casadi);
+  auto jac = jacobian(so3_casadi, quat_casadi);
+
+  auto so3_func = casadi::Function("log3_func", {quat_casadi}, {so3_casadi}, {"quat_in"}, {"so3_out"});
+  auto jac_func = casadi::Function("jac_func", {quat_casadi}, {jac}, {"quat_in"}, {"jac_out"});
+
+  auto so3_result = so3_func(casadi::DMDict{{"quat_in", {0, 0, 0, 1}}}).at("so3_out");
+  auto jac_result = jac_func(casadi::DMDict{{"quat_in", {0, 0, 0, 1}}}).at("jac_out");
+
+  Eigen::Vector<double, 3> so3_expected(0, 0, 0);
+  Eigen::Matrix<double, 3, 4> jac_expected;
+  jac_expected << 2, 0, 0, 0,
+                  0, 2, 0, 0,
+                  0, 0, 2, 0;
+
+  for (int i = 0; i < 3; ++i)
+  {
+      for (int j = 0; j < 4; ++j)
+      {
+          BOOST_CHECK(double(jac_result(i, j)) == jac_expected(i, j));
+      }
+      BOOST_CHECK(double(so3_result(i)) == so3_expected[i]);
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/quaternion.cpp
+++ b/unittest/quaternion.cpp
@@ -57,12 +57,16 @@ BOOST_AUTO_TEST_CASE(test_isNormalized)
 #endif
   for(int i = 0; i < max_test; ++i)
   {
-    Quaternion q;
-    q.coeffs() = Vector4::Random() + Vector4::Constant(2);
-    BOOST_CHECK(!quaternion::isNormalized(q));
+    Quaternion q1, q2;
+    q1.coeffs() = Vector4::Random() + Vector4::Constant(2);
+    BOOST_CHECK(!quaternion::isNormalized(q1));
+    q2.coeffs() = Vector4::Random() + Vector4::Constant(3);
+    BOOST_CHECK(!quaternion::isNormalized(q2));
     
-    q.normalize();
-    BOOST_CHECK(quaternion::isNormalized(q));
+    q1.normalize();
+    BOOST_CHECK(quaternion::isNormalized(q1));
+    quaternion::normalize(q2);
+    BOOST_CHECK(quaternion::isNormalized(q2));
   }
   
   // Specific check for the Zero vector


### PR DESCRIPTION
Related to #2050, this PR fixes a bug in `quaternion::normalize` and `quaternion::log3` methods.
