### PR TITLE
add python test for `contactInverseDynamics`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fix compilation issue for Boost 1.85 ([#2255](https://github.com/stack-of-tasks/pinocchio/pull/2255))
+- Fix python bindings of `contactInverseDynamics` ([#2263](https://github.com/stack-of-tasks/pinocchio/pull/2263))
 
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix compilation issue for Boost 1.85 ([#2255](https://github.com/stack-of-tasks/pinocchio/pull/2255))
 
+
+### Added
+
+- Python unittest for `contactInverseDynamics` function ([#2263](https://github.com/stack-of-tasks/pinocchio/pull/2263))
+
 ## [3.0.0] - 2024-05-27
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Python unittest for `contactInverseDynamics` function ([#2263](https://github.com/stack-of-tasks/pinocchio/pull/2263))
 
+### Removed
+
+- Remove header `list.hpp` include for bindings of model and rnea ([#2263](https://github.com/stack-of-tasks/pinocchio/pull/2263))
+
 ## [3.0.0] - 2024-05-27
 
 ### Added

--- a/bindings/python/algorithm/expose-contact-inverse-dynamics.cpp
+++ b/bindings/python/algorithm/expose-contact-inverse-dynamics.cpp
@@ -5,7 +5,7 @@
 #define BOOST_PYTHON_MAX_ARITY 24
 
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
-#include "pinocchio/bindings/python/utils/list.hpp"
+#include "pinocchio/bindings/python/utils/std-vector.hpp"
 #include "pinocchio/algorithm/contact-inverse-dynamics.hpp"
 
 namespace pinocchio

--- a/bindings/python/algorithm/expose-model.cpp
+++ b/bindings/python/algorithm/expose-model.cpp
@@ -1,9 +1,8 @@
 //
-// Copyright (c) 2019-2020 INRIA
+// Copyright (c) 2019-2024 INRIA
 //
 
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
-#include "pinocchio/bindings/python/utils/list.hpp"
 #include "pinocchio/bindings/python/utils/std-vector.hpp"
 #include "pinocchio/algorithm/model.hpp"
 

--- a/bindings/python/algorithm/expose-rnea.cpp
+++ b/bindings/python/algorithm/expose-rnea.cpp
@@ -1,9 +1,8 @@
 //
-// Copyright (c) 2015-2021 CNRS INRIA
+// Copyright (c) 2015-2024 CNRS INRIA
 //
 
 #include "pinocchio/bindings/python/algorithm/algorithms.hpp"
-#include "pinocchio/bindings/python/utils/list.hpp"
 #include "pinocchio/algorithm/rnea.hpp"
 
 namespace pinocchio

--- a/unittest/python/CMakeLists.txt
+++ b/unittest/python/CMakeLists.txt
@@ -54,7 +54,7 @@ endif(hpp-fcl_FOUND)
 
 if(urdfdom_FOUND)
   set(${PROJECT_NAME}_PYTHON_TESTS ${${PROJECT_NAME}_PYTHON_TESTS} bindings_urdf
-                                   bindings_geometry_model_urdf)
+                                   bindings_geometry_model_urdf bindings_contact_inverse_dynamics)
 endif(urdfdom_FOUND)
 
 foreach(TEST ${${PROJECT_NAME}_PYTHON_TESTS})

--- a/unittest/python/bindings_contact_inverse_dynamics.py
+++ b/unittest/python/bindings_contact_inverse_dynamics.py
@@ -1,0 +1,142 @@
+import os
+import unittest
+import numpy as np
+
+import pinocchio as pin
+
+
+@unittest.skipUnless(pin.WITH_URDFDOM, "Needs URDFDOM")
+class TestContactInverseDynamics(unittest.TestCase):
+    def setUp(self):
+        self.current_file = os.path.dirname(str(os.path.abspath(__file__)))
+        self.model_dir = os.path.abspath(
+            os.path.join(self.current_file, "../../models/")
+        )
+        self.model_path = os.path.abspath(
+            os.path.join(
+                self.model_dir,
+                "example-robot-data/robots/talos_data",
+            )
+        )
+        self.urdf_filename = "talos_reduced.urdf"
+        self.srdf_filename = "talos.srdf"
+        self.urdf_model_path = os.path.join(
+            self.model_path,
+            "robots",
+            self.urdf_filename,
+        )
+        self.srdf_full_path = os.path.join(
+            self.model_path,
+            "srdf",
+            self.srdf_filename,
+        )
+
+    def load_model(self):
+        self.model = pin.buildModelFromUrdf(
+            self.urdf_model_path, pin.JointModelFreeFlyer()
+        )
+        pin.loadReferenceConfigurations(self.model, self.srdf_full_path)
+        self.q0 = self.model.referenceConfigurations["half_sitting"]
+
+    def test_call_to_contact_inverse_dynamics(self):
+        self.load_model()
+        model = self.model
+        feet_name = ["left_sole_link", "right_sole_link"]
+        frame_ids = [model.getFrameId(frame_name) for frame_name in feet_name]
+
+        q = self.q0
+        v = np.zeros((model.nv))
+        a = np.zeros((model.nv))
+        data = model.createData()
+
+        contact_models_list = []
+        contact_datas_list = []
+        cones_list = []
+
+        contact_models_vec = pin.StdVec_RigidConstraintModel()
+        contact_datas_vec = pin.StdVec_RigidConstraintData()
+        cones_vec = pin.StdVec_CoulombFrictionCone()
+
+        for frame_id in frame_ids:
+            frame = model.frames[frame_id]
+            contact_model = pin.RigidConstraintModel(
+                pin.ContactType.CONTACT_3D, model, frame.parentJoint, frame.placement
+            )
+
+            contact_models_list.append(contact_model)
+            contact_datas_list.append(contact_model.createData())
+            cones_list.append(pin.CoulombFrictionCone(0.4))
+
+            contact_models_vec.append(contact_model)
+            contact_datas_vec.append(contact_model.createData())
+            cones_vec.append(pin.CoulombFrictionCone(0.4))
+
+        constraint_dim = 0
+        for m in contact_models_list:
+            constraint_dim += m.size()
+
+        dt = 1e-3
+        R = np.zeros(constraint_dim)
+        constraint_correction = np.zeros(constraint_dim)
+        lambda_guess = np.zeros(constraint_dim)
+        prox_settings = pin.ProximalSettings(1e-12, 1e-6, 1)
+        # pin.initConstraintDynamics(model, data, contact_models_list)  # not needed
+
+        # test 1 with vector of contact models, contact datas and cones
+        tau1 = pin.contactInverseDynamics(
+            model,
+            data,
+            q,
+            v,
+            a,
+            dt,
+            contact_models_vec,
+            contact_datas_vec,
+            cones_vec,
+            R,
+            constraint_correction,
+            prox_settings,
+            lambda_guess,
+        )
+        print(f"{tau1=}")
+
+        # test 2 with list of contact models, cones
+        tau2 = pin.contactInverseDynamics(
+            model,
+            data,
+            q,
+            v,
+            a,
+            dt,
+            contact_models_list,
+            contact_datas_vec,
+            cones_list,
+            R,
+            constraint_correction,
+            prox_settings,
+            lambda_guess,
+        )
+        print(f"{tau2=}")
+
+        # Not working
+        # test 3 with list of contact models, contact datas and cones
+        # tau3 = pin.contactInverseDynamics(
+        #     model,
+        #     data,
+        #     q,
+        #     v,
+        #     a,
+        #     dt,
+        #     contact_models_list,
+        #     contact_datas_list,
+        #     cones_list,
+        #     R,
+        #     constraint_correction,
+        #     prox_settings,
+        #     lambda_guess,
+        # )
+        # print(f"{tau3=}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unittest/python/bindings_contact_inverse_dynamics.py
+++ b/unittest/python/bindings_contact_inverse_dynamics.py
@@ -3,10 +3,11 @@ import unittest
 import numpy as np
 
 import pinocchio as pin
+from test_case import PinocchioTestCase as TestCase
 
 
 @unittest.skipUnless(pin.WITH_URDFDOM, "Needs URDFDOM")
-class TestContactInverseDynamics(unittest.TestCase):
+class TestContactInverseDynamics(TestCase):
     def setUp(self):
         self.current_file = os.path.dirname(str(os.path.abspath(__file__)))
         self.model_dir = os.path.abspath(
@@ -132,8 +133,8 @@ class TestContactInverseDynamics(unittest.TestCase):
             prox_settings,
             lambda_guess,
         )
-        assert np.allclose(tau1, tau2)
-        assert np.allclose(tau1, tau3)
+        self.assertApprox(tau1, tau2)
+        self.assertApprox(tau1, tau3)
 
 
 if __name__ == "__main__":

--- a/unittest/python/bindings_contact_inverse_dynamics.py
+++ b/unittest/python/bindings_contact_inverse_dynamics.py
@@ -98,7 +98,6 @@ class TestContactInverseDynamics(unittest.TestCase):
             prox_settings,
             lambda_guess,
         )
-        print(f"{tau1=}")
 
         # test 2 with list of contact models, cones
         tau2 = pin.contactInverseDynamics(
@@ -116,26 +115,25 @@ class TestContactInverseDynamics(unittest.TestCase):
             prox_settings,
             lambda_guess,
         )
-        print(f"{tau2=}")
 
-        # Not working
         # test 3 with list of contact models, contact datas and cones
-        # tau3 = pin.contactInverseDynamics(
-        #     model,
-        #     data,
-        #     q,
-        #     v,
-        #     a,
-        #     dt,
-        #     contact_models_list,
-        #     contact_datas_list,
-        #     cones_list,
-        #     R,
-        #     constraint_correction,
-        #     prox_settings,
-        #     lambda_guess,
-        # )
-        # print(f"{tau3=}")
+        tau3 = pin.contactInverseDynamics(
+            model,
+            data,
+            q,
+            v,
+            a,
+            dt,
+            contact_models_list,
+            contact_datas_list,
+            cones_list,
+            R,
+            constraint_correction,
+            prox_settings,
+            lambda_guess,
+        )
+        assert np.allclose(tau1, tau2)
+        assert np.allclose(tau1, tau3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In a similar way to the [cpp test](https://github.com/stack-of-tasks/pinocchio/blob/master/unittest/contact-inverse-dynamics.cpp#L82) for the `contactInverseDynamics` function, I propose to add a python test and check if this function is usable from Python. 

the c++ function requires for the contact models, data and cones
```
contactInverseDynamics(..., 
const std::vector<RigidConstraintModelTpl<Scalar, Options>, ConstraintModelAllocator> & contact_models,
std::vector<RigidConstraintDataTpl<Scalar, Options>, ConstraintDataAllocator> & contact_datas,
const std::vector<CoulombFrictionConeTpl<Scalar>, CoulombFrictionConelAllocator> & cones,
```

and this works well when constructing them as `StdVec_RigidConstraintData()` and then appending contact data here (see test1). However, if you try to pass a list of contact data, it does not work (see test3).
This is not the case for contact models and cones, they work both as list of model/cones and as `pin.StdVec` (see test2).

The different is, that models/cones are `const std::vectors` while data is not const.