### PR TITLE
Activate collision specific features in pinocchio_default

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -87,7 +87,6 @@ jobs:
       - name: Set and install dependencies
         run: |
           export PYTHON3_VERSION=$(python3 -c "import sys; print(str(sys.version_info.major)+str(sys.version_info.minor))")
-          # Force eigenpy 3.10.0 to be compatible with hpp-fcl
           export APT_DEPENDENCIES="doxygen \
                                    ccache \
                                    curl \
@@ -104,8 +103,8 @@ jobs:
                                    libboost-python-dev \
                                    python3-numpy \
                                    python3-matplotlib \
-                                   robotpkg-py${PYTHON3_VERSION}-eigenpy=3.10.0 \
-                                   robotpkg-py${PYTHON3_VERSION}-hpp-fcl \
+                                   robotpkg-py${PYTHON3_VERSION}-eigenpy \
+                                   robotpkg-py${PYTHON3_VERSION}-coal \
                                    robotpkg-py${PYTHON3_VERSION}-casadi"
           echo $APT_DEPENDENCIES
 
@@ -126,6 +125,7 @@ jobs:
           export PYTHON3_DOT_VERSION=$(python3 -c "import sys; print(str(sys.version_info.major)+'.'+str(sys.version_info.minor))")
           export PYTHONPATH=${PYTHONPATH}:/opt/openrobots/lib/python$PYTHON3_DOT_VERSION/site-packages
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/openrobots/lib:/usr/local/lib:/usr/lib:/usr/lib/x86_64-linux-gnu
+          export CMAKE_PREFIX_PATH=/opt/openrobots/lib
 
           mkdir build
           cd build

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -150,6 +150,7 @@ jobs:
           export PATH=$PATH:/opt/openrobots/bin
           export PKG_CONFIG_PATH=$PKG_CONFIG_PATH:/opt/openrobots/lib/pkgconfig
           export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/opt/openrobots/lib:/usr/local/lib:/usr/lib:/usr/lib/x86_64-linux-gnu
+          export CMAKE_PREFIX_PATH=/opt/openrobots/lib
           cd ./unittest/packaging/cmake
           mkdir build
           cd build

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - On GNU/Linux and macOS, hide all symbols by default ([#2469](https://github.com/stack-of-tasks/pinocchio/pull/2469))
+- Build `pinocchio_default` with collision features ([#2517](https://github.com/stack-of-tasks/pinocchio/pull/2517))
 
 ## [3.3.0] - 2024-11-06
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -331,9 +331,7 @@ else()
 endif()
 
 if(BUILD_WITH_HPP_FCL_SUPPORT)
-  list(APPEND CFLAGS_DEPENDENCIES "-DPINOCCHIO_WITH_HPP_FCL")
-  list(APPEND LIBRARIES_DEPENDENCIES ${PROJECT_NAME}_collision)
-  add_project_dependency(hpp-fcl 2.1.2 REQUIRED PKG_CONFIG_REQUIRES "hpp-fcl >= 2.1.2")
+  add_project_dependency(hpp-fcl 2.1.2 REQUIRED "hpp-fcl >= 2.1.2")
 endif()
 
 if(BUILD_WITH_ACCELERATE_SUPPORT)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -185,6 +185,13 @@ add_header_group(${PROJECT_NAME}_CORE_GENERATED_PUBLIC_HEADERS)
 # This target will also have hpp-fcl and workspace module in it.
 pinocchio_specific_type(default DEFAULT_SCOPE)
 
+# Some core library algorithms have different behavior if PINOCCHIO_WITH_HPP_FCL is defined. Since
+# some are template instantiated, or some user can link only on pinocchio_default, we muste define
+# PINOCCHIO_WITH_HPP_FCL in pinocchio_default.
+if(BUILD_WITH_HPP_FCL_SUPPORT)
+  target_compile_definitions(pinocchio_default PUBLIC PINOCCHIO_WITH_HPP_FCL)
+endif()
+
 # Define the extra target This target hold extra algorithms.
 if(BUILD_WITH_EXTRA_SUPPORT)
   set(EXTRA_LIB_NAME "${PROJECT_NAME}_extra")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -190,6 +190,9 @@ pinocchio_specific_type(default DEFAULT_SCOPE)
 # PINOCCHIO_WITH_HPP_FCL in pinocchio_default.
 if(BUILD_WITH_HPP_FCL_SUPPORT)
   target_compile_definitions(pinocchio_default PUBLIC PINOCCHIO_WITH_HPP_FCL)
+  target_include_directories(
+    pinocchio_default PUBLIC $<TARGET_PROPERTY:hpp-fcl::hpp-fcl,INTERFACE_INCLUDE_DIRECTORIES>)
+
 endif()
 
 # Define the extra target This target hold extra algorithms.


### PR DESCRIPTION
Add `PINOCCHIO_WITH_HPP_FCL` definiton on `pinocchio_default` target (when build with collision support) to build with core algorithms with collision support.

Draw back is if an user build pinocchio from sources with collision support but then want to build against `pinocchio_default` target without hpp-fcl/coal.

Bonus:
 - Fix linux.yml CI
 - Remove hpp-fcl from pkg-config file since hpp-fcl doesn't provide a .pc file