### PR TITLE
Modify model appending algorithm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Changed
+- Modify algorithm that appends a model to another.
 - Set NOMINMAX as a public definitions on Windows ([#2139](https://github.com/stack-of-tasks/pinocchio/pull/2139))
 - Improve documentation of enum ReferenceFrame.
 - Improve documentation of `getJointJacobian`([#2193](https://github.com/stack-of-tasks/pinocchio/pull/2193)).

--- a/include/pinocchio/algorithm/model.hpp
+++ b/include/pinocchio/algorithm/model.hpp
@@ -19,6 +19,10 @@ namespace pinocchio
    *  \param[in] aMb pose of modelB universe joint (index 0) in frameInModelA.
    *  \param[out] model the resulting model.
    *
+   *  The order of the joints in the output models are
+   *    - joints of modelA up to the parent of FrameInModelA,
+   *    - all the descendents of parent of FrameInModelA,
+   *    - the remaining joints of modelA.
    */
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
   void
@@ -38,6 +42,10 @@ namespace pinocchio
    *
    *  \return A new model containing the fusion of modelA and modelB.
    *
+   *  The order of the joints in the output models are
+   *    - joints of modelA up to the parent of FrameInModelA,
+   *    - all the descendents of parent of FrameInModelA,
+   *    - the remaining joints of modelA.
    */
   template<typename Scalar, int Options, template<typename,int> class JointCollectionTpl>
   ModelTpl<Scalar,Options,JointCollectionTpl>

--- a/include/pinocchio/algorithm/model.hxx
+++ b/include/pinocchio/algorithm/model.hxx
@@ -283,6 +283,7 @@ namespace pinocchio
       AJointsBeforeB.push_back(jid);
     }
     // descendants of the parent of frameInModelA come also before model B
+    // TODO(jcarpent): enhancement by taking into account the compactness of the joint ordering.
     for (JointIndex jid = frame.parent+1; jid < modelA.joints.size(); ++jid)
     {
       if (hasAncestor(modelA, jid, frame.parent))

--- a/include/pinocchio/multibody/model.hpp
+++ b/include/pinocchio/multibody/model.hpp
@@ -145,8 +145,10 @@ namespace pinocchio
     FrameVector frames;
     
     /// \brief Vector of joint supports.
-    /// supports[j] corresponds to the collection of all joints located on the path between body *j*  and the root.
-    /// The last element of supports[j] is the index of the joint *j* itself.
+    /// supports[j] corresponds to the vector of indices of the joints located on the path between
+    /// joint *j*  and "universe".
+    /// The first element of supports[j] is "universe", the last one is the index of joint *j*
+    /// itself.
     std::vector<IndexVector> supports;
     
     /// \brief Vector of joint subtrees.


### PR DESCRIPTION
This modification follows https://github.com/stack-of-tasks/pinocchio/discussions/2203.
  
In the new version, when appending model B to model A on frame F, joints are copied in the
following order
  - joints of model A up to the parent of F,
  - all the descendents of parent of F,
  - the remaining joints of A.