### PR TITLE
Add candlewick Python example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Add Python example showcasing the candlewick visualizer (https://github.com/stack-of-tasks/pinocchio/pull/2681)
+
+### Changed
+
+- bindings/python : Add missing arg names in `visualizer-visitor.hpp`
+
 ## [3.7.0] - 2025-05-21
 
 ### Changed

--- a/include/pinocchio/bindings/python/visualizers/visualizer-visitor.hpp
+++ b/include/pinocchio/bindings/python/visualizers/visualizer-visitor.hpp
@@ -52,9 +52,9 @@ namespace pinocchio
     bp::make_function(                                                                             \
       +[](Visualizer & v) -> auto & { return v.name(); }, bp::return_internal_reference<>()))
 
-        cl.def("initViewer", &Visualizer::initViewer)
-          .def("loadViewerModel", &Visualizer::loadViewerModel)
-          .def("rebuildData", &Visualizer::rebuildData)
+        cl.def("initViewer", &Visualizer::initViewer, bp::arg("self"))
+          .def("loadViewerModel", &Visualizer::loadViewerModel, bp::arg("self"))
+          .def("rebuildData", &Visualizer::rebuildData, bp::arg("self"))
           .def(
             "display", +[](Visualizer & v, const ConstVectorRef & q) { v.display(q); },
             (bp::arg("self"), bp::arg("q") = boost::none))
@@ -65,7 +65,7 @@ namespace pinocchio
           .def("setCameraPose", setCameraPose_proxy2, (bp::arg("self"), "pose"))
           .def("setCameraZoom", &Visualizer::setCameraZoom, (bp::arg("self"), "value"))
           .def("clean", &Visualizer::clean, bp::arg("self"))
-          .def("hasExternalData", &Visualizer::hasExternalData)
+          .def("hasExternalData", &Visualizer::hasExternalData, bp::arg("self"))
           .DEF_PROP_PROXY(model)
           .DEF_PROP_PROXY(visualModel)
           .DEF_PROP_PROXY(collisionModel)


### PR DESCRIPTION
This PR adds a small example using candlewick, copying `meshcat-viewer-solo.py` but with an actual render loop.

Here's what it looks like:

![cdw_screenshot 2025-05-21 18-50-16 +0200](https://github.com/user-attachments/assets/662aa21d-00bc-492b-8d9e-7fdb32c97da2)

In motion: (sorry for the quality, GitHub has a 10Mb file limit...)

[solo-heightfield (1).webm](https://github.com/user-attachments/assets/a1468cc5-2438-4ddc-a157-b71e7e46d45d)

