### PR TITLE
Fix : make nvSubtree consistent with mimic joint in all configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Check row dimensions of input Jacobians when computing kinematics Jacobian ([#2684](https://github.com/stack-of-tasks/pinocchio/pull/2684))
 - Fix case joint_id == 0 in getJointKinematicHessian ([#2705](https://github.com/stack-of-tasks/pinocchio/pull/2705))
+- Fix nvSubtree computation in case a mimic joint is the last joint in the branch ([#2707](https://github.com/stack-of-tasks/pinocchio/pull/2707))
 
 ### Changed
 - Disable coal/hpp-fcl warnings when building Pinocchio ([#2686](https://github.com/stack-of-tasks/pinocchio/pull/2686))

--- a/include/pinocchio/algorithm/check-data.hxx
+++ b/include/pinocchio/algorithm/check-data.hxx
@@ -8,7 +8,6 @@
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
 
-
 namespace pinocchio
 {
 
@@ -104,7 +103,7 @@ namespace pinocchio
     {
       JointIndex c = (JointIndex)data.lastChild[j];
       CHECK_DATA((int)c < model.njoints);
-      
+
       int nv = model.joints[j].nv();
       for (JointIndex d = j + 1; d <= c; ++d) // explore all descendant
       {

--- a/include/pinocchio/algorithm/check-data.hxx
+++ b/include/pinocchio/algorithm/check-data.hxx
@@ -8,6 +8,7 @@
 #include "pinocchio/multibody/model.hpp"
 #include "pinocchio/multibody/data.hpp"
 
+
 namespace pinocchio
 {
 
@@ -103,20 +104,15 @@ namespace pinocchio
     {
       JointIndex c = (JointIndex)data.lastChild[j];
       CHECK_DATA((int)c < model.njoints);
-      int nv;
-      // For mimic, since in nvSubtree we're using the idx_vExtended, we need to do the same here
-      if (boost::get<JointModelMimicTpl<Scalar, Options, JointCollectionTpl>>(&model.joints[j]))
-        nv = 0;
-      else
+      
+      int nv = model.joints[j].nv();
+      for (JointIndex d = j + 1; d <= c; ++d) // explore all descendant
       {
-        nv = model.joints[j].nv();
-        for (JointIndex d = j + 1; d <= c; ++d) // explore all descendant
-        {
-          CHECK_DATA(model.parents[d] >= j);
+        CHECK_DATA(model.parents[d] >= j);
 
-          nv += model.joints[d].nv();
-        }
+        nv += model.joints[d].nv();
       }
+
       CHECK_DATA(nv == data.nvSubtree[j]);
 
       for (JointIndex d = c + 1; (int)d < model.njoints; ++d)

--- a/include/pinocchio/multibody/data.hxx
+++ b/include/pinocchio/multibody/data.hxx
@@ -207,21 +207,21 @@ namespace pinocchio
 
       lastChild[parent] = std::max<int>(lastChild[(Index)i], lastChild[parent]);
 
-      // Build a "correct" representation of mimic nvSubtree by using nvExtended, which will cover
-      // its children nv, and allow for a simple check
+      // Build a "correct" representation of mimic nvSubtree by using idx_vExtended, which
+      // allows to compute the right value for nvSubtree when mimic is the last child
       if (boost::get<JointModelMimicTpl<Scalar, Options, JointCollectionTpl>>(
             &model.joints[size_t(i)]))
         nvSubtree[(Index)i] = 0;
       else
       {
-        int nv_;
+        int idx_v_;
         if (boost::get<JointModelMimicTpl<Scalar, Options, JointCollectionTpl>>(
               &model.joints[(Index)lastChild[(Index)i]]))
-          nv_ = model.joints[(Index)lastChild[(Index)i]].nvExtended();
+          idx_v_ = model.joints[(Index)lastChild[(Index)i]].idx_vExtended();
         else
-          nv_ = model.joints[(Index)lastChild[(Index)i]].nv();
+          idx_v_ = model.joints[(Index)lastChild[(Index)i]].idx_v();
         nvSubtree[(Index)i] =
-          model.joints[(Index)lastChild[(Index)i]].idx_v() + nv_ - model.joints[(Index)i].idx_v();
+          idx_v_ + model.joints[(Index)lastChild[(Index)i]].nv() - model.joints[(Index)i].idx_v();
       }
     }
     // fill mimic data

--- a/include/pinocchio/multibody/data.hxx
+++ b/include/pinocchio/multibody/data.hxx
@@ -215,12 +215,16 @@ namespace pinocchio
     {
       const auto & mimicking_sub = model.subtrees[mimicking_id];
       size_t j = 1;
+      bool found = false;
       for (; j < mimicking_sub.size(); j++)
       {
         if (model.nvs[mimicking_sub[j]] != 0)
+        {
+          found = true;
           break;
+        }
       }
-      if (mimicking_sub.size() == 1)
+      if (mimicking_sub.size() == 1 || !found)
         mimic_subtree_joint.push_back(0);
       else
         mimic_subtree_joint.push_back(mimicking_sub[j]);

--- a/include/pinocchio/multibody/data.hxx
+++ b/include/pinocchio/multibody/data.hxx
@@ -69,7 +69,7 @@ namespace pinocchio
   , Ig(Inertia::Zero())
   , Fcrb((std::size_t)model.njoints, Matrix6x::Zero(6, model.nv))
   , lastChild((std::size_t)model.njoints, -1)
-  , nvSubtree((std::size_t)model.njoints, -1)
+  , nvSubtree((std::size_t)model.njoints, 0)
   , start_idx_v_fromRow((std::size_t)model.nvExtended, -1)
   , end_idx_v_fromRow((std::size_t)model.nvExtended, -1)
   , idx_vExtended_to_idx_v_fromRow((std::size_t)model.nvExtended, -1)
@@ -207,22 +207,8 @@ namespace pinocchio
 
       lastChild[parent] = std::max<int>(lastChild[(Index)i], lastChild[parent]);
 
-      // Build a "correct" representation of mimic nvSubtree by using idx_vExtended, which
-      // allows to compute the right value for nvSubtree when mimic is the last child
-      if (boost::get<JointModelMimicTpl<Scalar, Options, JointCollectionTpl>>(
-            &model.joints[size_t(i)]))
-        nvSubtree[(Index)i] = 0;
-      else
-      {
-        int idx_v_;
-        if (boost::get<JointModelMimicTpl<Scalar, Options, JointCollectionTpl>>(
-              &model.joints[(Index)lastChild[(Index)i]]))
-          idx_v_ = model.joints[(Index)lastChild[(Index)i]].idx_vExtended();
-        else
-          idx_v_ = model.joints[(Index)lastChild[(Index)i]].idx_v();
-        nvSubtree[(Index)i] =
-          idx_v_ + model.joints[(Index)lastChild[(Index)i]].nv() - model.joints[(Index)i].idx_v();
-      }
+      nvSubtree[(Index)i] += model.joints[(Index)i].nv();
+      nvSubtree[parent] += nvSubtree[(Index)i];
     }
     // fill mimic data
     for (const JointIndex mimicking_id : model.mimicking_joints)

--- a/unittest/utils/model-generator.hpp
+++ b/unittest/utils/model-generator.hpp
@@ -125,7 +125,7 @@ namespace pinocchio
   class MimicTestCases
   {
   public:
-    static const int N_CASES = 6;
+    static const int N_CASES = 7;
 
     pinocchio::Model model_mimic;
     pinocchio::Model model_full;
@@ -218,6 +218,17 @@ namespace pinocchio
           std::cout << "Mimicking terminal joint";
         }
         mimicked_ids.push_back(model_full.getJointId("larm5_joint"));
+        mimicking_ids.push_back(model_full.getJointId("larm6_joint"));
+        ratios.push_back(2.5);
+        offsets.push_back(0.75);
+
+        break;
+      case 6:
+        if (verbose)
+        {
+          std::cout << "Mimicking terminal joint with primary not the direct parent";
+        }
+        mimicked_ids.push_back(model_full.getJointId("larm4_joint"));
         mimicking_ids.push_back(model_full.getJointId("larm6_joint"));
         ratios.push_back(2.5);
         offsets.push_back(0.75);


### PR DESCRIPTION
This PR changes the way nvSubtree is computed when a mimic joint is the last child in the branch. 

Before we were using nvExtended and idx_v when the mimic joint was the last joint in the branch. However when primary joint is not parent of the mimic joint, nvSubtree computation is wrong. 

Now we use idx_vExtended and nv of the mimic to keep nvSubtree coherent no matter the placement of the mimic joint and its primary. 

It also adds a test case that was missing for mimic joints position in the tree.

Related to issue [#2698](https://github.com/stack-of-tasks/pinocchio/issues/2698)