### PR TITLE
clean useless uses of PINOCCHIO_WITH_CXX11_SUPPORT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix aba explicit template instantiation ([#2541](https://github.com/stack-of-tasks/pinocchio/pull/2541))
 - Fix mjcf parsing of keyframe qpos with newlines ([#2535](https://github.com/stack-of-tasks/pinocchio/pull/2535))
 - Fix sites parsing for MJCF format ([#2548](https://github.com/stack-of-tasks/pinocchio/pull/2548))
+- Removed useless uses of `PINOCCHIO_WITH_CXX11_SUPPORT` ([#2564](https://github.com/stack-of-tasks/pinocchio/pull/2564))
 
 
 ## [3.3.1] - 2024-12-13

--- a/include/pinocchio/bindings/python/fwd.hpp
+++ b/include/pinocchio/bindings/python/fwd.hpp
@@ -9,13 +9,8 @@
 #include "pinocchio/bindings/python/context.hpp"
 #include <eigenpy/eigenpy.hpp>
 
-#ifdef PINOCCHIO_WITH_CXX11_SUPPORT
-  #include <memory>
-  #define PINOCCHIO_SHARED_PTR_HOLDER_TYPE(T) ::std::shared_ptr<T>
-#else
-  #include <boost/shared_ptr.hpp>
-  #define PINOCCHIO_SHARED_PTR_HOLDER_TYPE(T) ::boost::shared_ptr<T>
-#endif
+#include <memory>
+#define PINOCCHIO_SHARED_PTR_HOLDER_TYPE(T) ::std::shared_ptr<T>
 
 namespace pinocchio
 {

--- a/include/pinocchio/codegen/cppadcg.hpp
+++ b/include/pinocchio/codegen/cppadcg.hpp
@@ -15,10 +15,6 @@
 
 #include "pinocchio/autodiff/cppad.hpp"
 
-#ifndef PINOCCHIO_WITH_CXX11_SUPPORT
-  #error CppADCodeGen requires C++11 or more
-#endif
-
 namespace boost
 {
   namespace math

--- a/include/pinocchio/container/boost-container-limits.hpp
+++ b/include/pinocchio/container/boost-container-limits.hpp
@@ -7,8 +7,6 @@
 
 #include "pinocchio/macros.hpp"
 
-// #ifndef PINOCCHIO_WITH_CXX11_SUPPORT
-
 #define PINOCCHIO_BOOST_MPL_LIMIT_CONTAINER_SIZE_DEFAULT 30
 
 #ifndef PINOCCHIO_BOOST_MPL_LIMIT_CONTAINER_SIZE
@@ -36,7 +34,5 @@
   #endif
 
 #endif
-
-// #endif // ifndef PINOCCHIO_WITH_CXX11_SUPPORT
 
 #endif // ifndef __pinocchio_container_boost_container_limits_hpp__

--- a/include/pinocchio/eigen-macros.hpp
+++ b/include/pinocchio/eigen-macros.hpp
@@ -51,7 +51,7 @@
 #define PINOCCHIO_EIGEN_CONST_CAST(TYPE, OBJ) const_cast<TYPE &>(OBJ.derived())
 
 ///  \brief Tell if Pinocchio should use the Eigen Tensor Module or not
-#if defined(PINOCCHIO_WITH_CXX11_SUPPORT) && EIGEN_VERSION_AT_LEAST(3, 2, 90)
+#if EIGEN_VERSION_AT_LEAST(3, 2, 90)
   #define PINOCCHIO_WITH_EIGEN_TENSOR_MODULE
 #endif
 

--- a/include/pinocchio/math/multiprecision.hpp
+++ b/include/pinocchio/math/multiprecision.hpp
@@ -7,10 +7,6 @@
 
 #include "pinocchio/math/fwd.hpp"
 
-#ifndef PINOCCHIO_WITH_CXX11_SUPPORT
-  #error C++11 compiler required.
-#endif
-
 #include <boost/multiprecision/number.hpp>
 #include <boost/random.hpp>
 #include <Eigen/Dense>

--- a/include/pinocchio/multibody/liegroup/liegroup-base.hpp
+++ b/include/pinocchio/multibody/liegroup/liegroup-base.hpp
@@ -11,14 +11,7 @@
 
 namespace pinocchio
 {
-#ifdef PINOCCHIO_WITH_CXX11_SUPPORT
   constexpr int SELF = 0;
-#else
-  enum
-  {
-    SELF = 0
-  };
-#endif
 
 #define PINOCCHIO_LIE_GROUP_PUBLIC_INTERFACE_GENERIC(Derived, TYPENAME)                            \
   typedef LieGroupBase<Derived> Base;                                                              \


### PR DESCRIPTION
since C++11 is already enforced in CMakeLists.txt