### PR TITLE
Check if internal J_cols definition is necessary

### DIFF
--- a/include/pinocchio/algorithm/aba.hxx
+++ b/include/pinocchio/algorithm/aba.hxx
@@ -307,10 +307,6 @@ namespace pinocchio
       else
         data.oMi[i] = data.liMi[i];
 
-      typedef typename SizeDepType<JointModel::NV>::template ColsReturn<typename Data::Matrix6x>::Type ColsBlock;
-      ColsBlock J_cols = jmodel.jointCols(data.J);
-      J_cols = data.oMi[i].act(jdata.S());
-
       data.Yaba[i] = model.inertias[i].matrix();
     }
 


### PR DESCRIPTION
See https://github.com/stack-of-tasks/pinocchio/issues/2171

Checking if removing `J_cols` here breaks a unit test. There are two potential outcomes:

1. It is necessary and all tests pass, meaning we have an opportunity to add one :wink: 
2. It is not necessary, all tests pass, we can double check and merge.