### PR TITLE
Add material to GeometryObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Add `GeometryObject::meshMaterial` attribute ([#2084](https://github.com/stack-of-tasks/pinocchio/issues/2084))
+
 ### Fixed
 
 - Use bp::ssize_t for recent version of Windows compilers ([#2102](https://github.com/stack-of-tasks/pinocchio/pull/2102))

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -446,19 +446,28 @@ class MeshcatVisualizer(BaseVisualizer):
         elif isinstance(obj, meshcat.geometry.Geometry):
             material = meshcat.geometry.MeshPhongMaterial()
             # Set material color from URDF, converting for triplet of doubles to a single int.
+
+            def to_material_color(rgba) -> int:
+                """Convert rgba color as list into rgba color as int"""
+                return (int(rgba[0] * 255) * 256**2
+                        + int(rgba[1] * 255) * 256
+                        + int(rgba[2] * 255)
+                        )
+
             if color is None:
                 meshColor = geometry_object.meshColor
             else:
                 meshColor = color
-            material.color = (
-                int(meshColor[0] * 255) * 256**2
-                + int(meshColor[1] * 255) * 256
-                + int(meshColor[2] * 255)
-            )
             # Add transparency, if needed.
+            material.color = to_material_color(meshColor)
+
             if float(meshColor[3]) != 1.0:
                 material.transparent = True
                 material.opacity = float(meshColor[3])
+            if geometry_object.overrideMaterial:
+                material.emissive = to_material_color(geometry_object.meshEmissionColor)
+                material.specular = to_material_color(geometry_object.meshSpecularColor)
+                material.shininess = geometry_object.meshShininess*100.
             self.viewer[viewer_name].set_object(obj, material)
 
         if is_mesh:  # Apply the scaling

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -464,10 +464,11 @@ class MeshcatVisualizer(BaseVisualizer):
             if float(meshColor[3]) != 1.0:
                 material.transparent = True
                 material.opacity = float(meshColor[3])
-            if geometry_object.overrideMaterial:
-                material.emissive = to_material_color(geometry_object.meshEmissionColor)
-                material.specular = to_material_color(geometry_object.meshSpecularColor)
-                material.shininess = geometry_object.meshShininess*100.
+            geom_material = geometry_object.meshMaterial
+            if geometry_object.overrideMaterial and isinstance(geom_material, pin.GeometryPhongMaterial):
+                material.emissive = to_material_color(geom_material.meshEmissionColor)
+                material.specular = to_material_color(geom_material.meshSpecularColor)
+                material.shininess = geom_material.meshShininess*100.
             self.viewer[viewer_name].set_object(obj, material)
 
         if is_mesh:  # Apply the scaling

--- a/examples/meshcat-viewer.py
+++ b/examples/meshcat-viewer.py
@@ -19,7 +19,8 @@ mesh_dir = pinocchio_model_dir
 # urdf_filename = "talos_reduced.urdf"
 # urdf_model_path = join(join(model_path,"talos_data/robots"),urdf_filename)
 urdf_filename = "solo.urdf"
-urdf_model_path = join(join(model_path, "solo_description/robots"), urdf_filename)
+urdf_model_path = join(
+    join(model_path, "solo_description/robots"), urdf_filename)
 
 model, collision_model, visual_model = pin.buildModelsFromUrdf(
     urdf_model_path, mesh_dir, pin.JointModelFreeFlyer()
@@ -48,19 +49,29 @@ viz.loadViewerModel()
 # Display a robot configuration.
 q0 = pin.neutral(model)
 viz.display(q0)
-viz.displayCollisions(True)
-viz.displayVisuals(False)
+viz.displayVisuals(True)
 
+# Create a convex shape from solo main body
 mesh = visual_model.geometryObjects[0].geometry
 mesh.buildConvexRepresentation(True)
 convex = mesh.convex
 
+# Place the convex object on the scene and display it
 if convex is not None:
     placement = pin.SE3.Identity()
     placement.translation[0] = 2.0
     geometry = pin.GeometryObject("convex", 0, convex, placement)
     geometry.meshColor = np.ones((4))
+    # Add a PhongMaterial to the convex object
+    geometry.overrideMaterial = True
+    geometry.meshMaterial = pin.GeometryPhongMaterial()
+    geometry.meshMaterial.meshEmissionColor = np.array([1., 0.1, 0.1, 1.])
+    geometry.meshMaterial.meshSpecularColor = np.array([0.1, 1., 0.1, 1.])
+    geometry.meshMaterial.meshShininess = 0.8
     visual_model.addGeometryObject(geometry)
+    # After modifying the visual_model we must rebuild
+    # associated data inside the visualizer
+    viz.rebuildData()
 
 # Display another robot.
 viz2 = MeshcatVisualizer(model, collision_model, visual_model)
@@ -72,7 +83,8 @@ viz2.display(q)
 
 # standing config
 q1 = np.array(
-    [0.0, 0.0, 0.235, 0.0, 0.0, 0.0, 1.0, 0.8, -1.6, 0.8, -1.6, -0.8, 1.6, -0.8, 1.6]
+    [0.0, 0.0, 0.235, 0.0, 0.0, 0.0, 1.0, 0.8, -
+        1.6, 0.8, -1.6, -0.8, 1.6, -0.8, 1.6]
 )
 
 v0 = np.random.randn(model.nv) * 2

--- a/include/pinocchio/bindings/python/multibody/geometry-object.hpp
+++ b/include/pinocchio/bindings/python/multibody/geometry-object.hpp
@@ -33,7 +33,7 @@ namespace pinocchio
         template<typename T>
         result_type operator()(T & t) const
         {
-          return boost::python::incref(boost::python::object(t).ptr());
+          return bp::incref(bp::object(t).ptr());
         }
       };
 

--- a/include/pinocchio/bindings/python/multibody/geometry-object.hpp
+++ b/include/pinocchio/bindings/python/multibody/geometry-object.hpp
@@ -29,16 +29,18 @@ namespace pinocchio
       {
         cl
         .def(bp::init<std::string,FrameIndex,JointIndex,CollisionGeometryPtr,SE3,
-                      bp::optional<std::string,Eigen::Vector3d,bool,Eigen::Vector4d,std::string> >
+                      bp::optional<std::string,Eigen::Vector3d,bool,Eigen::Vector4d,std::string,Eigen::Vector4d,Eigen::Vector4d,double> >
              (
              bp::args("self","name","parent_frame","parent_joint","collision_geometry",
-                      "placement", "mesh_path", "mesh_scale", "override_material", "mesh_color", "mesh_texture_path"),
+                      "placement", "mesh_path", "mesh_scale", "override_material", "mesh_color", "mesh_texture_path",
+                      "mesh_emission_color", "mesh_specular_color", "mesh_shininess"),
              "Full constructor of a GeometryObject."))
         .def(bp::init<std::string,JointIndex,CollisionGeometryPtr,SE3,
-                      bp::optional<std::string,Eigen::Vector3d,bool,Eigen::Vector4d,std::string> >
+                      bp::optional<std::string,Eigen::Vector3d,bool,Eigen::Vector4d,std::string,Eigen::Vector4d,Eigen::Vector4d,double> >
              (
               bp::args("self","name","parent_joint","collision_geometry",
-                       "placement", "mesh_path", "mesh_scale", "override_material", "mesh_color", "mesh_texture_path"),
+                       "placement", "mesh_path", "mesh_scale", "override_material", "mesh_color", "mesh_texture_path",
+                       "mesh_emission_color", "mesh_specular_color", "mesh_shininess"),
               "Reduced constructor of a GeometryObject. This constructor does not require to specify the parent frame index."
               ))
         .def(bp::init<const GeometryObject&>
@@ -74,6 +76,18 @@ namespace pinocchio
                        "Path to the mesh texture file.")
         .def_readwrite("disableCollision", &GeometryObject::disableCollision,
                        "If true, no collision or distance check will be done between the Geometry and any other geometry.")
+        .add_property("meshEmissionColor",
+                      bp::make_getter(&GeometryObject::meshEmissionColor,
+                                      bp::return_internal_reference<>()),
+                      bp::make_setter(&GeometryObject::meshEmissionColor),
+                      "Emissive (ambient) color rgba value of the mesh")
+        .add_property("meshSpecularColor",
+                      bp::make_getter(&GeometryObject::meshSpecularColor,
+                                      bp::return_internal_reference<>()),
+                      bp::make_setter(&GeometryObject::meshSpecularColor),
+                      "Specular color rgba value of the mesh")
+        .def_readwrite("meshShininess", &GeometryObject::meshShininess,
+                       "Shininess associated to the specular lighting model (between 0 and 1).")
 
         .def(bp::self == bp::self)
         .def(bp::self != bp::self)

--- a/include/pinocchio/bindings/python/multibody/geometry-object.hpp
+++ b/include/pinocchio/bindings/python/multibody/geometry-object.hpp
@@ -95,8 +95,8 @@ namespace pinocchio
                        "If true, no collision or distance check will be done between the Geometry and any other geometry.")
         .add_property("meshMaterial",
                       bp::make_getter(&GeometryObject::meshMaterial,
-                                      bp::return_internal_reference<>()),
-                      bp::make_setter(&GeometryObject::meshMaterial),
+                                      bp::return_value_policy<bp::return_by_value>()),
+                      bp::make_setter(&GeometryObject::meshMaterial, bp::return_value_policy<bp::return_by_value>()),
                       "Material associated to the mesh (applied only if overrideMaterial is True)")
 
         .def(bp::self == bp::self)
@@ -153,15 +153,6 @@ namespace pinocchio
                       "RGBA specular value of the mesh")
         .def_readwrite("meshShininess", &GeometryPhongMaterial::meshShininess,
                        "Shininess associated to the specular lighting model (between 0 and 1)");
-
-        /// This class wrap a GeometryMaterial.
-        /// This is mandatory to be able to access GeometryObject::meshMaterial.
-        bp::class_<GeometryMaterial>("GeometryMaterial", bp::init<>())
-        .def(bp::init<GeometryNoMaterial>())
-        .def(bp::init<GeometryPhongMaterial>())
-        /// content allow to go through to_python_converter and to convert
-        /// GeometryMaterial actual variant into a Python type
-        .def("content", &GeometryObjectPythonVisitor::get_content);
 
         /// Define material conversion from C++ variant to python object
         bp::to_python_converter<GeometryMaterial, VariantToObject>();

--- a/include/pinocchio/multibody/fcl.hpp
+++ b/include/pinocchio/multibody/fcl.hpp
@@ -302,6 +302,9 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     meshScale           = other.meshScale;
     overrideMaterial    = other.overrideMaterial;
     meshColor           = other.meshColor;
+    meshEmissionColor   = other.meshEmissionColor;
+    meshSpecularColor   = other.meshSpecularColor;
+    meshShininess       = other.meshShininess;
     meshTexturePath     = other.meshTexturePath;
     disableCollision   = other.disableCollision;
     return *this;

--- a/include/pinocchio/multibody/fcl.hpp
+++ b/include/pinocchio/multibody/fcl.hpp
@@ -148,17 +148,33 @@ struct GeometryObject
   /// \brief Position of geometry object in parent joint frame
   SE3 placement;
 
-  /// \brief Absolute path to the mesh file (if the fcl pointee is also a Mesh)
+  /// \brief Absolute path to the mesh file (if the geometry pointee is also a Mesh)
   std::string meshPath;
 
-  /// \brief Scaling vector applied to the GeometryObject::fcl object.
+  /// \brief Scaling vector applied to the GeometryObject::geometry object.
   Eigen::Vector3d meshScale;
 
   /// \brief Decide whether to override the Material.
   bool overrideMaterial;
 
-  /// \brief RGBA color value of the GeometryObject::fcl object.
+  /// \defgroup pinocchio_mesh_material Mesh material definition
+  /// Mesh material based on the Phong lighting model:
+  /// \{
+
+  /// \brief RGBA diffuse color value of the GeometryObject::geometry object.
   Eigen::Vector4d meshColor;
+
+  /// \brief RGBA emission (ambient) color value of the GeometryObject::geometry object.
+  Eigen::Vector4d meshEmissionColor;
+
+  /// \brief RGBA specular color value of the GeometryObject::geometry object.
+  Eigen::Vector4d meshSpecularColor;
+
+  /// \brief shininess associated to the specular lighting model.
+  ///
+  /// This value must normalized between 0 and 1.
+  double meshShininess;
+  /// \}
 
   /// \brief Absolute path to the mesh texture file.
   std::string meshTexturePath;
@@ -191,7 +207,10 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
                  const Eigen::Vector3d & meshScale = Eigen::Vector3d::Ones(),
                  const bool overrideMaterial = false,
                  const Eigen::Vector4d & meshColor = Eigen::Vector4d(0,0,0,1),
-                 const std::string & meshTexturePath = "")
+                 const std::string & meshTexturePath = "",
+                 const Eigen::Vector4d & meshEmissionColor = Eigen::Vector4d(0,0,0,1),
+                 const Eigen::Vector4d & meshSpecularColor = Eigen::Vector4d(0,0,0,1),
+                 double meshShininess = 0.)
   : name(name)
   , parentFrame(parent_frame)
   , parentJoint(parent_joint)
@@ -202,6 +221,9 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
   , meshScale(meshScale)
   , overrideMaterial(overrideMaterial)
   , meshColor(meshColor)
+  , meshEmissionColor(meshEmissionColor)
+  , meshSpecularColor(meshSpecularColor)
+  , meshShininess(meshShininess)
   , meshTexturePath(meshTexturePath)
   , disableCollision(false)
   {}
@@ -242,6 +264,9 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
   , meshScale(meshScale)
   , overrideMaterial(overrideMaterial)
   , meshColor(meshColor)
+  , meshEmissionColor(Eigen::Vector4d(0., 0., 0., 1.))
+  , meshSpecularColor(Eigen::Vector4d(0., 0., 0., 1.))
+  , meshShininess(0.)
   , meshTexturePath(meshTexturePath)
   , disableCollision(false)
   {}

--- a/include/pinocchio/multibody/fcl.hpp
+++ b/include/pinocchio/multibody/fcl.hpp
@@ -170,7 +170,7 @@ struct GeometryObject
   /// \brief RGBA specular color value of the GeometryObject::geometry object.
   Eigen::Vector4d meshSpecularColor;
 
-  /// \brief shininess associated to the specular lighting model.
+  /// \brief Shininess associated to the specular lighting model.
   ///
   /// This value must normalized between 0 and 1.
   double meshShininess;
@@ -197,6 +197,9 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
   /// \param[in] overrideMaterial If true, this option allows to overrite the material [if applicable].
   /// \param[in] meshColor Color of the mesh [if applicable].
   /// \param[in] meshTexturePath Path to the file containing the texture information [if applicable].
+  /// \param[in] meshEmissionColor Emissive color of mesh [if applicable].
+  /// \param[in] meshSpecularColor Specular color of mesh [if applicable].
+  /// \param[in] meshShininess Shininess of mesh [if applicable].
   ///
   GeometryObject(const std::string & name,
                  const FrameIndex parent_frame,
@@ -244,6 +247,9 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
   /// \param[in] overrideMaterial If true, this option allows to overrite the material [if applicable].
   /// \param[in] meshColor Color of the mesh [if applicable].
   /// \param[in] meshTexturePath Path to the file containing the texture information [if applicable].
+  /// \param[in] meshEmissionColor Emissive color of mesh [if applicable].
+  /// \param[in] meshSpecularColor Specular color of mesh [if applicable].
+  /// \param[in] meshShininess Shininess of mesh [if applicable].
   ///
   GeometryObject(const std::string & name,
                  const JointIndex parent_joint,
@@ -253,7 +259,10 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
                  const Eigen::Vector3d & meshScale = Eigen::Vector3d::Ones(),
                  const bool overrideMaterial = false,
                  const Eigen::Vector4d & meshColor = Eigen::Vector4d::Ones(),
-                 const std::string & meshTexturePath = "")
+                 const std::string & meshTexturePath = "",
+                 const Eigen::Vector4d & meshEmissionColor = Eigen::Vector4d(0,0,0,1),
+                 const Eigen::Vector4d & meshSpecularColor = Eigen::Vector4d(0,0,0,1),
+                 double meshShininess = 0.)
   : name(name)
   , parentFrame(std::numeric_limits<FrameIndex>::max())
   , parentJoint(parent_joint)
@@ -264,9 +273,9 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_IGNORED_DEPRECECATED_DECLARATIONS
   , meshScale(meshScale)
   , overrideMaterial(overrideMaterial)
   , meshColor(meshColor)
-  , meshEmissionColor(Eigen::Vector4d(0., 0., 0., 1.))
-  , meshSpecularColor(Eigen::Vector4d(0., 0., 0., 1.))
-  , meshShininess(0.)
+  , meshEmissionColor(meshEmissionColor)
+  , meshSpecularColor(meshSpecularColor)
+  , meshShininess(meshShininess)
   , meshTexturePath(meshTexturePath)
   , disableCollision(false)
   {}

--- a/unittest/python/bindings_build_geom_from_urdf_memorycheck.py
+++ b/unittest/python/bindings_build_geom_from_urdf_memorycheck.py
@@ -9,10 +9,10 @@ class TestBuildGeomFromUrdfMemoryCheck(unittest.TestCase):
     def setUp(self):
         self.current_file = os.path.dirname(str(os.path.abspath(__file__)))
         self.model_dir = os.path.abspath(
-            os.path.join(self.current_file, "../../models/example-robot-data/robots")
+            os.path.join(self.current_file, "../../models/")
         )
         self.model_path = os.path.abspath(
-            os.path.join(self.model_dir, "ur_description/urdf/ur5_robot.urdf")
+            os.path.join(self.model_dir, "example-robot-data/robots/ur_description/urdf/ur5_robot.urdf")
         )
 
     def test_load(self):

--- a/unittest/python/bindings_geometry_object.py
+++ b/unittest/python/bindings_geometry_object.py
@@ -78,7 +78,6 @@ class TestGeometryObjectBindings(unittest.TestCase):
         self.assertTrue(isinstance(material, (pin.GeometryPhongMaterial)))
         material.meshEmissionColor = np.array([1., 1., 1., 1.])
         material.meshShininess = 0.7
-        # TODO make reference boost variant work
         self.assertTrue((material.meshEmissionColor == col.meshMaterial.meshEmissionColor).all())
         self.assertEqual(material.meshShininess, col.meshMaterial.meshShininess)
 

--- a/unittest/python/bindings_geometry_object.py
+++ b/unittest/python/bindings_geometry_object.py
@@ -71,16 +71,16 @@ class TestGeometryObjectBindings(unittest.TestCase):
 
     def test_material_get_set(self):
         col = self.collision_model.geometryObjects[0]
-        self.assertTrue(isinstance(col.meshMaterial.content(), (pin.GeometryNoMaterial)))
+        self.assertTrue(isinstance(col.meshMaterial, (pin.GeometryNoMaterial)))
         col.meshMaterial = pin.GeometryPhongMaterial()
-        self.assertTrue(isinstance(col.meshMaterial.content(), (pin.GeometryPhongMaterial)))
-        col.meshMaterial.meshEmissionColor = np.array([1., 1., 1., 1.])
-        col.meshMaterial.meshSpecularColor = 1.
+        self.assertTrue(isinstance(col.meshMaterial, (pin.GeometryPhongMaterial)))
         material = col.meshMaterial
-        self.assertTrue(isinstance(material.content(), (pin.GeometryPhongMaterial)))
+        self.assertTrue(isinstance(material, (pin.GeometryPhongMaterial)))
+        material.meshEmissionColor = np.array([1., 1., 1., 1.])
+        material.meshShininess = 0.7
         # TODO make reference boost variant work
-        # self.assertEqual(material.meshEmissionColor, col.meshMaterial.meshEmissionColor)
-        # self.assertEqual(material.meshSpecular, col.meshMaterial.meshSpecular)
+        self.assertTrue((material.meshEmissionColor == col.meshMaterial.meshEmissionColor).all())
+        self.assertEqual(material.meshShininess, col.meshMaterial.meshShininess)
 
 if __name__ == '__main__':
     unittest.main()

--- a/unittest/python/bindings_geometry_object.py
+++ b/unittest/python/bindings_geometry_object.py
@@ -69,5 +69,18 @@ class TestGeometryObjectBindings(unittest.TestCase):
         collision_data_copy = collision_data.copy()
         self.assertEqual(len(collision_data.oMg),len(collision_data_copy.oMg))
 
+    def test_material_get_set(self):
+        col = self.collision_model.geometryObjects[0]
+        self.assertTrue(isinstance(col.meshMaterial.content(), (pin.GeometryNoMaterial)))
+        col.meshMaterial = pin.GeometryPhongMaterial()
+        self.assertTrue(isinstance(col.meshMaterial.content(), (pin.GeometryPhongMaterial)))
+        col.meshMaterial.meshEmissionColor = np.array([1., 1., 1., 1.])
+        col.meshMaterial.meshSpecularColor = 1.
+        material = col.meshMaterial
+        self.assertTrue(isinstance(material.content(), (pin.GeometryPhongMaterial)))
+        # TODO make reference boost variant work
+        # self.assertEqual(material.meshEmissionColor, col.meshMaterial.meshEmissionColor)
+        # self.assertEqual(material.meshSpecular, col.meshMaterial.meshSpecular)
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR solve #2084.

I have added `GeometryObject::meshMaterial` attribute to store different kind of material with a boost::variant.

Right now, only two material type exists : GeometryNoMaterial and GeometryPhongMaterial.
But more complex ones can be added in the future.

The boost::variant Python binding is working well and can maybe be ported to manage the `Model::joints`.

`meshcat_visualizer.py` use this new feature BUT [meshcat-python Phong material](https://github.com/meshcat-dev/meshcat-python/blob/785bc9d5ba6f8a8bb79ee8b25f523805946c1fbd/src/meshcat/geometry.py#L185) is not implemented.
I had to patch my meshcat-python to be able to display specular et emissive light.

Before merging I have to add an example but I would like to have a technical review before going further.