### PR TITLE
cmake : sync submodule + fix MathJax relpath, remove DOXYGEN_USE_TEMPLATE_CSS, remove MATHJAX_FORMAT spec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,7 +59,6 @@ else()
 endif()
 
 set(DOXYGEN_USE_MATHJAX YES)
-set(DOXYGEN_USE_TEMPLATE_CSS YES)
 
 # ----------------------------------------------------
 # --- Policy -----------------------------------------

--- a/doc/Doxyfile.extra.in
+++ b/doc/Doxyfile.extra.in
@@ -661,23 +661,7 @@ EXAMPLE_PATH = @PROJECT_SOURCE_DIR@/examples
 # A dedicated BIB_PATH would be preferable
 EXAMPLE_PATH += @PROJECT_SOURCE_DIR@/doc/bib
 
-# Enable the USE_MATHJAX option to render $\mbox{\LaTeX}$ formulas using
-# MathJax (see http://www.mathjax.org) which uses client side Javascript for
-# the rendering instead of using pre-rendered bitmaps. Use this if you do not
-# have $\mbox{\LaTeX}$ installed or if you want to formulas look prettier in
-# the HTML output. When enabled you may also need to install MathJax separately
-# and configure the path to it using the MATHJAX_RELPATH option.
-
 USE_MATHJAX            = YES
-MATHJAX_RELPATH        = MathJax/
-
-# When MathJax is enabled you can set the default output format to be used for
-# the MathJax output. See the MathJax site for more details. Possible values
-# are: HTML-CSS (which is slower, but has the best compatibility), NativeMML
-# (i.e. MathML) and SVG. The default value is: HTML-CSS. This tag requires that
-# the tag USE_MATHJAX is set to YES.
-
-MATHJAX_FORMAT         = SVG
 
 #---------------------------------------------------------------------------
 # Aliases


### PR DESCRIPTION
This PR follows the following two PRs on jrl-cmakemodules:
- https://github.com/jrl-umi3218/jrl-cmakemodules/pull/738
- https://github.com/jrl-umi3218/jrl-cmakemodules/pull/741

Local changes on Pinocchio include:
- removing the `DOXYGEN_USE_TEMPLATE_CSS` option which is irrelevant (removed in the first cmakemodules PR)
- removing the empty spec for `MATHJAX_RELPATH` which was wrong and broke the math