### PR TITLE
configurable default visualizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Default visualizer can be changed with `PINOCCHIO_VIEWER` environment variable ([#2419](https://github.com/stack-of-tasks/pinocchio/pull/2419))
+
 ### Fixed
 - Fix linkage of Boost.Serialization on Windows ([#2400](https://github.com/stack-of-tasks/pinocchio/pull/2400))
 - Fix mjcf parser appending of inertias at root joint ([#2403](https://github.com/stack-of-tasks/pinocchio/pull/2403))

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -224,8 +224,14 @@ if(BUILD_PYTHON_INTERFACE)
 
   # --- INSTALL VISUALIZATION SCRIPTS
   install_python_files(
-    MODULE visualize FILES __init__.py base_visualizer.py gepetto_visualizer.py
-                           meshcat_visualizer.py panda3d_visualizer.py rviz_visualizer.py)
+    MODULE visualize
+    FILES __init__.py
+          base_visualizer.py
+          gepetto_visualizer.py
+          meshcat_visualizer.py
+          panda3d_visualizer.py
+          rviz_visualizer.py
+          visualizers.py)
 
   # --- STUBS --- #
   if(GENERATE_PYTHON_STUBS)

--- a/bindings/python/pinocchio/robot_wrapper.py
+++ b/bindings/python/pinocchio/robot_wrapper.py
@@ -413,14 +413,14 @@ class RobotWrapper(object):
         """Init the viewer"""
         # Set viewer to use to MeshCat.
         if self.viz is None:
-            from .visualize import MeshcatVisualizer
+            from .visualize import Visualizer
 
             data, collision_data, visual_data = None, None, None
             if share_data:
                 data = self.data
                 collision_data = self.collision_data
                 visual_data = self.visual_data
-            self.viz = MeshcatVisualizer(
+            self.viz = Visualizer.default()(
                 self.model,
                 self.collision_model,
                 self.visual_model,

--- a/bindings/python/pinocchio/visualize/__init__.py
+++ b/bindings/python/pinocchio/visualize/__init__.py
@@ -4,3 +4,4 @@ from .gepetto_visualizer import GepettoVisualizer
 from .meshcat_visualizer import MeshcatVisualizer
 from .panda3d_visualizer import Panda3dVisualizer
 from .rviz_visualizer import RVizVisualizer
+from .visualizers import Visualizer

--- a/bindings/python/pinocchio/visualize/visualizers.py
+++ b/bindings/python/pinocchio/visualize/visualizers.py
@@ -1,0 +1,55 @@
+from enum import Enum
+from importlib.util import find_spec
+from os import environ
+
+from .base_visualizer import BaseVisualizer
+from .gepetto_visualizer import GepettoVisualizer
+from .meshcat_visualizer import MeshcatVisualizer
+from .panda3d_visualizer import Panda3dVisualizer
+from .rviz_visualizer import RVizVisualizer
+
+
+class Visualizer(Enum):
+    BASE = BaseVisualizer
+    GEPETTO = GepettoVisualizer
+    MESHCAT = MeshcatVisualizer
+    PANDA3D = Panda3dVisualizer
+    RVIZ = RVizVisualizer
+
+    @classmethod
+    def default(cls):
+        """
+        Allow user to choose their prefered viewer with eg.
+        export PINOCCHIO_VIEWER=RVIZ.
+
+        Otherwise, try to find one which is installed.
+        """
+        # Allow user to define which viewer they want
+        if "PINOCCHIO_VIEWER" in environ:
+            selected = environ["PINOCCHIO_VIEWER"].upper()
+            if hasattr(cls, selected):
+                return getattr(cls, selected).value
+            err = (
+                f"The visualizer '{selected}' is not available.\n"
+                "Please set PINOCCHIO_VIEWER to something installed among:\n"
+                "- meshcat\n"
+                "- gepetto-viewer\n"
+                "- panda3d\n"
+                "- rviz\n"
+            )
+            raise ImportError(err)
+
+        # Otherwise, use the first available
+        for v in ["meshcat", "gepetto", "panda3d_viewer", "rviz"]:
+            if find_spec(v) is not None:
+                return getattr(cls, v.replace("_viewer", "").upper()).value
+
+        err = (
+            "No visualizer could be found.\n"
+            "Please install one of those:\n"
+            "- meshcat\n"
+            "- gepetto-viewer\n"
+            "- panda3d\n"
+            "- rviz\n"
+        )
+        raise ImportError(err)


### PR DESCRIPTION
Following #2331, the default viewer was updated from gepetto to meshcat.
This caused some troubles for users with gepetto set up and not meshcat.

This PR allows users to define their favorite viewer with the `PINOCCHIO_VIEWER` environment variable.
When it is not defined, the default viewer is automatically inferred from the available python modules.
