### PR TITLE
Fix urdfdom dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Append pinocchio optional libraries into pkg-config file ([#2322](https://github.com/stack-of-tasks/pinocchio/pull/2322))
 - Fixed support of DAE meshes with MeshCat ([#2331](https://github.com/stack-of-tasks/pinocchio/pull/2331))
 - Fixed pointer casts in urdf parser ([#2339](https://github.com/stack-of-tasks/pinocchio/pull/2339))
+- Fixed urdfdom in ROS packaging ([#2341](https://github.com/stack-of-tasks/pinocchio/pull/2341))
 
 ### Added
 - Add getMotionAxis method to helical, prismatic, revolute and ubounded revolute joint ([#2315](https://github.com/stack-of-tasks/pinocchio/pull/2315))

--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,7 @@
   <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
   <depend>python3</depend>
   <depend>python3-numpy</depend>
-  <depend>liburdfdom-dev</depend>
+  <depend>urdfdom</depend>
   <depend>eigen</depend>
   <depend>boost</depend>
   <depend>eigenpy</depend>

--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,8 @@
   <exec_depend condition="$ROS_VERSION == 1">catkin</exec_depend>
   <depend>python3</depend>
   <depend>python3-numpy</depend>
-  <depend>urdfdom</depend>
+  <depend condition="$ROS_VERSION == 2">urdfdom</depend>
+  <depend condition="$ROS_VERSION == 1">liburdfdom-dev</depend>
   <depend>eigen</depend>
   <depend>boost</depend>
   <depend>eigenpy</depend>


### PR DESCRIPTION
The package.xml relies on liburdfdom-dev, which comes from Ubuntu instead of the one that comes from ROS 2. This usually leads to a situation where you have urdfdom installed twice on your system. Once from this package as liburdfdom-dev that is installed in `/usr/lib/x86_64-linux-gnu/` and once from other ROS 2  packages on your system that use the urdfdom from ROS 2 (like the urdf package), which is installed in `/opt/ros/{ROS_DISTRO}/lib/x86_64-linux-gnu`. This will now lead to [CMake warnings in other ROS 2 project that try to use urdfdom](https://github.com/Gauss-Robotics/xbot2_interface/pull/1#issuecomment-2238603609). It still works, but it might break in the future.

 This PR changes the package.xml to rely on the urdfdom package that comes from ROS.