### PR TITLE
Test vector transport and its inverse with `dIntegrateTransport`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Python unittest for `contactInverseDynamics` function ([#2263](https://github.com/stack-of-tasks/pinocchio/pull/2263))
-- Cpp unittest for `dIntegrateTransport` to check vector transport and its inverse ([#2273](https://github.com/stack-of-tasks/pinocchio/pull/2273))
-- Python unittest for `dIntegrateTransport` to check vector transport and its inverse ([#2273](https://github.com/stack-of-tasks/pinocchio/pull/2273))
+- c++ and Python unittest for `dIntegrateTransport` to check vector transport and its inverse ([#2273](https://github.com/stack-of-tasks/pinocchio/pull/2273))
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Python unittest for `contactInverseDynamics` function ([#2263](https://github.com/stack-of-tasks/pinocchio/pull/2263))
+- Cpp unittest for `dIntegrateTransport` to check vector transport and its inverse ([#2273](https://github.com/stack-of-tasks/pinocchio/pull/2273))
 - Python unittest for `dIntegrateTransport` to check vector transport and its inverse ([#2273](https://github.com/stack-of-tasks/pinocchio/pull/2273))
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 
 - Python unittest for `contactInverseDynamics` function ([#2263](https://github.com/stack-of-tasks/pinocchio/pull/2263))
+- Python unittest for `dIntegrateTransport` to check vector transport and its inverse ([#2273](https://github.com/stack-of-tasks/pinocchio/pull/2273))
 
 ### Removed
 

--- a/unittest/liegroups.cpp
+++ b/unittest/liegroups.cpp
@@ -505,35 +505,31 @@ struct LieGroup_dIntegrateTransport
     BOOST_TEST_MESSAGE(lg.name());
     ConfigVector_t qa, qb(lg.nq());
     qa = lg.random();
-    TangentVector_t v(lg.nv()), tvec_at_q1(lg.nv()), tvec_at_q0(lg.nv()), tvec_at_q0_(lg.nv());
+    TangentVector_t v(lg.nv()), tvec_at_qb(lg.nv()), tvec_at_qa(lg.nv()), tvec_at_qa_r(lg.nv());
     v.setRandom();
     lg.integrate(qa, v, qb);
 
     // transport random tangent vector from q1 to q0
-    tvec_at_q1.setRandom();
-    lg.dIntegrateTransport(qa, v, tvec_at_q1, tvec_at_q0, ARG0);
+    tvec_at_qb.setRandom();
+    lg.dIntegrateTransport(qa, v, tvec_at_qb, tvec_at_qa, ARG0);
 
-    // test opposite direction
-    ConfigVector_t qa_ = qb;
-    TangentVector_t v_ = -v; // reverse path
-    ConfigVector_t qb_ = lg.integrate(qa_, v_);
+    // test reverse direction
+    TangentVector_t v_r = -v; // reverse path
+    ConfigVector_t qa_r = lg.integrate(qb, v_r);
+    lg.dIntegrateTransport(qa_r, v_r, tvec_at_qa, tvec_at_qa_r, ARG0);
 
-    BOOST_CHECK_SMALL((qa - qb_).norm(), 1e-6); // recover init point on manifold
-
-    TangentVector_t tvec_at_q1_ = tvec_at_q0;
-    lg.dIntegrateTransport(qa_, v_, tvec_at_q1_, tvec_at_q0_, ARG0);
-
-    BOOST_CHECK_SMALL((tvec_at_q1 - tvec_at_q0_).norm(), 1e-6);
+    BOOST_CHECK_SMALL((qa - qa_r).norm(), 1e-6); // recover init point on manifold
+    BOOST_CHECK_SMALL((tvec_at_qb - tvec_at_qa_r).norm(), 1e-6);
 
     // same test for matrix
-    JacobianMatrix_t J_at_q1(lg.nv(), lg.nv());
-    J_at_q1.setRandom();
-    JacobianMatrix_t J_at_q0(lg.nv(), lg.nv());
-    lg.dIntegrateTransport(qa, v, J_at_q1, J_at_q0, ARG0);
-    JacobianMatrix_t J_at_q1_(lg.nv(), lg.nv());
-    lg.dIntegrateTransport(qa_, v_, J_at_q0, J_at_q1_, ARG0);
+    JacobianMatrix_t J_at_qa(lg.nv(), lg.nv());
+    J_at_qa.setRandom();
+    JacobianMatrix_t J_at_qb(lg.nv(), lg.nv());
+    lg.dIntegrateTransport(qa, v, J_at_qa, J_at_qb, ARG0);
+    JacobianMatrix_t J_at_qa_r(lg.nv(), lg.nv());
+    lg.dIntegrateTransport(qa_r, v_r, J_at_qb, J_at_qa_r, ARG0);
 
-    BOOST_CHECK_SMALL((J_at_q1 - J_at_q1_).norm(), 1e-6);
+    BOOST_CHECK_SMALL((J_at_qa - J_at_qa_r).norm(), 1e-6);
   }
 };
 

--- a/unittest/python/bindings_liegroups.py
+++ b/unittest/python/bindings_liegroups.py
@@ -104,6 +104,35 @@ class TestLiegroupBindings(TestCase):
                 Jout1_ref = Jint.dot(J0)
                 self.assertApprox(Jout1, Jout1_ref)
 
+    def test_dIntegrateTransport_inverse(self):
+        for lg in [
+            pin.liegroups.R3(),
+            pin.liegroups.SO3(),
+            pin.liegroups.SO2(),
+            pin.liegroups.SE3(),
+            pin.liegroups.SE2(),
+            pin.liegroups.R3() * pin.liegroups.SO3(),
+        ]:
+            q0 = lg.random()
+            v = np.random.rand(lg.nv)
+            q1 = lg.integrate(q0, v)
+
+            # transport random tangent vector from q1 to q0
+            tvec_at_q1 = np.random.rand(lg.nv)
+            tvec_at_q0 = lg.dIntegrateTransport(q0, v, tvec_at_q1, pin.ARG0)
+
+            # test opposite direction
+            q0_ = q1.copy()
+            v_ = -v.copy()  # reverse path
+            q1_ = lg.integrate(q0_, v_)
+
+            self.assertApprox(q0, q1_)  # recover init point on manifold
+
+            tvec_at_q1_ = tvec_at_q0
+            tvec_at_q0_ = lg.dIntegrateTransport(q0_, v_, tvec_at_q1_, pin.ARG0)
+
+            self.assertApprox(tvec_at_q1, tvec_at_q0_)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/unittest/python/bindings_liegroups.py
+++ b/unittest/python/bindings_liegroups.py
@@ -121,23 +121,21 @@ class TestLiegroupBindings(TestCase):
             tvec_at_q1 = np.random.rand(lg.nv)
             tvec_at_q0 = lg.dIntegrateTransport(q0, v, tvec_at_q1, pin.ARG0)
 
-            # test opposite direction
-            q0_ = q1.copy()
-            v_ = -v.copy()  # reverse path
-            q1_ = lg.integrate(q0_, v_)
+            # test reverse direction
+            v_r = -v.copy()  # reverse path
+            q0_r = lg.integrate(q1, v_r)
 
-            self.assertApprox(q0, q1_)  # recover init point on manifold
+            self.assertApprox(q0, q0_r)  # recover init point on manifold
 
-            tvec_at_q1_ = tvec_at_q0
-            tvec_at_q0_ = lg.dIntegrateTransport(q0_, v_, tvec_at_q1_, pin.ARG0)
+            tvec_at_q1_r = lg.dIntegrateTransport(q1, v_r, tvec_at_q0, pin.ARG0)
 
-            self.assertApprox(tvec_at_q1, tvec_at_q0_)
+            self.assertApprox(tvec_at_q1, tvec_at_q1_r)
 
             # same test for matrix
             J_at_q1 = np.random.rand(lg.nv, lg.nv)
             J_at_q0 = lg.dIntegrateTransport(q0, v, J_at_q1, pin.ARG0)
             self.assertApprox(
-                J_at_q1, lg.dIntegrateTransport(q0_, v_, J_at_q0, pin.ARG0)
+                J_at_q1, lg.dIntegrateTransport(q1, v_r, J_at_q0, pin.ARG0)
             )
 
 

--- a/unittest/python/bindings_liegroups.py
+++ b/unittest/python/bindings_liegroups.py
@@ -133,6 +133,13 @@ class TestLiegroupBindings(TestCase):
 
             self.assertApprox(tvec_at_q1, tvec_at_q0_)
 
+            # same test for matrix
+            J_at_q1 = np.random.rand(lg.nv, lg.nv)
+            J_at_q0 = lg.dIntegrateTransport(q0, v, J_at_q1, pin.ARG0)
+            self.assertApprox(
+                J_at_q1, lg.dIntegrateTransport(q0_, v_, J_at_q0, pin.ARG0)
+            )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Hi, I propose adding another test for the `dIntegrateTransport` function to check its "inverse" by using the reverse path. I use this function for vector transport along different manifolds. 