### PR TITLE
unittest/python : add visualizer bindings visitor test, add CMake util to create C++ Python modules for tests

### DIFF
--- a/include/pinocchio/bindings/python/visualizers/visualizer-visitor.hpp
+++ b/include/pinocchio/bindings/python/visualizers/visualizer-visitor.hpp
@@ -20,7 +20,9 @@ namespace pinocchio
     {
       typedef ::pinocchio::visualizers::BaseVisualizer Base;
       typedef ::pinocchio::visualizers::ConstMatrixRef ConstMatrixRef;
-      static_assert(std::is_base_of_v<Base, Visualizer>);
+      static_assert(
+        std::is_base_of_v<Base, Visualizer>,
+        "Visualizer class must be derived from pinocchio::visualizers::BaseVisualizer.");
 
       static void setCameraPose_proxy(Visualizer & vis, const Base::Matrix4 & pose)
       {

--- a/include/pinocchio/bindings/python/visualizers/visualizer-visitor.hpp
+++ b/include/pinocchio/bindings/python/visualizers/visualizer-visitor.hpp
@@ -21,7 +21,7 @@ namespace pinocchio
       typedef ::pinocchio::visualizers::BaseVisualizer Base;
       typedef ::pinocchio::visualizers::ConstMatrixRef ConstMatrixRef;
       static_assert(
-        std::is_base_of_v<Base, Visualizer>,
+        std::is_base_of<Base, Visualizer>::value,
         "Visualizer class must be derived from pinocchio::visualizers::BaseVisualizer.");
 
       static void setCameraPose_proxy(Visualizer & vis, const Base::Matrix4 & pose)

--- a/unittest/python/CMakeLists.txt
+++ b/unittest/python/CMakeLists.txt
@@ -1,6 +1,7 @@
 #
-# Copyright (c) 2015-2023 CNRS INRIA
+# Copyright (c) 2015-2023 CNRS INRIA, 2024-2025 INRIA
 #
+include(${JRL_CMAKE_MODULES}/python-helpers.cmake)
 
 set(${PROJECT_NAME}_PYTHON_TESTS
     bindings
@@ -45,6 +46,49 @@ set(${PROJECT_NAME}_PYTHON_TESTS
     version
     bindings_std_vector
     bindings_std_map)
+
+function(pinocchio_add_python_cpp_module name)
+  set(target_name "test-ext-${name}")
+  string(REPLACE "-" "_" target_name ${target_name})
+  set(source_file "${name}.cpp")
+  set(options)
+  set(oneValueArgs)
+  set(multiValueArgs "PIN_TARGETS")
+  cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+  if(BUILD_TESTING)
+    set(_exclude)
+  else()
+    set(_exclude EXCLUDE_FROM_ALL)
+  endif()
+
+  add_library(${target_name} MODULE ${_exclude} ${source_file})
+  target_compile_definitions(${target_name} PRIVATE EXT_MODULE_NAME=${target_name})
+  target_link_libraries(${target_name} PRIVATE pinocchio_default eigenpy::eigenpy)
+  foreach(_dep ${ARGS_PIN_TARGETS})
+    target_link_libraries(${target_name} PRIVATE ${_dep})
+  endforeach()
+  set_target_properties(${target_name} PROPERTIES PREFIX "" SUFFIX "${PYTHON_EXT_SUFFIX}")
+
+  add_test(
+    NAME ${target_name}
+    COMMAND ${PYTHON_EXECUTABLE} -c "import ${target_name}"
+    WORKING_DIRECTORY $<TARGET_FILE_DIR:${target_name}>)
+  set(PYTHONPATH)
+  compute_pythonpath(ENV_VARIABLES bindings/python)
+  set_tests_properties(${target_name} PROPERTIES ENVIRONMENT "${ENV_VARIABLES}")
+
+  add_dependencies(build_tests ${target_name})
+  if(NOT BUILD_TESTING)
+    set_tests_properties(${target_name} PROPERTIES DEPENDS ctest_build_tests)
+  endif()
+endfunction()
+
+function(pinocchio_add_lib_unit_test name)
+  set(TEST_NAME "${PROJECT_NAME}-test-py-${name}")
+  add_python_unit_test(${TEST_NAME} "unittest/python/${name}.py" "bindings/python"
+                       "unittest/python")
+  add_windows_dll_path_to_test(${TEST_NAME})
+endfunction()
 
 if(BUILD_WITH_HPP_FCL_SUPPORT)
   set(${PROJECT_NAME}_PYTHON_TESTS ${${PROJECT_NAME}_PYTHON_TESTS} bindings_geometry_object)

--- a/unittest/python/CMakeLists.txt
+++ b/unittest/python/CMakeLists.txt
@@ -49,7 +49,8 @@ set(${PROJECT_NAME}_PYTHON_TESTS
 
 function(pinocchio_add_python_cpp_module name)
   set(target_name "test-ext-${name}")
-  string(REPLACE "-" "_" target_name ${target_name})
+  string(REPLACE "_" "-" target_name ${target_name})
+  string(REPLACE "-" "_" module_name ${target_name})
   set(source_file "${name}.cpp")
   set(options)
   set(oneValueArgs)
@@ -62,16 +63,21 @@ function(pinocchio_add_python_cpp_module name)
   endif()
 
   add_library(${target_name} MODULE ${_exclude} ${source_file})
-  target_compile_definitions(${target_name} PRIVATE EXT_MODULE_NAME=${target_name})
+  target_compile_definitions(${target_name} PRIVATE EXT_MODULE_NAME=${module_name})
   target_link_libraries(${target_name} PRIVATE pinocchio_default eigenpy::eigenpy)
   foreach(_dep ${ARGS_PIN_TARGETS})
     target_link_libraries(${target_name} PRIVATE ${_dep})
   endforeach()
-  set_target_properties(${target_name} PROPERTIES PREFIX "" SUFFIX "${PYTHON_EXT_SUFFIX}")
+  set_target_properties(
+    ${target_name}
+    PROPERTIES PREFIX ""
+               SUFFIX "${PYTHON_EXT_SUFFIX}"
+               LIBRARY_OUTPUT_NAME ${module_name}
+               RUNTIME_OUTPUT_NAME ${module_name})
 
   add_test(
     NAME ${target_name}
-    COMMAND ${PYTHON_EXECUTABLE} -c "import ${target_name}"
+    COMMAND ${PYTHON_EXECUTABLE} -c "import ${module_name}"
     WORKING_DIRECTORY $<TARGET_FILE_DIR:${target_name}>)
   set(PYTHONPATH)
   compute_pythonpath(ENV_VARIABLES bindings/python)

--- a/unittest/python/CMakeLists.txt
+++ b/unittest/python/CMakeLists.txt
@@ -143,7 +143,10 @@ else()
   message(STATUS "Valgrind not found, memory checks are disabled")
 endif()
 
-pinocchio_add_python_cpp_module(bindings_visualizer PIN_TARGETS pinocchio_visualizers)
-pinocchio_add_lib_unit_test(bindings_visualizer)
+# TODO @jorisv: reenable these on windows when we normalize paths to lib/bin like on eigenpy
+if(NOT WIN32)
+  pinocchio_add_python_cpp_module(bindings_visualizer PIN_TARGETS pinocchio_visualizers)
+  pinocchio_add_lib_unit_test(bindings_visualizer)
+endif()
 
 add_subdirectory(pybind11)

--- a/unittest/python/CMakeLists.txt
+++ b/unittest/python/CMakeLists.txt
@@ -137,4 +137,7 @@ else()
   message(STATUS "Valgrind not found, memory checks are disabled")
 endif()
 
+pinocchio_add_python_cpp_module(bindings_visualizer PIN_TARGETS pinocchio_visualizers)
+pinocchio_add_lib_unit_test(bindings_visualizer)
+
 add_subdirectory(pybind11)

--- a/unittest/python/bindings_visualizer.cpp
+++ b/unittest/python/bindings_visualizer.cpp
@@ -1,0 +1,29 @@
+#include "pinocchio/bindings/python/visualizers/visualizer-visitor.hpp"
+
+namespace bp = boost::python;
+namespace pin = pinocchio;
+using pin::python::VisualizerPythonVisitor;
+using pin::visualizers::BaseVisualizer;
+
+using pin::GeometryModel;
+using pin::Model;
+
+struct DummyVisualizer : public BaseVisualizer
+{
+  using BaseVisualizer::BaseVisualizer;
+  void loadViewerModel() override
+  {
+  }
+  void displayImpl() override
+  {
+  }
+};
+
+BOOST_PYTHON_MODULE(EXT_MODULE_NAME)
+{
+  bp::import("pinocchio");
+
+  bp::class_<DummyVisualizer>("DummyVisualizer", bp::no_init)
+    .def(bp::init<const Model &, const GeometryModel &>())
+    .def(VisualizerPythonVisitor<DummyVisualizer>{});
+}

--- a/unittest/python/bindings_visualizer.py
+++ b/unittest/python/bindings_visualizer.py
@@ -1,0 +1,20 @@
+import unittest
+
+import pinocchio as pin
+from test_case import PinocchioTestCase as TestCase
+from test_ext_bindings_visualizer import DummyVisualizer
+
+
+class TestBindingsViz(TestCase):
+    def setUp(self):
+        self.model = pin.Model()
+        self.visual = pin.GeometryModel()
+        self.viz = DummyVisualizer(self.model, self.visual)
+
+    def test_getters(self):
+        self.assertEqual(self.model, self.viz.model)
+        self.assertEqual(self.visual, self.viz.visualModel)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
- **unittest/python/CMakeLists.txt : add util function to create test C++ extension Python modules, and associated Python tests**
- **unittest/python : add test for visualizer bindings (visitor)**
