### PR TITLE
Fix two equations and typos in the documentation

### DIFF
--- a/include/pinocchio/algorithm/constrained-dynamics.hpp
+++ b/include/pinocchio/algorithm/constrained-dynamics.hpp
@@ -40,16 +40,18 @@ namespace pinocchio
 
   ///
   /// \brief Computes the forward dynamics with contact constraints according to a given list of
-  /// Contact information.
-  ///        When using forwardDynamics for the first time, you should call first
+  /// contact information.
+  ///
+  /// \note  When using forwardDynamics for the first time, you should call first
   ///        initConstraintDynamics to initialize the internal memory used in the algorithm.
   ///
-  /// \note It computes the following problem: <BR>
-  ///       <CENTER> \f$ \begin{eqnarray} \underset{\ddot{q}}{\min} & & \| \ddot{q} -
-  ///       \ddot{q}_{\text{free}} \|_{M(q)} \\ %
-  ///           \text{s.t.} & & J (q) \ddot{q} + \gamma (q, \dot{q}) = 0 \end{eqnarray} \f$
-  ///           </CENTER> <BR>
-  ///       where \f$ \ddot{q}_{\text{free}} \f$ is the free acceleration (i.e. without
+  /// It computes the following problem: \[
+  ///       \f[
+  ///       \begin{eqnarray}
+  ///       \underset{\ddot{q}}{\min} & & \| \ddot{q} - \ddot{q}_{\text{free}} \|_{M(q)} \\
+  ///           \text{s.t.} & & J (q) \ddot{q} + \gamma (q, \dot{q}) = 0
+  ///       \end{eqnarray}
+  ///       \f] where \f$ \ddot{q}_{\text{free}} \f$ is the free acceleration (i.e. without
   ///       constraints), \f$ M \f$ is the mass matrix, \f$ J \f$ the constraint Jacobian and \f$
   ///       \gamma \f$ is the constraint drift.
   ///  By default, the constraint Jacobian is assumed to be full rank, and undamped Cholesky inverse
@@ -101,15 +103,16 @@ namespace pinocchio
   ///
   /// \brief Computes the forward dynamics with contact constraints according to a given list of
   /// Contact information.
-  ///        When using forwardDynamics for the first time, you should call first
+  ///
+  /// \note  When using forwardDynamics for the first time, you should call first
   ///        initConstraintDynamics to initialize the internal memory used in the algorithm.
   ///
-  /// \note It computes the following problem: <BR>
-  ///       <CENTER> \f$ \begin{eqnarray} \underset{\ddot{q}}{\min} & & \| \ddot{q} -
-  ///       \ddot{q}_{\text{free}} \|_{M(q)} \\ %
-  ///           \text{s.t.} & & J (q) \ddot{q} + \gamma (q, \dot{q}) = 0 \end{eqnarray} \f$
-  ///           </CENTER> <BR>
-  ///       where \f$ \ddot{q}_{\text{free}} \f$ is the free acceleration (i.e. without
+  /// It computes the following problem: \f[
+  ///       \begin{eqnarray}
+  ///           \underset{\ddot{q}}{\min} & & \| \ddot{q} - \ddot{q}_{\text{free}} \|_{M(q)} \\
+  ///           \text{s.t.} & & J (q) \ddot{q} + \gamma (q, \dot{q}) = 0
+  ///       \end{eqnarray}
+  ///       \f] where \f$ \ddot{q}_{\text{free}} \f$ is the free acceleration (i.e. without
   ///       constraints), \f$ M \f$ is the mass matrix, \f$ J \f$ the constraint Jacobian and \f$
   ///       \gamma \f$ is the constraint drift.
   ///  By default, the constraint Jacobian is assumed to be full rank, and undamped Cholesky inverse

--- a/include/pinocchio/algorithm/proximal.hpp
+++ b/include/pinocchio/algorithm/proximal.hpp
@@ -13,7 +13,7 @@ namespace pinocchio
 {
 
   ///
-  /// \brief Structure containing all the settings paramters for the proximal algorithms.
+  /// \brief Structure containing all the settings parameters for the proximal algorithms.
   ///
   ///  \tparam _Scalar Scalar type of the for the regularization and the accuracy parameter.
   ///
@@ -91,7 +91,7 @@ namespace pinocchio
     /// \brief Relative proximal accuracy between two iterates.
     Scalar relative_accuracy;
 
-    /// \brief Regularization parameter of the Proximal algorithms.
+    /// \brief Regularization parameter of the proximal algorithm.
     Scalar mu;
 
     /// \brief Maximal number of iterations.

--- a/include/pinocchio/bindings/python/algorithm/proximal.hpp
+++ b/include/pinocchio/bindings/python/algorithm/proximal.hpp
@@ -28,11 +28,11 @@ namespace pinocchio
         cl.def(bp::init<>("Default constructor.", bp::arg("self")))
           .def(bp::init<const Scalar, const Scalar, int>(
             (bp::arg("self"), bp::arg("accuracy"), bp::arg("mu"), bp::arg("max_iter")),
-            "Structure containing all the settings paramters for the proximal algorithms."))
+            "Structure containing all the settings parameters for the proximal algorithms."))
           .def(bp::init<const Scalar, const Scalar, const Scalar, int>(
             (bp::arg("self"), bp::arg("absolute_accuracy"), bp::arg("relative_accuracy"),
              bp::arg("mu"), bp::arg("max_iter")),
-            "Structure containing all the settings paramters for the proximal algorithms."))
+            "Structure containing all the settings parameters for the proximal algorithms."))
 
           .add_property(
             "absolute_accuracy", &ProximalSettings::absolute_accuracy,
@@ -61,7 +61,7 @@ namespace pinocchio
       {
         bp::class_<ProximalSettings>(
           "ProximalSettings",
-          "Structure containing all the settings paramters for Proximal algorithms.", bp::no_init)
+          "Structure containing all the settings parameters for proximal algorithms.", bp::no_init)
           .def(ProximalSettingsPythonVisitor<ProximalSettings>());
       }
 


### PR DESCRIPTION
* Fix two equations that were not rendering correctly
* Fix typos: paramters → parameters