### PR TITLE
CMakeLists.txt: remove a duplicate option()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,6 @@ if(APPLE)
 else(APPLE)
   set(BUILD_WITH_ACCELERATE_SUPPORT FALSE)
 endif(APPLE)
-option(GENERATE_PYTHON_STUBS "Generate the Python stubs associated to the Python library" OFF)
 
 option(INITIALIZE_WITH_NAN "Initialize Eigen entries with NaN" OFF)
 option(CHECK_RUNTIME_MALLOC "Check if some memory allocations are performed at runtime" OFF)


### PR DESCRIPTION
Just a cosmetic change to CMakeLists.txt - `GENERATE_PYTHON_STUBS` is already defined a few lines above at
https://github.com/stack-of-tasks/pinocchio/blob/2207d5677654397e4cff07a68ff138d0b1e6d288/CMakeLists.txt#L117-L118