### PR TITLE
Fix ambiguous function call on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Remove a lot of warnings ([#2139](https://github.com/stack-of-tasks/pinocchio/pull/2139))
 - `MeshcatVisualizer` doesn't crash anymore when there is no collision model defined ([#2147](https://github.com/stack-of-tasks/pinocchio/pull/2147))
+- Fix MSVC build ([#2155](https://github.com/stack-of-tasks/pinocchio/pull/2155))
 
 ### Added
 - Add `examples/floating-base-velocity-viewer.py` to visualize floating base velocity [#2143](https://github.com/stack-of-tasks/pinocchio/pull/2143)

--- a/include/pinocchio/multibody/liegroup/special-euclidean.hpp
+++ b/include/pinocchio/multibody/liegroup/special-euclidean.hpp
@@ -362,10 +362,10 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & J_out) const
+                                     const Eigen::MatrixBase<JacobianOut_t> & J_out)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out);
 PINOCCHIO_COMPILER_DIAGNOSTIC_PUSH
@@ -384,10 +384,10 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & J_out) const
+                                     const Eigen::MatrixBase<JacobianOut_t> & J_out)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out);
       MotionTpl<Scalar,0> nu; nu.toVector() << v.template head<2>(), 0, 0, 0, v[2]; 
@@ -410,9 +410,9 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     }
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
-                                     const Eigen::MatrixBase<Jacobian_t> & J) const
+                                     const Eigen::MatrixBase<Jacobian_t> & J)
     {
       Jacobian_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J);
 PINOCCHIO_COMPILER_DIAGNOSTIC_PUSH
@@ -431,9 +431,9 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     }
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
-                                     const Eigen::MatrixBase<Jacobian_t> & J) const
+                                     const Eigen::MatrixBase<Jacobian_t> & J)
     {
       Jacobian_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J);
       MotionTpl<Scalar,0> nu; nu.toVector() << v.template head<2>(), 0, 0, 0, v[2]; 
@@ -470,16 +470,15 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     }
 
     template <class Config_t>
-    void random_impl(const Eigen::MatrixBase<Config_t> & qout) const
+    static void random_impl(const Eigen::MatrixBase<Config_t> & qout)
     {
       R2crossSO2_t().random(qout);
     }
 
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
-    void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & lower,
+    static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & lower,
                                   const Eigen::MatrixBase<ConfigR_t> & upper,
                                   const Eigen::MatrixBase<ConfigOut_t> & qout)
-      const
     {
       R2crossSO2_t ().randomConfiguration(lower, upper, qout);
     }
@@ -581,9 +580,9 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
 
     /// \cheatsheet \f$ \frac{\partial\ominus}{\partial q_1} {}^1X_0 = - \frac{\partial\ominus}{\partial q_0} \f$
     template <ArgumentPosition arg, class ConfigL_t, class ConfigR_t, class JacobianOut_t>
-    void dDifference_impl (const Eigen::MatrixBase<ConfigL_t> & q0,
+    static void dDifference_impl (const Eigen::MatrixBase<ConfigL_t> & q0,
                            const Eigen::MatrixBase<ConfigR_t> & q1,
-                           const Eigen::MatrixBase<JacobianOut_t> & J) const
+                           const Eigen::MatrixBase<JacobianOut_t> & J)
     {
       typedef typename SE3::Vector3 Vector3;
       typedef typename SE3::Matrix3 Matrix3;
@@ -741,10 +740,10 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & J_out) const
+                                     const Eigen::MatrixBase<JacobianOut_t> & J_out)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out);
       Eigen::Matrix<Scalar,6,6> Jtmp6;
@@ -759,10 +758,10 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & J_out) const
+                                     const Eigen::MatrixBase<JacobianOut_t> & J_out)
     {
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out);
 PINOCCHIO_COMPILER_DIAGNOSTIC_PUSH
@@ -781,9 +780,9 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
 
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
-                                     const Eigen::MatrixBase<Jacobian_t> & J_out) const
+                                     const Eigen::MatrixBase<Jacobian_t> & J_out)
     {
       Jacobian_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J_out);
       Eigen::Matrix<Scalar,6,6> Jtmp6;
@@ -799,9 +798,9 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     }
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
-                                     const Eigen::MatrixBase<Jacobian_t> & J_out) const
+                                     const Eigen::MatrixBase<Jacobian_t> & J_out)
     {
       Jacobian_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J_out);
 PINOCCHIO_COMPILER_DIAGNOSTIC_PUSH
@@ -847,16 +846,15 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     }
 
     template <class Config_t>
-    void random_impl (const Eigen::MatrixBase<Config_t>& qout) const
+    static void random_impl (const Eigen::MatrixBase<Config_t>& qout)
     {
       R3crossSO3_t().random(qout);
     }
 
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
-    void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & lower,
+    static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> & lower,
                                   const Eigen::MatrixBase<ConfigR_t> & upper,
                                   const Eigen::MatrixBase<ConfigOut_t> & qout)
-      const
     {
       R3crossSO3_t ().randomConfiguration(lower, upper, qout);
     }

--- a/include/pinocchio/multibody/liegroup/special-orthogonal.hpp
+++ b/include/pinocchio/multibody/liegroup/special-orthogonal.hpp
@@ -143,9 +143,9 @@ namespace pinocchio
     }
 
     template <ArgumentPosition arg, class ConfigL_t, class ConfigR_t, class JacobianOut_t>
-    void dDifference_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
+    static void dDifference_impl(const Eigen::MatrixBase<ConfigL_t> & q0,
                           const Eigen::MatrixBase<ConfigR_t> & q1,
-                          const Eigen::MatrixBase<JacobianOut_t> & J) const
+                          const Eigen::MatrixBase<JacobianOut_t> & J)
     {
       Matrix2 R; // R0.transpose() * R1;
       R(0,0) = R(1,1) = q0.dot(q1);
@@ -237,32 +237,32 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & /*v*/,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+                                     const Eigen::MatrixBase<JacobianOut_t> & Jout)
     {
       PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout) = Jin;
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & /*v*/,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+                                     const Eigen::MatrixBase<JacobianOut_t> & Jout)
     {
       PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout) = Jin;
     }
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & /*v*/,
-                                     const Eigen::MatrixBase<Jacobian_t> & /*J*/) const {}
+                                     const Eigen::MatrixBase<Jacobian_t> & /*J*/) {}
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & /*v*/,
-                                     const Eigen::MatrixBase<Jacobian_t> & /*J*/) const {}
+                                     const Eigen::MatrixBase<Jacobian_t> & /*J*/) {}
     
 
     
@@ -316,7 +316,7 @@ namespace pinocchio
     }
 
     template <class Config_t>
-    void random_impl (const Eigen::MatrixBase<Config_t>& qout) const
+    static void random_impl (const Eigen::MatrixBase<Config_t>& qout)
     {
       Config_t & out = PINOCCHIO_EIGEN_CONST_CAST(Config_t,qout);
       
@@ -326,9 +326,9 @@ namespace pinocchio
     }
 
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
-    void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> &,
+    static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> &,
                                   const Eigen::MatrixBase<ConfigR_t> &,
-                                  const Eigen::MatrixBase<ConfigOut_t> & qout) const
+                                  const Eigen::MatrixBase<ConfigOut_t> & qout)
     {
       random_impl(qout);
     }
@@ -387,9 +387,9 @@ namespace pinocchio
     }
 
     template <ArgumentPosition arg, class ConfigL_t, class ConfigR_t, class JacobianOut_t>
-    void dDifference_impl (const Eigen::MatrixBase<ConfigL_t> & q0,
+    static void dDifference_impl (const Eigen::MatrixBase<ConfigL_t> & q0,
                            const Eigen::MatrixBase<ConfigR_t> & q1,
-                           const Eigen::MatrixBase<JacobianOut_t> & J) const
+                           const Eigen::MatrixBase<JacobianOut_t> & J)
     {
       typedef typename SE3::Matrix3 Matrix3;
 
@@ -510,10 +510,10 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & J_out) const
+                                     const Eigen::MatrixBase<JacobianOut_t> & J_out)
     {
       typedef typename SE3::Matrix3 Matrix3;
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out);
@@ -522,10 +522,10 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & J_out) const
+                                     const Eigen::MatrixBase<JacobianOut_t> & J_out)
     {
       typedef typename SE3::Matrix3 Matrix3;
       JacobianOut_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,J_out);
@@ -538,9 +538,9 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     }
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
-                                     const Eigen::MatrixBase<Jacobian_t> & J_out) const
+                                     const Eigen::MatrixBase<Jacobian_t> & J_out)
     {
       typedef typename SE3::Matrix3 Matrix3;
       Jacobian_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J_out);
@@ -549,9 +549,9 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     }
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & v,
-                                     const Eigen::MatrixBase<Jacobian_t> & J_out) const
+                                     const Eigen::MatrixBase<Jacobian_t> & J_out)
     {
       typedef typename SE3::Matrix3 Matrix3;
       Jacobian_t & Jout = PINOCCHIO_EIGEN_CONST_CAST(Jacobian_t,J_out);
@@ -610,7 +610,7 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     }
 
     template <class Config_t>
-    void random_impl(const Eigen::MatrixBase<Config_t> & qout) const
+    static void random_impl(const Eigen::MatrixBase<Config_t> & qout)
     {
       QuaternionMap_t quat_map(PINOCCHIO_EIGEN_CONST_CAST(Config_t,qout).data());
       quaternion::uniformRandom(quat_map);
@@ -619,9 +619,9 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     }
 
     template <class ConfigL_t, class ConfigR_t, class ConfigOut_t>
-    void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> &,
+    static void randomConfiguration_impl(const Eigen::MatrixBase<ConfigL_t> &,
                                   const Eigen::MatrixBase<ConfigR_t> &,
-                                  const Eigen::MatrixBase<ConfigOut_t> & qout) const
+                                  const Eigen::MatrixBase<ConfigOut_t> & qout)
     {
       random_impl(qout);
     }

--- a/include/pinocchio/multibody/liegroup/special-orthogonal.hpp
+++ b/include/pinocchio/multibody/liegroup/special-orthogonal.hpp
@@ -176,7 +176,7 @@ namespace pinocchio
       // See quaternion::firstOrderNormalize for equations.
       const Scalar norm2 = out.squaredNorm();
       out *= (3 - norm2) / 2;
-      assert (isNormalized(out));
+      assert (pinocchio::isNormalized(out));
     }
     
     template <class Config_t, class Jacobian_t>

--- a/include/pinocchio/multibody/liegroup/vector-space.hpp
+++ b/include/pinocchio/multibody/liegroup/vector-space.hpp
@@ -95,12 +95,12 @@ namespace pinocchio
     }
 
     template <ArgumentPosition arg, class ConfigL_t, class ConfigR_t, class JacobianIn_t, class JacobianOut_t>
-    void dDifference_product_impl(const ConfigL_t &,
+    static void dDifference_product_impl(const ConfigL_t &,
                                   const ConfigR_t &,
                                   const JacobianIn_t & Jin,
                                   JacobianOut_t & Jout,
                                   bool,
-                                  const AssignmentOperatorType op) const
+                                  const AssignmentOperatorType op)
     {
       switch (op) {
         case SETTO:
@@ -182,13 +182,13 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrate_product_impl(const Config_t &,
+    static void dIntegrate_product_impl(const Config_t &,
                                  const Tangent_t &,
                                  const JacobianIn_t & Jin,
                                  JacobianOut_t & Jout,
                                  bool,
                                  const ArgumentPosition,
-                                 const AssignmentOperatorType op) const
+                                 const AssignmentOperatorType op)
     {
       switch(op) {
         case SETTO:
@@ -207,32 +207,32 @@ namespace pinocchio
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & /*v*/,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+                                     const Eigen::MatrixBase<JacobianOut_t> & Jout)
     {
       PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout) = Jin;
     }
 
     template <class Config_t, class Tangent_t, class JacobianIn_t, class JacobianOut_t>
-    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & /*v*/,
                                      const Eigen::MatrixBase<JacobianIn_t> & Jin,
-                                     const Eigen::MatrixBase<JacobianOut_t> & Jout) const
+                                     const Eigen::MatrixBase<JacobianOut_t> & Jout)
     {
       PINOCCHIO_EIGEN_CONST_CAST(JacobianOut_t,Jout) = Jin;
     }
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dq_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & /*v*/,
-                                     const Eigen::MatrixBase<Jacobian_t> & /*J*/) const {}
+                                     const Eigen::MatrixBase<Jacobian_t> & /*J*/) {}
 
     template <class Config_t, class Tangent_t, class Jacobian_t>
-    void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
+    static void dIntegrateTransport_dv_impl(const Eigen::MatrixBase<Config_t > & /*q*/,
                                      const Eigen::MatrixBase<Tangent_t> & /*v*/,
-                                     const Eigen::MatrixBase<Jacobian_t> & /*J*/) const {}
+                                     const Eigen::MatrixBase<Jacobian_t> & /*J*/) {}
 
 
 
@@ -251,7 +251,7 @@ namespace pinocchio
     }
 
     template <class Config_t>
-    void random_impl (const Eigen::MatrixBase<Config_t>& qout) const
+    static void random_impl (const Eigen::MatrixBase<Config_t>& qout)
     {
       PINOCCHIO_EIGEN_CONST_CAST(Config_t,qout).setRandom();
     }


### PR DESCRIPTION
Call `pinocchio::isNormalized` intead of `isNormalized` that it seen ambiguous by MSVC (LieGroupBase or namespace).

Close #2154 