### PR TITLE
Implement `captureImage` for Panda3D visualizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Changed
 - Change the default branch to `devel` ([#2666](https://github.com/stack-of-tasks/pinocchio/pull/2666))
+- Implement `captureImage` for Panda3D visualizer for video recording ([#2668](https://github.com/stack-of-tasks/pinocchio/pull/2668))
 
 ## [3.6.0] - 2025-04-28
 

--- a/bindings/python/pinocchio/visualize/panda3d_visualizer.py
+++ b/bindings/python/pinocchio/visualize/panda3d_visualizer.py
@@ -140,7 +140,10 @@ class Panda3dVisualizer(BaseVisualizer):
         raise NotImplementedError()
 
     def captureImage(self, w=None, h=None):
-        raise NotImplementedError()
+        rgb = self.viewer.get_screenshot(requested_format="RGB")
+        if rgb is None:
+            raise RuntimeError("Failed to capture image from viewer")
+        return rgb
 
     def disableCameraControl(self):
         raise NotImplementedError()

--- a/bindings/python/pinocchio/visualize/panda3d_visualizer.py
+++ b/bindings/python/pinocchio/visualize/panda3d_visualizer.py
@@ -19,7 +19,7 @@ class Panda3dVisualizer(BaseVisualizer):
     A Pinocchio display using panda3d engine.
     """
 
-    def initViewer(self, viewer=None, load_model=False):  # pylint: disable=arguments-differ
+    def initViewer(self, viewer=None, load_model=False, open=True):  # pylint: disable=arguments-differ
         """Init the viewer by attaching to / creating a GUI viewer."""
         self.visual_group = None
         self.collision_group = None
@@ -30,7 +30,12 @@ class Panda3dVisualizer(BaseVisualizer):
         from panda3d_viewer import Viewer as Panda3dViewer
 
         if viewer is None:
-            self.viewer = Panda3dViewer(window_title="python-pinocchio")
+            if not open:
+                self.viewer = Panda3dViewer(
+                    window_title="python-pinocchio", window_type="offscreen"
+                )
+            else:
+                self.viewer = Panda3dViewer(window_title="python-pinocchio")
 
         if load_model:
             self.loadViewerModel(group_name=self.model.name)

--- a/examples/panda3d-viewer-play.py
+++ b/examples/panda3d-viewer-play.py
@@ -23,6 +23,7 @@ talos = TalosLoader().robot
 talos.setVisualizer(Panda3dVisualizer())
 talos.initViewer()
 talos.loadViewerModel(group_name="talos", color=(1, 1, 1, 1))
+record_video = False
 
 
 # Play a sample trajectory in a loop
@@ -43,9 +44,24 @@ def play_sample_trajectory():
         -0.1 - beta * 1.56,
     )
 
+    if record_video:
+        dt = 1 / 60
+        fps = 1.0 / dt
+        filename = "talos.mp4"
+        ctx = talos.viz.create_video_ctx(filename, fps=fps)
+        print(f"[video will be recorded @ {filename}]")
+    else:
+        from contextlib import nullcontext
+
+        ctx = nullcontext()
+        print("[no recording]")
+
     while True:
-        talos.play(traj.T, 1.0 / update_rate)
-        traj = np.flip(traj, 1)
+        with ctx:
+            talos.play(traj.T, 1.0 / update_rate)
+            traj = np.flip(traj, 1)
+            if record_video:
+                break
 
 
 try:


### PR DESCRIPTION
allows recording videos in headless mode. The usage is shown in a Talos example.