### PR TITLE
Separate collision_color in MeshcatVisualizer.loadViewerModel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add getMotionAxis method to helical, prismatic, revolute and ubounded revolute joint ([#2315](https://github.com/stack-of-tasks/pinocchio/pull/2315))
 - Add initial compatiblity with coal (coal needs `-DCOAL_BACKWARD_COMPATIBILITY_WITH_HPP_FCL=ON`) ([#2323](https://github.com/stack-of-tasks/pinocchio/pull/2323))
 - Add compatibility with jrl-cmakemodules workspace ([#2333](https://github.com/stack-of-tasks/pinocchio/pull/2333))
+- Add ``collision_color`` parameter to `MeshcatVisualizer.loadViewerModel` ([#2350](https://github.com/stack-of-tasks/pinocchio/pull/2350))
 
 ### Changed
 - Use eigenpy to expose `GeometryObject::meshMaterial` variant ([#2315](https://github.com/stack-of-tasks/pinocchio/pull/2315))

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -1,4 +1,5 @@
 from .. import pinocchio_pywrap_default as pin
+from ..deprecation import DeprecatedWarning
 from ..utils import npToTuple
 
 from . import BaseVisualizer
@@ -853,18 +854,35 @@ class MeshcatVisualizer(BaseVisualizer):
             meshcat_node.set_property("scale", scale)
 
     def loadViewerModel(
-        self, rootNodeName="pinocchio", color=None, collision_color=None
+        self,
+        rootNodeName="pinocchio",
+        color=None,
+        collision_color=None,
+        visual_color=None,
     ):
         """Load the robot in a MeshCat viewer.
         Parameters:
             rootNodeName: name to give to the robot in the viewer
-            color: optional, color to give to the visual model of the robot.
-                This overwrites the color present in the urdf. Format is a list
-                of four RGBA floats (between 0 and 1)
+            color: deprecated and optional, color to give to both the collision
+                and visual models of the robot. This setting overwrites any color
+                specified in the robot description. Format is a list of four
+                RGBA floating-point numbers (between 0 and 1)
             collision_color: optional, color to give to the collision model of
-                the robot. Format is a list of four RGBA floating point numbers
+                the robot. Format is a list of four RGBA floating-point numbers
+                (between 0 and 1)
+            visual_color: optional, color to give to the visual model of
+                the robot. Format is a list of four RGBA floating-point numbers
                 (between 0 and 1)
         """
+        if color is not None:
+            warnings.warn(
+                "The 'color' argument is deprecated and will be removed in a "
+                "future version of Pinocchio. Consider using "
+                "'collision_color' and 'visual_color' instead.",
+                category=DeprecatedWarning,
+            )
+            collision_color = color
+            visual_color = color
 
         # Set viewer to use to gepetto-gui.
         self.viewerRootNodeName = rootNodeName
@@ -883,7 +901,9 @@ class MeshcatVisualizer(BaseVisualizer):
         self.viewerVisualGroupName = self.viewerRootNodeName + "/" + "visuals"
         if self.visual_model is not None:
             for visual in self.visual_model.geometryObjects:
-                self.loadViewerGeometryObject(visual, pin.GeometryType.VISUAL, color)
+                self.loadViewerGeometryObject(
+                    visual, pin.GeometryType.VISUAL, visual_color
+                )
         self.displayVisuals(True)
 
         # Frames

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -852,12 +852,16 @@ class MeshcatVisualizer(BaseVisualizer):
             scale = list(np.asarray(geometry_object.meshScale).flatten())
             meshcat_node.set_property("scale", scale)
 
-    def loadViewerModel(self, rootNodeName="pinocchio", color=None):
+    def loadViewerModel(self, rootNodeName="pinocchio", color=None, collision_color=None):
         """Load the robot in a MeshCat viewer.
         Parameters:
             rootNodeName: name to give to the robot in the viewer
-            color: optional, color to give to the robot. This overwrites the color present in the urdf.
-                   Format is a list of four RGBA floats (between 0 and 1)
+            color: optional, color to give to the visual model of the robot.
+                This overwrites the color present in the urdf. Format is a list
+                of four RGBA floats (between 0 and 1)
+            collision_color: optional, color to give to the collision model of
+                the robot. Format is a list of four RGBA floating point numbers
+                (between 0 and 1)
         """
 
         # Set viewer to use to gepetto-gui.
@@ -869,7 +873,7 @@ class MeshcatVisualizer(BaseVisualizer):
         if self.collision_model is not None:
             for collision in self.collision_model.geometryObjects:
                 self.loadViewerGeometryObject(
-                    collision, pin.GeometryType.COLLISION, color
+                    collision, pin.GeometryType.COLLISION, collision_color
                 )
         self.displayCollisions(False)
 

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -852,7 +852,9 @@ class MeshcatVisualizer(BaseVisualizer):
             scale = list(np.asarray(geometry_object.meshScale).flatten())
             meshcat_node.set_property("scale", scale)
 
-    def loadViewerModel(self, rootNodeName="pinocchio", color=None, collision_color=None):
+    def loadViewerModel(
+        self, rootNodeName="pinocchio", color=None, collision_color=None
+    ):
         """Load the robot in a MeshCat viewer.
         Parameters:
             rootNodeName: name to give to the robot in the viewer


### PR DESCRIPTION
The proposal of this PR is to add a separate ``collision_color`` argument to `MeshcatVisualizer.loadViewerModel`.

- **Before:** `color` applies to both visual and collision model
- **After:** `color` applies to visual, `collision_color` to collision model

This can be convenient to debug collision meshes alongside the visual model (with only `color`, meshes overlapped):

```py
robot.setVisualizer(MeshcatVisualizer())
robot.initViewer(open=True)
robot.loadViewerModel(collision_color=(1.0, 0.0, 0.0, 0.3))
robot.viz.displayCollisions(True)
```

![image](https://github.com/user-attachments/assets/ce227a29-6c0d-448c-82a0-f4bb841717fe)