### PR TITLE
Enhacing casting support for multiple floating-point scalars and Casadi and CppAD types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 - Add missing Python examples ([#2528](https://github.com/stack-of-tasks/pinocchio/pull/2528))
+- Fix nominal accuracy check for Quaternion based on the scalar type ([#2608](https://github.com/stack-of-tasks/pinocchio/pull/2608))
 
 ## [3.4.0] - 2025-02-12
 

--- a/include/pinocchio/autodiff/casadi/math/quaternion.hpp
+++ b/include/pinocchio/autodiff/casadi/math/quaternion.hpp
@@ -12,15 +12,6 @@ namespace pinocchio
   namespace quaternion
   {
 
-    template<>
-    struct DefaultNormTolerance<::casadi::SX>
-    {
-      static constexpr double value()
-      {
-        return 1e-8;
-      } // CasADi uses double internally
-    };
-
     namespace internal
     {
 

--- a/include/pinocchio/autodiff/casadi/math/quaternion.hpp
+++ b/include/pinocchio/autodiff/casadi/math/quaternion.hpp
@@ -11,6 +11,13 @@ namespace pinocchio
 {
   namespace quaternion
   {
+
+    template <>
+    struct DefaultNormTolerance<::casadi::SX>
+    {
+      static constexpr double value() { return 1e-8; } // CasADi uses double internally
+    };
+
     namespace internal
     {
 

--- a/include/pinocchio/autodiff/casadi/math/quaternion.hpp
+++ b/include/pinocchio/autodiff/casadi/math/quaternion.hpp
@@ -12,10 +12,13 @@ namespace pinocchio
   namespace quaternion
   {
 
-    template <>
+    template<>
     struct DefaultNormTolerance<::casadi::SX>
     {
-      static constexpr double value() { return 1e-8; } // CasADi uses double internally
+      static constexpr double value()
+      {
+        return 1e-8;
+      } // CasADi uses double internally
     };
 
     namespace internal

--- a/include/pinocchio/autodiff/cppad/math/quaternion.hpp
+++ b/include/pinocchio/autodiff/cppad/math/quaternion.hpp
@@ -11,10 +11,13 @@ namespace pinocchio
 {
   namespace quaternion
   {
-    template <typename BaseScalar>
+    template<typename BaseScalar>
     struct DefaultNormTolerance<CppAD::AD<BaseScalar>>
     {
-      static constexpr BaseScalar value() { return DefaultNormTolerance<BaseScalar>::value(); }
+      static constexpr BaseScalar value()
+      {
+        return DefaultNormTolerance<BaseScalar>::value();
+      }
     };
 
     namespace internal

--- a/include/pinocchio/autodiff/cppad/math/quaternion.hpp
+++ b/include/pinocchio/autodiff/cppad/math/quaternion.hpp
@@ -11,6 +11,12 @@ namespace pinocchio
 {
   namespace quaternion
   {
+    template <typename BaseScalar>
+    struct DefaultNormTolerance<CppAD::AD<BaseScalar>>
+    {
+      static constexpr BaseScalar value() { return DefaultNormTolerance<BaseScalar>::value(); }
+    };
+
     namespace internal
     {
 

--- a/include/pinocchio/autodiff/cppad/math/quaternion.hpp
+++ b/include/pinocchio/autodiff/cppad/math/quaternion.hpp
@@ -11,14 +11,6 @@ namespace pinocchio
 {
   namespace quaternion
   {
-    template<typename BaseScalar>
-    struct DefaultNormTolerance<CppAD::AD<BaseScalar>>
-    {
-      static constexpr BaseScalar value()
-      {
-        return DefaultNormTolerance<BaseScalar>::value();
-      }
-    };
 
     namespace internal
     {

--- a/include/pinocchio/bindings/python/spatial/explog.hpp
+++ b/include/pinocchio/bindings/python/spatial/explog.hpp
@@ -170,8 +170,7 @@ namespace pinocchio
       typedef Eigen::Map<const Quaternion_t> ConstQuaternionMap_t;
 
       ConstQuaternionMap_t q(v.derived().data());
-      assert(quaternion::isNormalized(
-        q, typename Vector4Like::RealScalar(quaternion::DefaultNormTolerance<Scalar>::value())));
+      assert(quaternion::isNormalized(q));
       return quaternion::log3(q);
     }
 
@@ -187,8 +186,7 @@ namespace pinocchio
       typedef Eigen::Map<const Quaternion_t> ConstQuaternionMap_t;
 
       ConstQuaternionMap_t q(v.derived().data());
-      assert(quaternion::isNormalized(
-        q, typename Vector4Like::RealScalar(quaternion::DefaultNormTolerance<Scalar>::value())));
+      assert(quaternion::isNormalized(q));
 
       return quaternion::log3(q, theta.coeffRef(0, 0));
     }
@@ -205,8 +203,7 @@ namespace pinocchio
       typedef Eigen::Map<const Quaternion_t> ConstQuaternionMap_t;
 
       ConstQuaternionMap_t q(v.derived().data());
-      assert(quaternion::isNormalized(
-        q, typename Vector4Like::RealScalar(quaternion::DefaultNormTolerance<Scalar>::value())));
+      assert(quaternion::isNormalized(q));
 
       return quaternion::log3(q, theta);
     }

--- a/include/pinocchio/bindings/python/spatial/explog.hpp
+++ b/include/pinocchio/bindings/python/spatial/explog.hpp
@@ -171,7 +171,7 @@ namespace pinocchio
 
       ConstQuaternionMap_t q(v.derived().data());
       assert(quaternion::isNormalized(
-        q, typename Vector4Like::RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        q, typename Vector4Like::RealScalar(quaternion::DefaultNormTolerance<Scalar>::value())));
       return quaternion::log3(q);
     }
 
@@ -188,7 +188,7 @@ namespace pinocchio
 
       ConstQuaternionMap_t q(v.derived().data());
       assert(quaternion::isNormalized(
-        q, typename Vector4Like::RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        q, typename Vector4Like::RealScalar(quaternion::DefaultNormTolerance<Scalar>::value())));
 
       return quaternion::log3(q, theta.coeffRef(0, 0));
     }
@@ -206,7 +206,7 @@ namespace pinocchio
 
       ConstQuaternionMap_t q(v.derived().data());
       assert(quaternion::isNormalized(
-        q, typename Vector4Like::RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        q, typename Vector4Like::RealScalar(quaternion::DefaultNormTolerance<Scalar>::value())));
 
       return quaternion::log3(q, theta);
     }

--- a/include/pinocchio/codegen/cppadcg.hpp
+++ b/include/pinocchio/codegen/cppadcg.hpp
@@ -113,23 +113,26 @@ namespace pinocchio
     }
   };
 
-   template <typename NewScalar, typename Scalar>
-   struct ScalarCast<NewScalar, CppAD::cg::CG<Scalar>>
-   {
-     static NewScalar cast(const CppAD::cg::CG<Scalar>& cg_value)
-     {
-       return static_cast<NewScalar>(cg_value.getValue());
-     }
-   };
+  template<typename NewScalar, typename Scalar>
+  struct ScalarCast<NewScalar, CppAD::cg::CG<Scalar>>
+  {
+    static NewScalar cast(const CppAD::cg::CG<Scalar> & cg_value)
+    {
+      return static_cast<NewScalar>(cg_value.getValue());
+    }
+  };
 
   namespace quaternion
   {
-    template <typename BaseScalar>
+    template<typename BaseScalar>
     struct DefaultNormTolerance<CppAD::AD<CppAD::cg::CG<BaseScalar>>>
     {
-      static constexpr BaseScalar value() { return DefaultNormTolerance<CppAD::AD<BaseScalar>>::value(); }
+      static constexpr BaseScalar value()
+      {
+        return DefaultNormTolerance<CppAD::AD<BaseScalar>>::value();
+      }
     };
-  }
+  } // namespace quaternion
 } // namespace pinocchio
 
 #endif // #ifndef __pinocchio_codegen_ccpadcg_hpp__

--- a/include/pinocchio/codegen/cppadcg.hpp
+++ b/include/pinocchio/codegen/cppadcg.hpp
@@ -122,20 +122,6 @@ namespace pinocchio
     }
   };
 
-  namespace quaternion
-  {
-    template<typename Scalar>
-    struct DefaultNormTolerance<CppAD::AD<CppAD::cg::CG<Scalar>>>
-    {
-      typedef DefaultNormTolerance<Scalar> Base;
-      typedef CppAD::cg::CG<Scalar> CGScalar;
-
-      static constexpr CGScalar value()
-      {
-        return CGScalar(Base::value());
-      }
-    };
-  } // namespace quaternion
 } // namespace pinocchio
 
 #endif // #ifndef __pinocchio_codegen_ccpadcg_hpp__

--- a/include/pinocchio/codegen/cppadcg.hpp
+++ b/include/pinocchio/codegen/cppadcg.hpp
@@ -113,14 +113,14 @@ namespace pinocchio
     }
   };
 
-  template<typename Scalar>
-  struct ScalarCast<Scalar, CppAD::cg::CG<Scalar>>
-  {
-    static Scalar cast(const CppAD::cg::CG<Scalar> & cg_value)
-    {
-      return cg_value.getValue();
-    }
-  };
+   template <typename NewScalar, typename Scalar>
+   struct ScalarCast<NewScalar, CppAD::cg::CG<Scalar>>
+   {
+     static NewScalar cast(const CppAD::cg::CG<Scalar>& cg_value)
+     {
+       return static_cast<NewScalar>(cg_value.getValue());
+     }
+   };
 
 } // namespace pinocchio
 

--- a/include/pinocchio/codegen/cppadcg.hpp
+++ b/include/pinocchio/codegen/cppadcg.hpp
@@ -122,6 +122,14 @@ namespace pinocchio
      }
    };
 
+  namespace quaternion
+  {
+    template <typename BaseScalar>
+    struct DefaultNormTolerance<CppAD::AD<CppAD::cg::CG<BaseScalar>>>
+    {
+      static constexpr BaseScalar value() { return DefaultNormTolerance<CppAD::AD<BaseScalar>>::value(); }
+    };
+  }
 } // namespace pinocchio
 
 #endif // #ifndef __pinocchio_codegen_ccpadcg_hpp__

--- a/include/pinocchio/codegen/cppadcg.hpp
+++ b/include/pinocchio/codegen/cppadcg.hpp
@@ -124,12 +124,15 @@ namespace pinocchio
 
   namespace quaternion
   {
-    template<typename BaseScalar>
-    struct DefaultNormTolerance<CppAD::AD<CppAD::cg::CG<BaseScalar>>>
+    template<typename Scalar>
+    struct DefaultNormTolerance<CppAD::AD<CppAD::cg::CG<Scalar>>>
     {
-      static constexpr BaseScalar value()
+      typedef DefaultNormTolerance<Scalar> Base;
+      typedef CppAD::cg::CG<Scalar> CGScalar;
+
+      static constexpr CGScalar value()
       {
-        return DefaultNormTolerance<CppAD::AD<BaseScalar>>::value();
+        return CGScalar(Base::value());
       }
     };
   } // namespace quaternion

--- a/include/pinocchio/math/quaternion.hpp
+++ b/include/pinocchio/math/quaternion.hpp
@@ -19,19 +19,25 @@ namespace pinocchio
 {
   namespace quaternion
   {
-    template <typename Scalar>
+    template<typename Scalar>
     struct DefaultNormTolerance;
 
-    template <>
+    template<>
     struct DefaultNormTolerance<double>
     {
-      static constexpr double value() { return 1e-8; }
+      static constexpr double value()
+      {
+        return 1e-8;
+      }
     };
 
-    template <>
+    template<>
     struct DefaultNormTolerance<float>
     {
-      static constexpr float value() { return 1e-4f; } // Adjust if needed
+      static constexpr float value()
+      {
+        return 1e-4f;
+      } // Adjust if needed
     };
 
     ///

--- a/include/pinocchio/math/quaternion.hpp
+++ b/include/pinocchio/math/quaternion.hpp
@@ -1,13 +1,10 @@
 //
 // Copyright (c) 2016-2020 CNRS INRIA
+// Copyright (c) 2025 Heriot-Watt University
 //
 
 #ifndef __pinocchio_math_quaternion_hpp__
 #define __pinocchio_math_quaternion_hpp__
-
-#ifndef PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE
-  #define PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE 1e-8
-#endif
 
 #include "pinocchio/math/fwd.hpp"
 #include "pinocchio/math/comparison-operators.hpp"
@@ -22,6 +19,24 @@ namespace pinocchio
 {
   namespace quaternion
   {
+    template <typename Scalar>
+    struct DefaultNormTolerance
+    {
+        static constexpr Scalar value() { return Scalar(1e-8); } // Generic fallback
+    };
+
+    template <>
+    struct DefaultNormTolerance<double>
+    {
+      static constexpr double value() { return 1e-8; }
+    };
+
+    template <>
+    struct DefaultNormTolerance<float>
+    {
+      static constexpr float value() { return 1e-4f; } // Adjust if needed
+    };
+
     ///
     /// \brief Compute the minimal angle between q1 and q2.
     ///

--- a/include/pinocchio/math/quaternion.hpp
+++ b/include/pinocchio/math/quaternion.hpp
@@ -1,6 +1,5 @@
 //
 // Copyright (c) 2016-2020 CNRS INRIA
-// Copyright (c) 2025 Heriot-Watt University
 //
 
 #ifndef __pinocchio_math_quaternion_hpp__
@@ -19,26 +18,6 @@ namespace pinocchio
 {
   namespace quaternion
   {
-    template<typename Scalar>
-    struct DefaultNormTolerance;
-
-    template<>
-    struct DefaultNormTolerance<double>
-    {
-      static constexpr double value()
-      {
-        return 1e-8;
-      }
-    };
-
-    template<>
-    struct DefaultNormTolerance<float>
-    {
-      static constexpr float value()
-      {
-        return 1e-4f;
-      } // Adjust if needed
-    };
 
     ///
     /// \brief Compute the minimal angle between q1 and q2.
@@ -246,9 +225,23 @@ namespace pinocchio
     template<typename Quaternion>
     inline bool isNormalized(
       const Eigen::QuaternionBase<Quaternion> & quat,
-      const typename Quaternion::Coefficients::RealScalar & prec =
-        DefaultNormTolerance<typename Quaternion::Coefficients::RealScalar>::value())
+      const typename Quaternion::Coefficients::RealScalar & prec)
     {
+      return pinocchio::isNormalized(quat.coeffs(), prec);
+    }
+
+    ///
+    /// \brief Check whether the input quaternion is Normalized within the default precision.
+    ///
+    /// \param[in] quat Input quaternion
+    ///
+    /// \returns true if quat is normalized within the default precision.
+    ///
+    template<typename Quaternion>
+    inline bool isNormalized(const Eigen::QuaternionBase<Quaternion> & quat)
+    {
+      typedef typename Quaternion::Coefficients::RealScalar RealScalar;
+      const RealScalar prec = math::sqrt(Eigen::NumTraits<RealScalar>::epsilon());
       return pinocchio::isNormalized(quat.coeffs(), prec);
     }
 

--- a/include/pinocchio/math/quaternion.hpp
+++ b/include/pinocchio/math/quaternion.hpp
@@ -20,10 +20,7 @@ namespace pinocchio
   namespace quaternion
   {
     template <typename Scalar>
-    struct DefaultNormTolerance
-    {
-        static constexpr Scalar value() { return Scalar(1e-8); } // Generic fallback
-    };
+    struct DefaultNormTolerance;
 
     template <>
     struct DefaultNormTolerance<double>

--- a/include/pinocchio/math/quaternion.hpp
+++ b/include/pinocchio/math/quaternion.hpp
@@ -247,7 +247,7 @@ namespace pinocchio
     inline bool isNormalized(
       const Eigen::QuaternionBase<Quaternion> & quat,
       const typename Quaternion::Coefficients::RealScalar & prec =
-        Eigen::NumTraits<typename Quaternion::Coefficients::RealScalar>::dummy_precision())
+        DefaultNormTolerance<typename Quaternion::Coefficients::RealScalar>::value())
     {
       return pinocchio::isNormalized(quat.coeffs(), prec);
     }

--- a/include/pinocchio/multibody/data.hxx
+++ b/include/pinocchio/multibody/data.hxx
@@ -210,7 +210,8 @@ namespace pinocchio
 
       // Build a "correct" representation of mimic nvSubtree by using nvExtended, which will cover
       // its children nv, and allow for a simple check
-      if (boost::get<JointModelMimicTpl<Scalar, Options, JointCollectionTpl>>(&model.joints[i]))
+      if (boost::get<JointModelMimicTpl<Scalar, Options, JointCollectionTpl>>(
+            &model.joints[size_t(i)]))
         nvSubtree[(Index)i] = 0;
       else
       {

--- a/include/pinocchio/multibody/data.hxx
+++ b/include/pinocchio/multibody/data.hxx
@@ -72,6 +72,7 @@ namespace pinocchio
   , nvSubtree((std::size_t)model.njoints, -1)
   , start_idx_v_fromRow((std::size_t)model.nvExtended, -1)
   , end_idx_v_fromRow((std::size_t)model.nvExtended, -1)
+  , idx_vExtended_to_idx_v_fromRow((std::size_t)model.nvExtended, -1)
   , U(MatrixXs::Identity(model.nv, model.nv))
   , D(VectorXs::Zero(model.nv))
   , Dinv(VectorXs::Zero(model.nv))
@@ -79,7 +80,6 @@ namespace pinocchio
   , parents_fromRow((std::size_t)model.nvExtended, -1)
   , mimic_parents_fromRow((std::size_t)model.nvExtended, -1)
   , non_mimic_parents_fromRow((std::size_t)model.nvExtended, -1)
-  , idx_vExtended_to_idx_v_fromRow((std::size_t)model.nvExtended, -1)
   , supports_fromRow((std::size_t)model.nv)
   , nvSubtree_fromRow((std::size_t)model.nvExtended, -1)
   , J(Matrix6x::Zero(6, model.nvExtended))
@@ -162,7 +162,6 @@ namespace pinocchio
   , constraints_supported_dim((std::size_t)model.njoints, 0)
   , constraints_supported((std::size_t)model.njoints)
   , constraints_on_joint((std::size_t)model.njoints)
-  , mimic_subtree_joint()
   {
     typedef typename Model::JointIndex JointIndex;
 

--- a/include/pinocchio/multibody/joint/joint-basic-visitors.hxx
+++ b/include/pinocchio/multibody/joint/joint-basic-visitors.hxx
@@ -209,9 +209,10 @@ namespace pinocchio
 
       // VectorBlock does not implemet such getter, hack the Eigen::Block base class to retreive
       // such values.
-      const Index start = vectorBlock.startRow()
-                          + vectorBlock.startCol(); // The other dimension is always 0 (for vectors)
-      const Index size =
+      const Eigen::DenseIndex start =
+        vectorBlock.startRow()
+        + vectorBlock.startCol(); // The other dimension is always 0 (for vectors)
+      const Eigen::DenseIndex size =
         vectorBlock.rows() * vectorBlock.cols(); // The other dimension is always 1 (for vectors)
 
       return ReturnType(vectorBlock.nestedExpression(), start, size);

--- a/include/pinocchio/multibody/joint/joint-mimic.hpp
+++ b/include/pinocchio/multibody/joint/joint-mimic.hpp
@@ -103,7 +103,8 @@ namespace pinocchio
     typedef typename SE3GroupAction<RefJointMotionSubspace>::ReturnType SE3ActionReturnType;
 
     ScaledJointMotionSubspaceTpl()
-    : ScaledJointMotionSubspaceTpl(1.0)
+    : m_constraint(0)
+    , m_scaling_factor(Scalar(1))
     {
     }
 

--- a/include/pinocchio/multibody/liegroup/special-euclidean.hpp
+++ b/include/pinocchio/multibody/liegroup/special-euclidean.hpp
@@ -600,10 +600,10 @@ namespace pinocchio
       typedef typename Tangent_t::Scalar Scalar;
       ConstQuaternionMap_t quat0(q0.derived().template tail<4>().data());
       assert(quaternion::isNormalized(
-        quat0, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
       ConstQuaternionMap_t quat1(q1.derived().template tail<4>().data());
       assert(quaternion::isNormalized(
-        quat1, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
 
       typedef Eigen::Matrix<Scalar, 3, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Tangent_t)::Options> Vector3;
       const Vector3 dv_pre = q1.derived().template head<3>() - q0.derived().template head<3>();
@@ -624,10 +624,10 @@ namespace pinocchio
 
       ConstQuaternionMap_t quat0(q0.derived().template tail<4>().data());
       assert(quaternion::isNormalized(
-        quat0, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
       ConstQuaternionMap_t quat1(q1.derived().template tail<4>().data());
       assert(quaternion::isNormalized(
-        quat1, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
 
       const Vector3 dv_pre = q1.derived().template head<3>() - q0.derived().template head<3>();
       const Vector3 trans = quat0.conjugate() * dv_pre;
@@ -669,7 +669,7 @@ namespace pinocchio
       ConfigOut_t & out = PINOCCHIO_EIGEN_CONST_CAST(ConfigOut_t, qout);
       Quaternion_t const quat(q.derived().template tail<4>());
       assert(quaternion::isNormalized(
-        quat, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat, quaternion::DefaultNormTolerance<RealScalar>::value()));
       QuaternionMap_t res_quat(out.template tail<4>().data());
 
       using internal::if_then_else;
@@ -701,7 +701,7 @@ namespace pinocchio
       // quaternion.
       quaternion::firstOrderNormalize(res_quat);
       assert(quaternion::isNormalized(
-        res_quat, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        res_quat, quaternion::DefaultNormTolerance<RealScalar>::value()));
     }
 
     template<class Config_t, class Jacobian_t>
@@ -719,7 +719,7 @@ namespace pinocchio
 
       ConstQuaternionMap_t quat_map(q.derived().template tail<4>().data());
       assert(quaternion::isNormalized(
-        quat_map, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat_map, quaternion::DefaultNormTolerance<RealScalar>::value()));
       Jout.template topLeftCorner<3, 3>() = quat_map.toRotationMatrix();
       //      Jexp3(quat,Jout.template bottomRightCorner<4,3>());
 

--- a/include/pinocchio/multibody/liegroup/special-euclidean.hpp
+++ b/include/pinocchio/multibody/liegroup/special-euclidean.hpp
@@ -599,11 +599,11 @@ namespace pinocchio
     {
       typedef typename Tangent_t::Scalar Scalar;
       ConstQuaternionMap_t quat0(q0.derived().template tail<4>().data());
-      assert(quaternion::isNormalized(
-        quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
       ConstQuaternionMap_t quat1(q1.derived().template tail<4>().data());
-      assert(quaternion::isNormalized(
-        quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
 
       typedef Eigen::Matrix<Scalar, 3, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Tangent_t)::Options> Vector3;
       const Vector3 dv_pre = q1.derived().template head<3>() - q0.derived().template head<3>();
@@ -623,11 +623,11 @@ namespace pinocchio
       typedef typename SE3::Vector3 Vector3;
 
       ConstQuaternionMap_t quat0(q0.derived().template tail<4>().data());
-      assert(quaternion::isNormalized(
-        quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
       ConstQuaternionMap_t quat1(q1.derived().template tail<4>().data());
-      assert(quaternion::isNormalized(
-        quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
 
       const Vector3 dv_pre = q1.derived().template head<3>() - q0.derived().template head<3>();
       const Vector3 trans = quat0.conjugate() * dv_pre;
@@ -668,8 +668,7 @@ namespace pinocchio
     {
       ConfigOut_t & out = PINOCCHIO_EIGEN_CONST_CAST(ConfigOut_t, qout);
       Quaternion_t const quat(q.derived().template tail<4>());
-      assert(quaternion::isNormalized(
-        quat, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat, quaternion::DefaultNormTolerance<RealScalar>::value()));
       QuaternionMap_t res_quat(out.template tail<4>().data());
 
       using internal::if_then_else;
@@ -700,8 +699,8 @@ namespace pinocchio
       // rotation matrix. It is then safer to re-normalized after converting M1.rotation to
       // quaternion.
       quaternion::firstOrderNormalize(res_quat);
-      assert(quaternion::isNormalized(
-        res_quat, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(res_quat, quaternion::DefaultNormTolerance<RealScalar>::value()));
     }
 
     template<class Config_t, class Jacobian_t>
@@ -718,8 +717,8 @@ namespace pinocchio
       Jout.setZero();
 
       ConstQuaternionMap_t quat_map(q.derived().template tail<4>().data());
-      assert(quaternion::isNormalized(
-        quat_map, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(quat_map, quaternion::DefaultNormTolerance<RealScalar>::value()));
       Jout.template topLeftCorner<3, 3>() = quat_map.toRotationMatrix();
       //      Jexp3(quat,Jout.template bottomRightCorner<4,3>());
 

--- a/include/pinocchio/multibody/liegroup/special-euclidean.hpp
+++ b/include/pinocchio/multibody/liegroup/special-euclidean.hpp
@@ -599,11 +599,9 @@ namespace pinocchio
     {
       typedef typename Tangent_t::Scalar Scalar;
       ConstQuaternionMap_t quat0(q0.derived().template tail<4>().data());
-      assert(
-        quaternion::isNormalized(quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat0));
       ConstQuaternionMap_t quat1(q1.derived().template tail<4>().data());
-      assert(
-        quaternion::isNormalized(quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat1));
 
       typedef Eigen::Matrix<Scalar, 3, 1, PINOCCHIO_EIGEN_PLAIN_TYPE(Tangent_t)::Options> Vector3;
       const Vector3 dv_pre = q1.derived().template head<3>() - q0.derived().template head<3>();
@@ -623,11 +621,9 @@ namespace pinocchio
       typedef typename SE3::Vector3 Vector3;
 
       ConstQuaternionMap_t quat0(q0.derived().template tail<4>().data());
-      assert(
-        quaternion::isNormalized(quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat0));
       ConstQuaternionMap_t quat1(q1.derived().template tail<4>().data());
-      assert(
-        quaternion::isNormalized(quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat1));
 
       const Vector3 dv_pre = q1.derived().template head<3>() - q0.derived().template head<3>();
       const Vector3 trans = quat0.conjugate() * dv_pre;
@@ -668,7 +664,7 @@ namespace pinocchio
     {
       ConfigOut_t & out = PINOCCHIO_EIGEN_CONST_CAST(ConfigOut_t, qout);
       Quaternion_t const quat(q.derived().template tail<4>());
-      assert(quaternion::isNormalized(quat, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat));
       QuaternionMap_t res_quat(out.template tail<4>().data());
 
       using internal::if_then_else;
@@ -699,8 +695,7 @@ namespace pinocchio
       // rotation matrix. It is then safer to re-normalized after converting M1.rotation to
       // quaternion.
       quaternion::firstOrderNormalize(res_quat);
-      assert(
-        quaternion::isNormalized(res_quat, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(res_quat));
     }
 
     template<class Config_t, class Jacobian_t>
@@ -717,8 +712,7 @@ namespace pinocchio
       Jout.setZero();
 
       ConstQuaternionMap_t quat_map(q.derived().template tail<4>().data());
-      assert(
-        quaternion::isNormalized(quat_map, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat_map));
       Jout.template topLeftCorner<3, 3>() = quat_map.toRotationMatrix();
       //      Jexp3(quat,Jout.template bottomRightCorner<4,3>());
 

--- a/include/pinocchio/multibody/liegroup/special-orthogonal.hpp
+++ b/include/pinocchio/multibody/liegroup/special-orthogonal.hpp
@@ -410,10 +410,10 @@ namespace pinocchio
     {
       ConstQuaternionMap_t quat0(q0.derived().data());
       assert(quaternion::isNormalized(
-        quat0, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
       ConstQuaternionMap_t quat1(q1.derived().data());
       assert(quaternion::isNormalized(
-        quat1, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
 
       PINOCCHIO_EIGEN_CONST_CAST(Tangent_t, d) =
         quaternion::log3(Quaternion_t(quat0.conjugate() * quat1));
@@ -429,10 +429,10 @@ namespace pinocchio
 
       ConstQuaternionMap_t quat0(q0.derived().data());
       assert(quaternion::isNormalized(
-        quat0, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
       ConstQuaternionMap_t quat1(q1.derived().data());
       assert(quaternion::isNormalized(
-        quat1, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
 
       // TODO: check whether the merge with 2.6.9 is correct
       const Quaternion_t q = quat0.conjugate() * quat1;
@@ -475,7 +475,7 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     {
       ConstQuaternionMap_t quat(q.derived().data());
       assert(quaternion::isNormalized(
-        quat, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat, quaternion::DefaultNormTolerance<RealScalar>::value()));
       QuaternionMap_t quat_map(PINOCCHIO_EIGEN_CONST_CAST(ConfigOut_t, qout).data());
 
       Quaternion_t pOmega;
@@ -483,7 +483,7 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
       quat_map = quat * pOmega;
       quaternion::firstOrderNormalize(quat_map);
       assert(quaternion::isNormalized(
-        quat_map, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat_map, quaternion::DefaultNormTolerance<RealScalar>::value()));
     }
 
     template<class Config_t, class Jacobian_t>
@@ -498,7 +498,7 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
 
       ConstQuaternionMap_t quat_map(q.derived().data());
       assert(quaternion::isNormalized(
-        quat_map, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat_map, quaternion::DefaultNormTolerance<RealScalar>::value()));
 
       PINOCCHIO_COMPILER_DIAGNOSTIC_PUSH
       PINOCCHIO_COMPILER_DIAGNOSTIC_IGNORED_MAYBE_UNINITIALIZED
@@ -640,10 +640,10 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     {
       ConstQuaternionMap_t quat0(q0.derived().data());
       assert(quaternion::isNormalized(
-        quat0, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
       ConstQuaternionMap_t quat1(q1.derived().data());
       assert(quaternion::isNormalized(
-        quat1, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
 
       QuaternionMap_t quat_res(PINOCCHIO_EIGEN_CONST_CAST(ConfigOut_t, qout).data());
 
@@ -651,7 +651,7 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
       difference_impl(q0, q1, w);
       integrate_impl(q0, u * w, qout);
       assert(quaternion::isNormalized(
-        quat_res, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat_res, quaternion::DefaultNormTolerance<RealScalar>::value()));
     }
 
     template<class ConfigL_t, class ConfigR_t>
@@ -687,7 +687,7 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
       quaternion::uniformRandom(quat_map);
 
       assert(quaternion::isNormalized(
-        quat_map, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat_map, quaternion::DefaultNormTolerance<RealScalar>::value()));
     }
 
     template<class ConfigL_t, class ConfigR_t, class ConfigOut_t>
@@ -707,10 +707,10 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
     {
       ConstQuaternionMap_t quat1(q0.derived().data());
       assert(quaternion::isNormalized(
-        quat1, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
       ConstQuaternionMap_t quat2(q1.derived().data());
       assert(quaternion::isNormalized(
-        quat1, RealScalar(PINOCCHIO_DEFAULT_QUATERNION_NORM_TOLERANCE_VALUE)));
+        quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
 
       return quaternion::defineSameRotation(quat1, quat2, prec);
     }

--- a/include/pinocchio/multibody/liegroup/special-orthogonal.hpp
+++ b/include/pinocchio/multibody/liegroup/special-orthogonal.hpp
@@ -409,11 +409,11 @@ namespace pinocchio
       const Eigen::MatrixBase<Tangent_t> & d)
     {
       ConstQuaternionMap_t quat0(q0.derived().data());
-      assert(quaternion::isNormalized(
-        quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
       ConstQuaternionMap_t quat1(q1.derived().data());
-      assert(quaternion::isNormalized(
-        quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
 
       PINOCCHIO_EIGEN_CONST_CAST(Tangent_t, d) =
         quaternion::log3(Quaternion_t(quat0.conjugate() * quat1));
@@ -428,11 +428,11 @@ namespace pinocchio
       typedef typename SE3::Matrix3 Matrix3;
 
       ConstQuaternionMap_t quat0(q0.derived().data());
-      assert(quaternion::isNormalized(
-        quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
       ConstQuaternionMap_t quat1(q1.derived().data());
-      assert(quaternion::isNormalized(
-        quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
 
       // TODO: check whether the merge with 2.6.9 is correct
       const Quaternion_t q = quat0.conjugate() * quat1;
@@ -474,16 +474,15 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
       const Eigen::MatrixBase<ConfigOut_t> & qout)
     {
       ConstQuaternionMap_t quat(q.derived().data());
-      assert(quaternion::isNormalized(
-        quat, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat, quaternion::DefaultNormTolerance<RealScalar>::value()));
       QuaternionMap_t quat_map(PINOCCHIO_EIGEN_CONST_CAST(ConfigOut_t, qout).data());
 
       Quaternion_t pOmega;
       quaternion::exp3(v, pOmega);
       quat_map = quat * pOmega;
       quaternion::firstOrderNormalize(quat_map);
-      assert(quaternion::isNormalized(
-        quat_map, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(quat_map, quaternion::DefaultNormTolerance<RealScalar>::value()));
     }
 
     template<class Config_t, class Jacobian_t>
@@ -497,8 +496,8 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
       typedef typename SE3::Matrix3 Matrix3;
 
       ConstQuaternionMap_t quat_map(q.derived().data());
-      assert(quaternion::isNormalized(
-        quat_map, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(quat_map, quaternion::DefaultNormTolerance<RealScalar>::value()));
 
       PINOCCHIO_COMPILER_DIAGNOSTIC_PUSH
       PINOCCHIO_COMPILER_DIAGNOSTIC_IGNORED_MAYBE_UNINITIALIZED
@@ -639,19 +638,19 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
       const Eigen::MatrixBase<ConfigOut_t> & qout)
     {
       ConstQuaternionMap_t quat0(q0.derived().data());
-      assert(quaternion::isNormalized(
-        quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
       ConstQuaternionMap_t quat1(q1.derived().data());
-      assert(quaternion::isNormalized(
-        quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
 
       QuaternionMap_t quat_res(PINOCCHIO_EIGEN_CONST_CAST(ConfigOut_t, qout).data());
 
       TangentVector_t w;
       difference_impl(q0, q1, w);
       integrate_impl(q0, u * w, qout);
-      assert(quaternion::isNormalized(
-        quat_res, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(quat_res, quaternion::DefaultNormTolerance<RealScalar>::value()));
     }
 
     template<class ConfigL_t, class ConfigR_t>
@@ -686,8 +685,8 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
       QuaternionMap_t quat_map(PINOCCHIO_EIGEN_CONST_CAST(Config_t, qout).data());
       quaternion::uniformRandom(quat_map);
 
-      assert(quaternion::isNormalized(
-        quat_map, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(quat_map, quaternion::DefaultNormTolerance<RealScalar>::value()));
     }
 
     template<class ConfigL_t, class ConfigR_t, class ConfigOut_t>
@@ -706,11 +705,11 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
       const Scalar & prec)
     {
       ConstQuaternionMap_t quat1(q0.derived().data());
-      assert(quaternion::isNormalized(
-        quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
       ConstQuaternionMap_t quat2(q1.derived().data());
-      assert(quaternion::isNormalized(
-        quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(
+        quaternion::isNormalized(quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
 
       return quaternion::defineSameRotation(quat1, quat2, prec);
     }

--- a/include/pinocchio/multibody/liegroup/special-orthogonal.hpp
+++ b/include/pinocchio/multibody/liegroup/special-orthogonal.hpp
@@ -409,11 +409,9 @@ namespace pinocchio
       const Eigen::MatrixBase<Tangent_t> & d)
     {
       ConstQuaternionMap_t quat0(q0.derived().data());
-      assert(
-        quaternion::isNormalized(quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat0));
       ConstQuaternionMap_t quat1(q1.derived().data());
-      assert(
-        quaternion::isNormalized(quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat1));
 
       PINOCCHIO_EIGEN_CONST_CAST(Tangent_t, d) =
         quaternion::log3(Quaternion_t(quat0.conjugate() * quat1));
@@ -428,11 +426,9 @@ namespace pinocchio
       typedef typename SE3::Matrix3 Matrix3;
 
       ConstQuaternionMap_t quat0(q0.derived().data());
-      assert(
-        quaternion::isNormalized(quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat0));
       ConstQuaternionMap_t quat1(q1.derived().data());
-      assert(
-        quaternion::isNormalized(quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat1));
 
       // TODO: check whether the merge with 2.6.9 is correct
       const Quaternion_t q = quat0.conjugate() * quat1;
@@ -474,15 +470,14 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
       const Eigen::MatrixBase<ConfigOut_t> & qout)
     {
       ConstQuaternionMap_t quat(q.derived().data());
-      assert(quaternion::isNormalized(quat, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat));
       QuaternionMap_t quat_map(PINOCCHIO_EIGEN_CONST_CAST(ConfigOut_t, qout).data());
 
       Quaternion_t pOmega;
       quaternion::exp3(v, pOmega);
       quat_map = quat * pOmega;
       quaternion::firstOrderNormalize(quat_map);
-      assert(
-        quaternion::isNormalized(quat_map, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat_map));
     }
 
     template<class Config_t, class Jacobian_t>
@@ -496,8 +491,7 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
       typedef typename SE3::Matrix3 Matrix3;
 
       ConstQuaternionMap_t quat_map(q.derived().data());
-      assert(
-        quaternion::isNormalized(quat_map, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat_map));
 
       PINOCCHIO_COMPILER_DIAGNOSTIC_PUSH
       PINOCCHIO_COMPILER_DIAGNOSTIC_IGNORED_MAYBE_UNINITIALIZED
@@ -638,19 +632,16 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
       const Eigen::MatrixBase<ConfigOut_t> & qout)
     {
       ConstQuaternionMap_t quat0(q0.derived().data());
-      assert(
-        quaternion::isNormalized(quat0, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat0));
       ConstQuaternionMap_t quat1(q1.derived().data());
-      assert(
-        quaternion::isNormalized(quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat1));
 
       QuaternionMap_t quat_res(PINOCCHIO_EIGEN_CONST_CAST(ConfigOut_t, qout).data());
 
       TangentVector_t w;
       difference_impl(q0, q1, w);
       integrate_impl(q0, u * w, qout);
-      assert(
-        quaternion::isNormalized(quat_res, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat_res));
     }
 
     template<class ConfigL_t, class ConfigR_t>
@@ -685,8 +676,7 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
       QuaternionMap_t quat_map(PINOCCHIO_EIGEN_CONST_CAST(Config_t, qout).data());
       quaternion::uniformRandom(quat_map);
 
-      assert(
-        quaternion::isNormalized(quat_map, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat_map));
     }
 
     template<class ConfigL_t, class ConfigR_t, class ConfigOut_t>
@@ -705,11 +695,9 @@ PINOCCHIO_COMPILER_DIAGNOSTIC_POP
       const Scalar & prec)
     {
       ConstQuaternionMap_t quat1(q0.derived().data());
-      assert(
-        quaternion::isNormalized(quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat1));
       ConstQuaternionMap_t quat2(q1.derived().data());
-      assert(
-        quaternion::isNormalized(quat1, quaternion::DefaultNormTolerance<RealScalar>::value()));
+      assert(quaternion::isNormalized(quat1));
 
       return quaternion::defineSameRotation(quat1, quat2, prec);
     }

--- a/src/parsers/mjcf/mjcf-graph-geom.cpp
+++ b/src/parsers/mjcf/mjcf-graph-geom.cpp
@@ -79,7 +79,7 @@ namespace pinocchio
           {
             auto vertices = currentMesh.vertices;
             // Scale vertices
-            for (std::size_t i = 0; i < vertices.rows(); ++i)
+            for (Eigen::DenseIndex i = 0; i < vertices.rows(); ++i)
               vertices.row(i) = vertices.row(i).cwiseProduct(currentMesh.scale.transpose());
             auto model = std::make_shared<hpp::fcl::BVHModel<fcl::OBBRSS>>();
             model->beginModel();

--- a/unittest/all-joints.cpp
+++ b/unittest/all-joints.cpp
@@ -201,8 +201,10 @@ struct TestJointModelTransform : TestJointModel<TestJointModelTransform>
   {
     typedef typename JointModel::JointDataDerived JointData;
     JointData jdata = jmodel.createData();
-    Eigen::Matrix<typename JointModel::Scalar, 3, 1> v = jdata.M_accessor().translation();
+    Eigen::Matrix<typename JointModel::Scalar, 3, 1> t = jdata.M_accessor().translation();
+    PINOCCHIO_UNUSED_VARIABLE(t);
     Eigen::Matrix<typename JointModel::Scalar, 3, 3> R = jdata.M_accessor().rotation();
+    PINOCCHIO_UNUSED_VARIABLE(R);
   }
 };
 

--- a/unittest/data.cpp
+++ b/unittest/data.cpp
@@ -82,16 +82,18 @@ BOOST_AUTO_TEST_CASE(test_data_mimic_idx_vExtended_to_idx_v_fromRow)
     Data data_mimic(model_mimic);
     Data data_full(model_full);
 
-    for (int joint_id = 1; joint_id < model_mimic.njoints; joint_id++)
+    for (size_t joint_id = 1; joint_id < model_mimic.njoints; joint_id++)
     {
       const int idx_vj = model_mimic.joints[joint_id].idx_v();
       const int idx_vExtended_j = model_mimic.joints[joint_id].idx_vExtended();
       const int nvExtended_j = model_mimic.joints[joint_id].nvExtended();
       for (int v = 0; v < nvExtended_j; v++)
       {
-        BOOST_CHECK(data_mimic.idx_vExtended_to_idx_v_fromRow[idx_vExtended_j + v] == idx_vj + v);
         BOOST_CHECK(
-          data_full.idx_vExtended_to_idx_v_fromRow[idx_vExtended_j + v] == idx_vExtended_j + v);
+          data_mimic.idx_vExtended_to_idx_v_fromRow[size_t(idx_vExtended_j + v)] == idx_vj + v);
+        BOOST_CHECK(
+          data_full.idx_vExtended_to_idx_v_fromRow[size_t(idx_vExtended_j + v)]
+          == idx_vExtended_j + v);
       }
     }
   }
@@ -106,7 +108,7 @@ BOOST_AUTO_TEST_CASE(test_data_mimic_mimic_parents_fromRow)
 
     Data data_mimic(model_mimic);
 
-    for (int joint_id = 1; joint_id < model_mimic.njoints; joint_id++)
+    for (size_t joint_id = 1; joint_id < model_mimic.njoints; joint_id++)
     {
       const int idx_vExtended_j = model_mimic.joints[joint_id].idx_vExtended();
       const int nvExtended_j = model_mimic.joints[joint_id].nvExtended();
@@ -125,7 +127,7 @@ BOOST_AUTO_TEST_CASE(test_data_mimic_mimic_parents_fromRow)
       for (int v = 1; v < nvExtended_j; v++)
       {
         BOOST_CHECK(
-          data_mimic.mimic_parents_fromRow[idx_vExtended_j + v] == idx_vExtended_j + v - 1);
+          data_mimic.mimic_parents_fromRow[size_t(idx_vExtended_j + v)] == idx_vExtended_j + v - 1);
       }
     }
   }

--- a/unittest/utils/model-generator.hpp
+++ b/unittest/utils/model-generator.hpp
@@ -1,5 +1,6 @@
 //
-// Copyright (c) 2015-2020 CNRS INRIA
+// Copyright (c) 2015-2020 CNRS
+// Copyright (c) 2018-2025 INRIA
 //
 
 #include "pinocchio/multibody/model.hpp"
@@ -84,19 +85,19 @@ namespace pinocchio
       auto it = std::find(mimicking_ids.begin(), mimicking_ids.end(), n);
       if (it != mimicking_ids.end()) // If n was found
       {
-        joint_ratio = ratio[std::distance(mimicking_ids.begin(), it)];
-        joint_offset = offset[std::distance(mimicking_ids.begin(), it)];
+        joint_ratio = ratio[size_t(std::distance(mimicking_ids.begin(), it))];
+        joint_offset = offset[size_t(std::distance(mimicking_ids.begin(), it))];
       }
-      model_full.joints[n].JointMappedConfigSelector(q_full) =
-        joint_ratio * model_mimic.joints[n].JointMappedConfigSelector(q)
-        + joint_offset * Eigen::VectorXd::Ones(model_full.joints[n].nq());
+      model_full.joints[size_t(n)].JointMappedConfigSelector(q_full) =
+        joint_ratio * model_mimic.joints[size_t(n)].JointMappedConfigSelector(q)
+        + joint_offset * Eigen::VectorXd::Ones(model_full.joints[size_t(n)].nq());
     }
   }
 
   void mimicTransformMatrix(
     const Model & model_full,
     const Model & model_mimic,
-    const std::vector<pinocchio::JointIndex> & mimicked_ids,
+    const std::vector<pinocchio::JointIndex> & /*mimicked_ids*/,
     const std::vector<pinocchio::JointIndex> & mimicking_ids,
     const std::vector<double> & ratios,
     Eigen::MatrixXd & G)
@@ -109,8 +110,8 @@ namespace pinocchio
     {
       if (std::find(mimicking_ids.begin(), mimicking_ids.end(), j) == mimicking_ids.end())
         G.block(
-           model_full.joints[j].idx_v(), model_mimic.joints[j].idx_v(), model_full.joints[j].nv(),
-           model_mimic.joints[j].nv())
+           model_full.joints[size_t(j)].idx_v(), model_mimic.joints[size_t(j)].idx_v(),
+           model_full.joints[size_t(j)].nv(), model_mimic.joints[size_t(j)].nv())
           .setIdentity();
     }
 


### PR DESCRIPTION
Dear Pinocchio folks,

As you know, I am working hard to support casting of multiple floating-point types as well as CppAD types in Crocoddyl. Currently, I have a draft version that needs to be reviewed before merging. However, there are changes in Pinocchio that prevent us from merging this new development, and I would very appreciate it if we can get them done quickly. Concretely, the needed changes are introduced in this PR, which can be summarized as:
  1. Introduced a mechanism to change tolerance in quaternions. For instance, `1e-8` is not appropriate for float numbers and triggers issues during debug mode in Crocoddyl. In this PR, I propose using `1e-4` for float numbers, indeed. This code is also tested with CppAD types in Crocoddyl.
  2. Fixed bug for casting `CppAD::cg::CG` scalars. Without this, Crocoddyl fails to compile.
  3. Added a missing scalar constructor in `log.hpp`. Without this, Crocoddyl also fails to compile.

Please help me to merge this PR as soon as possible, also creating a new Pinocchio release, as this is blocking Crocoddyl development.

Many thanks,
Carlos