### PR TITLE
Fix hasConfigurationLimit() for mimic joints to return empty vector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Check row dimensions of input Jacobians when computing kinematics Jacobian ([#2684](https://github.com/stack-of-tasks/pinocchio/pull/2684))
 - Fix case joint_id == 0 in getJointKinematicHessian ([#2705](https://github.com/stack-of-tasks/pinocchio/pull/2705))
 - Fix nvSubtree computation in case a mimic joint is the last joint in the branch ([#2707](https://github.com/stack-of-tasks/pinocchio/pull/2707))
+- Fix `JointModelMimic::hasConfigurationLimit()` to return empty vector instead of delegating to mimicking joint ([#2715](https://github.com/stack-of-tasks/pinocchio/pull/2715))
 
 ### Changed
 - Disable coal/hpp-fcl warnings when building Pinocchio ([#2686](https://github.com/stack-of-tasks/pinocchio/pull/2686))

--- a/include/pinocchio/multibody/joint/joint-mimic.hpp
+++ b/include/pinocchio/multibody/joint/joint-mimic.hpp
@@ -686,7 +686,7 @@ namespace pinocchio
 
     const std::vector<bool> hasConfigurationLimitInTangent() const
     {
-      return m_jmodel_mimicking.hasConfigurationLimitInTangent();
+      return {};
     }
 
     template<typename ConfigVector>

--- a/include/pinocchio/multibody/joint/joint-mimic.hpp
+++ b/include/pinocchio/multibody/joint/joint-mimic.hpp
@@ -681,7 +681,7 @@ namespace pinocchio
 
     const std::vector<bool> hasConfigurationLimit() const
     {
-      return m_jmodel_mimicking.hasConfigurationLimit();
+      return {};
     }
 
     const std::vector<bool> hasConfigurationLimitInTangent() const

--- a/unittest/model.cpp
+++ b/unittest/model.cpp
@@ -1057,4 +1057,20 @@ BOOST_AUTO_TEST_CASE(test_mimicked_mimicking_vectors)
   }
 }
 
+BOOST_AUTO_TEST_CASE(test_has_configuration_limit_mimic)
+{
+  Model model;
+  // j1 -- j2
+  //    -- j3
+  // with j3 mimicking j2
+  model.addJoint(0, JointModelRX(), SE3::Identity(), "j1");
+  model.addJoint(1, JointModelRX(), SE3::Identity(), "j2");
+  model.addJoint(
+    2, JointModelMimic(JointModelRX(), model.joints[1], 1., 0.), SE3::Identity(), "j3");
+
+  BOOST_CHECK_EQUAL(model.lowerPositionLimit.size(), 2);
+  BOOST_CHECK_EQUAL(model.upperPositionLimit.size(), 2);
+  BOOST_CHECK_EQUAL(model.hasConfigurationLimit().size(), 2);
+}
+
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/model.cpp
+++ b/unittest/model.cpp
@@ -1071,6 +1071,7 @@ BOOST_AUTO_TEST_CASE(test_has_configuration_limit_mimic)
   BOOST_CHECK_EQUAL(model.lowerPositionLimit.size(), 2);
   BOOST_CHECK_EQUAL(model.upperPositionLimit.size(), 2);
   BOOST_CHECK_EQUAL(model.hasConfigurationLimit().size(), 2);
+  BOOST_CHECK_EQUAL(model.hasConfigurationLimitInTangent().size(), 2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Fix `JointModelMimic::hasConfigurationLimit()` to return an empty vector instead of delegating to the mimicking joint.

Mimic joints have `nq=0` and don't contribute independent configuration constraints, so they shouldn't report configuration limits. This is my understanding of https://github.com/stack-of-tasks/pinocchio/pull/2441 :D:D

Added unit test to verify the fix.

I had this issue while playing with [pink](https://github.com/stephane-caron/pink) and it was throwing exception in this [line](https://github.com/stephane-caron/pink/blob/main/pink/limits/configuration_limit.py#L49-L55) for a robot with a mimic joint

```bash
  File "/home/juruc/workspaces/ramp/.pixi/envs/default/lib/python3.11/site-packages/pink/configuration.py", line 104, in __init__
    model.configuration_limit = ConfigurationLimit(model)
                                ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/juruc/workspaces/ramp/.pixi/envs/default/lib/python3.11/site-packages/pink/limits/configuration_limit.py", line 51, in __init__
    has_configuration_limit = np.logical_and(
                              ^^^^^^^^^^^^^^^
ValueError: operands could not be broadcast together with shapes (9,) (8,)
```