### PR TITLE
Fix ModelTpl::check() link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Use [Google benchmark](https://github.com/google/benchmark/tree/main) in benchmarks ([#2607](https://github.com/stack-of-tasks/pinocchio/pull/2607))
 
 ### Fixed
+- Fix `ModelTpl::check()` link ([#2624](https://github.com/stack-of-tasks/pinocchio/pull/2624))
 - Add missing Python examples ([#2528](https://github.com/stack-of-tasks/pinocchio/pull/2528))
 - Fix nominal accuracy check for Quaternion based on the scalar type ([#2608](https://github.com/stack-of-tasks/pinocchio/pull/2608))
 

--- a/include/pinocchio/algorithm/contact-cholesky.hxx
+++ b/include/pinocchio/algorithm/contact-cholesky.hxx
@@ -5,7 +5,7 @@
 #ifndef __pinocchio_algorithm_contact_cholesky_hxx__
 #define __pinocchio_algorithm_contact_cholesky_hxx__
 
-#include "pinocchio/algorithm/check-model.hpp"
+#include "pinocchio/algorithm/check.hpp"
 #include "pinocchio/multibody/data.hpp"
 
 #include <algorithm>

--- a/include/pinocchio/algorithm/contact-jacobian.hxx
+++ b/include/pinocchio/algorithm/contact-jacobian.hxx
@@ -7,6 +7,7 @@
 
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
+#include "pinocchio/algorithm/check.hpp"
 
 namespace pinocchio
 {


### PR DESCRIPTION
When cross-compiling, I get a link error that `ModelTpl::check()` is undefined : 
```bash
ld: src/libpinocchio_default.so.3.4.0: undefined reference to `pinocchio::ModelTpl<double, 0, pinocchio::JointCollectionDefaultTpl>::check(pinocchio::DataTpl<double, 0, pinocchio::JointCollectionDefaultTpl> const&) const'
```
Indeed the command `objdump` returns
```bash
❯ objdump -TC src/libpinocchio_default.so | grep check
0000000000000000      D  *UND*	0000000000000000  Base        pinocchio::ModelTpl<double, 0, pinocchio::JointCollectionDefaultTpl>::check(pinocchio::DataTpl<double, 0, pinocchio::JointCollectionDefaultTpl> const&) const
```
I don't know why I get this error when cross-compiling, and not with a native build. The fix I propose seems innocuous enough. It seems to be the right place to add it.

In my investigation, I added `inline` to the declaration and got a warning : 
```bash
/.../include/pinocchio/multibody/model.hpp:517:17: warning: inline function 'bool pinocchio::ModelTpl<_Scalar, _Options, JointCollectionTpl>::check(const Data&) const [with _Scalar = double; int _Options = 0; JointCollectionTpl = pinocchio::JointCollectionDefaultTpl; Data = pinocchio::DataTpl<double, 0>]' used but never defined
  517 |     inline bool check(const Data & data) const;
```
when `src/algorithm/contact-jacobian.cpp` and `src/algorithm/contact-cholesky.cpp` are compiled.

Instead of fixing these specific files, I figured that a global fix was more foolproof.