### PR TITLE
depend on packaging module

### DIFF
--- a/.github/workflows/conda/conda-env.yml
+++ b/.github/workflows/conda/conda-env.yml
@@ -10,4 +10,5 @@ dependencies:
   - eigenpy
   - urdfdom
   - python
+  - packaging
   - mamba

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -6,7 +6,7 @@ from . import BaseVisualizer
 import os
 import warnings
 import numpy as np
-from distutils.version import LooseVersion
+from packaging.version import Version
 
 try:
     import hppfcl
@@ -154,7 +154,7 @@ def loadMesh(mesh):
             tri = call_triangles(k)
             faces[k] = [tri[i] for i in range(3)]
 
-        if LooseVersion(hppfcl.__version__) >= LooseVersion("1.7.7"):
+        if Version(hppfcl.__version__) >= Version("1.7.7"):
             vertices = call_vertices()
         else:
             vertices = np.empty((num_vertices, 3))


### PR DESCRIPTION
Python's [`distutils` module is deprecated](https://peps.python.org/pep-0632/), and [has been removed from Python 3.12](https://docs.python.org/3/whatsnew/3.12.html#distutils). Pinocchio is importing from `distutils.version` -- the recommended upgrade path for this is to switch to the [`packaging` module](https://pypi.org/project/packaging/), which includes [utilities for version comparison](https://packaging.pypa.io/en/stable/version.html).

Without this change, Pinocchio will not run on Python 3.12.