### PR TITLE
Add example to visualize floating base velocity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Remove a lot of warnings ([#2139](https://github.com/stack-of-tasks/pinocchio/pull/2139))
 
 ### Added
-- Add example to visualize floating base velocity [#2143](https://github.com/stack-of-tasks/pinocchio/pull/2143)
+- Add `examples/floating-base-velocity-viewer.py` to visualize floating base velocity [#2143](https://github.com/stack-of-tasks/pinocchio/pull/2143)
 
 ## [2.7.0] - 2024-01-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Remove a lot of warnings ([#2139](https://github.com/stack-of-tasks/pinocchio/pull/2139))
 
+### Added
+- Add example to visualize floating base velocity [#2143](https://github.com/stack-of-tasks/pinocchio/pull/2143)
+
 ## [2.7.0] - 2024-01-23
 
 ### Added

--- a/examples/floating-base-velocity-viewer.py
+++ b/examples/floating-base-velocity-viewer.py
@@ -43,9 +43,6 @@ def pin_step(model, vizer, v_index_increment, dt = 0.1, enable_gravity=True):
     if not enable_gravity:
         model.gravity.setZero()
 
-    data = model.createData()
-
-    tau = np.zeros(model.nv)
     q = pin.neutral(model)
     v = np.zeros(model.nv)
     v[v_index_increment] += 1.
@@ -55,12 +52,10 @@ def pin_step(model, vizer, v_index_increment, dt = 0.1, enable_gravity=True):
 
     sleep(1)
 
-    a = pin.aba(model, data, q, v, tau)
-    v_next = v + a * dt
-    q_next = pin.integrate(model, q, v_next * dt)
+    q_next = pin.integrate(model, q, v * dt)
 
-    print(f"{a=}, {q_next=}, {v_next=}")
-    return q_next, v_next
+    print(f"{q_next=}")
+    return q_next
 
 
 if __name__ == "__main__":
@@ -86,7 +81,7 @@ if __name__ == "__main__":
 
         for i in range(model.nv):
             print(f"v[{i}] += 1")
-            q_next, v_next = pin_step(model, vizer, i, dt=0.2, enable_gravity=False)
+            q_next = pin_step(model, vizer, i, dt=0.2, enable_gravity=False)
             vizer.display(q_next)
             sleep(2)
 

--- a/examples/floating-base-velocity-viewer.py
+++ b/examples/floating-base-velocity-viewer.py
@@ -1,0 +1,92 @@
+import pinocchio as pin
+import numpy as np
+import hppfcl
+
+from pinocchio.visualize import MeshcatVisualizer
+from time import sleep
+
+def create_pin_cube_model(j0='freeflyer'):
+    model = pin.Model()
+
+    if j0 == 'freeflyer':
+        j0 = pin.JointModelFreeFlyer()
+    elif j0 == 'spherical':
+        j0 = pin.JointModelSpherical()
+    elif j0 == 'sphericalzyx':
+        j0 = pin.JointModelSphericalZYX()
+    else:
+        raise ValueError("Unknown joint type")
+
+    jointCube = model.addJoint(0, j0, pin.SE3.Identity(), "joint0")
+    M = pin.SE3(np.eye(3), np.matrix([0.0, 0.0, 0.0]).T)
+    model.appendBodyToJoint(jointCube, pin.Inertia.FromBox(1, 0.8, 0.4, 0.2), M)
+    return model
+
+def create_pin_geometry_cube_model(model):
+    jointCube = model.getFrameId("joint0")
+    geom_model = pin.GeometryModel()
+    cube_shape = hppfcl.Box(0.8, 0.4, 0.2)  # x, y, z
+    cube = pin.GeometryObject(
+        "cube_shape", 0, jointCube, cube_shape, pin.SE3.Identity()
+    )
+    cube.meshColor = np.array([1.0, 0.1, 0.1, 0.5])
+    geom_model.addGeometryObject(cube)
+    return geom_model
+
+def create_model(joint0_type='freeflyer'):
+    model = create_pin_cube_model(joint0_type)
+    geom_model = create_pin_geometry_cube_model(model)
+    return model, geom_model
+
+def pin_step(model, vizer, v_index_increment, dt = 0.1, enable_gravity=True):
+
+    if not enable_gravity:
+        model.gravity.setZero()
+
+    data = model.createData()
+
+    tau = np.zeros(model.nv)
+    q = pin.neutral(model)
+    v = np.zeros(model.nv)
+    v[v_index_increment] += 1.
+
+    vizer.display(q)
+    print(f"{q=}, {v=}")
+
+    sleep(1)
+
+    a = pin.aba(model, data, q, v, tau)
+    v_next = v + a * dt
+    q_next = pin.integrate(model, q, v_next * dt)
+
+    print(f"{a=}, {q_next=}, {v_next=}")
+    return q_next, v_next
+
+
+if __name__ == "__main__":
+
+    list_joint0 = ['freeflyer', 'sphericalzyx', 'spherical']
+
+    for joint0_name in list_joint0:
+
+        print(f"\njoint0_name = {joint0_name}")
+
+        model, geom_model = create_model(joint0_name)
+        print(f"{model.nq=}")
+        print(f"{model.nv=}")
+
+        q = pin.neutral(model)
+        print(f"neutral q configuration: {q=}")
+
+        vizer = MeshcatVisualizer(model, geom_model, geom_model)
+        vizer.initViewer(open=True, loadModel=True)
+        vizer.display(q)
+
+        sleep(2)
+
+        for i in range(model.nv):
+            print(f"v[{i}] += 1")
+            q_next, v_next = pin_step(model, vizer, i, dt=0.2, enable_gravity=False)
+            vizer.display(q_next)
+            sleep(2)
+

--- a/examples/floating-base-velocity-viewer.py
+++ b/examples/floating-base-velocity-viewer.py
@@ -38,11 +38,8 @@ def create_model(joint0_type='freeflyer'):
     geom_model = create_pin_geometry_cube_model(model)
     return model, geom_model
 
-def pin_step(model, vizer, v_index_increment, dt = 0.1, enable_gravity=True):
 
-    if not enable_gravity:
-        model.gravity.setZero()
-
+def pin_step(model, vizer, v_index_increment, dt=0.1):
     q = pin.neutral(model)
     v = np.zeros(model.nv)
     v[v_index_increment] += 1.
@@ -81,7 +78,6 @@ if __name__ == "__main__":
 
         for i in range(model.nv):
             print(f"v[{i}] += 1")
-            q_next = pin_step(model, vizer, i, dt=0.2, enable_gravity=False)
+            q_next = pin_step(model, vizer, i, dt=0.2)
             vizer.display(q_next)
             sleep(2)
-

--- a/examples/floating-base-velocity-viewer.py
+++ b/examples/floating-base-velocity-viewer.py
@@ -5,14 +5,15 @@ import hppfcl
 from pinocchio.visualize import MeshcatVisualizer
 from time import sleep
 
-def create_pin_cube_model(j0='freeflyer'):
+
+def create_pin_cube_model(j0="freeflyer"):
     model = pin.Model()
 
-    if j0 == 'freeflyer':
+    if j0 == "freeflyer":
         j0 = pin.JointModelFreeFlyer()
-    elif j0 == 'spherical':
+    elif j0 == "spherical":
         j0 = pin.JointModelSpherical()
-    elif j0 == 'sphericalzyx':
+    elif j0 == "sphericalzyx":
         j0 = pin.JointModelSphericalZYX()
     else:
         raise ValueError("Unknown joint type")
@@ -21,6 +22,7 @@ def create_pin_cube_model(j0='freeflyer'):
     M = pin.SE3.Identity()
     model.appendBodyToJoint(jointCube, pin.Inertia.FromBox(1, 0.8, 0.4, 0.2), M)
     return model
+
 
 def create_pin_geometry_cube_model(model):
     jointCube = model.getFrameId("joint0")
@@ -33,7 +35,8 @@ def create_pin_geometry_cube_model(model):
     geom_model.addGeometryObject(cube)
     return geom_model
 
-def create_model(joint0_type='freeflyer'):
+
+def create_model(joint0_type="freeflyer"):
     model = create_pin_cube_model(joint0_type)
     geom_model = create_pin_geometry_cube_model(model)
     return model, geom_model
@@ -42,7 +45,7 @@ def create_model(joint0_type='freeflyer'):
 def pin_step(model, vizer, v_index_increment, dt=0.1):
     q = pin.neutral(model)
     v = np.zeros(model.nv)
-    v[v_index_increment] += 1.
+    v[v_index_increment] += 1.0
 
     vizer.display(q)
     print(f"{q=}, {v=}")
@@ -56,11 +59,9 @@ def pin_step(model, vizer, v_index_increment, dt=0.1):
 
 
 if __name__ == "__main__":
-
-    list_joint0 = ['freeflyer', 'sphericalzyx', 'spherical']
+    list_joint0 = ["freeflyer", "sphericalzyx", "spherical"]
 
     for joint0_name in list_joint0:
-
         print(f"\njoint0_name = {joint0_name}")
 
         model, geom_model = create_model(joint0_name)

--- a/examples/floating-base-velocity-viewer.py
+++ b/examples/floating-base-velocity-viewer.py
@@ -18,7 +18,7 @@ def create_pin_cube_model(j0='freeflyer'):
         raise ValueError("Unknown joint type")
 
     jointCube = model.addJoint(0, j0, pin.SE3.Identity(), "joint0")
-    M = pin.SE3(np.eye(3), np.matrix([0.0, 0.0, 0.0]).T)
+    M = pin.SE3.Identity()
     model.appendBodyToJoint(jointCube, pin.Inertia.FromBox(1, 0.8, 0.4, 0.2), M)
     return model
 


### PR DESCRIPTION
After several questions/discussions (e.g. #1657, #1357, #1137, #1122) about the conventions used for the velocity vector for different joints that can serve as a floating base, I started a small script to verify. 

This script builds a simple robot that is just a box with dimensions x=0.8, y=0.4, z=0.2. The floating base can be set to either `JointModelFreeFlyer`, `JointModelSphericalZYX` or `JointModelSpherical`. It prints several properties of the mode, increments each velocity component by 1, calculates the resulting `a`, `v_next`, `q_next` via `pin.aba` and visualizes the integrated configuration q_next via MeshCat. 
This could be useful for people who want to try it out for themselves. Also, we could add more joints in the future to test them as well.

