### PR TITLE
fix: fix typo

### DIFF
--- a/doc/d-practical-exercises/1-directgeom.md
+++ b/doc/d-practical-exercises/1-directgeom.md
@@ -235,7 +235,7 @@ later call to your scripts, you can set the argument to `False`. A side
 effector of `=True` is that it will move the viewpoint inside the GUI to
 a reference zero position.
 
-### More details about loading the model (optionnal)
+### More details about loading the model (optional)
 
 You can access the visual object composing the robot model by
 `robot.visual_model.geometryObject`.

--- a/doc/d-practical-exercises/2-invgeom.md
+++ b/doc/d-practical-exercises/2-invgeom.md
@@ -183,7 +183,7 @@ end effector at position `pdes`.
 Finally, implements a callback function that display in
 Gepetto-Viewer every candidate configuration tried by the solver.
 
-## 2.2) Approaching the redundancy (optionnal)
+## 2.2) Approaching the redundancy (optional)
 
 The manipulator arm has 6 DOF, while the cost function only constraints
 3 of them (the position of the end effector). A continuum of solutions
@@ -238,7 +238,7 @@ desired placement.
 Optionally, try other metrics, like the log metric of \f$R^3 \times SO(3)\f$, or
 the Froebenius norm of the homogeneous matrix.
 
-## 2.4) Working with a mobile robot (optionnal)
+## 2.4) Working with a mobile robot (optional)
 
 Until now, the tutorial only worked with a simple manipulator robot,
 i.e. whose configuration space is a real vector space. Consider now the

--- a/include/pinocchio/algorithm/geometry.hpp
+++ b/include/pinocchio/algorithm/geometry.hpp
@@ -65,7 +65,7 @@ namespace pinocchio
   /// \li add the collision pairs of geom_model2 into geom_model1 (indexes are updated)
   /// \li add all the collision pairs between geometry objects of geom_model1 and geom_model2.
   /// It is possible to ommit both data (an additional function signature is available which makes
-  /// them optionnal), then inner/outer objects are not updated.
+  /// them optional), then inner/outer objects are not updated.
   ///
   /// \param[out] geom_model1   geometry model where the data is added
   /// \param[in]  geom_model2   geometry model from which new geometries are taken


### PR DESCRIPTION
Fix typo from `optionnal` to `optional`