### PR TITLE
CI - Change Environment for Linux CI

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -32,7 +32,7 @@ jobs:
     container: ${{ matrix.container }}
     strategy:
       matrix:
-        container: ['ubuntu:20.04', 'ubuntu:20.04']
+        container: ['ubuntu:20.04', 'ubuntu:22.04']
 
     env:
       CCACHE_BASEDIR: ${GITHUB_WORKSPACE}

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -28,11 +28,13 @@ concurrency:
 jobs:
   build:
 
-    runs-on: ${{ matrix.os }}
-
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.container }}
+      options: --user root
     strategy:
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04]
+        container: ['ubuntu:20.04', 'ubuntu:20.04']
 
     env:
       CCACHE_BASEDIR: ${GITHUB_WORKSPACE}
@@ -41,6 +43,9 @@ jobs:
       CCACHE_COMPRESSLEVEL: 5
 
     steps:
+      - name: Setup Container
+        run: |
+          apt update && DEBIAN_FRONTEND="noninteractive" apt install -y sudo lsb-release gnupg2 cmake git
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
@@ -50,9 +55,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .ccache
-          save-always: true
-          key: ccache-linux-${{ matrix.os }}-${{ github.sha }}
-          restore-keys: ccache-linux-${{ matrix.os }}-
+          save-always: false
+          key: ccache-linux-${{ matrix.container }}-${{ github.sha }}
+          restore-keys: ccache-linux-${{ matrix.container }}-
 
     # extract branch name
       - name: Get branch name (merge)
@@ -98,6 +103,7 @@ jobs:
                                    robotpkg-py${PYTHON3_VERSION}-hpp-fcl \
                                    robotpkg-py${PYTHON3_VERSION}-casadi"
           echo $APT_DEPENDENCIES
+
           sudo apt-get update -qq
           sudo apt-get install -qq ${APT_DEPENDENCIES}
       - name: Free disk space
@@ -106,6 +112,7 @@ jobs:
           df -h
       - name: Run cmake
         run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git submodule update --init
           export PATH=$PATH:/opt/openrobots/bin
           export PYTHON3_DOT_VERSION=$(python3 -c "import sys; print(str(sys.version_info.major)+'.'+str(sys.version_info.minor))")

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -29,9 +29,7 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-    container:
-      image: ${{ matrix.container }}
-      options: --user root
+    container: ${{ matrix.container }}
     strategy:
       matrix:
         container: ['ubuntu:20.04', 'ubuntu:20.04']

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .ccache
-          save-always: false
+          save-always: true
           key: ccache-linux-${{ matrix.container }}-${{ github.sha }}
           restore-keys: ccache-linux-${{ matrix.container }}-
 

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -75,11 +75,11 @@ jobs:
 
       - name: Register robotpkg
         run: |
-          sudo sh -c "echo \"deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub $(lsb_release -cs) robotpkg\" >> /etc/apt/sources.list "
-          sudo apt-key adv --fetch-keys http://robotpkg.openrobots.org/packages/debian/robotpkg.key
+          sh -c "echo \"deb [arch=amd64] http://robotpkg.openrobots.org/packages/debian/pub $(lsb_release -cs) robotpkg\" >> /etc/apt/sources.list "
+          apt-key adv --fetch-keys http://robotpkg.openrobots.org/packages/debian/robotpkg.key
       - name: Set and install dependencies
         run: |
-          sudo rm -rf /usr/local/share/boost/1.69.0
+          rm -rf /usr/local/share/boost/1.69.0
           export PYTHON3_VERSION=$(python3 -c "import sys; print(str(sys.version_info.major)+str(sys.version_info.minor))")
           export APT_DEPENDENCIES="doxygen \
                                    ccache \
@@ -102,14 +102,15 @@ jobs:
                                    robotpkg-py${PYTHON3_VERSION}-casadi"
           echo $APT_DEPENDENCIES
 
-          sudo apt-get update -qq
-          sudo apt-get install -qq ${APT_DEPENDENCIES}
+          apt-get update -qq
+          DEBIAN_FRONTEND="noninteractive" apt-get install -qq ${APT_DEPENDENCIES}
       - name: Free disk space
         run: |
-          sudo apt clean
+          apt clean
           df -h
       - name: Run cmake
         run: |
+          # Add cloned repo to safe.directory, since it was not cloned by the container
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           git submodule update --init
           export PATH=$PATH:/opt/openrobots/bin


### PR DESCRIPTION
This PR changes the environment in which the Linux CI is run. Instead of using the github action environment, it is now run into a minimal docker container.
For more info, please see https://github.com/stack-of-tasks/pinocchio/issues/2253