### PR TITLE
Parser/mjcf : Add warning and fix root joint of mjcf models

### DIFF
--- a/src/parsers/mjcf/mjcf-graph.cpp
+++ b/src/parsers/mjcf/mjcf-graph.cpp
@@ -500,15 +500,29 @@ namespace pinocchio
         namespace fs = boost::filesystem;
         MjcfTexture text;
         auto file = el.get_optional<std::string>("<xmlattr>.file");
+        auto name_ = el.get_optional<std::string>("<xmlattr>.name");
+        auto type = el.get_optional<std::string>("<xmlattr>.type");
+
+        std::string name;
+        if (name_)
+          name = *name_;
+        else if (*type == "skybox")
+          name = *type;
         if (!file)
-          throw std::invalid_argument("Only textures with files are supported");
+        {
+          std::cout << "Warning - Only texture with files are supported" << std::endl;
+          if (name.empty())
+            throw std::invalid_argument("Textures need a name.");
+        }
+        else
+        {
+          fs::path filePath(*file);
+          name = getName(el, filePath);
 
-        fs::path filePath(*file);
-        std::string name = getName(el, filePath);
-
-        text.filePath =
-          updatePath(compilerInfo.strippath, compilerInfo.texturedir, modelPath, filePath).string();
-
+          text.filePath =
+            updatePath(compilerInfo.strippath, compilerInfo.texturedir, modelPath, filePath)
+              .string();
+        }
         auto str_v = el.get_optional<std::string>("<xmlattr>.type");
         if (str_v)
           text.textType = *str_v;

--- a/src/parsers/mjcf/mjcf-graph.cpp
+++ b/src/parsers/mjcf/mjcf-graph.cpp
@@ -785,15 +785,12 @@ namespace pinocchio
       {
 
         FrameIndex parentFrameId = 0;
-        Inertia inert = Inertia::Zero();
         if (!currentBody.bodyParent.empty())
-        {
           parentFrameId = urdfVisitor.getBodyId(currentBody.bodyParent);
-          inert = currentBody.bodyInertia;
-        }
+
         // get body pose in body parent
         const SE3 bodyPose = currentBody.bodyPlacement;
-
+        Inertia inert = currentBody.bodyInertia;
         SE3 jointInParent = bodyPose * joint.jointPlacement;
         bodyInJoint = joint.jointPlacement.inverse();
         UrdfVisitor::JointType jType;
@@ -1036,7 +1033,8 @@ namespace pinocchio
         // get name and inertia of first root link
         std::string rootLinkName = bodiesList.at(0);
         MjcfBody rootBody = mapOfBodies.find(rootLinkName)->second;
-        urdfVisitor.addRootJoint(rootBody.bodyInertia, rootLinkName);
+        if (rootBody.jointChildren.size() == 0)
+          urdfVisitor.addRootJoint(rootBody.bodyInertia, rootLinkName);
 
         fillReferenceConfig(rootBody);
         for (const auto & entry : bodiesList)


### PR DESCRIPTION
This pr aims at being a bit more flexible concerning textures in mjcf model that are not supported in pinocchio.

It also fix a small bug that was introduced in https://github.com/stack-of-tasks/pinocchio/pull/2386. 
