### PR TITLE
Changed Geometry Objects bindings and added getMotionAxis function

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 ci:
   autoupdate_branch: devel
   autofix_prs: false
+  autoupdate_schedule: quarterly
 repos:
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v18.1.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Add getMotionAxis method to helical, prismatic, revolute and ubounded revolute joint. ([#2315](https://github.com/stack-of-tasks/pinocchio/pull/2315))
+
+### Changed
+- Use eigenpy to expose `GeometryObject::meshMaterial` variant ([#2315](https://github.com/stack-of-tasks/pinocchio/pull/2315))
+
 ## [3.1.0] - 2024-07-04
 
 ### Fixed

--- a/include/pinocchio/bindings/python/multibody/joint/joints-models.hpp
+++ b/include/pinocchio/bindings/python/multibody/joint/joints-models.hpp
@@ -26,6 +26,37 @@ namespace pinocchio
       return cl;
     }
 
+    // specialization for JointModelPrismatic
+    template<>
+    bp::class_<context::JointModelRX> &
+    expose_joint_model<context::JointModelRX>(bp::class_<context::JointModelRX> & cl)
+    {
+      return cl.def(bp::init<>(bp::args("self"), "Init JointModelRX with x as rotation axis"))
+        .def(
+          "getMotionAxis", &context::JointModelRX::getMotionAxis,
+          "Rotation axis of the JointModelRX.");
+    }
+
+    template<>
+    bp::class_<context::JointModelRY> &
+    expose_joint_model<context::JointModelRY>(bp::class_<context::JointModelRY> & cl)
+    {
+      return cl.def(bp::init<>(bp::args("self"), "Init JointModelRY with y as rotation axis"))
+        .def(
+          "getMotionAxis", &context::JointModelRY::getMotionAxis,
+          "Rotation axis of the JointModelRY.");
+    }
+
+    template<>
+    bp::class_<context::JointModelRZ> &
+    expose_joint_model<context::JointModelRZ>(bp::class_<context::JointModelRZ> & cl)
+    {
+      return cl.def(bp::init<>(bp::args("self"), "Init JointModelRZ with z as rotation axis"))
+        .def(
+          "getMotionAxis", &context::JointModelRZ::getMotionAxis,
+          "Rotation axis of the JointModelRZ.");
+    }
+
     // specialization for JointModelRevoluteUnaligned
     template<>
     bp::class_<context::JointModelRevoluteUnaligned> &
@@ -42,6 +73,37 @@ namespace pinocchio
         .def_readwrite(
           "axis", &context::JointModelRevoluteUnaligned::axis,
           "Rotation axis of the JointModelRevoluteUnaligned.");
+    }
+
+    // specialization for JointModelPrismatic
+    template<>
+    bp::class_<context::JointModelPX> &
+    expose_joint_model<context::JointModelPX>(bp::class_<context::JointModelPX> & cl)
+    {
+      return cl.def(bp::init<>(bp::args("self"), "Init JointModelPX with x as rotation axis"))
+        .def(
+          "getMotionAxis", &context::JointModelPX::getMotionAxis,
+          "Rotation axis of the JointModelPX.");
+    }
+
+    template<>
+    bp::class_<context::JointModelPY> &
+    expose_joint_model<context::JointModelPY>(bp::class_<context::JointModelPY> & cl)
+    {
+      return cl.def(bp::init<>(bp::args("self"), "Init JointModelPY with y as rotation axis"))
+        .def(
+          "getMotionAxis", &context::JointModelPY::getMotionAxis,
+          "Rotation axis of the JointModelPY.");
+    }
+
+    template<>
+    bp::class_<context::JointModelPZ> &
+    expose_joint_model<context::JointModelPZ>(bp::class_<context::JointModelPZ> & cl)
+    {
+      return cl.def(bp::init<>(bp::args("self"), "Init JointModelPZ with z as rotation axis"))
+        .def(
+          "getMotionAxis", &context::JointModelPZ::getMotionAxis,
+          "Rotation axis of the JointModelPZ.");
     }
 
     // specialization for JointModelPrismaticUnaligned
@@ -92,6 +154,9 @@ namespace pinocchio
         .def(bp::init<context::Scalar>(
           bp::args("self", "pitch"), "Init JointModelHX with pitch value"))
         .def(bp::init<>(bp::args("self"), "Init JointModelHX with pitch 0.0"))
+        .def(
+          "getMotionAxis", &context::JointModelHX::getMotionAxis,
+          "Rotation axis of the JointModelHX.")
         .def_readwrite("pitch", &context::JointModelHX::m_pitch, "Pitch h of the JointModelHX.");
     }
 
@@ -103,6 +168,9 @@ namespace pinocchio
         .def(bp::init<context::Scalar>(
           bp::args("self", "pitch"), "Init JointModelHY with pitch value."))
         .def(bp::init<>(bp::args("self"), "Init JointModelHY with pitch 0.0"))
+        .def(
+          "getMotionAxis", &context::JointModelHY::getMotionAxis,
+          "Rotation axis of the JointModelHY.")
         .def_readwrite("pitch", &context::JointModelHY::m_pitch, "Pitch h of the JointModelHY.");
     }
 
@@ -114,6 +182,9 @@ namespace pinocchio
         .def(bp::init<context::Scalar>(
           bp::args("self", "pitch"), "Init JointModelHZ with pitch value"))
         .def(bp::init<>(bp::args("self"), "Init JointModelHZ with pitch 0.0"))
+        .def(
+          "getMotionAxis", &context::JointModelHZ::getMotionAxis,
+          "Rotation axis of the JointModelHZ.")
         .def_readwrite("pitch", &context::JointModelHZ::m_pitch, "Pitch h of the JointModelHZ.");
     }
 

--- a/include/pinocchio/bindings/python/multibody/joint/joints-models.hpp
+++ b/include/pinocchio/bindings/python/multibody/joint/joints-models.hpp
@@ -26,7 +26,7 @@ namespace pinocchio
       return cl;
     }
 
-    // specialization for JointModelPrismatic
+    // specialization for JointModelRevolute
     template<>
     bp::class_<context::JointModelRX> &
     expose_joint_model<context::JointModelRX>(bp::class_<context::JointModelRX> & cl)
@@ -73,6 +73,37 @@ namespace pinocchio
         .def_readwrite(
           "axis", &context::JointModelRevoluteUnaligned::axis,
           "Rotation axis of the JointModelRevoluteUnaligned.");
+    }
+
+    // specialization for JointModelRevoluteUnbounded
+    template<>
+    bp::class_<context::JointModelRUBX> &
+    expose_joint_model<context::JointModelRUBX>(bp::class_<context::JointModelRUBX> & cl)
+    {
+      return cl.def(bp::init<>(bp::args("self"), "Init JointModelRUBX with x as rotation axis"))
+        .def(
+          "getMotionAxis", &context::JointModelRUBX::getMotionAxis,
+          "Rotation axis of the JointModelRUBX.");
+    }
+
+    template<>
+    bp::class_<context::JointModelRUBY> &
+    expose_joint_model<context::JointModelRUBY>(bp::class_<context::JointModelRUBY> & cl)
+    {
+      return cl.def(bp::init<>(bp::args("self"), "Init JointModelRUBY with y as rotation axis"))
+        .def(
+          "getMotionAxis", &context::JointModelRUBY::getMotionAxis,
+          "Rotation axis of the JointModelRUBY.");
+    }
+
+    template<>
+    bp::class_<context::JointModelRUBZ> &
+    expose_joint_model<context::JointModelRUBZ>(bp::class_<context::JointModelRUBZ> & cl)
+    {
+      return cl.def(bp::init<>(bp::args("self"), "Init JointModelRUBZ with z as rotation axis"))
+        .def(
+          "getMotionAxis", &context::JointModelRUBZ::getMotionAxis,
+          "Rotation axis of the JointModelRUBZ.");
     }
 
     // specialization for JointModelPrismatic

--- a/include/pinocchio/bindings/python/multibody/joint/joints-models.hpp
+++ b/include/pinocchio/bindings/python/multibody/joint/joints-models.hpp
@@ -31,7 +31,9 @@ namespace pinocchio
     bp::class_<context::JointModelRX> &
     expose_joint_model<context::JointModelRX>(bp::class_<context::JointModelRX> & cl)
     {
-      return cl.def(bp::init<>(bp::args("self"), "Init JointModelRX with x as rotation axis"))
+      return cl
+        .def(bp::init<>(
+          bp::args("self"), "Init JointModelRX with the X axis ([1, 0, 0]) as rotation axis."))
         .def(
           "getMotionAxis", &context::JointModelRX::getMotionAxis,
           "Rotation axis of the JointModelRX.");
@@ -41,7 +43,9 @@ namespace pinocchio
     bp::class_<context::JointModelRY> &
     expose_joint_model<context::JointModelRY>(bp::class_<context::JointModelRY> & cl)
     {
-      return cl.def(bp::init<>(bp::args("self"), "Init JointModelRY with y as rotation axis"))
+      return cl
+        .def(bp::init<>(
+          bp::args("self"), "Init JointModelRY with the Y axis ([0, 1, 0]) as rotation axis."))
         .def(
           "getMotionAxis", &context::JointModelRY::getMotionAxis,
           "Rotation axis of the JointModelRY.");
@@ -51,7 +55,9 @@ namespace pinocchio
     bp::class_<context::JointModelRZ> &
     expose_joint_model<context::JointModelRZ>(bp::class_<context::JointModelRZ> & cl)
     {
-      return cl.def(bp::init<>(bp::args("self"), "Init JointModelRZ with z as rotation axis"))
+      return cl
+        .def(bp::init<>(
+          bp::args("self"), "Init JointModelRZ with the Z axis ([0, 0, 1]) as rotation axis"))
         .def(
           "getMotionAxis", &context::JointModelRZ::getMotionAxis,
           "Rotation axis of the JointModelRZ.");
@@ -80,7 +86,9 @@ namespace pinocchio
     bp::class_<context::JointModelRUBX> &
     expose_joint_model<context::JointModelRUBX>(bp::class_<context::JointModelRUBX> & cl)
     {
-      return cl.def(bp::init<>(bp::args("self"), "Init JointModelRUBX with x as rotation axis"))
+      return cl
+        .def(bp::init<>(
+          bp::args("self"), "Init JointModelRUBX with the X axis ([1, 0, 0]) as rotation axis"))
         .def(
           "getMotionAxis", &context::JointModelRUBX::getMotionAxis,
           "Rotation axis of the JointModelRUBX.");
@@ -90,7 +98,9 @@ namespace pinocchio
     bp::class_<context::JointModelRUBY> &
     expose_joint_model<context::JointModelRUBY>(bp::class_<context::JointModelRUBY> & cl)
     {
-      return cl.def(bp::init<>(bp::args("self"), "Init JointModelRUBY with y as rotation axis"))
+      return cl
+        .def(bp::init<>(
+          bp::args("self"), "Init JointModelRUBY with the Y axis ([0, 1, 0]) as rotation axis"))
         .def(
           "getMotionAxis", &context::JointModelRUBY::getMotionAxis,
           "Rotation axis of the JointModelRUBY.");
@@ -100,7 +110,9 @@ namespace pinocchio
     bp::class_<context::JointModelRUBZ> &
     expose_joint_model<context::JointModelRUBZ>(bp::class_<context::JointModelRUBZ> & cl)
     {
-      return cl.def(bp::init<>(bp::args("self"), "Init JointModelRUBZ with z as rotation axis"))
+      return cl
+        .def(bp::init<>(
+          bp::args("self"), "Init JointModelRUBZ with the Z axis ([0, 0, 1]) as rotation axis"))
         .def(
           "getMotionAxis", &context::JointModelRUBZ::getMotionAxis,
           "Rotation axis of the JointModelRUBZ.");
@@ -111,7 +123,9 @@ namespace pinocchio
     bp::class_<context::JointModelPX> &
     expose_joint_model<context::JointModelPX>(bp::class_<context::JointModelPX> & cl)
     {
-      return cl.def(bp::init<>(bp::args("self"), "Init JointModelPX with x as rotation axis"))
+      return cl
+        .def(bp::init<>(
+          bp::args("self"), "Init JointModelPX with the X axis ([1, 0, 0]) as rotation axis"))
         .def(
           "getMotionAxis", &context::JointModelPX::getMotionAxis,
           "Rotation axis of the JointModelPX.");
@@ -121,7 +135,9 @@ namespace pinocchio
     bp::class_<context::JointModelPY> &
     expose_joint_model<context::JointModelPY>(bp::class_<context::JointModelPY> & cl)
     {
-      return cl.def(bp::init<>(bp::args("self"), "Init JointModelPY with y as rotation axis"))
+      return cl
+        .def(bp::init<>(
+          bp::args("self"), "Init JointModelPY with the Y axis ([0, 1, 0]) as rotation axis"))
         .def(
           "getMotionAxis", &context::JointModelPY::getMotionAxis,
           "Rotation axis of the JointModelPY.");
@@ -131,7 +147,9 @@ namespace pinocchio
     bp::class_<context::JointModelPZ> &
     expose_joint_model<context::JointModelPZ>(bp::class_<context::JointModelPZ> & cl)
     {
-      return cl.def(bp::init<>(bp::args("self"), "Init JointModelPZ with z as rotation axis"))
+      return cl
+        .def(bp::init<>(
+          bp::args("self"), "Init JointModelPZ with the Z axis ([0, 0, 1]) as rotation axis"))
         .def(
           "getMotionAxis", &context::JointModelPZ::getMotionAxis,
           "Rotation axis of the JointModelPZ.");
@@ -183,8 +201,11 @@ namespace pinocchio
     {
       return cl
         .def(bp::init<context::Scalar>(
-          bp::args("self", "pitch"), "Init JointModelHX with pitch value"))
-        .def(bp::init<>(bp::args("self"), "Init JointModelHX with pitch 0.0"))
+          bp::args("self", "pitch"),
+          "Init JointModelHX with pitch value and the X axis ([1, 0, 0]) as a rotation axis."))
+        .def(bp::init<>(
+          bp::args("self"),
+          "Init JointModelHX with pitch 0.0 and the X axis ([1, 0, 0]) as a rotation axis."))
         .def(
           "getMotionAxis", &context::JointModelHX::getMotionAxis,
           "Rotation axis of the JointModelHX.")
@@ -197,8 +218,11 @@ namespace pinocchio
     {
       return cl
         .def(bp::init<context::Scalar>(
-          bp::args("self", "pitch"), "Init JointModelHY with pitch value."))
-        .def(bp::init<>(bp::args("self"), "Init JointModelHY with pitch 0.0"))
+          bp::args("self", "pitch"),
+          "Init JointModelHY with pitch value and the Y axis ([0, 1, 0]) as a rotation axis."))
+        .def(bp::init<>(
+          bp::args("self"),
+          "Init JointModelHY with pitch 0.0 and the Y axis ([0, 1, 0]) as a rotation axis."))
         .def(
           "getMotionAxis", &context::JointModelHY::getMotionAxis,
           "Rotation axis of the JointModelHY.")
@@ -211,8 +235,11 @@ namespace pinocchio
     {
       return cl
         .def(bp::init<context::Scalar>(
-          bp::args("self", "pitch"), "Init JointModelHZ with pitch value"))
-        .def(bp::init<>(bp::args("self"), "Init JointModelHZ with pitch 0.0"))
+          bp::args("self", "pitch"),
+          "Init JointModelHZ with pitch value and the Z axis ([0, 0, 1]) as a rotation axis."))
+        .def(bp::init<>(
+          bp::args("self"),
+          "Init JointModelHZ with pitch 0.0 and the Z axis ([0, 0, 1]) as a rotation axis."))
         .def(
           "getMotionAxis", &context::JointModelHZ::getMotionAxis,
           "Rotation axis of the JointModelHZ.")

--- a/include/pinocchio/multibody/joint/joint-helical.hpp
+++ b/include/pinocchio/multibody/joint/joint-helical.hpp
@@ -839,6 +839,8 @@ namespace pinocchio
     using Base::idx_v;
     using Base::setIndexes;
 
+    typedef Eigen::Matrix<Scalar, 3, 1, _Options> Vector3;
+
     JointDataDerived createData() const
     {
       return JointDataDerived();
@@ -921,6 +923,21 @@ namespace pinocchio
     std::string shortname() const
     {
       return classname();
+    }
+
+    Vector3 getMotionAxis()
+    {
+      switch (axis)
+      {
+      case 0:
+        return Vector3::UnitX();
+      case 1:
+        return Vector3::UnitY();
+      case 2:
+        return Vector3::UnitZ();
+      default:
+        return Vector3::Zero();
+      }
     }
 
     /// \returns An expression of *this with the Scalar type casted to NewScalar.

--- a/include/pinocchio/multibody/joint/joint-helical.hpp
+++ b/include/pinocchio/multibody/joint/joint-helical.hpp
@@ -925,7 +925,7 @@ namespace pinocchio
       return classname();
     }
 
-    Vector3 getMotionAxis()
+    Vector3 getMotionAxis() const
     {
       switch (axis)
       {
@@ -936,7 +936,8 @@ namespace pinocchio
       case 2:
         return Vector3::UnitZ();
       default:
-        return Vector3::Zero();
+        assert(false && "must never happen");
+        break;
       }
     }
 

--- a/include/pinocchio/multibody/joint/joint-prismatic.hpp
+++ b/include/pinocchio/multibody/joint/joint-prismatic.hpp
@@ -744,7 +744,7 @@ namespace pinocchio
       return classname();
     }
 
-    Vector3 getMotionAxis()
+    Vector3 getMotionAxis() const
     {
       switch (axis)
       {
@@ -755,7 +755,8 @@ namespace pinocchio
       case 2:
         return Vector3::UnitZ();
       default:
-        return Vector3::Zero();
+        assert(false && "must never happen");
+        break;
       }
     }
 

--- a/include/pinocchio/multibody/joint/joint-prismatic.hpp
+++ b/include/pinocchio/multibody/joint/joint-prismatic.hpp
@@ -675,6 +675,8 @@ namespace pinocchio
     using Base::idx_v;
     using Base::setIndexes;
 
+    typedef Eigen::Matrix<Scalar, 3, 1, _Options> Vector3;
+
     JointDataDerived createData() const
     {
       return JointDataDerived();
@@ -740,6 +742,21 @@ namespace pinocchio
     std::string shortname() const
     {
       return classname();
+    }
+
+    Vector3 getMotionAxis()
+    {
+      switch (axis)
+      {
+      case 0:
+        return Vector3::UnitX();
+      case 1:
+        return Vector3::UnitY();
+      case 2:
+        return Vector3::UnitZ();
+      default:
+        return Vector3::Zero();
+      }
     }
 
     /// \returns An expression of *this with the Scalar type casted to NewScalar.

--- a/include/pinocchio/multibody/joint/joint-revolute-unbounded.hpp
+++ b/include/pinocchio/multibody/joint/joint-revolute-unbounded.hpp
@@ -202,7 +202,7 @@ namespace pinocchio
       return classname();
     }
 
-    Vector3 getMotionAxis()
+    Vector3 getMotionAxis() const
     {
       switch (axis)
       {
@@ -213,7 +213,8 @@ namespace pinocchio
       case 2:
         return Vector3::UnitZ();
       default:
-        return Vector3::Zero();
+        assert(false && "must never happen");
+        break;
       }
     }
 

--- a/include/pinocchio/multibody/joint/joint-revolute-unbounded.hpp
+++ b/include/pinocchio/multibody/joint/joint-revolute-unbounded.hpp
@@ -129,6 +129,8 @@ namespace pinocchio
     using Base::idx_v;
     using Base::setIndexes;
 
+    typedef Eigen::Matrix<Scalar, 3, 1, _Options> Vector3;
+
     JointDataDerived createData() const
     {
       return JointDataDerived();
@@ -198,6 +200,21 @@ namespace pinocchio
     std::string shortname() const
     {
       return classname();
+    }
+
+    Vector3 getMotionAxis()
+    {
+      switch (axis)
+      {
+      case 0:
+        return Vector3::UnitX();
+      case 1:
+        return Vector3::UnitY();
+      case 2:
+        return Vector3::UnitZ();
+      default:
+        return Vector3::Zero();
+      }
     }
 
     /// \returns An expression of *this with the Scalar type casted to NewScalar.

--- a/include/pinocchio/multibody/joint/joint-revolute.hpp
+++ b/include/pinocchio/multibody/joint/joint-revolute.hpp
@@ -763,6 +763,8 @@ namespace pinocchio
     using Base::idx_v;
     using Base::setIndexes;
 
+    typedef Eigen::Matrix<Scalar, 3, 1, _Options> Vector3;
+
     JointDataDerived createData() const
     {
       return JointDataDerived();
@@ -836,6 +838,21 @@ namespace pinocchio
     std::string shortname() const
     {
       return classname();
+    }
+
+    Vector3 getMotionAxis()
+    {
+      switch (axis)
+      {
+      case 0:
+        return Vector3::UnitX();
+      case 1:
+        return Vector3::UnitY();
+      case 2:
+        return Vector3::UnitZ();
+      default:
+        return Vector3::Zero();
+      }
     }
 
     /// \returns An expression of *this with the Scalar type casted to NewScalar.

--- a/include/pinocchio/multibody/joint/joint-revolute.hpp
+++ b/include/pinocchio/multibody/joint/joint-revolute.hpp
@@ -840,7 +840,7 @@ namespace pinocchio
       return classname();
     }
 
-    Vector3 getMotionAxis()
+    Vector3 getMotionAxis() const
     {
       switch (axis)
       {
@@ -851,7 +851,8 @@ namespace pinocchio
       case 2:
         return Vector3::UnitZ();
       default:
-        return Vector3::Zero();
+        assert(false && "must never happen");
+        break;
       }
     }
 


### PR DESCRIPTION
As discussed in https://github.com/stack-of-tasks/pinocchio/issues/2258, this pr changed the way the geometry material is parsed using eigenpy variant. 

It also adds a function to have an easy access to the joint axis for prismatic, revolute and helicoidal joints. https://github.com/stack-of-tasks/pinocchio/discussions/2196