### PR TITLE
Turn `BUILD_WITH_LIBPYTHON` OFF when building with PyPy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix compilation issue for Boost 1.85 ([#2255](https://github.com/stack-of-tasks/pinocchio/pull/2255))
 - Fix python bindings of `contactInverseDynamics` ([#2263](https://github.com/stack-of-tasks/pinocchio/pull/2263))
-
+- Deactivate `BUILD_WITH_LIBPYTHON` when building with PyPy ([#2274](https://github.com/stack-of-tasks/pinocchio/pull/2274))
 
 ### Added
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -280,15 +280,17 @@ if(BUILD_PYTHON_INTERFACE)
 
   message(STATUS "Python compiler: ${_python_implementation_value}")
   if(_python_implementation_value MATCHES "PyPy")
-    set(BUILD_PYTHON_INTERFACE_WITH_PYPY TRUE)
+    set(BUILD_WITH_LIBPYTHON OFF)
+    message(
+      STATUS
+        "PyPy detected, therefore libpython is not available and BUILD_WITH_LIBPYTHON set to OFF.")
   endif()
-
-else(BUILD_PYTHON_INTERFACE)
+else()
   message(
     STATUS
       "Pinocchio won't be compiled with its Python bindings. If you want to enable this feature, please set the option BUILD_PYTHON_INTERFACE to ON."
   )
-endif(BUILD_PYTHON_INTERFACE)
+endif()
 
 if(BUILD_WITH_HPP_FCL_SUPPORT)
   list(APPEND CFLAGS_DEPENDENCIES "-DPINOCCHIO_WITH_HPP_FCL")


### PR DESCRIPTION
This already had been fixed in 4d521ec but had been lost in CMakeLists refactoring.