### PR TITLE
doc: Fix typos and errors.

### DIFF
--- a/doc/a-features/e-lie.md
+++ b/doc/a-features/e-lie.md
@@ -193,7 +193,7 @@ Indeed, we find :
 
 Assuming that we want to make the robot pass through known positions, we can use interpolations to plot a trajectory.
 
-The problem is an interpolation such as Lagrange's one only takes into account translations whlie the robot interact with its environment by performing translations and rotations.
+The problem is an interpolation such as Lagrange's one only takes into account translations while the robot interact with its environment by performing translations and rotations.
 
 A possibility is to use the \f$ \delta_{theta} \f$ method by using quaternions. The method is simple, we just vary the angle, the scalar component of the quaternion, with very small variations.
 

--- a/doc/a-features/g-dynamic.md
+++ b/doc/a-features/g-dynamic.md
@@ -1,1 +1,1 @@
-# Dynamc algorithms
+# Dynamic algorithms

--- a/doc/a-features/intro.md
+++ b/doc/a-features/intro.md
@@ -35,7 +35,7 @@ all the algorithms in Pinocchio follow the signature:
 algorithm(model, data, arg1, arg2, ...)
 ```
 
-where are the arguments of the function (e.g. configuration or
+where ??? are the arguments of the function (e.g. configuration or
 velocity). Keeping model and data separated reduces memory footprint
 when performing several different tasks on the same robot, notably when
 this involves parallel computation. Each process can employ its own data
@@ -57,7 +57,7 @@ belongs to one of the following categories:
 - **Revolute** joints, rotating around a fixed axis, either one of \f$X,Y,Z\f$ or a custom one;
 - **Prismatic** joints, translating along any fixed axis, as in the revolute case;
 - **Spherical** joints, free rotations in the 3D space;
-- **Translation** joint, for free translations in the 3D space;
+- **Translation** joints, for free translations in the 3D space;
 - **Planar** joints, for free movements in the 2D space;
 - **Free-floating** joints, for free movements in the 3D space. Planar and free-floating joints are meant to be
   employed as the basis of kinematic tree of mobile robots (humanoids, automated vehicles, or objects in manipulation
@@ -83,13 +83,13 @@ operators.
 
 ## Geometric models
 
-Aside the kinematic model, Pinocchio defines a geometric model, i.e. the
+Aside from the kinematic model, Pinocchio defines a geometric model, i.e. the
 volumes attached to the kinematic tree. This model can be used for
 displaying the robot and computing quantities associated to collisions.
 Like the kinematic model, the fixed quantities (placement and shape of
 the volumes) are stored in a *GeometricModel* object, while buffers and
-quantities used by associated algorithms are defined in a object. The
-volumes are represented using the FCL library . Bodies
+quantities used by associated algorithms are defined in an object. The
+volumes are represented using the FCL library. Bodies
 of the robot are attached to each joint, while obstacles of the
 environment are defined in the world frame. Collision and distance
 algorithms for the kinematic trees are implemented, based on FCL

--- a/doc/c-maths/a-rigid-bodies.md
+++ b/doc/c-maths/a-rigid-bodies.md
@@ -2,13 +2,13 @@
 
 ## Geometry
 
-A rigid body system is an assembly of different parts which are joints, rigid bodies and forces. A joint connects two different bodies and gather all kinematic relations between those two bodies, allowing the creation of a relative displacement between the two bodies. This displacement is described by breaking it down into three parts, rotations, translations or the compositions of a rotation and a translation.
+A rigid body system is an assembly of different parts which are joints, rigid bodies and forces. A joint connects two different bodies and gather all kinematic relations between those two bodies, allowing the creation of a relative displacement between the two bodies. This displacement is described by breaking it down into three parts: rotations, translations or the compositions of a rotation and a translation.
 
-Rotation matrices form the so-called **Special Orthogonal** group \f$ SO(n) \f$. There are two groups within the latter which interest us as for now: \f$ SO(2) \f$ and \f$ SO(3) \f$. \f$ SO(3) \f$ is the group of all rotations in the 3-dimensionnal space. Its elements are matrices of size 3 by 3. \f$ SO(3) \f$ is useful for planar problems. It is the group of rotations in the 2-dimensionnal space. Its elements are matrices of size 2 by 2.
+Rotation matrices form the so-called **Special Orthogonal** group \f$ SO(n) \f$. There are two groups within the latter which interest us as for now: \f$ SO(2) \f$ and \f$ SO(3) \f$. \f$ SO(3) \f$ is the group of all rotations in the 3-dimensionnal space. Its elements are matrices of size 3 by 3. \f$ SO(2) \f$ is useful for planar problems. It is the group of rotations in the 2-dimensionnal space. Its elements are matrices of size 2 by 2.
 
-The set that brings together all the homogeneous transformations matrices is the **Special Euclidean** group \f$ SE(n) \f$. As with rotation matrices, there are two different groups, \f$ SE(3) \f$ for 3-dimensional transformations and \f$ SE(2) \f$ for 2-dimensional transformation, i.e. transformation in a plane.
+The set that brings together all the homogeneous transformations matrices is the **Special Euclidean** group \f$ SE(n) \f$. As with rotation matrices, there are two different groups, \f$ SE(3) \f$ for 3-dimensional transformations and \f$ SE(2) \f$ for 2-dimensional transformations, i.e. transformations in a plane.
 
-### Using quaternions for an \\( SO(3) \\) object
+### Using quaternions for an SO(3) object
 
 To use quaternions for a \f$ SO(3) \f$ object we have several methods, we can do as in the \f$ SE(3) \f$ example in the [Dealing with Lie group geometry](@ref e-lie) section by removing the translation vector.
 
@@ -44,21 +44,21 @@ we have:
 
 ### Benefits of using quaternions
 
-Determining the matrix corresponding to a rotation is not immediate, so that very often the physical problem is defined by the couple \f$ (\alpha,\overrightarrow{r} ) \f$. Another problem related to the composition of rotations is known as "blocking of Cardan" : we can see it in specific cases, for example when two successive joints have close or even aligned axes of rotation. In this case, a very large variation of the first angle does not change the position of the end of the device. A robot could then generate very strong violent movements without realizing it, due to the approximation of the calculations. To remedy these two points, we use quaternions.
+Determining the matrix corresponding to a rotation is not immediate, so that very often the physical problem is defined by the couple \f$ (\alpha,\overrightarrow{r} ) \f$. Another problem related to the composition of rotations is known as "Gimbal lock" : we can see it in specific cases, for example when two successive joints have close or even aligned axes of rotation. In this case, a very large variation of the first angle does not change the position of the end of the device. A robot could then generate very strong violent movements without realizing it, due to the approximation of the calculations. To remedy these two points, we use quaternions.
 
 
 
 ### Cartesian product
 
-Of course the cartesian product is essential for analysis and description of the movement in our Euclidean space. But here, it's specific to the lie algebra, this is different from the cartesian product which define our space.
-The cartesian product can also be used to create a specific space by associating spaces related to the lie algebra as \f$ SE(n) \f$ and \f$ SO(n) \f$ groups.
+Of course the cartesian product is essential for analysis and description of the movement in our Euclidean space. But here, it's specific to the Lie algebra, this is different from the cartesian product which define our space.
+The cartesian product can also be used to create a specific space by associating spaces related to the Lie algebra as \f$ SE(n) \f$ and \f$ SO(n) \f$ groups.
 
-For example let's consider a wheeled robot like Tiago. It can only move on the ground. It is possible to assimilate the ground to a plane. The robot can rotate around the z-axis so we have to deal with a \f$ SE(2) \f$ object. Then we attach to this \f$ SE(2) \f$ object an articulated arm with four revolute joints spread out his arm, each has one degree of freedom of rotation so they are \f$ SO(2) \f$ objects. To deal with this set we use the cartesian product related to the lie algebra and we get a new space in which we are able to represent all the possible trajectories of the robot and its arm.
+For example let's consider a wheeled robot like Tiago. It can only move on the ground. It is possible to assimilate the ground to a plane. The robot can rotate around the z-axis so we have to deal with a \f$ SE(2) \f$ object. Then we attach to this \f$ SE(2) \f$ object an articulated arm with four revolute joints spread out his arm, each has one degree of freedom of rotation so they are \f$ SO(2) \f$ objects. To deal with this set we use the cartesian product related to the Lie algebra and we get a new space in which we are able to represent all the possible trajectories of the robot and its arm.
 
 
 ### Vector space
 
-If you want to create a tangent space to simplify calculations of a trajectory it is necessary to use vector spaces. Indeed, a tangent space is a vector space that is the whole of all velocity vectors.
+If you want to create a tangent space to simplify calculations of a trajectory, it is necessary to use vector spaces. Indeed, a tangent space is a vector space that is the set of all velocity vectors.
 Let's consider an object having a trajectory, all points of it have a velocity which is tangent to the trajectory and the space associate to one velocity and passing by one point of the trajectory is the \b tangent \b space.
 
 

--- a/doc/c-maths/b-joints.md
+++ b/doc/c-maths/b-joints.md
@@ -2,7 +2,7 @@
 
 ## Geometry
 
-Joints are not simple objects, it can be difficult to deal with. To facilitate their description Pinocchio use the lie algebra which is describe in the *Dealing with Lie bgroup geometry * chapter. Let's take the base joints and express them using lie algebra :
+Joints are not simple objects, it can be difficult to deal with. To facilitate their description Pinocchio uses the Lie algebra which is described in the *Dealing with Lie bgroup geometry * chapter. Let's take the base joints and express them using Lie algebra :
 
 - the **revolute** joint is a \f$ SO(2)\f$ object.
 
@@ -12,7 +12,7 @@ Joints are not simple objects, it can be difficult to deal with. To facilitate t
 - the **cylindrical** joint :
 
 \f$Mat_{move} =
-\begin{bmatrix} 0 &0 \\ 0 &0 \\ 1 &0 \\ 0 &0 \\ 0 &0 \\ 0 &1 \end{bmatrix} \ \ Mat_{const} = \begin{bmatrix} 1 &0 &0 &0 \\ 0 &1 &0 &0 \\ 0 &0 &1 &0 \\ 0 &0 &0 &1 \\ 0 &0 &0 &0 \end{bmatrix} \f$
+\begin{bmatrix} 0 &0 \\ 0 &0 \\ 1 &0 \\ 0 &0 \\ 0 &0 \\ 0 &1 \end{bmatrix} \ \ Mat_{const} = \begin{bmatrix} 1 &0 &0 &0 \\ 0 &1 &0 &0 \\ 0 &0 &0 &0 \\ 0 &0 &1 &0 \\ 0 &0 &0 &1 \\ 0 &0 &0 &0 \end{bmatrix} \f$
 
 
 - The **spherical** joint is a \f$ SO(3) \f$ object.
@@ -54,20 +54,20 @@ TODO : Pyrene's moving picture
 
 ## List of Joints
 
-Joints are essentials components of a robot to allow it to move in his environment. Joints are in some ways robot's articulations. There are several types of them, each caracterised by its shape and degrees of freedom:
+Joints are essential components of a robot to allow it to move in his environment. Joints are in some ways robot's articulations. There are several types of them, each caracterised by its shape and degrees of freedom:
 
 - Revolute
 - Prismatic
-- cylindrical
+- Cylindrical
 - Spherical
 - Translation
 - Free-flyer
 
-Furthermore, we can creat more complicated joints called **composite joints** by combining them with each other.
+Furthermore, we can create more complicated joints called **composite joints** by combining them with each other.
 
 ### Revolute joint
 
-The most simple rotational joint we have to deal with is the revolute joint, he has juste one degree of freedom so it is possible just to focus on it. We can find three differents types of revolute joints, each type can rotate around one of the 3-axis, x-axis, y-axis or z-axis.
+The most simple rotational joint we have to deal with is the revolute joint, he has just one degree of freedom so it is possible just to focus on it. We can find three different types of revolute joints, each type can rotate around one of the 3-axis, x-axis, y-axis or z-axis.
 Revolute joints are used to describe rotational movements.
 
 ![Revolute joint. One rotation possible](revolute_laas.gif)
@@ -84,13 +84,13 @@ The cylindrical joint has two degrees of freedom, one of rotation and this other
 ![Cylindrical joint. It can slide along an axis and turn around](cylindrical_laas.gif)
 ### Spherical joint
 
-The spherical joint is the closest thing to an human's articulation, it is very close for our hip for example but even our body is restricted, we can not do a full tour around one of the 3-axis. This joint is almost the same except for the fact it can do a full rotation on itself. So this joint can moved around the 3-axis. He allows the robot to move its members as we do and even better.
+The spherical joint is the closest thing to an human's articulation, it is very close for our hip for example but even our body is restricted, we can not do a full tour around one of the 3-axis. This joint is almost the same except for the fact it can do a full rotation on itself. So this joint can move around the 3-axis. He allows the robot to move its members as we do and even better.
 
 ![Spherical joint. It can perform three rotations at the same time](spherical_laas.gif)
 
 ### Planar joint
 
-As its name suggests, a planar joint allows movements that a object can do in a plan. Indeed, he allows two translations and one rotation, therefore it has three degrees of freedom. We find this type of movement all over our daily lives, a car has this movement, we have it most of the time when we walk on a flat floor and for example this is exactly Tiago's movement.
+As its name suggests, a planar joint allows movements that an object can do in a plane. Indeed, he allows two translations and one rotation, therefore it has three degrees of freedom. We find this type of movement all over our daily lives, a car has this movement, we have it most of the time when we walk on a flat floor and for example this is exactly Tiago's movement.
 
 ![Planar joint. It is subject to moving only on the map](planar_laas.gif)
 

--- a/doc/c-maths/se3.md
+++ b/doc/c-maths/se3.md
@@ -201,7 +201,7 @@ This last form cost five \f$\times\f$, four \f$+\f$ and one \f$3\times3\f$ matri
 
 ## Joint
 
-We denote by \f$1\f$ the coordinate system attached to the parent (predecessor) body at the joint input, ad by \f$2\f$
+We denote by \f$1\f$ the coordinate system attached to the parent (predecessor) body at the joint input, and by \f$2\f$
 the coordinate system attached to the (child) successor body at the joint output. We neglect the possible time
 variation of the joint model (ie the bias velocity \f$\sigma = \nu(q,0)\f$ is null).
 
@@ -238,7 +238,7 @@ initial position \f$q_0\f$, the velocity \f$v_q\f$  and the length of the integr
 
 \f$ q_t = q_0 + \int_0^t v_q dt\f$
 
-For the simple vectorial case where \f$v_q=\dot q\f$, we have \f$q_t=q_0 + t v_q\f$. Written in the more general case of a Lie groupe, we have \f$q_t = q_0 exp(t v_q)\f$ where \f$exp\f$ denotes the exponential map (i.e. integration of a constant vector field from the Lie algebra into the Lie group). This integration only consider first order explicit Euler. More general integrators (e.g. Runge-Kutta in Lie groupes) remains to be written. Adequate references are welcome.
+For the simple vectorial case where \f$v_q=\dot q\f$, we have \f$q_t=q_0 + t v_q\f$. Written in the more general case of a Lie group, we have \f$q_t = q_0 exp(t v_q)\f$ where \f$exp\f$ denotes the exponential map (i.e. integration of a constant vector field from the Lie algebra into the Lie group). This integration only considers first order explicit Euler. More general integrators (e.g. Runge-Kutta in Lie groups) remains to be written. Adequate references are welcome.
 
 ## RNEA
 


### PR DESCRIPTION
I corrected typos and errors I found reading the docs : https://gepettoweb.laas.fr/doc/stack-of-tasks/pinocchio/master/doxygen-html/

Here are the less trivial ones, i.e. the ones I'm not totally sure about:

- in the intro, there is `where are the arguments...`. I added `arg1, arg2, ...`, and didn't include `model` and `data`.
- a SO(3) was used instead of SO(2).
- `\\( SO(3) \\)` is used in a title and render as is in chrome. I simply replaced with `SO(3)`
- I assume that "blocking of Cardan" refers to Gimbal Lock ?
- `the whole of all velocity vectors` means `the set of all velocity vectors` ?
- I think that a zero line is missing in the constraint matrix of the cylindrical joint.