### PR TITLE
Set policy CMP0167 to avoid warnings with CMake 3.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Append pinocchio optional libraries into pkg-config file ([#2322](https://github.com/stack-of-tasks/pinocchio/pull/2322))
 - Fixed support of DAE meshes with MeshCat ([#2331](https://github.com/stack-of-tasks/pinocchio/pull/2331))
 - Fixed pointer casts in urdf parser ([#2339](https://github.com/stack-of-tasks/pinocchio/pull/2339))
+- Remove CMake CMP0167 warnings ([#2347](https://github.com/stack-of-tasks/pinocchio/pull/2347))
 
 ### Added
 - Add getMotionAxis method to helical, prismatic, revolute and ubounded revolute joint ([#2315](https://github.com/stack-of-tasks/pinocchio/pull/2315))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,11 @@ endif()
 set(DOXYGEN_USE_MATHJAX YES)
 set(DOXYGEN_USE_TEMPLATE_CSS YES)
 
+# Use BoostConfig module distributed by boost library instead of using FindBoost module distributed
+# by CMake
+if(POLICY CMP0167)
+  cmake_policy(SET CMP0167 NEW)
+endif()
 include("${JRL_CMAKE_MODULES}/base.cmake")
 
 compute_project_args(PROJECT_ARGS LANGUAGES CXX)


### PR DESCRIPTION
CMake 3.30 don't package anymore the FindBoost.cmake file. Instead, it encourage to use the BoostModule.cmake distributed by Boost.

To avoid a warning message, we must set the CMP0167 policy to NEW.

Here the policy documentation:

> The FindBoost module is removed.

> CMake 3.29 and below provide a FindBoost module, but it needs constant
> updates to keep up with upstream Boost releases.  Upstream Boost 1.70

> and above provide a BoostConfig.cmake package configuration file.
> find_package(Boost CONFIG) finds the upstream package directly,
> without the find module.
> 
> CMake 3.30 and above prefer to not provide the FindBoost module
> so that find_package(Boost) calls, without the CONFIG or
> NO_MODULE options, find the upstream BoostConfig.cmake directly.
> This policy provides compatibility for projects that have not been ported
> to use the upstream Boost package.
> 
> The OLD behavior of this policy is for find_package(Boost) to
> load CMake's FindBoost module.  The NEW behavior is for
> find_package(Boost) to search for the upstream BoostConfig.cmake.
> 
> This policy was introduced in CMake version 3.30.
> It may be set by cmake_policy() or cmake_minimum_required().
> If it is not set, CMake warns, and uses OLD behavior.