### PR TITLE
meshcat_visualizer: force type of image paths to pathlib.Path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Fix mjcf parsing of armature and of the default tag in models ([#2477](https://github.com/stack-of-tasks/pinocchio/pull/2477))
 - Fix undefined behavior when using the site attribute in mjcf ([#2477](https://github.com/stack-of-tasks/pinocchio/pull/2477))
+- Fix the type of image paths when loading textures in the meshcat visualizer ([#2478](https://github.com/stack-of-tasks/pinocchio/pull/2478))
 
 ### Changed
 - On GNU/Linux and macOS, hide all symbols by default ([#2469](https://github.com/stack-of-tasks/pinocchio/pull/2469))

--- a/bindings/python/pinocchio/visualize/meshcat_visualizer.py
+++ b/bindings/python/pinocchio/visualize/meshcat_visualizer.py
@@ -143,9 +143,9 @@ if import_meshcat_succeed:
 
                 # Encode texture in base64
                 img_path_abs = img_path
-                if not img_path.is_absolute():
+                if not Path(img_path).is_absolute():
                     img_path_abs = os.path.normpath(dae_dir / img_path_abs)
-                if not img_path_abs.is_file():
+                if not Path(img_path_abs).is_file():
                     raise UserWarning(f"Texture '{img_path}' not found.")
                 with Path(img_path_abs).open("rb") as img_file:
                     img_data = base64.b64encode(img_file.read())


### PR DESCRIPTION
I got the following error while using the meshcat visualizer:

```
/root/miniforge3/lib/python3.12/site-packages/pinocchio/visualize/meshcat_visualizer.py:916: UserWarning: Error while loading geometry object: LThigh_0
Error message:
'str' object has no attribute 'is_absolute'
```
Therefore I forced the type to `Path`. This is coherent with the `Path(img_path_abs).open("rb")` two lines below.