### PR TITLE
[doc] Improve documentation of getJointJacobian.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 - Set NOMINMAX as a public definitions on Windows ([#2139](https://github.com/stack-of-tasks/pinocchio/pull/2139))
 - Improve documentation of enum ReferenceFrame.
+- Improve documentation of `getJointJacobian`([#2193](https://github.com/stack-of-tasks/pinocchio/pull/2193)).
 
 ### Fixed
 - Order of frames in ReducedModel is now the same as in the full model ([#2160](https://github.com/stack-of-tasks/pinocchio/pull/2160))

--- a/include/pinocchio/algorithm/jacobian.hpp
+++ b/include/pinocchio/algorithm/jacobian.hpp
@@ -61,6 +61,8 @@ namespace pinocchio
   ///
   /// When serialized to a 6D vector, the order of coordinates is: three linear followed by three angular.
   ///
+  /// For further details regarding the different velocities or the Jacobian see Chapter 2 and 3 respectively in [A Mathematical Introduction to Robotic Manipulation](https://www.cse.lehigh.edu/~trink/Courses/RoboticsII/reading/murray-li-sastry-94-complete.pdf) by Murray, Li and Sastry.
+  ///
   /// \note This jacobian is extracted from data.J. You have to run pinocchio::computeJointJacobians before calling it.
   ///
   /// \tparam JointCollection Collection of Joint types.

--- a/include/pinocchio/algorithm/jacobian.hpp
+++ b/include/pinocchio/algorithm/jacobian.hpp
@@ -50,12 +50,16 @@ namespace pinocchio
   computeJointJacobians(const ModelTpl<Scalar,Options,JointCollectionTpl> & model,
                         DataTpl<Scalar,Options,JointCollectionTpl> & data);
   
+  /// \brief Computes the Jacobian of a specific joint frame expressed in one of the pinocchio::ReferenceFrame options.
   ///
-  /// \brief Computes the Jacobian of a specific joint frame expressed either in the world (rf = WORLD) frame or in the local frame (rf = LOCAL) of the joint.
+  /// \details For the LOCAL reference frame, the Jacobian \f${}^j J_{0j}\f$ from the joint frame \f$j\f$ to the world frame \f$0\f$ is such that \f${}^j v_{0j} = {}^j J_{0j} \dot{q}\f$,
+  /// where \f${}^j v_{0j}\f$ is the velocity of the origin of the moving joint frame relative to the fixed world frame, projected into the basis of the joint frame. LOCAL_WORLD_ALIGNED is the same
+  /// velocity but projected into the world frame basis.
   ///
-  /// For the world frame W, the Jacobian \f${}^0 J_{0j}$ from the joint frame \f$j$ to the world frame $0$ is such that \f${}^0 v_{0j} = {}^0 J_{0j} \dot{q}$,
-  /// where \f${}^0 v_{0j}$ is the spatial velocity of the joint frame. (When serialized to a 6D vector, the three linear coordinates are followed by the three
-  /// angular coordinates).
+  /// For the WORLD reference frame, the Jacobian \f${}^0 J_{0j}\f$ from the joint frame \f$j\f$ to the world frame \f$0\f$ is such that \f${}^0 v_{0j} = {}^0 J_{0j} \dot{q}\f$,
+  /// where \f${}^0 v_{0j}\f$ is the spatial velocity of the joint frame. The linear component of this spatial velocity is the velocity of a (possibly imaginary) point attached to the moving joint frame j which is traveling through the origin of the world frame at that instant. The angular component is the instantaneous angular velocity of the joint frame as viewed in the world frame.
+  ///
+  /// When serialized to a 6D vector, the order of coordinates is: three linear followed by three angular.
   ///
   /// \note This jacobian is extracted from data.J. You have to run pinocchio::computeJointJacobians before calling it.
   ///

--- a/include/pinocchio/algorithm/jacobian.hpp
+++ b/include/pinocchio/algorithm/jacobian.hpp
@@ -61,7 +61,7 @@ namespace pinocchio
   ///
   /// When serialized to a 6D vector, the order of coordinates is: three linear followed by three angular.
   ///
-  /// For further details regarding the different velocities or the Jacobian see Chapter 2 and 3 respectively in [A Mathematical Introduction to Robotic Manipulation](https://www.cse.lehigh.edu/~trink/Courses/RoboticsII/reading/murray-li-sastry-94-complete.pdf) by Murray, Li and Sastry.
+  /// For further details regarding the different velocities or the Jacobian see Chapters 2 and 3 respectively in [A Mathematical Introduction to Robotic Manipulation](https://www.cse.lehigh.edu/~trink/Courses/RoboticsII/reading/murray-li-sastry-94-complete.pdf) by Murray, Li and Sastry.
   ///
   /// \note This jacobian is extracted from data.J. You have to run pinocchio::computeJointJacobians before calling it.
   ///


### PR DESCRIPTION
After several discussions about Jacobians and ReferenceFrames, and the nice improvement of the doc string #2190, I propose to fix and improve the docstring of `getJointJacobian`.

This doc string did not render properly due to some missing `\f` in front of `$`. While adding it, I tried to add further details about the calculated quantities and be verbose about their meaning.

For more rigorous mathematical details, we could also refer to [A Mathematical Introduction to Robotic Manipulation](https://www.cse.lehigh.edu/~trink/Courses/RoboticsII/reading/murray-li-sastry-94-complete.pdf) by Murray, Li and Sastry (thanks for the pointer @stephane-caron). 