### PR TITLE
CMake: modernize link to console_bridge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix visualization of meshes in meshcat ([#2294](https://github.com/stack-of-tasks/pinocchio/pull/2294))
 - Fix Anymal simulation test ([#2299](https://github.com/stack-of-tasks/pinocchio/pull/2299))
 - Fix contact derivatives and impulse dynamics tests ([#2300](https://github.com/stack-of-tasks/pinocchio/pull/2300))
+- Fix CMake compatibility with old console_bridge version ([#2312](https://github.com/stack-of-tasks/pinocchio/pull/2312))
 
 ### Added
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -81,7 +81,12 @@ function(PINOCCHIO_PYTHON_BINDINGS_SPECIFIC_TYPE scalar_name)
   if(BUILD_WITH_URDF_SUPPORT)
     # Link directly against console_bridge since we bind some enums and call
     # console_bridge::setLogLevel function.
-    target_link_libraries(${PYTHON_LIB_NAME} PUBLIC console_bridge::console_bridge)
+    modernize_target_link_libraries(
+      ${PYTHON_LIB_NAME}
+      SCOPE PUBLIC
+      TARGETS console_bridge::console_bridge
+      LIBRARIES ${console_bridge_LIBRARIES}
+      INCLUDE_DIRS ${console_bridge_INCLUDE_DIRS})
   endif()
   if(BUILD_WITH_HPP_FCL_SUPPORT)
     target_compile_definitions(${PYTHON_LIB_NAME}


### PR DESCRIPTION
Hi,

This provide compatibility with older console_bridge versions.
This was not tested yet, so let's keep it as draft for now.