### PR TITLE
Add support for vertex-based mesh definitions in MJCF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Fix mjcf Euler angle parsing: use xyz as a default value for eulerseq compiler option ([#2526](https://github.com/stack-of-tasks/pinocchio/pull/2526))
+- Add parsing meshes with vertices for MJCF format ([#2537](https://github.com/stack-of-tasks/pinocchio/pull/2537))
 
 ## [3.3.1] - 2024-12-13
 

--- a/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
+++ b/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
@@ -209,6 +209,8 @@ namespace pinocchio
         Eigen::Vector3d scale = Eigen::Vector3d::Constant(1);
         // Path to the mesh file
         std::string filePath;
+        // Vertices of the mesh
+        hpp::fcl::MatrixX3s vertices;
       };
 
       /// @brief All informations related to a texture are stored here

--- a/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
+++ b/include/pinocchio/parsers/mjcf/mjcf-graph.hpp
@@ -210,7 +210,7 @@ namespace pinocchio
         // Path to the mesh file
         std::string filePath;
         // Vertices of the mesh
-        hpp::fcl::MatrixX3s vertices;
+        Eigen::MatrixX3d vertices;
       };
 
       /// @brief All informations related to a texture are stored here

--- a/src/parsers/mjcf/mjcf-graph-geom.cpp
+++ b/src/parsers/mjcf/mjcf-graph-geom.cpp
@@ -75,6 +75,19 @@ namespace pinocchio
         if (geom.geomType == "mesh")
         {
           MjcfMesh currentMesh = currentGraph.mapOfMeshes.at(geom.meshName);
+          if (currentMesh.vertices.size() > 0)
+          {
+            auto vertices = currentMesh.vertices;
+            // Scale vertices
+            for (std::size_t i = 0; i < vertices.rows(); ++i)
+              vertices.row(i) = vertices.row(i).cwiseProduct(currentMesh.scale.transpose());
+            auto model = std::make_shared<hpp::fcl::BVHModel<fcl::OBBRSS>>();
+            model->beginModel();
+            model->addVertices(vertices);
+            model->endModel();
+            model->buildConvexHull(true, "Qt");
+            return model->convex;
+          }
           meshPath = currentMesh.filePath;
           meshScale = currentMesh.scale;
           hpp::fcl::BVHModelPtr_t bvh = meshLoader->load(meshPath, meshScale);

--- a/src/parsers/mjcf/mjcf-graph.cpp
+++ b/src/parsers/mjcf/mjcf-graph.cpp
@@ -582,20 +582,51 @@ namespace pinocchio
 
         MjcfMesh mesh;
         auto file = el.get_optional<std::string>("<xmlattr>.file");
-        if (!file)
-          throw std::invalid_argument("Only meshes with files are supported");
-
-        fs::path filePath(*file);
-        std::string name = getName(el, filePath);
-
-        mesh.filePath =
-          updatePath(compilerInfo.strippath, compilerInfo.meshdir, modelPath, filePath).string();
-
         auto scale = el.get_optional<std::string>("<xmlattr>.scale");
         if (scale)
           mesh.scale = internal::getVectorFromStream<3>(*scale);
+        if (file)
+        {
+          fs::path filePath(*file);
+          std::string name = getName(el, filePath);
 
-        mapOfMeshes.insert(std::make_pair(name, mesh));
+          mesh.filePath =
+            updatePath(compilerInfo.strippath, compilerInfo.meshdir, modelPath, filePath).string();
+          mapOfMeshes.insert(std::make_pair(name, mesh));
+          return;
+        }
+
+        // Handle vertex-based mesh
+        auto vertex = el.get_optional<std::string>("<xmlattr>.vertex");
+        if (!vertex)
+        {
+          throw std::invalid_argument("Only meshes with files/vertices are supported");
+        }
+
+        auto name = el.get_optional<std::string>("<xmlattr>.name");
+        if (!name)
+        {
+          throw std::invalid_argument("Mesh with vertices without a name is not supported");
+        }
+
+        // Parse and validate vertices
+        Eigen::VectorXd meshVertices = internal::getUnknownSizeVectorFromStream(*vertex);
+        if (meshVertices.size() % 3 != 0)
+        {
+          throw std::invalid_argument("Number of vertices is not a multiple of 3");
+        }
+
+        // Convert to 3D vertex matrix
+        const size_t numVertices = meshVertices.size() / 3;
+        hpp::fcl::MatrixX3s vertices(numVertices, 3);
+
+        for (size_t i = 0; i < meshVertices.size(); i += 3)
+        {
+          vertices.row(i / 3) = meshVertices.segment<3>(i).transpose();
+        }
+
+        mesh.vertices = vertices;
+        mapOfMeshes.insert(std::make_pair(*name, mesh));
       }
 
       void MjcfGraph::parseAsset(const ptree & el)

--- a/src/parsers/mjcf/mjcf-graph.cpp
+++ b/src/parsers/mjcf/mjcf-graph.cpp
@@ -600,20 +600,23 @@ namespace pinocchio
         auto vertex = el.get_optional<std::string>("<xmlattr>.vertex");
         if (!vertex)
         {
-          throw std::invalid_argument("Only meshes with files/vertices are supported");
+          PINOCCHIO_THROW_PRETTY(
+            std::invalid_argument, "Only meshes with files/vertices are supported.")
         }
 
         auto name = el.get_optional<std::string>("<xmlattr>.name");
         if (!name)
         {
-          throw std::invalid_argument("Mesh with vertices without a name is not supported");
+          PINOCCHIO_THROW_PRETTY(
+            std::invalid_argument, "Mesh with vertices without a name is not supported");
         }
 
         // Parse and validate vertices
         Eigen::VectorXd meshVertices = internal::getUnknownSizeVectorFromStream(*vertex);
         if (meshVertices.size() % 3 != 0)
         {
-          throw std::invalid_argument("Number of vertices is not a multiple of 3");
+          PINOCCHIO_THROW_PRETTY(
+            std::invalid_argument, "Number of vertices is not a multiple of 3");
         }
 
         // Convert to 3D vertex matrix

--- a/src/parsers/mjcf/mjcf-graph.cpp
+++ b/src/parsers/mjcf/mjcf-graph.cpp
@@ -617,14 +617,12 @@ namespace pinocchio
         }
 
         // Convert to 3D vertex matrix
-        const size_t numVertices = meshVertices.size() / 3;
-        hpp::fcl::MatrixX3s vertices(numVertices, 3);
-
-        for (size_t i = 0; i < meshVertices.size(); i += 3)
+        const auto numVertices = meshVertices.size() / 3;
+        Eigen::MatrixX3d vertices(numVertices, 3);
+        for (auto i = 0; i < numVertices; ++i)
         {
-          vertices.row(i / 3) = meshVertices.segment<3>(i).transpose();
+          vertices.row(i) = meshVertices.segment<3>(3 * i).transpose();
         }
-
         mesh.vertices = vertices;
         mapOfMeshes.insert(std::make_pair(*name, mesh));
       }

--- a/unittest/mjcf.cpp
+++ b/unittest/mjcf.cpp
@@ -1388,7 +1388,7 @@ BOOST_AUTO_TEST_CASE(parse_mesh_with_vertices)
   // Test Meshes
   pinocchio::mjcf::details::MjcfMesh mesh = graph.mapOfMeshes.at("chasis");
   BOOST_CHECK_EQUAL(mesh.scale, Eigen::Vector3d(0.01, 0.006, 0.0015));
-  hpp::fcl::MatrixX3s vertices(3, 9);
+  Eigen::MatrixX3d vertices(9, 3);
   vertices << 9, 2, 0, -10, 10, 10, 9, -2, 0, 10, 3, -10, 10, -3, -10, -8, 10, -10, -10, -10, 10,
     -8, -10, -10, -5, 0, 20;
   BOOST_CHECK_EQUAL(mesh.vertices.rows(), 9);


### PR DESCRIPTION
This PR adds support for parsing MJCF meshes that are defined directly with vertices in the XML, rather than only supporting external mesh files. This makes it possible to load https://github.com/google-deepmind/mujoco/blob/main/model/car/car.xml and https://github.com/google-deepmind/mujoco/tree/main/model/cube