### PR TITLE
Add BuildFromMJCF function to RobotWrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add initial compatiblity with coal (coal needs `-DCOAL_BACKWARD_COMPATIBILITY_WITH_HPP_FCL=ON`) ([#2323](https://github.com/stack-of-tasks/pinocchio/pull/2323))
 - Add compatibility with jrl-cmakemodules workspace ([#2333](https://github.com/stack-of-tasks/pinocchio/pull/2333))
 - Add ``collision_color`` parameter to `MeshcatVisualizer.loadViewerModel` ([#2350](https://github.com/stack-of-tasks/pinocchio/pull/2350))
+- Add ``BuildFromMJCF`` function to RobotWrapper ([#2363](https://github.com/stack-of-tasks/pinocchio/pull/2363))
 
 ### Changed
 - Use eigenpy to expose `GeometryObject::meshMaterial` variant ([#2315](https://github.com/stack-of-tasks/pinocchio/pull/2315))

--- a/bindings/python/pinocchio/robot_wrapper.py
+++ b/bindings/python/pinocchio/robot_wrapper.py
@@ -92,16 +92,15 @@ class RobotWrapper(object):
 
     @staticmethod
     def BuildFromMJCF(
-        filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None
+        filename, root_joint=None, verbose=False, meshLoader=None
     ):
         robot = RobotWrapper()
-        robot.initFromMJCF(filename, package_dirs, root_joint, verbose, meshLoader)
+        robot.initFromMJCF(filename, root_joint, verbose, meshLoader)
         return robot
 
     def initFromMJCF(
         self,
         filename,
-        package_dirs=None,
         root_joint=None,
         verbose=False,
         meshLoader=None,

--- a/bindings/python/pinocchio/robot_wrapper.py
+++ b/bindings/python/pinocchio/robot_wrapper.py
@@ -4,7 +4,12 @@
 
 from . import pinocchio_pywrap_default as pin
 from . import utils
-from .shortcuts import buildModelsFromUrdf, createDatas, buildModelsFromSdf
+from .shortcuts import (
+    buildModelsFromMJCF,
+    buildModelsFromSdf,
+    buildModelsFromUrdf,
+    createDatas,
+)
 
 import numpy as np
 
@@ -84,6 +89,32 @@ class RobotWrapper(object):
             visual_model=visual_model,
         )
         self.constraint_models = constraint_models
+
+    @staticmethod
+    def BuildFromMJCF(
+        filename, package_dirs=None, root_joint=None, verbose=False, meshLoader=None
+    ):
+        robot = RobotWrapper()
+        robot.initFromMJCF(filename, package_dirs, root_joint, verbose, meshLoader)
+        return robot
+
+    def initFromMJCF(
+        self,
+        filename,
+        package_dirs=None,
+        root_joint=None,
+        verbose=False,
+        meshLoader=None,
+    ):
+        model, collision_model, visual_model = buildModelsFromMJCF(
+            filename, root_joint, verbose, meshLoader
+        )
+        RobotWrapper.__init__(
+            self,
+            model=model,
+            collision_model=collision_model,
+            visual_model=visual_model,
+        )
 
     def __init__(
         self, model=pin.Model(), collision_model=None, visual_model=None, verbose=False

--- a/unittest/python/CMakeLists.txt
+++ b/unittest/python/CMakeLists.txt
@@ -39,6 +39,7 @@ set(${PROJECT_NAME}_PYTHON_TESTS
     # Parsers
     bindings_sample_models
     # Others
+    robot_wrapper
     utils
     serialization
     version

--- a/unittest/python/robot_wrapper.py
+++ b/unittest/python/robot_wrapper.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+import os
+import unittest
+
+import pinocchio as pin
+
+
+class TestRobotWrapper(unittest.TestCase):
+    def setUp(self):
+        self.current_file = os.path.dirname(str(os.path.abspath(__file__)))
+
+    def test_mjcf(self):
+        model_path = os.path.abspath(
+            os.path.join(self.current_file, "../models/test_mjcf.xml")
+        )
+        robot = pin.RobotWrapper.BuildFromMJCF(model_path)
+        self.assertEqual(robot.nq, 6)
+        self.assertEqual(robot.nv, 5)
+        self.assertEqual(robot.model.njoints, 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This PR adds a ``BuildFromMJCF`` function to ``RobotWrapper``, following the same pattern as the existing ``BuildFromURDF`` and ``BuildFromSDF``. It was prompted by [this feature request](https://github.com/robot-descriptions/robot_descriptions.py/discussions/100).