### PR TITLE
[Model] Fix appendModel for parallel joints at the base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fix `appendModel` when joints after the base are in parallel ([#2295](https://github.com/stack-of-tasks/pinocchio/pull/2295))
 - Fix `appendModel` build when called with template arguments different than the ones from `context` ([#2284](https://github.com/stack-of-tasks/pinocchio/pull/2284))
 - Fix `TransformRevoleTpl::rotation` and `TransformHelicalTpl::rotation` build ([#2284](https://github.com/stack-of-tasks/pinocchio/pull/2284))
 - Fix compilation issue for Boost 1.85 ([#2255](https://github.com/stack-of-tasks/pinocchio/pull/2255))

--- a/include/pinocchio/algorithm/model.hxx
+++ b/include/pinocchio/algorithm/model.hxx
@@ -348,7 +348,7 @@ namespace pinocchio
       geomModel);
     for (JointIndex jid = 1; jid < modelB.joints.size(); ++jid)
     {
-      SE3 pMi = (jid == 1 ? frame.placement * aMb : id);
+      SE3 pMi = (model.parents[jid] == 0 ? frame.placement * aMb : id);
       ArgsType args(modelB, geomModelB, frame.parentJoint, pMi, model, geomModel);
       AppendJointOfModelAlgo::run(modelB.joints[jid], args);
     }

--- a/include/pinocchio/algorithm/model.hxx
+++ b/include/pinocchio/algorithm/model.hxx
@@ -348,7 +348,7 @@ namespace pinocchio
       geomModel);
     for (JointIndex jid = 1; jid < modelB.joints.size(); ++jid)
     {
-      SE3 pMi = (model.parents[jid] == 0 ? frame.placement * aMb : id);
+      SE3 pMi = (modelB.parents[jid] == 0 ? frame.placement * aMb : id);
       ArgsType args(modelB, geomModelB, frame.parentJoint, pMi, model, geomModel);
       AppendJointOfModelAlgo::run(modelB.joints[jid], args);
     }

--- a/unittest/model.cpp
+++ b/unittest/model.cpp
@@ -449,6 +449,35 @@ BOOST_AUTO_TEST_CASE(append)
       geomModel4);
     BOOST_CHECK(model4.inertias[1] == model4.inertias[1]);
   }
+
+  {
+    Model model5, gripperModel;
+
+    Inertia inertia(1., SE3::Vector3(0.5, 0., 0.0), SE3::Matrix3::Identity());
+    SE3 pos(1);
+
+    pos.translation() = SE3::LinearType(0.1, 0., 0.);
+    JointIndex idx = gripperModel.addJoint(0, JointModelPX(), pos, "left_finger");
+    gripperModel.addJointFrame(idx);
+
+    pos.translation() = SE3::LinearType(-0.1, 0., 0.);
+    idx = gripperModel.addJoint(0, JointModelPX(), pos, "right_finger");
+    gripperModel.addJointFrame(idx);
+
+    SE3 transformManGr = SE3::Random();
+    FrameIndex fid = (FrameIndex)(manipulator.frames.size() - 1);
+    appendModel(manipulator, gripperModel, fid, transformManGr, model5);
+
+    JointIndex jid5 = model5.getJointId("left_finger");
+    JointIndex jidG = gripperModel.getJointId("left_finger");
+    BOOST_CHECK(
+      model5.jointPlacements[jid5].isApprox(transformManGr * gripperModel.jointPlacements[jidG]));
+
+    jid5 = model5.getJointId("right_finger");
+    jidG = gripperModel.getJointId("right_finger");
+    BOOST_CHECK(
+      model5.jointPlacements[jid5].isApprox(transformManGr * gripperModel.jointPlacements[jidG]));
+  }
 }
 #endif
 


### PR DESCRIPTION
Solves [#2293 ](https://github.com/stack-of-tasks/pinocchio/issues/2293)

When joints at the base are in parallel, the transformation between modelA and modelB was applied only the first joint of the list, whereas it should be applied on all joints whose parent is the base of modelB. 
