### PR TITLE
Update mjcf parser

### DIFF
--- a/src/parsers/mjcf/mjcf-graph.cpp
+++ b/src/parsers/mjcf/mjcf-graph.cpp
@@ -130,7 +130,6 @@ namespace pinocchio
         ret.friction = Vector::Constant(Nv, 0.);
         ret.damping = Vector::Constant(Nv, 0.);
         ret.armature = Vector::Constant(Nv, armature[0]);
-        ret.frictionLoss = frictionLoss;
         ret.springStiffness = springStiffness;
         ret.springReference = springReference;
         return ret;
@@ -220,7 +219,7 @@ namespace pinocchio
         // friction loss
         value = el.get_optional<double>("<xmlattr>.frictionloss");
         if (value)
-          range.frictionLoss = *value;
+          range.friction[0] = *value;
 
         value = el.get_optional<double>("<xmlattr>.ref");
         if (value)

--- a/unittest/mjcf.cpp
+++ b/unittest/mjcf.cpp
@@ -447,7 +447,7 @@ BOOST_AUTO_TEST_CASE(merge_default)
 }
 
 #ifdef PINOCCHIO_WITH_URDFDOM
-// @brief Test to check that default classes and child classes are taken into account
+// @brief Test to check that default classes and child classes are taken into account, also tests friction and damping parameters
 BOOST_AUTO_TEST_CASE(parse_default_class)
 {
   typedef pinocchio::SE3::Vector3 Vector3;
@@ -472,6 +472,12 @@ BOOST_AUTO_TEST_CASE(parse_default_class)
 
   for (size_t i = 0; i < size_t(model_m.njoints); i++)
     BOOST_CHECK_EQUAL(model_m.joints[i], model_u.joints[i]);
+  
+  for (size_t i = 0; i < model_m.friction.size(); i++)
+    BOOST_CHECK_EQUAL(model_m.friction[i], model_u.friction[i]);
+
+  for (size_t i = 0; i < model_m.damping.size(); i++)
+    BOOST_CHECK_EQUAL(model_m.damping[i], model_u.damping[i]);
 }
 #endif // PINOCCHIO_WITH_URDFDOM
 

--- a/unittest/models/test_mjcf.urdf
+++ b/unittest/models/test_mjcf.urdf
@@ -40,5 +40,6 @@
       <origin xyz="0 0 0" rpy="-1.57 0 0"/>
         <axis xyz="0 1 0" />
         <limit lower="-1.7628" upper="1.7628" effort="10" velocity="0"/>
+        <dynamics damping="0.01" friction="0.01"/>
   </joint>
 </robot>

--- a/unittest/models/test_mjcf.xml
+++ b/unittest/models/test_mjcf.xml
@@ -18,7 +18,7 @@
                 <body name="link2" quat="1 -1 0 0">
                     <inertial mass="0.629769" pos="-0.041018 -0.00014 0.049974"
                     fullinertia="0.00315 0.00388 0.004285 8.2904e-7 0.00015 8.2299e-6"/>
-                    <joint name="joint2" range="-1.7628 1.7628" class="second"/>
+                    <joint name="joint2" range="-1.7628 1.7628" class="second" frictionloss="0.01" damping="0.01"/>
                     <body name="link3" pos="0 0 0">
                         <inertial mass="0.629769" pos="-0.041018 -0.00014 0.049974"
                         fullinertia="0.00315 0.00388 0.004285 8.2904e-7 0.00015 8.2299e-6"/>


### PR DESCRIPTION
Fix: Add support for friction parameter in MJCF model parsing

I noticed that during the parsing of MJCF models, the friction parameter was not being passed through. According to the documentation for URDF models, [friction](https://wiki.ros.org/urdf/XML/joint#:~:text=friction%20(optional%2C%20defaults%20to%200)) refers to the static friction value.

In Mujoco, this same parameter is referred to as [frictionloss](https://mujoco.readthedocs.io/en/stable/XMLreference.html#body-joint-frictionloss), and it represents the same value. I have modified the code to ensure that the friction parameter is now properly passed through when parsing MJCF models.