### PR TITLE
Add <include> tag support in MJCF parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Add parsing meshes with vertices for MJCF format ([#2537](https://github.com/stack-of-tasks/pinocchio/pull/2537))
+- Add support for `<include>` tags for MJCF format ([#2557](https://github.com/stack-of-tasks/pinocchio/pull/2557))
 
 ### Fixed
+- Fix mjcf accessing root link without checking for empty bodies list ([#2557](https://github.com/stack-of-tasks/pinocchio/pull/2557))
 - Fix mjcf Euler angle parsing: use xyz as a default value for eulerseq compiler option ([#2526](https://github.com/stack-of-tasks/pinocchio/pull/2526))
 - Fix variable naming in Python ([#2530](https://github.com/stack-of-tasks/pinocchio/pull/2530))
 - Fix aba explicit template instantiation ([#2541](https://github.com/stack-of-tasks/pinocchio/pull/2541))

--- a/src/parsers/mjcf/mjcf-graph.cpp
+++ b/src/parsers/mjcf/mjcf-graph.cpp
@@ -1294,6 +1294,10 @@ namespace pinocchio
       void MjcfGraph::parseRootTree()
       {
         urdfVisitor.setName(modelName);
+        if (bodiesList.empty())
+        {
+          PINOCCHIO_THROW_PRETTY(std::runtime_error, modelName + " has no root link");
+        }
         // get name and inertia of first root link
         std::string rootLinkName = bodiesList.at(0);
         MjcfBody rootBody = mapOfBodies.find(rootLinkName)->second;

--- a/unittest/mjcf.cpp
+++ b/unittest/mjcf.cpp
@@ -1432,6 +1432,21 @@ BOOST_AUTO_TEST_CASE(test_get_unknown_size_vector_from_stream)
   BOOST_CHECK(v3 == expected3);
 }
 
+BOOST_AUTO_TEST_CASE(no_root_tree)
+{
+  std::istringstream xmlData("<mujoco></mujoco>");
+
+  auto namefile = createTempFile(xmlData);
+
+  typedef ::pinocchio::mjcf::details::MjcfGraph MjcfGraph;
+  pinocchio::Model model_m;
+  MjcfGraph::UrdfVisitor visitor(model_m);
+
+  MjcfGraph graph(visitor, "fakeMjcf");
+  graph.parseGraphFromXML(namefile.name());
+  BOOST_CHECK_THROW(graph.parseRootTree(), std::runtime_error);
+}
+
 BOOST_AUTO_TEST_CASE(process_include_basic)
 {
   namespace pt = boost::property_tree;


### PR DESCRIPTION
This PR adds support for the <include> tag in the MJCF parser, enabling nested includes and updating mesh paths relative to the included file's location. Includes some unit tests!

To test with a more complex model try https://github.com/RainbowRobotics/rby1-sdk/tree/main/models/rby1a/mujoco