### PR TITLE
Mjcf : Fix parsing of armature parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add `pinocchio_python_parser` target ([#2475](https://github.com/stack-of-tasks/pinocchio/pull/2475))
 
+### Fixed
+- Fix mjcf parsing of armature ([#2477](https://github.com/stack-of-tasks/pinocchio/pull/2477))
+
 ### Changed
 - On GNU/Linux and macOS, hide all symbols by default ([#2469](https://github.com/stack-of-tasks/pinocchio/pull/2469))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix mjcf parsing of armature and of the default tag in models ([#2477](https://github.com/stack-of-tasks/pinocchio/pull/2477))
+- Fix undefined behavior when using the site attribute in mjcf ([#2477](https://github.com/stack-of-tasks/pinocchio/pull/2477))
 
 ### Changed
 - On GNU/Linux and macOS, hide all symbols by default ([#2469](https://github.com/stack-of-tasks/pinocchio/pull/2469))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add `pinocchio_python_parser` target ([#2475](https://github.com/stack-of-tasks/pinocchio/pull/2475))
 
 ### Fixed
-- Fix mjcf parsing of armature ([#2477](https://github.com/stack-of-tasks/pinocchio/pull/2477))
+- Fix mjcf parsing of armature and of the default tag in models ([#2477](https://github.com/stack-of-tasks/pinocchio/pull/2477))
 
 ### Changed
 - On GNU/Linux and macOS, hide all symbols by default ([#2469](https://github.com/stack-of-tasks/pinocchio/pull/2469))

--- a/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
+++ b/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
@@ -135,7 +135,7 @@ namespace pinocchio
         Eigen::VectorXd damping;
 
         // Armature inertia created by this joint
-        double armature = 0.;
+        Eigen::VectorXd armature;
         // Dry friction.
         double frictionLoss = 0.;
 
@@ -152,6 +152,7 @@ namespace pinocchio
           ;
           friction = Eigen::VectorXd::Constant(1, 0.);
           damping = Eigen::VectorXd::Constant(1, 0.);
+          armature = Eigen::VectorXd::Constant(1, 0.);
         }
 
         /// @brief Set dimension to the limits to match the joint nq and nv.

--- a/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
+++ b/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
@@ -149,7 +149,6 @@ namespace pinocchio
           maxConfig = Eigen::VectorXd::Constant(1, infty);
           springStiffness = Eigen::VectorXd::Constant(1, v);
           springReference = Eigen::VectorXd::Constant(1, v);
-          ;
           friction = Eigen::VectorXd::Constant(1, 0.);
           damping = Eigen::VectorXd::Constant(1, 0.);
           armature = Eigen::VectorXd::Constant(1, 0.);

--- a/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
+++ b/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
@@ -446,7 +446,7 @@ namespace pinocchio
         /// @brief Go through the default part of the file and get all the class name. Fill the
         /// mapOfDefault for later use.
         /// @param el ptree element. Root of the default
-        void parseDefault(ptree & el, const ptree & parent);
+        void parseDefault(ptree & el, const ptree & parent, const std::string & parentTag);
 
         /// @brief Go through the main body of the mjcf file "worldbody" to get all the info ready
         /// to create the model.

--- a/src/parsers/mjcf/mjcf-graph-geom.cpp
+++ b/src/parsers/mjcf/mjcf-graph-geom.cpp
@@ -410,7 +410,13 @@ namespace pinocchio
           geomName =
             currentBody.bodyName + "Geom_" + std::to_string(currentBody.geomChildren.size());
 
-        // ChildClass < Class < Real Joint
+        // default < ChildClass < Class < Real Joint
+        if (currentGraph.mapOfClasses.find("mujoco_default") != currentGraph.mapOfClasses.end())
+        {
+          const MjcfClass & classD = currentGraph.mapOfClasses.at("mujoco_default");
+          if (auto geom_p = classD.classElement.get_child_optional("geom"))
+            goThroughElement(*geom_p, currentGraph);
+        }
         //  childClass
         if (currentBody.childClass != "")
         {
@@ -474,7 +480,13 @@ namespace pinocchio
           siteName =
             currentBody.bodyName + "Site_" + std::to_string(currentBody.siteChildren.size());
 
-        // ChildClass < Class < Real Joint
+        // default < ChildClass < Class < Real Joint
+        if (currentGraph.mapOfClasses.find("mujoco_default") != currentGraph.mapOfClasses.end())
+        {
+          const MjcfClass & classD = currentGraph.mapOfClasses.at("mujoco_default");
+          if (auto site_p = classD.classElement.get_child_optional("site"))
+            goThroughElement(*site_p, currentGraph);
+        }
         //  childClass
         if (currentBody.childClass != "")
         {

--- a/src/parsers/mjcf/mjcf-graph.cpp
+++ b/src/parsers/mjcf/mjcf-graph.cpp
@@ -1012,7 +1012,7 @@ namespace pinocchio
           FrameIndex jointFrameId = urdfVisitor.model.addJointFrame(joint_id, (int)parentFrameId);
           urdfVisitor.appendBodyToJoint(jointFrameId, inert, bodyInJoint, nameOfBody);
 
-          urdfVisitor.model.armature.segment(urdfVisitor.model.joints[joint_id].idx_q(), urdfVisitor.model.joints[joint_id].nq()) = rangeCompo.armature;
+          urdfVisitor.model.armature.segment(urdfVisitor.model.joints[joint_id].idx_v(), urdfVisitor.model.joints[joint_id].nv()) = rangeCompo.armature;
         }
 
         FrameIndex previousFrameId = urdfVisitor.model.frames.size();

--- a/src/parsers/mjcf/mjcf-graph.cpp
+++ b/src/parsers/mjcf/mjcf-graph.cpp
@@ -163,7 +163,7 @@ namespace pinocchio
         ret.springStiffness.tail(1) = range.springStiffness;
 
         ret.armature.conservativeResize(armature.size() + Nv);
-        ret.armature.tail(Nv) = Vector::Constant(Nv, range.armature[0]);
+        ret.armature.tail(Nv) = range.armature;
 
         return ret;
       }

--- a/src/parsers/mjcf/mjcf-graph.cpp
+++ b/src/parsers/mjcf/mjcf-graph.cpp
@@ -938,7 +938,7 @@ namespace pinocchio
         if (!currentBody.bodyParent.empty())
           parentFrameId = urdfVisitor.getBodyId(currentBody.bodyParent);
 
-        const Frame & frame = urdfVisitor.model.frames[parentFrameId];
+        Frame frame = urdfVisitor.model.frames[parentFrameId];
         // get body pose in body parent
         const SE3 bodyPose = currentBody.bodyPlacement;
         Inertia inert = currentBody.bodyInertia;

--- a/src/parsers/mjcf/mjcf-graph.cpp
+++ b/src/parsers/mjcf/mjcf-graph.cpp
@@ -137,7 +137,6 @@ namespace pinocchio
       template<int Nq, int Nv>
       RangeJoint RangeJoint::concatenate(const RangeJoint & range) const
       {
-        typedef UrdfVisitor::Vector Vector;
         assert(range.maxEffort.size() == Nv);
         assert(range.minConfig.size() == Nq);
 

--- a/unittest/mjcf.cpp
+++ b/unittest/mjcf.cpp
@@ -386,7 +386,7 @@ BOOST_AUTO_TEST_CASE(merge_default)
   MjcfGraph::UrdfVisitor visitor(model);
 
   MjcfGraph graph(visitor, "fakeMjcf");
-  graph.parseDefault(ptr.get_child("default"), ptr);
+  graph.parseDefault(ptr.get_child("default"), ptr, "default");
 
   std::unordered_map<std::string, pt::ptree> TrueMap;
 
@@ -978,9 +978,12 @@ BOOST_AUTO_TEST_CASE(armature)
 {
   typedef pinocchio::SE3::Vector3 Vector3;
   typedef pinocchio::SE3::Matrix3 Matrix3;
-
+  std::cout << " Armature ------------ " << std::endl;
   std::istringstream xmlData(R"(
             <mujoco model="model_RX">
+                <default>
+                  <joint armature="1" damping="1" limited="true"/>
+                </default>
                 <worldbody>
                     <body name="link0">
                         <body name="link1" pos="0 0 0">
@@ -988,7 +991,7 @@ BOOST_AUTO_TEST_CASE(armature)
                             <joint name="joint2" type="hinge" axis="0 1 0" armature="2.4"/>
                             <joint name="joint3" type="hinge" axis="0 0 1" armature="0.4"/>
                             <body pos=".2 0 0" name="body2">
-                              <joint type="ball" armature=".1"/>
+                              <joint type="ball"/>
                         </body>
                         </body>
                     </body>
@@ -1006,8 +1009,8 @@ BOOST_AUTO_TEST_CASE(armature)
   graph.parseRootTree();
 
   Eigen::VectorXd armature_real(model_m.nv);
-  armature_real << 1.3, 2.4, 0.4, 0.1, 0.1, 0.1;
-  
+  armature_real << 1.3, 2.4, 0.4, 1, 1, 1;
+
   for (size_t i = 0; i < size_t(model_m.nv); i++)
     BOOST_CHECK_EQUAL(model_m.armature[i], armature_real[i]);
 }

--- a/unittest/mjcf.cpp
+++ b/unittest/mjcf.cpp
@@ -974,6 +974,44 @@ BOOST_AUTO_TEST_CASE(joint_and_inertias)
   BOOST_CHECK(model_m.inertias[1].isApprox(real_inertia));
 }
 
+BOOST_AUTO_TEST_CASE(armature)
+{
+  typedef pinocchio::SE3::Vector3 Vector3;
+  typedef pinocchio::SE3::Matrix3 Matrix3;
+
+  std::istringstream xmlData(R"(
+            <mujoco model="model_RX">
+                <worldbody>
+                    <body name="link0">
+                        <body name="link1" pos="0 0 0">
+                            <joint name="joint1" type="hinge" axis="1 0 0" armature="1.3"/>
+                            <joint name="joint2" type="hinge" axis="0 1 0" armature="2.4"/>
+                            <joint name="joint3" type="hinge" axis="0 0 1" armature="0.4"/>
+                            <body pos=".2 0 0" name="body2">
+                              <joint type="ball" armature=".1"/>
+                        </body>
+                        </body>
+                    </body>
+                </worldbody>
+            </mujoco>)");
+
+  auto namefile = createTempFile(xmlData);
+
+  typedef ::pinocchio::mjcf::details::MjcfGraph MjcfGraph;
+  pinocchio::Model model_m;
+  MjcfGraph::UrdfVisitor visitor(model_m);
+
+  MjcfGraph graph(visitor, "fakeMjcf");
+  graph.parseGraphFromXML(namefile.name());
+  graph.parseRootTree();
+
+  Eigen::VectorXd armature_real(model_m.nv);
+  armature_real << 1.3, 2.4, 0.4, 0.1, 0.1, 0.1;
+  
+  for (size_t i = 0; i < size_t(model_m.nv); i++)
+    BOOST_CHECK_EQUAL(model_m.armature[i], armature_real[i]);
+}
+
 // Test reference positions and how it's included in keyframe
 BOOST_AUTO_TEST_CASE(reference_positions)
 {


### PR DESCRIPTION
This pr aims at correcting parsing of armature parameter available in mjcf models. As of now, mjcf provided only one value per joint, but in pinocchio armature is based on the `model.nv`.

In this pr, we modify how armature is parsed and use the pinocchio standard.

Another aim of this pr is to add support for default tag that does not have a class name. Until now, this was taken into account in the mjcf parser.