### PR TITLE
Add missing dependencies into pkg-config

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -145,12 +145,15 @@ jobs:
           mkdir build
           cd build
           export CMAKE_PREFIX_PATH=/usr/local
+          # Test CMake module packaging
           cmake .. \
             -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
             -DPYTHON_EXECUTABLE=$(which python3)
           make -j2
           ./run_rnea
           ./load_urdf
+
+          # Test pkg-config packaging
           cd ../../pkgconfig
           mkdir build
           cd build
@@ -159,6 +162,9 @@ jobs:
             -DPYTHON_EXECUTABLE=$(which python3)
           make -j2
           ./run_rnea
+          ./load_urdf
+
+          # Test FetchContent packaging
           cd ../../external
           export PINOCCHIO_GIT_REPOSITORY="file://"$GITHUB_WORKSPACE
           #export PINOCCHIO_GIT_REPOSITORY=$(git remote get-url origin)
@@ -172,6 +178,8 @@ jobs:
           make -j2
           ./run_rnea
           ./load_urdf
+
+          # Test CMake module packaging and pinocchio_header target
           cd ../../pinocchio_header
           mkdir build
           cd build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Append pinocchio optional libraries into pkg-config file ([#2322](https://github.com/stack-of-tasks/pinocchio/pull/2322))
+
 ### Added
-- Add getMotionAxis method to helical, prismatic, revolute and ubounded revolute joint. ([#2315](https://github.com/stack-of-tasks/pinocchio/pull/2315))
+- Add getMotionAxis method to helical, prismatic, revolute and ubounded revolute joint ([#2315](https://github.com/stack-of-tasks/pinocchio/pull/2315))
 
 ### Changed
 - Use eigenpy to expose `GeometryObject::meshMaterial` variant ([#2315](https://github.com/stack-of-tasks/pinocchio/pull/2315))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,7 +189,6 @@ if(BUILD_WITH_URDF_SUPPORT)
   add_project_dependency(urdfdom REQUIRED PKG_CONFIG_REQUIRES "urdfdom >= 0.2.0")
   set(urdfdom_VERSION ${urdfdom_headers_VERSION})
   list(APPEND CFLAGS_DEPENDENCIES "-DPINOCCHIO_WITH_URDFDOM")
-  list(APPEND LIBRARIES_DEPENDENCIES "urdfdom_world")
 
   if(${urdfdom_VERSION} VERSION_GREATER "0.4.2")
     check_minimal_cxx_standard(11 ENFORCE)
@@ -197,8 +196,8 @@ if(BUILD_WITH_URDF_SUPPORT)
       STATUS
         "Since urdfdom >= 1.0.0, the default C++ standard is C++11. The project is then compiled with C++11 standard."
     )
-  endif(${urdfdom_VERSION} VERSION_GREATER "0.4.2")
-endif(BUILD_WITH_URDF_SUPPORT)
+  endif()
+endif()
 
 if(BUILD_WITH_SDF_SUPPORT)
   include(${CMAKE_CURRENT_LIST_DIR}/cmake/sdformat.cmake)
@@ -207,25 +206,34 @@ if(BUILD_WITH_SDF_SUPPORT)
     check_minimal_cxx_standard(11 REQUIRED)
     include_directories(${SDFormat_INCLUDE_DIRS})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SDFormat_CXX_FLAGS}")
-  endif(SDFormat_FOUND)
-endif(BUILD_WITH_SDF_SUPPORT)
+    list(APPEND CFLAGS_DEPENDENCIES "-DPINOCCHIO_WITH_SDFORMAT")
+  endif()
+endif()
 
 set(BUILD_WITH_PARSERS_SUPPORT BUILD_WITH_URDF_SUPPORT OR BUILD_WITH_SDF_SUPPORT)
+
+if(BUILD_WITH_PARSERS_SUPPORT)
+  list(APPEND LIBRARIES_DEPENDENCIES ${PROJECT_NAME}_parsers)
+endif()
 
 if(BUILD_WITH_AUTODIFF_SUPPORT)
   # Check first CppADCodeGen
   if(BUILD_WITH_CODEGEN_SUPPORT)
+    # No need to add cppadcg to pkg-config (no lib and header in the same directory than cppad)
     add_project_dependency(cppadcg 2.4.1 REQUIRED)
+    list(APPEND LIBRARIES_DEPENDENCIES ${PROJECT_NAME}_cppadcg)
   endif(BUILD_WITH_CODEGEN_SUPPORT)
 
   add_project_dependency(
     cppad 20180000.0 REQUIRED
     PKG_CONFIG_REQUIRES "cppad >= 20220624.0"
     FIND_EXTERNAL "CppAD")
+  list(APPEND LIBRARIES_DEPENDENCIES ${PROJECT_NAME}_cppad)
 endif(BUILD_WITH_AUTODIFF_SUPPORT)
 
 if(BUILD_WITH_CASADI_SUPPORT)
   add_project_dependency(casadi 3.4.5 REQUIRED PKG_CONFIG_REQUIRES "casadi >= 3.4.5")
+  list(APPEND LIBRARIES_DEPENDENCIES ${PROJECT_NAME}_casadi)
 endif(BUILD_WITH_CASADI_SUPPORT)
 
 if(BUILD_WITH_OPENMP_SUPPORT)
@@ -233,6 +241,7 @@ if(BUILD_WITH_OPENMP_SUPPORT)
 endif()
 
 if(BUILD_WITH_EXTRA_SUPPORT)
+  list(APPEND LIBRARIES_DEPENDENCIES ${PROJECT_NAME}_extra qhullcpp qhull_r)
   add_project_dependency(Qhull COMPONENTS qhullcpp qhull_r REQUIRED)
   message(STATUS "Found Qhull.")
 endif()
@@ -294,7 +303,7 @@ endif()
 
 if(BUILD_WITH_HPP_FCL_SUPPORT)
   list(APPEND CFLAGS_DEPENDENCIES "-DPINOCCHIO_WITH_HPP_FCL")
-  list(APPEND LIBRARIES_DEPENDENCIES "hpp-fcl")
+  list(APPEND LIBRARIES_DEPENDENCIES ${PROJECT_NAME}_collision)
   add_project_dependency(hpp-fcl 2.1.2 REQUIRED PKG_CONFIG_REQUIRES "hpp-fcl >= 2.1.2")
 endif()
 

--- a/unittest/packaging/pkgconfig/CMakeLists.txt
+++ b/unittest/packaging/pkgconfig/CMakeLists.txt
@@ -1,10 +1,24 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.12)
 
 project(ExtraLib CXX)
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(PINOCCHIO REQUIRED pinocchio)
 
-include_directories(SYSTEM ${PINOCCHIO_INCLUDE_DIRS})
 add_executable(run_rnea ../run_rnea.cpp)
-target_link_libraries(run_rnea PUBLIC ${PINOCCHIO_LDFLAGS})
-message(STATUS "${PINOCCHIO_LDFLAGS}")
+target_link_libraries(run_rnea PRIVATE ${PINOCCHIO_LDFLAGS})
+target_include_directories(run_rnea SYSTEM PRIVATE ${PINOCCHIO_INCLUDE_DIRS})
+target_compile_definitions(run_rnea PRIVATE ${PINOCCHIO_CFLAGS_OTHER})
+
+if("-DPINOCCHIO_WITH_URDFDOM" IN_LIST PINOCCHIO_CFLAGS)
+  set(PINOCCHIO_MODEL_DIR "${PROJECT_SOURCE_DIR}/../../../models")
+
+  add_executable(load_urdf ../load_urdf.cpp)
+  target_link_libraries(load_urdf PRIVATE ${PINOCCHIO_LDFLAGS})
+  target_include_directories(load_urdf SYSTEM PRIVATE ${PINOCCHIO_INCLUDE_DIRS})
+  target_compile_definitions(load_urdf PRIVATE ${PINOCCHIO_CFLAGS_OTHER}
+                                               "PINOCCHIO_MODEL_DIR=\"${PINOCCHIO_MODEL_DIR}\"")
+endif()
+
+message(STATUS "LDFLAGS: ${PINOCCHIO_LDFLAGS}")
+message(STATUS "CFLAGS: ${PINOCCHIO_CFLAGS_OTHER}")
+message(STATUS "INCLUDE: ${PINOCCHIO_INCLUDE_DIRS}")


### PR DESCRIPTION
This PR add the following libraries into the pkg-config file (when built with the right option) :

- pinocchio_parsers
- pinocchio_collision
- pinocchio_extra
- pinocchio_casadi
- pinocchio_cppad
- pinocchio_cppadcg

Add missing defines.