### PR TITLE
Add direct boost is_floating_point import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Use bp::ssize_t for recent version of Windows compilers ([#2102](https://github.com/stack-of-tasks/pinocchio/pull/2102))
+- Fix missing include for Boost >= 1.83 ([#2103](https://github.com/stack-of-tasks/pinocchio/pull/2103))
 
 ## [2.6.21] - 2023-11-27
 

--- a/include/pinocchio/math/fwd.hpp
+++ b/include/pinocchio/math/fwd.hpp
@@ -8,6 +8,7 @@
 #include "pinocchio/fwd.hpp"
 #include <math.h>
 #include <boost/math/constants/constants.hpp>
+#include <boost/type_traits/is_floating_point.hpp>
 
 namespace pinocchio
 {


### PR DESCRIPTION
Add direct import of boost header containing `boost::math::is_floating_point` to avoid import error:
```
In file included from bazel-out/k8-opt/bin/external/com_github_stack_of_tasks_pinocchio/_virtual_includes/pinocchio/pinocchio/math/quaternion.hpp:12,
                 from bazel-out/k8-opt/bin/external/com_github_stack_of_tasks_pinocchio/_virtual_includes/pinocchio/pinocchio/spatial/se3-tpl.hpp:12,
                 from bazel-out/k8-opt/bin/external/com_github_stack_of_tasks_pinocchio/_virtual_includes/pinocchio/pinocchio/spatial/se3.hpp:44:
bazel-out/k8-opt/bin/external/com_github_stack_of_tasks_pinocchio/_virtual_includes/pinocchio/pinocchio/math/fwd.hpp:16:54: error: expected template-name before '<' token
   16 |   struct is_floating_point : boost::is_floating_point<T>
      |                                                      ^
bazel-out/k8-opt/bin/external/com_github_stack_of_tasks_pinocchio/_virtual_includes/pinocchio/pinocchio/math/fwd.hpp:16:54: error: expected '{' before '<' token
```
Seen in Pinocchio v2.6.21 with Boost 1.83.0.