### PR TITLE
Feature: Support for Parsing MJCF `equality/connect` Tag for Closed Chains

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Default visualizer can be changed with `PINOCCHIO_VIEWER` environment variable ([#2419](https://github.com/stack-of-tasks/pinocchio/pull/2419))
 - Add more Python and C++ examples related to inverse kinematics with 3d tasks ([#2428](https://github.com/stack-of-tasks/pinocchio/pull/2428))
+- Add parsing of equality/connect tag for closed-loop chains for MJCF format ([#2413](https://github.com/stack-of-tasks/pinocchio/pull/2413))
 
 ### Fixed
 - Fix linkage of Boost.Serialization on Windows ([#2400](https://github.com/stack-of-tasks/pinocchio/pull/2400))

--- a/include/pinocchio/parsers/mjcf.hpp
+++ b/include/pinocchio/parsers/mjcf.hpp
@@ -7,6 +7,9 @@
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/parsers/urdf.hpp"
+#include "pinocchio/multibody/model.hpp"
+#include "pinocchio/multibody/geometry.hpp"
+#include "pinocchio/algorithm/contact-info.hpp"
 
 namespace pinocchio
 {
@@ -73,6 +76,38 @@ namespace pinocchio
     ModelTpl<Scalar, Options, JointCollectionTpl> & buildModel(
       const std::string & filename,
       ModelTpl<Scalar, Options, JointCollectionTpl> & model,
+      const bool verbose = false);
+
+    template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
+    ModelTpl<Scalar, Options, JointCollectionTpl> & buildModelFromXML(
+      const std::string & xmlStream,
+      const typename ModelTpl<Scalar, Options, JointCollectionTpl>::JointModel & rootJoint,
+      ModelTpl<Scalar, Options, JointCollectionTpl> & model,
+      PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel) & contact_models,
+      const bool verbose = false);
+
+    // TODO: update description, buildModel with contact model
+    template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
+    ModelTpl<Scalar, Options, JointCollectionTpl> & buildModel(
+      const std::string & filename,
+      const typename ModelTpl<Scalar, Options, JointCollectionTpl>::JointModel & rootJoint,
+      ModelTpl<Scalar, Options, JointCollectionTpl> & model,
+      PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel) & contact_models,
+      const bool verbose = false);
+
+    template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
+    ModelTpl<Scalar, Options, JointCollectionTpl> & buildModelFromXML(
+      const std::string & xmlStream,
+      ModelTpl<Scalar, Options, JointCollectionTpl> & model,
+      PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel) & contact_models,
+      const bool verbose = false);
+
+    // TODO: update description, buildModel with contact model
+    template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
+    ModelTpl<Scalar, Options, JointCollectionTpl> & buildModel(
+      const std::string & filename,
+      ModelTpl<Scalar, Options, JointCollectionTpl> & model,
+      PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel) & contact_models,
       const bool verbose = false);
 
     /**

--- a/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
+++ b/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
@@ -325,6 +325,54 @@ namespace pinocchio
         void goThroughElement(const ptree & el, const MjcfGraph & currentGraph);
       };
 
+      /*
+      typedef struct mjsEquality_ {      // equality specification
+        mjsElement* element;             // element type
+        mjString* name;                  // name
+        mjtEq type;                      // constraint type
+        double data[mjNEQDATA];          // type-dependent data
+        mjtByte active;                  // is equality initially active
+        mjString* name1;                 // name of object 1
+        mjString* name2;                 // name of object 2
+        mjtNum solref[mjNREF];           // solver reference
+        mjtNum solimp[mjNIMP];           // solver impedance
+        mjString* info;                  // message appended to errors
+      } mjsEquality;
+      */
+      struct PINOCCHIO_PARSERS_DLLAPI MjcfEquality
+      {
+        typedef boost::property_tree::ptree ptree;
+
+        // Optional name of the equality constraint
+        std::string name;
+
+        // Type of the constraint: (weld or connect for now)
+        std::string type;
+
+        // // Optional class for setting unspecified attributes
+        // std::string class;
+
+        // active: 'true' or 'false' (default: 'true')
+        // solref and solimp
+
+        // Name of the first body participating in the constraint
+        std::string body1;
+        // Name of the second body participating in the constraint (optional, default: world)
+        std::string body2;
+
+        // Coordinates of the 3D anchor point where the two bodies are connected.
+        // Specified relative to the local coordinate frame of the first body.
+        Eigen::Vector3d anchor = Eigen::Vector3d::Zero();
+
+        // This attribute specifies the relative pose (3D position followed by 4D quaternion
+        // orientation) of body2 relative to body1. If the quaternion part (i.e., last 4 components
+        // of the vector) are all zeros, as in the default setting, this attribute is ignored and
+        // the relative pose is the one corresponding to the model reference pose in qpos0. The
+        // unusual default is because all equality constraint types share the same default for their
+        // numeric parameters.
+        Eigen::VectorXd relativePose = Eigen::VectorXd::Zero(7);
+      };
+
       /// @brief The graph which contains all information taken from the mjcf file
       struct PINOCCHIO_PARSERS_DLLAPI MjcfGraph
       {
@@ -337,6 +385,7 @@ namespace pinocchio
         typedef std::unordered_map<std::string, MjcfMesh> MeshMap_t;
         typedef std::unordered_map<std::string, MjcfTexture> TextureMap_t;
         typedef std::unordered_map<std::string, Eigen::VectorXd> ConfigMap_t;
+        typedef std::unordered_map<std::string, MjcfEquality> EqualityMap_t;
 
         // Compiler Info needed to properly parse the rest of file
         MjcfCompiler compilerInfo;
@@ -352,6 +401,8 @@ namespace pinocchio
         TextureMap_t mapOfTextures;
         // Map of model configurations
         ConfigMap_t mapOfConfigs;
+        // Map of equality constraints
+        EqualityMap_t mapOfEqualities;
 
         // reference configuration
         Eigen::VectorXd referenceConfig;
@@ -427,6 +478,10 @@ namespace pinocchio
         /// @brief Parse all the info from the meta tag keyframe
         /// @param el ptree keyframe node
         void parseKeyFrame(const ptree & el);
+
+        /// @brief Parse all the info from the equality tag
+        /// @param el ptree equality node
+        void parseEquality(const ptree & el);
 
         /// @brief parse the mjcf file into a graph
         void parseGraph();

--- a/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
+++ b/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
@@ -528,7 +528,7 @@ namespace pinocchio
         /// @brief Parse the equality constraints and add them to the model
         /// @param model Model to add the constraints to
         /// @param contact_models Vector of contact models to add the constraints to
-        PINOCCHIO_PARSERS_DLLAPI void parseContactInformation(
+        void parseContactInformation(
           const Model & model,
           PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel) & contact_models);
 

--- a/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
+++ b/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
@@ -21,6 +21,7 @@
 #include <limits>
 #include <iostream>
 #include <unordered_map>
+#include <map>
 
 namespace pinocchio
 {
@@ -386,7 +387,7 @@ namespace pinocchio
         typedef std::unordered_map<std::string, MjcfMesh> MeshMap_t;
         typedef std::unordered_map<std::string, MjcfTexture> TextureMap_t;
         typedef std::unordered_map<std::string, Eigen::VectorXd> ConfigMap_t;
-        typedef std::unordered_map<std::string, MjcfEquality> EqualityMap_t;
+        typedef std::map<std::string, MjcfEquality> EqualityMap_t;
 
         // Compiler Info needed to properly parse the rest of file
         MjcfCompiler compilerInfo;

--- a/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
+++ b/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
@@ -8,7 +8,7 @@
 #include "pinocchio/parsers/urdf.hpp"
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/joint/joints.hpp"
-
+#include "pinocchio/algorithm/contact-info.hpp"
 #include <boost/property_tree/xml_parser.hpp>
 #include <boost/property_tree/ptree.hpp>
 #include <boost/foreach.hpp>
@@ -346,7 +346,7 @@ namespace pinocchio
         // Optional name of the equality constraint
         std::string name;
 
-        // Type of the constraint: (weld or connect for now)
+        // Type of the constraint: (connect for now)
         std::string type;
 
         // // Optional class for setting unspecified attributes
@@ -364,13 +364,14 @@ namespace pinocchio
         // Specified relative to the local coordinate frame of the first body.
         Eigen::Vector3d anchor = Eigen::Vector3d::Zero();
 
+        // TODO: implement when weld is introduced
         // This attribute specifies the relative pose (3D position followed by 4D quaternion
         // orientation) of body2 relative to body1. If the quaternion part (i.e., last 4 components
         // of the vector) are all zeros, as in the default setting, this attribute is ignored and
         // the relative pose is the one corresponding to the model reference pose in qpos0. The
         // unusual default is because all equality constraint types share the same default for their
         // numeric parameters.
-        Eigen::VectorXd relativePose = Eigen::VectorXd::Zero(7);
+        // Eigen::VectorXd relativePose = Eigen::VectorXd::Zero(7);
       };
 
       /// @brief The graph which contains all information taken from the mjcf file
@@ -523,6 +524,13 @@ namespace pinocchio
         /// @param keyframe Keyframe to add
         /// @param keyName Name of the keyframe
         void addKeyFrame(const Eigen::VectorXd & keyframe, const std::string & keyName);
+
+        /// @brief Parse the equality constraints and add them to the model
+        /// @param model Model to add the constraints to
+        /// @param contact_models Vector of contact models to add the constraints to
+        PINOCCHIO_PARSERS_DLLAPI void parseContactInformation(
+          const Model & model,
+          PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel) & contact_models);
 
         /// @brief Fill geometry model with all the info taken from the mjcf model file
         /// @param type Type of geometry to parse (COLLISION or VISUAL)

--- a/include/pinocchio/parsers/mjcf/model.hxx
+++ b/include/pinocchio/parsers/mjcf/model.hxx
@@ -39,6 +39,7 @@ namespace pinocchio
 
       // // Use the Mjcf graph to create the model
       graph.parseRootTree();
+      // TODO: insert the parse contact information here
 
       return model;
     }
@@ -73,6 +74,7 @@ namespace pinocchio
 
       // // Use the Mjcf graph to create the model
       graph.parseRootTree();
+      // TODO: insert the parse contact information here
 
       return model;
     }

--- a/include/pinocchio/parsers/mjcf/model.hxx
+++ b/include/pinocchio/parsers/mjcf/model.hxx
@@ -7,6 +7,8 @@
 
 #include "pinocchio/parsers/mjcf.hpp"
 #include "pinocchio/parsers/mjcf/mjcf-graph.hpp"
+#include "pinocchio/multibody/model.hpp"
+#include "pinocchio/algorithm/contact-info.hpp"
 
 namespace pinocchio
 {
@@ -47,6 +49,40 @@ namespace pinocchio
     template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
     ModelTpl<Scalar, Options, JointCollectionTpl> & buildModel(
       const std::string & filename,
+      ModelTpl<Scalar, Options, JointCollectionTpl> & model,
+      PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel) & contact_models,
+      const bool verbose)
+    {
+      return buildModelFromXML(filename, model, contact_models, verbose);
+    }
+
+    template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
+    ModelTpl<Scalar, Options, JointCollectionTpl> & buildModelFromXML(
+      const std::string & xmlStr,
+      ModelTpl<Scalar, Options, JointCollectionTpl> & model,
+      PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel) & contact_models,
+      const bool verbose)
+    {
+      ::pinocchio::urdf::details::UrdfVisitor<Scalar, Options, JointCollectionTpl> visitor(model);
+
+      typedef ::pinocchio::mjcf::details::MjcfGraph MjcfGraph;
+
+      MjcfGraph graph(visitor, xmlStr);
+      if (verbose)
+        visitor.log = &std::cout;
+
+      graph.parseGraphFromXML(xmlStr);
+
+      // // Use the Mjcf graph to create the model
+      graph.parseRootTree();
+      // TODO: insert the parse contact information here
+
+      return model;
+    }
+
+    template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
+    ModelTpl<Scalar, Options, JointCollectionTpl> & buildModel(
+      const std::string & filename,
       const typename ModelTpl<Scalar, Options, JointCollectionTpl>::JointModel & rootJoint,
       ModelTpl<Scalar, Options, JointCollectionTpl> & model,
       const bool verbose)
@@ -59,6 +95,42 @@ namespace pinocchio
       const std::string & xmlStr,
       const typename ModelTpl<Scalar, Options, JointCollectionTpl>::JointModel & rootJoint,
       ModelTpl<Scalar, Options, JointCollectionTpl> & model,
+      const bool verbose)
+    {
+      ::pinocchio::urdf::details::UrdfVisitorWithRootJoint<Scalar, Options, JointCollectionTpl>
+        visitor(model, rootJoint);
+
+      typedef ::pinocchio::mjcf::details::MjcfGraph MjcfGraph;
+
+      MjcfGraph graph(visitor, xmlStr);
+      if (verbose)
+        visitor.log = &std::cout;
+
+      graph.parseGraphFromXML(xmlStr);
+
+      // // Use the Mjcf graph to create the model
+      graph.parseRootTree();
+
+      return model;
+    }
+
+    template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
+    ModelTpl<Scalar, Options, JointCollectionTpl> & buildModel(
+      const std::string & filename,
+      const typename ModelTpl<Scalar, Options, JointCollectionTpl>::JointModel & rootJoint,
+      ModelTpl<Scalar, Options, JointCollectionTpl> & model,
+      PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel) & contact_models,
+      const bool verbose)
+    {
+      return buildModelFromXML(filename, rootJoint, model, contact_models, verbose);
+    }
+
+    template<typename Scalar, int Options, template<typename, int> class JointCollectionTpl>
+    ModelTpl<Scalar, Options, JointCollectionTpl> & buildModelFromXML(
+      const std::string & xmlStr,
+      const typename ModelTpl<Scalar, Options, JointCollectionTpl>::JointModel & rootJoint,
+      ModelTpl<Scalar, Options, JointCollectionTpl> & model,
+      PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel) & contact_models,
       const bool verbose)
     {
       ::pinocchio::urdf::details::UrdfVisitorWithRootJoint<Scalar, Options, JointCollectionTpl>

--- a/include/pinocchio/parsers/mjcf/model.hxx
+++ b/include/pinocchio/parsers/mjcf/model.hxx
@@ -39,9 +39,8 @@ namespace pinocchio
 
       graph.parseGraphFromXML(xmlStr);
 
-      // // Use the Mjcf graph to create the model
+      // Use the Mjcf graph to create the model
       graph.parseRootTree();
-      // TODO: insert the parse contact information here
 
       return model;
     }
@@ -73,9 +72,9 @@ namespace pinocchio
 
       graph.parseGraphFromXML(xmlStr);
 
-      // // Use the Mjcf graph to create the model
+      // Use the Mjcf graph to create the model
       graph.parseRootTree();
-      // TODO: insert the parse contact information here
+      graph.parseContactInformation(model, contact_models);
 
       return model;
     }
@@ -108,7 +107,7 @@ namespace pinocchio
 
       graph.parseGraphFromXML(xmlStr);
 
-      // // Use the Mjcf graph to create the model
+      // Use the Mjcf graph to create the model
       graph.parseRootTree();
 
       return model;
@@ -144,9 +143,9 @@ namespace pinocchio
 
       graph.parseGraphFromXML(xmlStr);
 
-      // // Use the Mjcf graph to create the model
+      // Use the Mjcf graph to create the model
       graph.parseRootTree();
-      // TODO: insert the parse contact information here
+      graph.parseContactInformation(model, contact_models);
 
       return model;
     }

--- a/src/parsers/mjcf/mjcf-graph.cpp
+++ b/src/parsers/mjcf/mjcf-graph.cpp
@@ -741,8 +741,6 @@ namespace pinocchio
       {
         for (const ptree::value_type & v : el)
         {
-          // std::cout << v.first << " " << v.second << std::endl;
-
           std::string type = v.first;
           // List of supported constraints from mjcf description
           // equality -> connect
@@ -751,7 +749,7 @@ namespace pinocchio
           // warning: joint, flex, distance, weld
           if (type != "connect")
           {
-            std::cout << "Warning - Constraint " << type << " is not supported" << std::endl;
+            // TODO(jcarpent): support extra constraint types such as joint, flex, distance, weld.
             continue;
           }
 
@@ -781,15 +779,6 @@ namespace pinocchio
           auto anchor = v.second.get_optional<std::string>("<xmlattr>.anchor");
           if (anchor)
             eq.anchor = internal::getVectorFromStream<3>(*anchor);
-
-          // // print what constraint is being added
-          // std::cout << "MjcfEquality: {" << std::endl;
-          // std::cout << "  Name: " << eq.name << std::endl;
-          // std::cout << "  Type: " << eq.type << std::endl;
-          // std::cout << "  Body1: " << eq.body1 << std::endl;
-          // std::cout << "  Body2: " << eq.body2 << std::endl;
-          // std::cout << "  Anchor: [" << eq.anchor.transpose() << "]" << std::endl;
-          // std::cout << "}" << std::endl;
 
           mapOfEqualities.insert(std::make_pair(eq.name, eq));
         }

--- a/unittest/mjcf.cpp
+++ b/unittest/mjcf.cpp
@@ -1259,9 +1259,9 @@ BOOST_AUTO_TEST_CASE(test_contact_parsing)
 
   BOOST_CHECK_EQUAL(contact_models.size(), 4);
   BOOST_CHECK_EQUAL(
-    contact_models[0].joint1_placement.translation(), pinocchio::SE3::Vector3(0.35012, 0, 0));
+    contact_models[0].joint1_placement.translation(), pinocchio::SE3::Vector3(0.50120, 0, 0));
   BOOST_CHECK_EQUAL(
-    contact_models[1].joint1_placement.translation(), pinocchio::SE3::Vector3(0.50120, 0, 0));
+    contact_models[1].joint1_placement.translation(), pinocchio::SE3::Vector3(0.35012, 0, 0));
   BOOST_CHECK_EQUAL(
     contact_models[2].joint1_placement.translation(), pinocchio::SE3::Vector3(0.50120, 0, 0));
   BOOST_CHECK_EQUAL(

--- a/unittest/mjcf.cpp
+++ b/unittest/mjcf.cpp
@@ -1249,4 +1249,15 @@ BOOST_AUTO_TEST_CASE(test_geometry_parsing)
 }
 #endif // if defined(PINOCCHIO_WITH_HPP_FCL)
 
+BOOST_AUTO_TEST_CASE(test_contact_parsing)
+{
+  PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(pinocchio::RigidConstraintModel) contact_models;
+  std::string filename = PINOCCHIO_MODEL_DIR + std::string("/../unittest/models/closed_chain.xml");
+
+  pinocchio::Model model;
+  pinocchio::mjcf::buildModel(filename, model, contact_models);
+
+  BOOST_CHECK_EQUAL(contact_models.size(), 4);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/mjcf.cpp
+++ b/unittest/mjcf.cpp
@@ -1258,6 +1258,18 @@ BOOST_AUTO_TEST_CASE(test_contact_parsing)
   pinocchio::mjcf::buildModel(filename, model, contact_models);
 
   BOOST_CHECK_EQUAL(contact_models.size(), 4);
+  BOOST_CHECK_EQUAL(
+    contact_models[0].joint1_placement.translation(), pinocchio::SE3::Vector3(0.35012, 0, 0));
+  BOOST_CHECK_EQUAL(
+    contact_models[1].joint1_placement.translation(), pinocchio::SE3::Vector3(0.50120, 0, 0));
+  BOOST_CHECK_EQUAL(
+    contact_models[2].joint1_placement.translation(), pinocchio::SE3::Vector3(0.50120, 0, 0));
+  BOOST_CHECK_EQUAL(
+    contact_models[3].joint1_placement.translation(), pinocchio::SE3::Vector3(0.35012, 0, 0));
+  for (const auto & cm : contact_models)
+  {
+    BOOST_CHECK(cm.joint2_placement.isApprox(cm.joint1_placement.inverse()));
+  }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/mjcf.cpp
+++ b/unittest/mjcf.cpp
@@ -469,7 +469,7 @@ BOOST_AUTO_TEST_CASE(parse_default_class)
     "joint3");
   model_u.appendBodyToJoint(idx, inertia);
 
-  for (int i = 0; i < model_m.njoints; i++)
+  for (size_t i = 0; i < size_t(model_m.njoints); i++)
     BOOST_CHECK_EQUAL(model_m.joints[i], model_u.joints[i]);
 }
 #endif // PINOCCHIO_WITH_URDFDOM
@@ -582,7 +582,7 @@ BOOST_AUTO_TEST_CASE(parse_RX)
   idx = modelRX.addJoint(0, pinocchio::JointModelRX(), pinocchio::SE3::Identity(), "rx");
   modelRX.appendBodyToJoint(idx, inertia);
 
-  for (int i = 0; i < model_m.njoints; i++)
+  for (size_t i = 0; i < size_t(model_m.njoints); i++)
     BOOST_CHECK_EQUAL(model_m.joints[i], modelRX.joints[i]);
 }
 
@@ -619,7 +619,7 @@ BOOST_AUTO_TEST_CASE(parse_PX)
   idx = modelPX.addJoint(0, pinocchio::JointModelPX(), pinocchio::SE3::Identity(), "px");
   modelPX.appendBodyToJoint(idx, inertia);
 
-  for (int i = 0; i < model_m.njoints; i++)
+  for (size_t i = 0; i < size_t(model_m.njoints); i++)
     BOOST_CHECK_EQUAL(model_m.joints[i], modelPX.joints[i]);
 }
 
@@ -656,7 +656,7 @@ BOOST_AUTO_TEST_CASE(parse_Sphere)
   idx = modelS.addJoint(0, pinocchio::JointModelSpherical(), pinocchio::SE3::Identity(), "s");
   modelS.appendBodyToJoint(idx, inertia);
 
-  for (int i = 0; i < model_m.njoints; i++)
+  for (size_t i = 0; i < size_t(model_m.njoints); i++)
     BOOST_CHECK_EQUAL(model_m.joints[i], modelS.joints[i]);
 }
 
@@ -693,7 +693,7 @@ BOOST_AUTO_TEST_CASE(parse_Free)
   idx = modelF.addJoint(0, pinocchio::JointModelFreeFlyer(), pinocchio::SE3::Identity(), "f");
   modelF.appendBodyToJoint(idx, inertia);
 
-  for (int i = 0; i < model_m.njoints; i++)
+  for (size_t i = 0; i < size_t(model_m.njoints); i++)
     BOOST_CHECK_EQUAL(model_m.joints[i], modelF.joints[i]);
 }
 
@@ -735,7 +735,7 @@ BOOST_AUTO_TEST_CASE(parse_composite_RXRY)
   idx = modelRXRY.addJoint(0, joint_model_RXRY, pinocchio::SE3::Identity(), "rxry");
   modelRXRY.appendBodyToJoint(idx, inertia);
 
-  for (int i = 0; i < model_m.njoints; i++)
+  for (size_t i = 0; i < size_t(model_m.njoints); i++)
     BOOST_CHECK_EQUAL(model_m.joints[i], modelRXRY.joints[i]);
 }
 
@@ -777,7 +777,7 @@ BOOST_AUTO_TEST_CASE(parse_composite_PXPY)
   idx = modelPXPY.addJoint(0, joint_model_PXPY, pinocchio::SE3::Identity(), "pxpy");
   modelPXPY.appendBodyToJoint(idx, inertia);
 
-  for (int i = 0; i < model_m.njoints; i++)
+  for (size_t i = 0; i < size_t(model_m.njoints); i++)
     BOOST_CHECK_EQUAL(model_m.joints[i], modelPXPY.joints[i]);
 }
 
@@ -819,7 +819,7 @@ BOOST_AUTO_TEST_CASE(parse_composite_PXRY)
   idx = modelPXRY.addJoint(0, joint_model_PXRY, pinocchio::SE3::Identity(), "pxry");
   modelPXRY.appendBodyToJoint(idx, inertia);
 
-  for (int i = 0; i < model_m.njoints; i++)
+  for (size_t i = 0; i < size_t(model_m.njoints); i++)
     BOOST_CHECK_EQUAL(model_m.joints[i], modelPXRY.joints[i]);
 }
 
@@ -861,7 +861,7 @@ BOOST_AUTO_TEST_CASE(parse_composite_PXSphere)
   idx = modelPXSphere.addJoint(0, joint_model_PXSphere, pinocchio::SE3::Identity(), "pxsphere");
   modelPXSphere.appendBodyToJoint(idx, inertia);
 
-  for (int i = 0; i < model_m.njoints; i++)
+  for (size_t i = 0; i < size_t(model_m.njoints); i++)
     BOOST_CHECK_EQUAL(model_m.joints[i], modelPXSphere.joints[i]);
 }
 

--- a/unittest/mjcf.cpp
+++ b/unittest/mjcf.cpp
@@ -452,10 +452,11 @@ BOOST_AUTO_TEST_CASE(parse_default_class)
   typedef pinocchio::SE3::Vector3 Vector3;
   typedef pinocchio::SE3::Matrix3 Matrix3;
 
+  PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(pinocchio::RigidConstraintModel) contact_models;
   std::string filename = PINOCCHIO_MODEL_DIR + std::string("/../unittest/models/test_mjcf.xml");
 
   pinocchio::Model model_m;
-  pinocchio::mjcf::buildModel(filename, model_m);
+  pinocchio::mjcf::buildModel(filename, model_m, contact_models);
 
   std::string file_u = PINOCCHIO_MODEL_DIR + std::string("/../unittest/models/test_mjcf.urdf");
   pinocchio::Model model_u;

--- a/unittest/models/closed_chain.xml
+++ b/unittest/models/closed_chain.xml
@@ -1,0 +1,176 @@
+<mujoco model="cassie">
+  <compiler eulerseq="zyx" meshdir="assets" texturedir="assets" autolimits="true"/>
+
+  <option timestep="0.0005"/>
+  <!-- Timestep is set to 0.0005 because the standard Cassie controller runs at 2 kHz -->
+  <!-- Larger values still have stable dynamics -->
+
+  <default>
+    <geom contype="0" conaffinity="0" condim="1" solref="0.005 1"/>
+    <equality solref="0.005 1"/>
+    <default class="cassie">
+      <geom material="cassie" group="2"/>
+    </default>
+    <default class="collision">
+      <geom contype="1" group="3" type="capsule"/>
+      <default class="collision-left">
+        <geom contype="2" conaffinity="4"/>
+      </default>
+      <default class="collision-right">
+        <geom contype="4" conaffinity="2"/>
+      </default>
+    </default>
+  </default>
+  <worldbody>
+    <body name="cassie-pelvis" pos="0 0 1.1" childclass="cassie">
+      <camera name="track" pos="0 -3 1" zaxis="0 -1 0.5" mode="track"/>
+      <inertial pos="0.05066 0.000346 0.02841" mass="10.33"
+        fullinertia="0.085821 0.049222 0.08626 1.276e-05 -0.00016022 -0.000414"/>
+      <freejoint/>
+      <!-- <geom type="sphere" size="0.15" pos="0.02 0 0.02" class="collision"/> -->
+      <geom type="ellipsoid" size="0.15 0.12 0.13" pos="0.03 0 0.03" class="collision"/>
+      <geom size="0.095" fromto="-.04 0.14 .01 .02 0.14 .01" class="collision"/>
+      <geom size="0.095" fromto="-.04 -.14 .01 .02 -.14 .01" class="collision"/>
+      <site name="imu" size="0.01" pos="0.03155 0 -0.07996"/>
+      <body name="left-hip-roll" pos="0.021 0.135 0" xyaxes="0 0 -1 0 1 0">
+        <inertial pos="-0.01793 0.0001 -0.04428" mass="1.82"
+          fullinertia="0.003431 0.003793 0.002135 -6.65e-07 -0.00084 3.99e-06"/>
+        <joint name="left-hip-roll" type="hinge" range="-15 22.5" damping="1" armature="0.038125"/>
+        <body name="left-hip-yaw" pos="0 0 -0.07" xyaxes="0 0 1 0 1 0">
+          <inertial pos="0 -1e-05 -0.034277" mass="1.171"
+            fullinertia="0.002443 0.002803 0.000842 -4e-08 2.462e-07 -2.71e-08"/>
+          <joint name="left-hip-yaw" type="hinge" range="-22.5 22.5" damping="1" armature="0.038125"/>
+          <body name="left-hip-pitch" pos="0 0 -0.09" xyaxes="0 0 -1 1 0 0">
+            <inertial pos="0.05946 5e-05 -0.03581" mass="5.52"
+              fullinertia="0.010898 0.029714 0.030257 -0.0002669 -5.721e-05 9.17e-06"/>
+            <joint name="left-hip-pitch" type="hinge" range="-50 80" damping="1" armature="0.09344"/>
+            <geom size="0.08" fromto="0 0 -0.05 0.12 0 -0.05" class="collision"/>
+            <body name="left-achilles-rod" pos="0 0 0.045" xyaxes="0.7922 -0.60599 -0.072096 0.60349 0.79547 -0.054922">
+              <inertial pos="0.24719 0 0" mass="0.1567" fullinertia="3.754e-06 0.004487 0.004488 -3.74e-08 -1.61e-08 0"/>
+              <joint name="left-achilles-rod" type="ball" damping="0.01"/>
+            </body>
+            <body name="left-knee" pos="0.12 0 0.0045" xyaxes="0.70711 -0.70711 0 0.70711 0.70711 0">
+              <inertial pos="0.023 0.03207 -0.002181" mass="0.7578"
+                fullinertia="0.001376 0.0010335 0.0021637 -0.00039744 -4.085e-05 -5.374e-05"/>
+              <joint name="left-knee" type="hinge" ref="-45" range="-164 -37" damping="1" armature="0.09344"/>
+              <body name="left-knee-spring" pos="0.06068 0.08241 0">
+                <inertial pos="0.0836 0.0034 0" mass="0.186" fullinertia="5.215e-05 0.00041205 0.0003669 6.87e-06 0 0"/>
+              </body>
+              <body name="left-shin" pos="0.06068 0.04741 0">
+                <inertial pos="0.18338 0.001169 0.0002123" mass="0.577"
+                  fullinertia="0.00035939 0.014728 0.014707 -0.00020981 2.266e-05 -1.2e-07"/>
+                <joint name="left-shin" type="hinge" range="-20 20" stiffness="1500" damping="0.1"/>
+                <geom size="0.04" fromto="-.06 0 0 0.17 -.01 0" class="collision-left"/>
+                <geom size="0.027" fromto="0.17 -.023 0 0.38 0 0" class="collision-left"/>
+                <geom size="0.025" fromto="-.045 .045 0 0.43476 0 0" class="collision-left"/>
+                <body name="left-tarsus" pos="0.43476 0.02 0" xyaxes="0.52992 0.84805 0 -0.84805 0.52992 0">
+                  <inertial pos="0.11046 -0.03058 -0.00131" mass="0.782"
+                    fullinertia="0.00039238 0.013595 0.013674 0.00023651 -4.987e-05 -4.82e-06"/>
+                  <joint name="left-tarsus" type="hinge" ref="58" range="50 170" damping="0.1"/>
+                  <geom size="0.028" fromto=".01 -0.03059 0.00092 0.23 -0.04 0" class="collision-left"/>
+                  <geom size="0.033" fromto=".04 -0.07 0.00092 0.208 -0.04 0" class="collision-left"/>
+                  <geom size="0.02" fromto="0.208 -0.04 0 0.43 -0.04 0" class="collision-left"/>
+                  <body name="left-heel-spring" pos="-0.01269 -0.03059 0.00092"
+                    xyaxes="-0.91211 0.40829 0.036948 -0.40992 -0.90952 -0.068841">
+                    <inertial pos="0.081 0.0022 0" mass="0.126"
+                      fullinertia="2.959e-05 0.00022231 0.0002007 7.15e-06 -6e-07 1e-07"/>
+                    <joint name="left-heel-spring" type="hinge" stiffness="1250"/>
+                  </body>
+                  <body name="left-foot-crank" pos="0.058 -0.034 0.02275">
+                    <inertial pos="0.00493 2e-05 -0.00215" mass="0.1261"
+                      fullinertia="2.6941e-05 4.9621e-05 6.3362e-05 -2.1e-09 -3.9623e-06 -1.09e-08"/>
+                    <joint name="left-foot-crank" type="hinge" range="-140 -30" damping="1"/>
+                    <body name="left-plantar-rod" pos="0.055 0 -0.00791">
+                      <inertial pos="0.17792 0 0" mass="0.1186"
+                        fullinertia="2.779e-06 0.001774 0.001775 -2.34e-08 -8.1e-09 0"/>
+                      <joint name="left-plantar-rod" type="hinge"/>
+                    </body>
+                  </body>
+                  <body name="left-foot" pos="0.408 -0.04 0">
+                    <inertial pos="0.00474 0.02748 -0.00014" mass="0.1498"
+                      fullinertia="0.00017388 0.00016793 0.00033261 0.00011814 1.36e-06 -4e-07"/>
+                    <joint name="left-foot" type="hinge" range="-140 -30" damping="1" armature="0.01225"/>
+                    <geom size="0.02" fromto="-0.052821 0.092622 0 0.069746 -0.010224 0" class="collision-left"/>
+                  </body>
+                </body>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+      <body name="right-hip-roll" pos="0.021 -0.135 0" xyaxes="0 0 -1 0 1 0">
+        <inertial pos="-0.01793 0.0001 -0.04428" mass="1.82"
+          fullinertia="0.003431 0.003793 0.002135 6.65e-07 -0.00084 -3.99e-06"/>
+        <joint name="right-hip-roll" type="hinge" range="-22.5 15" damping="1" armature="0.038125"/>
+        <body name="right-hip-yaw" pos="0 0 -0.07" xyaxes="0 0 1 0 1 0">
+          <inertial pos="0 1e-05 -0.034277" mass="1.171"
+            fullinertia="0.002443 0.002803 0.000842 4e-08 2.462e-07 2.71e-08"/>
+          <joint name="right-hip-yaw" type="hinge" range="-22.5 22.5" damping="1" armature="0.038125"/>
+          <body name="right-hip-pitch" pos="0 0 -0.09" xyaxes="0 0 -1 1 0 0">
+            <inertial pos="0.05946 5e-05 0.03581" mass="5.52"
+              fullinertia="0.010898 0.029714 0.030257 -0.0002669 5.721e-05 -9.17e-06"/>
+            <joint name="right-hip-pitch" type="hinge" range="-50 80" damping="1" armature="0.09344"/>
+            <geom size="0.08" fromto="0 0 0.05 0.12 0 0.05" class="collision"/>
+            <body name="right-achilles-rod" pos="0 0 -0.045" xyaxes="0.7922 -0.60599 0.072096 0.60349 0.79547 0.054922">
+              <inertial pos="0.24719 0 0" mass="0.1567" fullinertia="3.754e-06 0.004487 0.004488 -3.74e-08 1.61e-08 0"/>
+              <joint name="right-achilles-rod" type="ball" damping="0.01"/>
+            </body>
+            <body name="right-knee" pos="0.12 0 -0.0045" xyaxes="0.70711 -0.70711 0 0.70711 0.70711 0">
+              <inertial pos="0.023 0.03207 0.002181" mass="0.7578"
+                fullinertia="0.001376 0.0010335 0.0021637 -0.00039744 4.085e-05 5.374e-05"/>
+              <joint name="right-knee" type="hinge" ref="-45" range="-164 -37" damping="1" armature="0.09344"/>
+              <body name="right-knee-spring" pos="0.06068 0.08241 0">
+                <inertial pos="0.0836 0.0034 0" mass="0.186" fullinertia="5.215e-05 0.00041205 0.0003669 6.87e-06 0 0"/>
+              </body>
+              <body name="right-shin" pos="0.06068 0.04741 0">
+                <inertial pos="0.18338 0.001169 -0.0002123" mass="0.577"
+                  fullinertia="0.00035939 0.014728 0.014707 -0.00020981 -2.266e-05 1.2e-07"/>
+                <joint name="right-shin" type="hinge" range="-20 20" stiffness="1500" damping="0.1"/>
+                <geom size="0.04" fromto="-.06 0 0 0.17 -.01 0" class="collision-right"/>
+                <geom size="0.027" fromto="0.17 -.023 0 0.38 0 0" class="collision-right"/>
+                <geom size="0.025" fromto="-.045 .045 0 0.43476 0 0" class="collision-right"/>
+                <body name="right-tarsus" pos="0.43476 0.02 0" xyaxes="0.52992 0.84805 0 -0.84805 0.52992 0">
+                  <inertial pos="0.11046 -0.03058 0.00131" mass="0.782"
+                    fullinertia="0.00039238 0.013595 0.013674 0.00023651 4.987e-05 4.82e-06"/>
+                  <joint name="right-tarsus" type="hinge" ref="58" range="50 170" damping="0.1"/>
+                  <geom size="0.028" fromto=".01 -0.03059 0.00092 0.23 -0.04 0" class="collision-right"/>
+                  <geom size="0.033" fromto=".04 -0.07 0.00092 0.208 -0.04 0" class="collision-right"/>
+                  <geom size="0.02" fromto="0.208 -0.04 0 0.43 -0.04 0" class="collision-right"/>
+                  <body name="right-heel-spring" pos="-0.01269 -0.03059 -0.00092"
+                    xyaxes="-0.91211 0.40829 -0.036948 -0.40992 -0.90952 0.068841">
+                    <inertial pos="0.081 0.0022 0" mass="0.126"
+                      fullinertia="2.959e-05 0.00022231 0.0002007 7.15e-06 6e-07 -1e-07"/>
+                    <joint name="right-heel-spring" type="hinge" stiffness="1250"/>
+                  </body>
+                  <body name="right-foot-crank" pos="0.058 -0.034 -0.02275">
+                    <inertial pos="0.00493 2e-05 0.00215" mass="0.1261"
+                      fullinertia="2.6941e-05 4.9621e-05 6.3362e-05 -2.1e-09 3.9623e-06 1.09e-08"/>
+                    <joint name="right-foot-crank" type="hinge" range="-140 -30" damping="1"/>
+                    <body name="right-plantar-rod" pos="0.055 0 0.00791">
+                      <inertial pos="0.17792 0 0" mass="0.1186"
+                        fullinertia="2.779e-06 0.001774 0.001775 -2.34e-08 8.1e-09 0"/>
+                      <joint name="right-plantar-rod" type="hinge"/>
+                    </body>
+                  </body>
+                  <body name="right-foot" pos="0.408 -0.04 0">
+                    <inertial pos="0.00474 0.02748 0.00014" mass="0.1498"
+                      fullinertia="0.00017388 0.00016793 0.00033261 0.00011814 -1.36e-06 4e-07"/>
+                    <joint name="right-foot" type="hinge" range="-140 -30" damping="1" armature="0.01225"/>
+                    <geom size="0.02" fromto="-0.052821 0.092622 0 0.069746 -0.010224 0" class="collision-right"/>
+                  </body>
+                </body>
+              </body>
+            </body>
+          </body>
+        </body>
+      </body>
+    </body>
+  </worldbody>
+
+  <equality>
+    <connect body1="left-plantar-rod" body2="left-foot" anchor="0.35012 0 0"/>
+    <connect body1="left-achilles-rod" body2="left-heel-spring" anchor="0.5012 0 0"/>
+    <connect body1="right-plantar-rod" body2="right-foot" anchor="0.35012 0 0"/>
+    <connect body1="right-achilles-rod" body2="right-heel-spring" anchor="0.5012 0 0"/>
+  </equality>
+</mujoco>

--- a/unittest/models/test_mjcf.xml
+++ b/unittest/models/test_mjcf.xml
@@ -28,4 +28,9 @@
             </body>
         </body>
     </worldbody>
+
+    <equality>
+        <weld body1="link0" body2="link1"/>
+        <connect body1="link1" body2="link2"/>
+    </equality>
 </mujoco>


### PR DESCRIPTION
Hello Pinocchio Team,

While working with the `buildModel` function, I noticed that when an SDF description is passed, it directly produces a vector of `RigidConstraintModel`s. However, the `mjcf` format, which also supports closed-chain descriptions, currently does not parse the `equality/connect` tag.

To address this, I have added a draft implementation to enable parsing of the `equality/connect` tag in the `mjcf` format. I believe this enhancement will ease the work for people who use it.

Please feel free to review the draft implementation and share your feedback on its applicability to the Pinocchio library. I look forward to your comments!

Best regards,
Lev Kozlov