### PR TITLE
Fix meshcat examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix mjcf parsing of armature and of the default tag in models ([#2477](https://github.com/stack-of-tasks/pinocchio/pull/2477))
 - Fix undefined behavior when using the site attribute in mjcf ([#2477](https://github.com/stack-of-tasks/pinocchio/pull/2477))
 - Fix the type of image paths when loading textures in the meshcat visualizer ([#2478](https://github.com/stack-of-tasks/pinocchio/pull/2478))
+- Fix meshcat examples ([#2503])[https://github.com/stack-of-tasks/pinocchio/pull/2503]
 
 ### Changed
 - On GNU/Linux and macOS, hide all symbols by default ([#2469](https://github.com/stack-of-tasks/pinocchio/pull/2469))

--- a/examples/append-urdf-model-with-another-model.py
+++ b/examples/append-urdf-model-with-another-model.py
@@ -1,5 +1,6 @@
 import math
 import sys
+import time
 from pathlib import Path
 
 import hppfcl as fcl
@@ -91,3 +92,4 @@ model.lowerPositionLimit.fill(-math.pi / 2)
 model.upperPositionLimit.fill(+math.pi / 2)
 q = pin.randomConfiguration(model)
 viz.display(q)
+time.sleep(1.0)

--- a/examples/collision-with-point-clouds.py
+++ b/examples/collision-with-point-clouds.py
@@ -4,6 +4,7 @@
 # pip install --user meshcat
 
 import sys
+import time
 from pathlib import Path
 
 import hppfcl as fcl
@@ -123,3 +124,4 @@ while not is_collision:
 
 print("Found a configuration in collision:", q)
 viz.display(q)
+time.sleep(1.0)

--- a/examples/meshcat-viewer-octree.py
+++ b/examples/meshcat-viewer-octree.py
@@ -3,6 +3,7 @@
 # pip install --user meshcat
 
 import sys
+import time
 
 import hppfcl as fcl
 import numpy as np
@@ -47,4 +48,4 @@ except ImportError as err:
     sys.exit(0)
 
 viz.loadViewerModel()
-viz.clearDefaultLights()
+time.sleep(1.0)

--- a/examples/meshcat-viewer-solo.py
+++ b/examples/meshcat-viewer-solo.py
@@ -3,12 +3,25 @@ Pose a Solo-12 robot on a surface defined through a function and displayed throu
 hppfcl.HeightField.
 """
 
+import time
+from pathlib import Path
+
 import numpy as np
 import pinocchio as pin
-from example_robot_data import load
 from pinocchio.visualize import MeshcatVisualizer
 
-robot = load("solo12")
+# Load the URDF model.
+# Conversion with str seems to be necessary when executing this file with ipython
+pinocchio_model_dir = Path(__file__).parent.parent / "models"
+
+model_path = pinocchio_model_dir / "example-robot-data/robots"
+mesh_dir = pinocchio_model_dir
+urdf_filename = "solo12.urdf"
+urdf_model_path = model_path / "solo_description/robots" / urdf_filename
+
+model, collision_model, visual_model = pin.buildModelsFromUrdf(
+    urdf_model_path, mesh_dir, pin.JointModelFreeFlyer()
+)
 
 q_ref = np.array(
     [
@@ -35,9 +48,8 @@ q_ref = np.array(
 )
 
 
-model = robot.model
-vizer = MeshcatVisualizer(model, robot.collision_model, robot.visual_model)
-vizer.initViewer(loadModel=True)
+vizer = MeshcatVisualizer(model, collision_model, visual_model)
+vizer.initViewer(open=True)
 
 
 def ground(xy):
@@ -66,11 +78,14 @@ def vizGround(viz, elevation_fn, space, name="ground", color=[1.0, 1.0, 0.6, 0.8
     obj = pin.GeometryObject("ground", 0, pl, heightField)
     obj.meshColor[:] = color
     viz.addGeometryObject(obj)
-    viz.viewer.open()
 
+
+# Load the robot in the viewer.
+vizer.loadViewerModel()
 
 colorrgb = [128, 149, 255, 200]
 colorrgb = np.array(colorrgb) / 255.0
 vizGround(vizer, ground, 0.02, color=colorrgb)
 
 vizer.display(q_ref)
+time.sleep(1.)

--- a/examples/meshcat-viewer-solo.py
+++ b/examples/meshcat-viewer-solo.py
@@ -88,4 +88,4 @@ colorrgb = np.array(colorrgb) / 255.0
 vizGround(vizer, ground, 0.02, color=colorrgb)
 
 vizer.display(q_ref)
-time.sleep(1.)
+time.sleep(1.0)


### PR DESCRIPTION
This PR fix meshcat examples.

- `meshcat-viewer-octree.py` used deprecated API
- `meshcat-viewer-solo.py` used example_robot_data, but this package can't be imported in Pinocchio
Some meshact examples where broken, but also, some display nothing except 
- I had to add a sleep at the end of the script to display something on my browser. Is it normal @ManifoldFR ?