### PR TITLE
Fix mimic patch for CRBA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix case joint_id == 0 in getJointKinematicHessian ([#2705](https://github.com/stack-of-tasks/pinocchio/pull/2705))
 - Fix nvSubtree computation in case a mimic joint is the last joint in the branch ([#2707](https://github.com/stack-of-tasks/pinocchio/pull/2707))
 - Fix `JointModelMimic::hasConfigurationLimit()` to return empty vector instead of delegating to mimicking joint ([#2715](https://github.com/stack-of-tasks/pinocchio/pull/2715))
+- Fix check mimic_subtree_joint ([#2716](https://github.com/stack-of-tasks/pinocchio/pull/2716))
+- Fix mimic patch for crba ([#2716](https://github.com/stack-of-tasks/pinocchio/pull/2716))
 
 ### Changed
 - Disable coal/hpp-fcl warnings when building Pinocchio ([#2686](https://github.com/stack-of-tasks/pinocchio/pull/2686))

--- a/include/pinocchio/algorithm/check-data.hxx
+++ b/include/pinocchio/algorithm/check-data.hxx
@@ -157,8 +157,8 @@ namespace pinocchio
           if (model.nvs[mimicking_sub[j]] != 0)
           {
             id_subtree = mimicking_sub[j];
+            break;
           }
-          break;
         }
         CHECK_DATA(id_subtree == data.mimic_subtree_joint[k]);
       }

--- a/unittest/utils/model-generator.hpp
+++ b/unittest/utils/model-generator.hpp
@@ -125,7 +125,7 @@ namespace pinocchio
   class MimicTestCases
   {
   public:
-    static const int N_CASES = 7;
+    static const int N_CASES = 12;
 
     pinocchio::Model model_mimic;
     pinocchio::Model model_full;
@@ -233,6 +233,91 @@ namespace pinocchio
         ratios.push_back(2.5);
         offsets.push_back(0.75);
 
+        break;
+      case 7:
+        if (verbose)
+        {
+          std::cout
+            << "Double mimic following each other at the end of the branch, not same parent";
+        }
+        mimicked_ids.push_back(model_full.getJointId("larm2_joint"));
+        mimicking_ids.push_back(model_full.getJointId("larm5_joint"));
+        ratios.push_back(2.5);
+        offsets.push_back(0.75);
+
+        mimicked_ids.push_back(model_full.getJointId("larm1_joint"));
+        mimicking_ids.push_back(model_full.getJointId("larm6_joint"));
+        ratios.push_back(3.2);
+        offsets.push_back(8);
+
+        break;
+      case 8:
+        if (verbose)
+        {
+          std::cout << "Double mimic following each other at the end of the branch, same parent";
+        }
+        mimicked_ids.push_back(model_full.getJointId("larm2_joint"));
+        mimicking_ids.push_back(model_full.getJointId("larm5_joint"));
+        ratios.push_back(2.5);
+        offsets.push_back(0.75);
+
+        mimicked_ids.push_back(model_full.getJointId("larm2_joint"));
+        mimicking_ids.push_back(model_full.getJointId("larm6_joint"));
+        ratios.push_back(3.2);
+        offsets.push_back(8);
+
+        break;
+      case 9:
+        if (verbose)
+        {
+          std::cout << "Double mimic following each other middle, not same parent";
+        }
+        mimicked_ids.push_back(model_full.getJointId("larm2_joint"));
+        mimicking_ids.push_back(model_full.getJointId("larm4_joint"));
+        ratios.push_back(2.5);
+        offsets.push_back(0.75);
+
+        mimicked_ids.push_back(model_full.getJointId("larm1_joint"));
+        mimicking_ids.push_back(model_full.getJointId("larm5_joint"));
+        ratios.push_back(3.2);
+        offsets.push_back(8);
+
+        break;
+      case 10:
+        if (verbose)
+        {
+          std::cout << "Double mimic following each other middle, same parent";
+        }
+        mimicked_ids.push_back(model_full.getJointId("larm2_joint"));
+        mimicking_ids.push_back(model_full.getJointId("larm4_joint"));
+        ratios.push_back(2.5);
+        offsets.push_back(0.75);
+
+        mimicked_ids.push_back(model_full.getJointId("larm2_joint"));
+        mimicking_ids.push_back(model_full.getJointId("larm5_joint"));
+        ratios.push_back(3.2);
+        offsets.push_back(8);
+        break;
+
+      case 11:
+        if (verbose)
+        {
+          std::cout << "Triple mimic following each other, same parent";
+        }
+        mimicked_ids.push_back(model_full.getJointId("larm2_joint"));
+        mimicking_ids.push_back(model_full.getJointId("larm3_joint"));
+        ratios.push_back(2);
+        offsets.push_back(0.);
+
+        mimicked_ids.push_back(model_full.getJointId("larm2_joint"));
+        mimicking_ids.push_back(model_full.getJointId("larm4_joint"));
+        ratios.push_back(2.5);
+        offsets.push_back(0.75);
+
+        mimicked_ids.push_back(model_full.getJointId("larm2_joint"));
+        mimicking_ids.push_back(model_full.getJointId("larm5_joint"));
+        ratios.push_back(3.2);
+        offsets.push_back(8);
         break;
       default:
         PINOCCHIO_THROW_PRETTY(


### PR DESCRIPTION
This PR aims at fixing the crba algorithm in case there are mimic joints in the model.
Please see https://github.com/stack-of-tasks/pinocchio/issues/2710 for more informations

it adds new mimic test cases, that triggers the crba break :
o---P---M---M

P1----P2---o---M1----M2

o---P---o---M---M---o

o---P1---P2---o---M1---M2---o

P---M---M----M

It also fix the check of mimic_subtree.
