### PR TITLE
parser: improve error message

### DIFF
--- a/include/pinocchio/parsers/utils.hpp
+++ b/include/pinocchio/parsers/utils.hpp
@@ -94,7 +94,7 @@ namespace pinocchio
       }
       else
       {
-        const std::string exception_message("Schemes of form" + scheme + "are not handled");
+        const std::string exception_message("Schemes of form '" + scheme + "' are not handled");
         throw std::invalid_argument(exception_message);
       }
     }


### PR DESCRIPTION
Hi,

In https://github.com/Gepetto/example-robot-data/pull/265, we got:
```
ValueError: Schemes of formppackageare not handled
```

Which is a bit puzzling. Here is a trivial improvement.