### PR TITLE
Fix Windows build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Deactivate `BUILD_WITH_LIBPYTHON` when building with PyPy ([#2274](https://github.com/stack-of-tasks/pinocchio/pull/2274))
 - Fix Python bindings cross building with `hpp-fcl` ([#2288](https://github.com/stack-of-tasks/pinocchio/pull/2288))
 - Fix build issue on Windows when a deprecated header is included ([#2292](https://github.com/stack-of-tasks/pinocchio/pull/2292))
+- Fix build issue on Windows when building in Debug mode ([#2292](https://github.com/stack-of-tasks/pinocchio/pull/2292))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix python bindings of `contactInverseDynamics` ([#2263](https://github.com/stack-of-tasks/pinocchio/pull/2263))
 - Deactivate `BUILD_WITH_LIBPYTHON` when building with PyPy ([#2274](https://github.com/stack-of-tasks/pinocchio/pull/2274))
 - Fix Python bindings cross building with `hpp-fcl` ([#2288](https://github.com/stack-of-tasks/pinocchio/pull/2288))
+- Fix build issue on Windows when a deprecated header is included ([#2292](https://github.com/stack-of-tasks/pinocchio/pull/2292))
 
 ### Added
 

--- a/include/pinocchio/algorithm/parallel/geometry.hpp
+++ b/include/pinocchio/algorithm/parallel/geometry.hpp
@@ -7,8 +7,9 @@
 
 #include "pinocchio/macros.hpp"
 
-PINOCCHIO_PRAGMA_DEPRECATED_HEADER(
-  pinocchio / algorithm / parallel / geometry.hpp, pinocchio / collision / parallel / geometry.hpp)
+// clang-format off
+PINOCCHIO_PRAGMA_DEPRECATED_HEADER(pinocchio/algorithm/parallel/geometry.hpp, pinocchio/collision/parallel/geometry.hpp)
+// clang-format on
 
 #include "pinocchio/collision/parallel/geometry.hpp"
 

--- a/include/pinocchio/macros.hpp
+++ b/include/pinocchio/macros.hpp
@@ -41,6 +41,12 @@
     PINOCCHIO_PRAGMA_WARNING(Deprecated header file                                                \
                              : #old_header has been replaced                                       \
                                  by #new_header.\n Please use #new_header instead of #old_header.)
+#else
+  #define PINOCCHIO_PRAGMA(x)
+  #define PINOCCHIO_PRAGMA_MESSAGE(the_message)
+  #define PINOCCHIO_PRAGMA_WARNING(the_message)
+  #define PINOCCHIO_PRAGMA_DEPRECATED(the_message)
+  #define PINOCCHIO_PRAGMA_DEPRECATED_HEADER(old_header, new_header)
 #endif
 
 // This macro can be used to prevent from macro expansion, similarly to EIGEN_NOT_A_MACRO

--- a/include/pinocchio/math/casadi.hpp
+++ b/include/pinocchio/math/casadi.hpp
@@ -7,7 +7,9 @@
 
 #include "pinocchio/macros.hpp"
 
-PINOCCHIO_PRAGMA_DEPRECATED_HEADER(pinocchio / math / casadi.hpp, pinocchio / autodiff / casadi.hpp)
+// clang-format off
+PINOCCHIO_PRAGMA_DEPRECATED_HEADER(pinocchio/math/casadi.hpp, pinocchio/autodiff/casadi.hpp)
+// clang-format on
 
 #include "pinocchio/autodiff/casadi.hpp"
 

--- a/include/pinocchio/math/cppad.hpp
+++ b/include/pinocchio/math/cppad.hpp
@@ -7,7 +7,9 @@
 
 #include "pinocchio/macros.hpp"
 
-PINOCCHIO_PRAGMA_DEPRECATED_HEADER(pinocchio / math / cppad.hpp, pinocchio / autodiff / cppad.hpp)
+// clang-format off
+PINOCCHIO_PRAGMA_DEPRECATED_HEADER(pinocchio/math/cppad.hpp, pinocchio/autodiff/cppad.hpp)
+// clang-format on
 
 #include "pinocchio/autodiff/cppad.hpp"
 

--- a/include/pinocchio/math/cppadcg.hpp
+++ b/include/pinocchio/math/cppadcg.hpp
@@ -7,8 +7,9 @@
 
 #include "pinocchio/macros.hpp"
 
-PINOCCHIO_PRAGMA_DEPRECATED_HEADER(
-  pinocchio / math / cppadcg.hpp, pinocchio / codegen / cppadcg.hpp)
+// clang-format off
+PINOCCHIO_PRAGMA_DEPRECATED_HEADER(pinocchio/math/cppadcg.hpp, pinocchio/codegen/cppadcg.hpp)
+// clang-format on
 
 #include "pinocchio/codegen/cppadcg.hpp"
 

--- a/include/pinocchio/parsers/sample-models.hpp
+++ b/include/pinocchio/parsers/sample-models.hpp
@@ -7,8 +7,9 @@
 
 #include "pinocchio/macros.hpp"
 
-PINOCCHIO_PRAGMA_DEPRECATED_HEADER(
-  pinocchio / parsers / sample - models.hpp, pinocchio / multibody / sample - models.hpp)
+// clang-format off
+PINOCCHIO_PRAGMA_DEPRECATED_HEADER(pinocchio/parsers/sample-models.hpp, pinocchio/multibody/sample-models.hpp)
+// clang-format on
 
 #include "pinocchio/multibody/sample-models.hpp"
 

--- a/include/pinocchio/spatial/fcl-pinocchio-conversions.hpp
+++ b/include/pinocchio/spatial/fcl-pinocchio-conversions.hpp
@@ -7,9 +7,11 @@
 
 #include "pinocchio/macros.hpp"
 
+// clang-format off
 PINOCCHIO_PRAGMA_DEPRECATED_HEADER(
-  pinocchio / spatial / fcl - pinocchio - conversions.hpp,
-  pinocchio / collision / fcl - pinocchio - conversions.hpp)
+  pinocchio/spatial/fcl-pinocchio-conversions.hpp,
+  pinocchio/collision/fcl-pinocchio-conversions.hpp)
+// clang-format on
 
 #include "pinocchio/collision/fcl-pinocchio-conversions.hpp"
 

--- a/include/pinocchio/spatial/inertia.hpp
+++ b/include/pinocchio/spatial/inertia.hpp
@@ -286,7 +286,7 @@ namespace pinocchio
 
     explicit InertiaTpl(const Matrix6 & I6)
     {
-      assert(check_expression_if_real<Scalar>(isZero(I6 - I6.transpose())));
+      assert(check_expression_if_real<Scalar>(pinocchio::isZero(I6 - I6.transpose())));
       mass() = I6(LINEAR, LINEAR);
       const typename Matrix6::template ConstFixedBlockXpr<3, 3>::Type mc_cross =
         I6.template block<3, 3>(ANGULAR, LINEAR);


### PR DESCRIPTION
- Windows build fail when calling the PINOCCHIO_PRAGMA_DEPRECATED_HEADER macro that is not defined on Windows in macros.hpp.
- Fix DEPRECATED_HEADER messages that had been modified by clang-format.
- Fix ambiguous setZero call in InertiaTpl()


Another issue (not fixed right now) is the multiple definition of PINOCCHIO_DEPRECATED_HEADER and PINOCCHIO_PRAGMA in the jrl-cmakemodule generate deprecated.hpp.
We maybe have to use PINOCCHIO_PRAGMA from derpecated.hpp and change the name of our PINOCCHIO_DEPRECATED_HEADER definition that doesn't take the same number of argument than the one in deprecated.hpp.