### PR TITLE
CMake: fix for hpp-fcl/coal v3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,7 +330,7 @@ else()
 endif()
 
 if(BUILD_WITH_HPP_FCL_SUPPORT)
-  add_project_dependency(hpp-fcl 2.1.2 REQUIRED "hpp-fcl >= 2.1.2")
+  add_project_dependency(hpp-fcl REQUIRED)
 endif()
 
 if(BUILD_WITH_ACCELERATE_SUPPORT)


### PR DESCRIPTION
Fix, at least on ROS buildfarm:
```
-- hpp-fcl FOUND. hpp-fcl at /opt/ros/rolling/lib/x86_64-linux-gnu/libhpp-fcl.so
-- Found Boost: /usr/include (found version "1.83.0") found components: chrono serialization filesystem
CMake Error at /opt/ros/rolling/lib/x86_64-linux-gnu/cmake/hpp-fcl/hpp-fclConfig.cmake:181 (message):
  hpp-fcl: hpp-fcl >= 2.1.2 not found.
Call Stack (most recent call first):
  cmake/package-config.cmake:133 (find_package)
  CMakeLists.txt:341 (add_project_dependency)
```