### PR TITLE
CMake: add COAL_DISABLE_HPP_FCL_WARNINGS

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,14 +2,14 @@ name: "CI - Nix"
 
 on:
   push:
-    paths-ignore:
-      - doc/**
-      - .gitlab-ci.yml
-      - .gitignore
-      - '**.md'
-      - CITATION.*
-      - COPYING.LESSER
-      - .pre-commit-config.yaml
+    branches:
+      - master
+      - devel
+  pull_request:
+    branches:
+      - master
+      - devel
+
 jobs:
   nix:
     runs-on: "${{ matrix.os }}-latest"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 - Check row dimensions of input Jacobians when computing kinematics Jacobian ([#2684](https://github.com/stack-of-tasks/pinocchio/pull/2684))
+- CMake: add COAL_DISABLE_HPP_FCL_WARNINGS ([#2686](https://github.com/stack-of-tasks/pinocchio/pull/2686))
 
 ## [3.7.0] - 2025-05-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
 - Check row dimensions of input Jacobians when computing kinematics Jacobian ([#2684](https://github.com/stack-of-tasks/pinocchio/pull/2684))
-- CMake: add COAL_DISABLE_HPP_FCL_WARNINGS ([#2686](https://github.com/stack-of-tasks/pinocchio/pull/2686))
+
+### Changed
+- Disable coal/hpp-fcl warnings when building Pinocchio ([#2686](https://github.com/stack-of-tasks/pinocchio/pull/2686))
 
 ## [3.7.0] - 2025-05-21
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -330,6 +330,7 @@ else()
 endif()
 
 if(BUILD_WITH_HPP_FCL_SUPPORT)
+  set(COAL_DISABLE_HPP_FCL_WARNINGS ON)
   add_project_dependency(hpp-fcl REQUIRED)
 endif()
 

--- a/benchmark/CMakeLists.txt
+++ b/benchmark/CMakeLists.txt
@@ -30,7 +30,8 @@ function(ADD_PINOCCHIO_BENCH name)
   set(bench_name "pinocchio-${name}")
   add_executable(${bench_name} ${name}.cpp)
 
-  target_compile_definitions(${bench_name} PRIVATE PINOCCHIO_MODEL_DIR="${PINOCCHIO_MODEL_DIR}")
+  target_compile_definitions(${bench_name} PRIVATE PINOCCHIO_MODEL_DIR="${PINOCCHIO_MODEL_DIR}"
+                                                   COAL_DISABLE_HPP_FCL_WARNINGS)
 
   target_link_libraries(${bench_name} PRIVATE pinocchio_default)
   target_link_libraries(${bench_name} PRIVATE benchmark::benchmark)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -100,8 +100,9 @@ function(PINOCCHIO_PYTHON_BINDINGS_SPECIFIC_TYPE scalar_name)
       INCLUDE_DIRS ${console_bridge_INCLUDE_DIRS})
   endif()
   if(BUILD_WITH_HPP_FCL_SUPPORT)
-    target_compile_definitions(${PYTHON_LIB_NAME}
-                               PRIVATE -DPINOCCHIO_PYTHON_INTERFACE_WITH_HPP_FCL_PYTHON_BINDINGS)
+    target_compile_definitions(
+      ${PYTHON_LIB_NAME} PRIVATE PINOCCHIO_PYTHON_INTERFACE_WITH_HPP_FCL_PYTHON_BINDINGS
+                                 COAL_DISABLE_HPP_FCL_WARNINGS)
   endif()
   if(WIN32)
     target_link_libraries(${PYTHON_LIB_NAME} PUBLIC ${PYTHON_LIBRARY})

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -32,8 +32,10 @@ function(ADD_PINOCCHIO_CPP_EXAMPLE EXAMPLE)
     target_link_libraries(${EXAMPLE_NAME} PUBLIC ${PROJECT_NAME}_casadi)
   endif()
 
-  target_compile_definitions(${EXAMPLE_NAME} PRIVATE ${EXAMPLE_PRIVATE_DEFINITIONS}
-                                                     PINOCCHIO_MODEL_DIR="${PINOCCHIO_MODEL_DIR}")
+  target_compile_definitions(
+    ${EXAMPLE_NAME}
+    PRIVATE ${EXAMPLE_PRIVATE_DEFINITIONS} PINOCCHIO_MODEL_DIR="${PINOCCHIO_MODEL_DIR}"
+            COAL_DISABLE_HPP_FCL_WARNINGS)
 
   # There is no RPATH in Windows, then we must use the PATH to find the DLL
   if(WIN32)

--- a/flake.lock
+++ b/flake.lock
@@ -1,28 +1,5 @@
 {
   "nodes": {
-    "coal": {
-      "inputs": {
-        "flake-parts": [
-          "flake-parts"
-        ],
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1748966839,
-        "narHash": "sha256-diQ2nZFxIgmLZHKK5bNMZnpfBk3qSecsUWHI0Dwj40E=",
-        "owner": "coal-library",
-        "repo": "coal",
-        "rev": "7a14a4721681c07ffd38256c7ecedf46ce4a6d65",
-        "type": "github"
-      },
-      "original": {
-        "owner": "coal-library",
-        "repo": "coal",
-        "type": "github"
-      }
-    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -74,7 +51,6 @@
     },
     "root": {
       "inputs": {
-        "coal": "coal",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -10,16 +10,15 @@
         ]
       },
       "locked": {
-        "lastModified": 1748964262,
+        "lastModified": 1748966839,
         "narHash": "sha256-diQ2nZFxIgmLZHKK5bNMZnpfBk3qSecsUWHI0Dwj40E=",
-        "owner": "nim65s",
+        "owner": "coal-library",
         "repo": "coal",
-        "rev": "329add676d6f0c72282e4b055884dea09e0e2a95",
+        "rev": "7a14a4721681c07ffd38256c7ecedf46ce4a6d65",
         "type": "github"
       },
       "original": {
-        "owner": "nim65s",
-        "ref": "nix-warning",
+        "owner": "coal-library",
         "repo": "coal",
         "type": "github"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,17 +1,25 @@
 {
   "nodes": {
-    "coal-src": {
-      "flake": false,
+    "coal": {
+      "inputs": {
+        "flake-parts": [
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
       "locked": {
-        "lastModified": 1748963201,
-        "narHash": "sha256-JIujAp/keTkZu0Fs+ageZTBprRFxNHd3Qqz7bOJvYWY=",
-        "owner": "coal-library",
+        "lastModified": 1748964262,
+        "narHash": "sha256-diQ2nZFxIgmLZHKK5bNMZnpfBk3qSecsUWHI0Dwj40E=",
+        "owner": "nim65s",
         "repo": "coal",
-        "rev": "d64eb6c8a6c3daaaae40ab3f093fc4732bb3d3c1",
+        "rev": "329add676d6f0c72282e4b055884dea09e0e2a95",
         "type": "github"
       },
       "original": {
-        "owner": "coal-library",
+        "owner": "nim65s",
+        "ref": "nix-warning",
         "repo": "coal",
         "type": "github"
       }
@@ -67,7 +75,7 @@
     },
     "root": {
       "inputs": {
-        "coal-src": "coal-src",
+        "coal": "coal",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,21 @@
 {
   "nodes": {
+    "coal-src": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1748963201,
+        "narHash": "sha256-JIujAp/keTkZu0Fs+ageZTBprRFxNHd3Qqz7bOJvYWY=",
+        "owner": "coal-library",
+        "repo": "coal",
+        "rev": "d64eb6c8a6c3daaaae40ab3f093fc4732bb3d3c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "coal-library",
+        "repo": "coal",
+        "type": "github"
+      }
+    },
     "flake-parts": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -51,6 +67,7 @@
     },
     "root": {
       "inputs": {
+        "coal-src": "coal-src",
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -4,9 +4,10 @@
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    coal-src = {
-      url = "github:coal-library/coal";
-      flake = false;
+    coal.url = "github:nim65s/coal/nix-warning";
+    coal.inputs = {
+      flake-parts.follows = "flake-parts";
+      nixpkgs.follows = "nixpkgs";
     };
   };
 
@@ -15,8 +16,18 @@
     inputs.flake-parts.lib.mkFlake { inherit inputs; } {
       systems = inputs.nixpkgs.lib.systems.flakeExposed;
       perSystem =
-        { pkgs, self', ... }:
         {
+          inputs',
+          pkgs,
+          self',
+          system,
+          ...
+        }:
+        {
+          _module.args.pkgs = import inputs.nixpkgs {
+            inherit system;
+            overlays = [ (_: _: { inherit (inputs'.coal.packages) coal; }) ];
+          };
           apps.default = {
             type = "app";
             program = pkgs.python3.withPackages (_: [ self'.packages.default ]);
@@ -24,31 +35,25 @@
           devShells.default = pkgs.mkShell { inputsFrom = [ self'.packages.default ]; };
           packages = {
             default = self'.packages.pinocchio;
-            coal = pkgs.coal.overrideAttrs (super: {
-              src = inputs.coal-src;
-              cmakeFlags = super.cmakeFlags ++ [ "-DCOAL_DISABLE_HPP_FCL_WARNINGS=ON" ];
-            });
-            pinocchio =
-              (pkgs.pinocchio.overrideAttrs (super: {
-                src = pkgs.lib.fileset.toSource {
-                  root = ./.;
-                  fileset = pkgs.lib.fileset.unions [
-                    ./benchmark
-                    ./bindings
-                    ./CMakeLists.txt
-                    ./doc
-                    ./examples
-                    ./include
-                    ./models
-                    ./package.xml
-                    ./sources.cmake
-                    ./src
-                    ./unittest
-                    ./utils
-                  ];
-                };
-              })).override
-                { inherit (self'.packages) coal; };
+            pinocchio = pkgs.python3Packages.pinocchio.overrideAttrs {
+              src = pkgs.lib.fileset.toSource {
+                root = ./.;
+                fileset = pkgs.lib.fileset.unions [
+                  ./benchmark
+                  ./bindings
+                  ./CMakeLists.txt
+                  ./doc
+                  ./examples
+                  ./include
+                  ./models
+                  ./package.xml
+                  ./sources.cmake
+                  ./src
+                  ./unittest
+                  ./utils
+                ];
+              };
+            };
           };
         };
     };

--- a/flake.nix
+++ b/flake.nix
@@ -4,11 +4,6 @@
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    coal.url = "github:coal-library/coal";
-    coal.inputs = {
-      flake-parts.follows = "flake-parts";
-      nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs =
@@ -24,15 +19,10 @@
           ...
         }:
         {
-          _module.args.pkgs = import inputs.nixpkgs {
-            inherit system;
-            overlays = [ (_: _: { inherit (inputs'.coal.packages) coal; }) ];
-          };
           apps.default = {
             type = "app";
             program = pkgs.python3.withPackages (_: [ self'.packages.default ]);
           };
-          devShells.default = pkgs.mkShell { inputsFrom = [ self'.packages.default ]; };
           packages = {
             default = self'.packages.pinocchio;
             pinocchio = pkgs.python3Packages.pinocchio.overrideAttrs {

--- a/flake.nix
+++ b/flake.nix
@@ -4,7 +4,7 @@
   inputs = {
     flake-parts.url = "github:hercules-ci/flake-parts";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    coal.url = "github:nim65s/coal/nix-warning";
+    coal.url = "github:coal-library/coal";
     coal.inputs = {
       flake-parts.follows = "flake-parts";
       nixpkgs.follows = "nixpkgs";

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -191,13 +191,12 @@ pinocchio_specific_type(default DEFAULT_SCOPE)
 # some are template instantiated, or some user can link only on pinocchio_default, we muste define
 # PINOCCHIO_WITH_HPP_FCL in pinocchio_default.
 if(BUILD_WITH_HPP_FCL_SUPPORT)
-  target_compile_definitions(pinocchio_default PUBLIC PINOCCHIO_WITH_HPP_FCL)
+  target_compile_definitions(
+    pinocchio_default
+    PUBLIC PINOCCHIO_WITH_HPP_FCL
+    PRIVATE COAL_DISABLE_HPP_FCL_WARNINGS)
   target_include_directories(
     pinocchio_default PUBLIC $<TARGET_PROPERTY:hpp-fcl::hpp-fcl,INTERFACE_INCLUDE_DIRECTORIES>)
-  if(COAL_DISABLE_HPP_FCL_WARNINGS)
-    target_compile_definitions(pinocchio_default PRIVATE COAL_DISABLE_HPP_FCL_WARNINGS)
-  endif()
-
 endif()
 
 # Define the extra target This target hold extra algorithms.
@@ -239,11 +238,11 @@ if(BUILD_WITH_HPP_FCL_SUPPORT)
     SOURCES ${${PROJECT_NAME}_COLLISION_SOURCES} ${${PROJECT_NAME}_COLLISION_PUBLIC_HEADERS})
   pinocchio_config(collision ${COLLISION_LIB_NAME})
 
-  target_compile_definitions(${COLLISION_LIB_NAME} PUBLIC PINOCCHIO_WITH_HPP_FCL)
+  target_compile_definitions(
+    ${COLLISION_LIB_NAME}
+    PUBLIC PINOCCHIO_WITH_HPP_FCL
+    PRIVATE COAL_DISABLE_HPP_FCL_WARNINGS)
   target_link_libraries(${COLLISION_LIB_NAME} PUBLIC ${PROJECT_NAME}_default hpp-fcl::hpp-fcl)
-  if(COAL_DISABLE_HPP_FCL_WARNINGS)
-    target_compile_definitions(${COLLISION_LIB_NAME} PRIVATE COAL_DISABLE_HPP_FCL_WARNINGS)
-  endif()
 
   # Define the collision parallel target
   if(BUILD_WITH_OPENMP_SUPPORT)
@@ -269,11 +268,11 @@ pinocchio_target(
 pinocchio_config(visualizers ${VISUALIZERS_LIB_NAME})
 target_link_libraries(${VISUALIZERS_LIB_NAME} PUBLIC ${PROJECT_NAME}_default)
 if(BUILD_WITH_HPP_FCL_SUPPORT)
-  target_compile_definitions(${VISUALIZERS_LIB_NAME} PUBLIC PINOCCHIO_WITH_HPP_FCL)
+  target_compile_definitions(
+    ${VISUALIZERS_LIB_NAME}
+    PUBLIC PINOCCHIO_WITH_HPP_FCL
+    PRIVATE COAL_DISABLE_HPP_FCL_WARNINGS)
   target_link_libraries(${VISUALIZERS_LIB_NAME} PUBLIC hpp-fcl::hpp-fcl)
-  if(COAL_DISABLE_HPP_FCL_WARNINGS)
-    target_compile_definitions(${VISUALIZERS_LIB_NAME} PRIVATE COAL_DISABLE_HPP_FCL_WARNINGS)
-  endif()
 endif()
 
 # Define the parsers target.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -290,6 +290,7 @@ if(BUILD_WITH_PARSERS_SUPPORT)
   target_link_libraries(${PARSERS_LIB_NAME} PUBLIC ${PROJECT_NAME}_default)
   if(BUILD_WITH_HPP_FCL_SUPPORT)
     target_link_libraries(${PARSERS_LIB_NAME} PUBLIC ${PROJECT_NAME}_collision)
+    target_compile_definitions(${PARSERS_LIB_NAME} PRIVATE COAL_DISABLE_HPP_FCL_WARNINGS)
   endif()
 
   modernize_target_link_libraries(
@@ -371,6 +372,7 @@ if(BUILD_WITH_PYTHON_PARSER_SUPPORT)
   pinocchio_config(python_parser ${PYTHON_PARSER_LIB_NAME})
 
   target_link_libraries(${PYTHON_PARSER_LIB_NAME} PUBLIC ${PROJECT_NAME}_default Python3::Python)
+  target_compile_definitions(${PYTHON_PARSER_LIB_NAME} PRIVATE COAL_DISABLE_HPP_FCL_WARNINGS)
   target_link_boost_python(${PYTHON_PARSER_LIB_NAME} PUBLIC)
 endif()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -194,6 +194,9 @@ if(BUILD_WITH_HPP_FCL_SUPPORT)
   target_compile_definitions(pinocchio_default PUBLIC PINOCCHIO_WITH_HPP_FCL)
   target_include_directories(
     pinocchio_default PUBLIC $<TARGET_PROPERTY:hpp-fcl::hpp-fcl,INTERFACE_INCLUDE_DIRECTORIES>)
+  if(COAL_DISABLE_HPP_FCL_WARNINGS)
+    target_compile_definitions(pinocchio_default PRIVATE COAL_DISABLE_HPP_FCL_WARNINGS)
+  endif()
 
 endif()
 
@@ -238,6 +241,9 @@ if(BUILD_WITH_HPP_FCL_SUPPORT)
 
   target_compile_definitions(${COLLISION_LIB_NAME} PUBLIC PINOCCHIO_WITH_HPP_FCL)
   target_link_libraries(${COLLISION_LIB_NAME} PUBLIC ${PROJECT_NAME}_default hpp-fcl::hpp-fcl)
+  if(COAL_DISABLE_HPP_FCL_WARNINGS)
+    target_compile_definitions(${COLLISION_LIB_NAME} PRIVATE COAL_DISABLE_HPP_FCL_WARNINGS)
+  endif()
 
   # Define the collision parallel target
   if(BUILD_WITH_OPENMP_SUPPORT)
@@ -265,6 +271,9 @@ target_link_libraries(${VISUALIZERS_LIB_NAME} PUBLIC ${PROJECT_NAME}_default)
 if(BUILD_WITH_HPP_FCL_SUPPORT)
   target_compile_definitions(${VISUALIZERS_LIB_NAME} PUBLIC PINOCCHIO_WITH_HPP_FCL)
   target_link_libraries(${VISUALIZERS_LIB_NAME} PUBLIC hpp-fcl::hpp-fcl)
+  if(COAL_DISABLE_HPP_FCL_WARNINGS)
+    target_compile_definitions(${VISUALIZERS_LIB_NAME} PRIVATE COAL_DISABLE_HPP_FCL_WARNINGS)
+  endif()
 endif()
 
 # Define the parsers target.

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -58,7 +58,7 @@ function(ADD_PINOCCHIO_UNIT_TEST name)
   target_compile_definitions(
     ${TEST_NAME}
     PRIVATE ${TEST_PRIVATE_DEFINITIONS} BOOST_TEST_DYN_LINK BOOST_TEST_MODULE=${MODULE_NAME}
-            PINOCCHIO_MODEL_DIR=\"${PINOCCHIO_MODEL_DIR}\")
+            PINOCCHIO_MODEL_DIR=\"${PINOCCHIO_MODEL_DIR}\" COAL_DISABLE_HPP_FCL_WARNINGS)
 
   # There is no RPATH in Windows, then we must use the PATH to find the DLL
   if(WIN32)

--- a/unittest/python/CMakeLists.txt
+++ b/unittest/python/CMakeLists.txt
@@ -63,7 +63,8 @@ function(pinocchio_add_python_cpp_module name)
   endif()
 
   add_library(${target_name} MODULE ${_exclude} ${source_file})
-  target_compile_definitions(${target_name} PRIVATE EXT_MODULE_NAME=${module_name})
+  target_compile_definitions(${target_name} PRIVATE EXT_MODULE_NAME=${module_name}
+                                                    COAL_DISABLE_HPP_FCL_WARNINGS)
   target_link_libraries(${target_name} PRIVATE pinocchio_default eigenpy::eigenpy)
   foreach(_dep ${ARGS_PIN_TARGETS})
     target_link_libraries(${target_name} PRIVATE ${_dep})


### PR DESCRIPTION
Because it is not linked to hpp-fcl::hpp-fcl.

Ref. https://github.com/coal-library/coal/pull/709