### PR TITLE
Fix SO(3) title and ref in the documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix MSVC build ([#2155](https://github.com/stack-of-tasks/pinocchio/pull/2155))
 - Fix stub generation ([#2166](https://github.com/stack-of-tasks/pinocchio/pull/2166))
 - Clean up empty documentation pages and sections ([#2167](https://github.com/stack-of-tasks/pinocchio/pull/2167))
+- Fix SO(3) title and cross-section reference in the documentation ([#2210](https://github.com/stack-of-tasks/pinocchio/pull/2210))
 
 ### Added
 - Add `examples/floating-base-velocity-viewer.py` to visualize floating base velocity ([#2143](https://github.com/stack-of-tasks/pinocchio/pull/2143))

--- a/doc/a-features/e-lie.md
+++ b/doc/a-features/e-lie.md
@@ -1,5 +1,5 @@
 
-# Dealing with Lie group geometry 
+# Dealing with Lie group geometry {#e-lie}
 
 Pinocchio relies heavily on Lie groups and Lie algebras to handle motions and more specifically rotations.
 For this reason it supports the following special groups \\( SO(2), SO(3), SE(2), SE(3) \\) and implements their associated algebras

--- a/doc/c-maths/a-rigid-bodies.md
+++ b/doc/c-maths/a-rigid-bodies.md
@@ -8,9 +8,9 @@ Rotation matrices form the so-called **Special Orthogonal** group \f$ SO(n) \f$.
 
 The set that brings together all the homogeneous transformations matrices is the **Special Euclidean** group \f$ SE(n) \f$. As with rotation matrices, there are two different groups, \f$ SE(3) \f$ for 3-dimensional transformations and \f$ SE(2) \f$ for 2-dimensional transformation, i.e. transformation in a plane. 
 
-### Using quaternions for an  <!-- $ SO(3) $ --> <img src="https://latex.codecogs.com/svg.image?\small%20\color{black}SO(3)" /> object
+### Using quaternions for an \\( SO(3) \\) object
 
-To use quaternions for a \f$ SO(3) \f$ object we have several methods, we can do as in the \f$ SE(3) \f$ example in the **e-lie** chapter by removing the translation vector. 
+To use quaternions for a \f$ SO(3) \f$ object we have several methods, we can do as in the \f$ SE(3) \f$ example in the [Dealing with Lie group geometry](@ref e-lie) section by removing the translation vector.
 
 Or we can just consider one rotation instead of two. For example, in a landmark link to the robot itself, we consider the starting position as the origin of this landmark.  
 


### PR DESCRIPTION
Just noticed this:

> ![image](https://github.com/stack-of-tasks/pinocchio/assets/1189580/d447949b-4874-47e1-9aa2-42642f022c18)

Also using this opportunity to fix the reference below :wink: