### PR TITLE
fix windows ci 

### DIFF
--- a/.github/workflows/windows-conda.yml
+++ b/.github/workflows/windows-conda.yml
@@ -76,8 +76,9 @@ jobs:
           :: This must be done here and not in env since
           :: cxx-compiler activation script set this variable
           :: and is called before.
-          set CC=${{ matrix.compiler.cmd }}
-          set CXX=${{ matrix.compiler.cmd }}
+          set CC=${{ matrix.compiler }}.exe
+          set CXX=${{ matrix.compiler }}.exe
+          echo Compiler set to: %CC%
 
           call conda list
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- Fix linkage of Boost.Serialization on Windows ([#2400](https://github.com/stack-of-tasks/pinocchio/pull/2400))
+
 ## [3.2.0] - 2024-08-27
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,8 +63,10 @@ set(DOXYGEN_USE_TEMPLATE_CSS YES)
 
 # Use BoostConfig module distributed by boost library instead of using FindBoost module distributed
 # by CMake
-if(POLICY CMP0167)
-  cmake_policy(SET CMP0167 NEW)
+if(NOT WIN32 OR NOT ${CMAKE_CXX_COMPILER_ID} MATCHES "Clang")
+  if(POLICY CMP0167)
+    cmake_policy(SET CMP0167 NEW)
+  endif()
 endif()
 include("${JRL_CMAKE_MODULES}/base.cmake")
 


### PR DESCRIPTION
On Windows, ensure proper handling of both cl.exe and clang-cl.exe. Previously, our setup did not use clang-cl.exe. 

