### PR TITLE
Beta version of Viser visualizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Beta version of Viser visualizer ([#2718](https://github.com/stack-of-tasks/pinocchio/pull/2718))
+
 ### Fixed
 - Check row dimensions of input Jacobians when computing kinematics Jacobian ([#2684](https://github.com/stack-of-tasks/pinocchio/pull/2684))
 - Fix case joint_id == 0 in getJointKinematicHessian ([#2705](https://github.com/stack-of-tasks/pinocchio/pull/2705))

--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ Please note that we always advise including the `pinocchio/fwd.hpp` header as th
 -   [Meshcat](https://github.com/rdeits/meshcat): supporting visualization in Python and which can be embedded inside any browser.
 -   [Panda3d](https://github.com/ikalevatykh/panda3d_viewer): supporting visualization in Python and which can be embedded inside any browser.
 -   [RViz](https://github.com/ros-visualization/rviz): supporting visualization in Python and which can interact with other ROS packages.
+-   [Viser](https://github.com/nerfstudio-project/viser): supporting browser-based visualization in Python, with support for widgets such as sliders and interactive markers.
 
 Many external viewers can also be integrated. For more information, see the example [here](https://github.com/stack-of-tasks/pinocchio/blob/devel/bindings/python/pinocchio/visualize/base_visualizer.py).
 
@@ -275,7 +276,7 @@ In addition to the core dev team, the following people have also been involved i
 -   [Sarah El Kazdadi](https://github.com/sarah-ek) (Inria): multi-precision arithmetic support
 -   [Nicolas Torres Alberto](https://scholar.google.com/citations?user=gYNLhEIAAAAJ&hl=en) (Inria): features extension
 -   [Shubham Singh](https://github.com/shubhamsingh91) (UT Austin): second-order inverse dynamics derivatives
--   [Sebastian Castro](https://roboticseabass.com) (The AI Institute): MeshCat viewer feature extension
+-   [Sebastian Castro](https://roboticseabass.com) (RAI Institute): Viser visualizer and MeshCat visualizer feature extension
 -   [Lev Kozlov](https://github.com/lvjonok): Kinetic and potential energy regressors
 -   [Simeon Nedelchev](https://github.com/simeon-ned): Pseudo inertia and Log-Cholesky parametrization
 

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -276,6 +276,7 @@ if(BUILD_PYTHON_INTERFACE)
           meshcat_visualizer.py
           panda3d_visualizer.py
           rviz_visualizer.py
+          viser_visualizer.py
           visualizers.py)
 
   # --- STUBS --- #

--- a/bindings/python/pinocchio/visualize/__init__.py
+++ b/bindings/python/pinocchio/visualize/__init__.py
@@ -4,4 +4,5 @@ from .gepetto_visualizer import GepettoVisualizer
 from .meshcat_visualizer import MeshcatVisualizer
 from .panda3d_visualizer import Panda3dVisualizer
 from .rviz_visualizer import RVizVisualizer
+from .viser_visualizer import ViserVisualizer
 from .visualizers import Visualizer

--- a/bindings/python/pinocchio/visualize/viser_visualizer.py
+++ b/bindings/python/pinocchio/visualize/viser_visualizer.py
@@ -326,8 +326,8 @@ class ViserVisualizer(BaseVisualizer):
         Capture an image from the Viser viewer and return an RGB array.
 
         Parameters:
-            w: The width of the captured image.
-            h: The height of the captured image.
+            w: The width of the captured image. If None, uses the actual camera width.
+            h: The height of the captured image. If None, uses the actual camera height.
             client_id: The ID of the Viser client handle.
                 If None, uses the first available client.
             transport_format: The transport format to use for the captured image.
@@ -346,7 +346,11 @@ class ViserVisualizer(BaseVisualizer):
         else:
             cli = clients[client_id]
 
-        return cli.get_render(height=h, width=w, transport_format=transport_format)
+        height = h or cli.camera.image_height
+        width = w or cli.camera.image_width
+        return cli.get_render(
+            height=height, width=width, transport_format=transport_format
+        )
 
     def setBackgroundColor(self, preset_name: str = "gray", col_top=None, col_bot=None):
         raise NotImplementedError("setBackgroundColor is not yet implemented.")

--- a/bindings/python/pinocchio/visualize/viser_visualizer.py
+++ b/bindings/python/pinocchio/visualize/viser_visualizer.py
@@ -1,0 +1,332 @@
+import time
+
+try:
+    import hppfcl
+except ImportError:
+    raise ImportError("hppfcl not found, but it is currently required by this viewer.")
+
+import numpy as np
+
+from .. import pinocchio_pywrap_default as pin
+from . import BaseVisualizer
+
+try:
+    import trimesh  # Required by viser
+    import viser
+except ImportError:
+    import_viser_succeed = False
+else:
+    import_viser_succeed = True
+
+
+MESH_TYPES = (hppfcl.BVHModelBase, hppfcl.HeightFieldOBBRSS, hppfcl.HeightFieldAABB)
+
+
+class ViserVisualizer(BaseVisualizer):
+    """A Pinocchio visualizer using Viser."""
+
+    def __init__(
+        self,
+        model=pin.Model(),
+        collision_model=None,
+        visual_model=None,
+        copy_models=False,
+        data=None,
+        collision_data=None,
+        visual_data=None,
+    ):
+        if not import_viser_succeed:
+            msg = (
+                "Error while importing the viewer client.\n"
+                "Check whether viser is properly installed "
+                "(pip install --user viser)."
+            )
+            raise ImportError(msg)
+
+        super().__init__(
+            model,
+            collision_model,
+            visual_model,
+            copy_models,
+            data,
+            collision_data,
+            visual_data,
+        )
+        self.static_objects = []
+
+    def initViewer(
+        self,
+        viewer=None,
+        open=False,
+        loadModel=False,
+        host="localhost",
+        port="8000",
+    ):
+        """
+        Start a new Viser server and client.
+        Note: the server can also be passed in through the `viewer` argument.
+
+        Parameters:
+            viewer: An existing ViserServer instance, or None.
+                If None, creates a new ViserServer in this visualizer.
+            open: If True, automatically opens a browser tab to the visualizer.
+            loadModel: If True, loads the Pinocchio models passed in.
+            host: If `viewer` is None, this will be the host URL.
+            port: If `viewer` is None, this will be the host port.
+        """
+        if (viewer is not None) and (not isinstance(viewer, viser.ViserServer)):
+            raise RuntimeError(
+                "'viewer' argument must be None or a valid ViserServer instance."
+            )
+
+        self.viewer = viewer or viser.ViserServer(host=host, server_port=port)
+        self.frames = {}
+
+        if open:
+            import webbrowser
+
+            webbrowser.open(f"http://{self.viewer.get_host()}:{self.viewer.get_port()}")
+
+            # Wait until clients are reported.
+            # Otherwise, capturing an image too soon after opening a browser window
+            # may not register any clients.
+            while len(self.viewer.get_clients()) == 0:
+                time.sleep(0.1)
+
+        if loadModel:
+            self.loadViewerModel()
+
+    def loadViewerModel(
+        self,
+        rootNodeName="pinocchio",
+        collision_color=None,
+        visual_color=None,
+        frame_axis_length=0.2,
+        frame_axis_radius=0.01,
+    ):
+        """Load the robot in a Viser viewer.
+
+        Parameters:
+            rootNodeName: name to give to the robot in the viewer
+            collision_color: optional, color to give to the collision model of
+                the robot. Format is a list of four RGBA floating-point numbers
+                (between 0 and 1)
+            visual_color: optional, color to give to the visual model of
+                the robot. Format is a list of four RGBA floating-point numbers
+                (between 0 and 1)
+            frame_axis_length: optional, length of frame axes if displaying frames.
+            frame_axis_radius: optional, radius of frame axes if displaying frames.
+        """
+        self.viewerRootNodeName = rootNodeName
+
+        # Create root frames to help toggle visibility in the Viser UI.
+        self.visualRootNodeName = rootNodeName + "/visual"
+        self.visualRootFrame = self.viewer.scene.add_frame(
+            self.visualRootNodeName, show_axes=False
+        )
+        self.collisionRootNodeName = rootNodeName + "/collision"
+        self.collisionRootFrame = self.viewer.scene.add_frame(
+            self.collisionRootNodeName, show_axes=False
+        )
+        self.framesRootNodeName = rootNodeName + "/frames"
+        self.framesRootFrame = self.viewer.scene.add_frame(
+            self.framesRootNodeName, show_axes=False
+        )
+
+        # Load visual model
+        if (visual_color is not None) and (len(visual_color) != 4):
+            raise RuntimeError("visual_color must have 4 elements for RGBA.")
+        if self.visual_model is not None:
+            for visual in self.visual_model.geometryObjects:
+                self.loadViewerGeometryObject(
+                    visual, self.visualRootNodeName, visual_color
+                )
+        self.displayVisuals(True)
+
+        # Load collision model
+        if (collision_color is not None) and (len(collision_color) != 4):
+            raise RuntimeError("collision_color must have 4 elements for RGBA.")
+        if self.collision_model is not None:
+            for collision in self.collision_model.geometryObjects:
+                self.loadViewerGeometryObject(
+                    collision, self.collisionRootNodeName, collision_color
+                )
+        self.displayCollisions(False)
+
+        # Load frames
+        for frame in self.model.frames:
+            frame_name = self.framesRootNodeName + "/" + frame.name
+            self.frames[frame_name] = self.viewer.scene.add_frame(
+                frame_name,
+                show_axes=True,
+                axes_length=frame_axis_length,
+                axes_radius=frame_axis_radius,
+            )
+        self.displayFrames(False)
+
+    def loadViewerGeometryObject(self, geometry_object, prefix="", color=None):
+        """Loads a single geometry object."""
+        name = geometry_object.name
+        if prefix:
+            name = prefix + "/" + name
+        geom = geometry_object.geometry
+        color_override = color or geometry_object.meshColor
+
+        if isinstance(geom, hppfcl.Box):
+            frame = self.viewer.scene.add_box(
+                name,
+                dimensions=geom.halfSide * 2.0,
+                color=color_override[:3],
+                opacity=color_override[3],
+            )
+        elif isinstance(geom, hppfcl.Sphere):
+            frame = self.viewer.scene.add_icosphere(
+                name,
+                radius=geom.radius,
+                color=color_override[:3],
+                opacity=color_override[3],
+            )
+        elif isinstance(geom, hppfcl.Cylinder):
+            mesh = trimesh.creation.cylinder(
+                radius=geom.radius,
+                height=geom.halfLength * 2.0,
+            )
+            frame = self.viewer.scene.add_mesh_simple(
+                name,
+                mesh.vertices,
+                mesh.faces,
+                color=color_override[:3],
+                opacity=color_override[3],
+            )
+        elif isinstance(geom, MESH_TYPES):
+            mesh = trimesh.load(geometry_object.meshPath)
+            if color is None:
+                frame = self.viewer.scene.add_mesh_trimesh(name, mesh)
+            else:
+                frame = self.viewer.scene.add_mesh_simple(
+                    name,
+                    mesh.vertices,
+                    mesh.faces,
+                    color=color_override[:3],
+                    opacity=color_override[3],
+                )
+        else:
+            raise RuntimeError(f"Unsupported geometry type for {name}: {type(geom)}")
+
+        self.frames[name] = frame
+
+    def display(self, q=None):
+        """
+        Display the robot at configuration q in the viewer by placing all the bodies
+        """
+        if q is not None:
+            pin.forwardKinematics(self.model, self.data, q)
+
+        if self.collisionRootFrame.visible:
+            self.updatePlacements(pin.GeometryType.COLLISION)
+
+        if self.visualRootFrame.visible:
+            self.updatePlacements(pin.GeometryType.VISUAL)
+
+        if self.framesRootFrame.visible:
+            self.updateFrames()
+
+    def displayCollisions(self, visibility):
+        self.collisionRootFrame.visible = visibility
+        self.updatePlacements(pin.GeometryType.COLLISION)
+
+    def displayVisuals(self, visibility):
+        self.visualRootFrame.visible = visibility
+        self.updatePlacements(pin.GeometryType.VISUAL)
+
+    def displayFrames(self, visibility):
+        self.framesRootFrame.visible = visibility
+        self.updateFrames()
+
+    def drawFrameVelocities(self, *args, **kwargs):
+        raise NotImplementedError("drawFrameVelocities is not yet implemented.")
+
+    def updatePlacements(self, geometry_type):
+        if geometry_type == pin.GeometryType.VISUAL:
+            geom_model = self.visual_model
+            geom_data = self.visual_data
+            prefix = self.viewerRootNodeName + "/visual"
+        else:
+            geom_model = self.collision_model
+            geom_data = self.collision_data
+            prefix = self.viewerRootNodeName + "/collision"
+
+        pin.updateGeometryPlacements(self.model, self.data, geom_model, geom_data)
+        for geom_id, geometry_object in enumerate(geom_model.geometryObjects):
+            # Get mesh pose.
+            M = geom_data.oMg[geom_id]
+
+            # Update viewer configuration.
+            frame_name = prefix + "/" + geometry_object.name
+            frame = self.frames[frame_name]
+            frame.position = M.translation * geometry_object.meshScale
+            frame.wxyz = pin.Quaternion(M.rotation).coeffs()[
+                [3, 0, 1, 2]
+            ]  # Pinocchio uses xyzw
+
+    def updateFrames(self):
+        pin.updateFramePlacements(self.model, self.data)
+        for frame_id, frame in enumerate(self.model.frames):
+            # Get frame pose.
+            M = self.data.oMf[frame_id]
+
+            # Update viewer configuration.
+            viser_frame_name = self.framesRootNodeName + "/" + frame.name
+            viser_frame = self.frames[viser_frame_name]
+            viser_frame.position = M.translation
+            viser_frame.wxyz = pin.Quaternion(M.rotation).coeffs()[
+                [3, 0, 1, 2]
+            ]  # Pinocchio uses xyzw
+
+    def captureImage(self, w=None, h=None, client_id=None, transport_format="jpeg"):
+        """
+        Capture an image from the Viser viewer and return an RGB array.
+
+        Parameters:
+            w: The width of the captured image.
+            h: The height of the captured image.
+            client_id: The ID of the Viser client handle.
+                If None, uses the first available client.
+            transport_format: The transport format to use for the captured image.
+                Can be "jpeg" (default) or "png".
+        """
+        clients = self.viewer.get_clients()
+        if len(clients) == 0:
+            raise RuntimeError("Viser server has no attached clients!")
+
+        if client_id is None:
+            cli = next(iter(clients.values()))
+        elif client_id not in clients:
+            raise RuntimeError(
+                f"Viser server does not have a client with ID '{client_id}'"
+            )
+        else:
+            cli = clients[client_id]
+
+        return cli.get_render(height=h, width=w, transport_format=transport_format)
+
+    def setBackgroundColor(self, preset_name: str = "gray", col_top=None, col_bot=None):
+        raise NotImplementedError("setBackgroundColor is not yet implemented.")
+
+    def setCameraTarget(self, target: np.ndarray):
+        raise NotImplementedError("setCameraTarget is not yet implemented.")
+
+    def setCameraPosition(self, position: np.ndarray):
+        raise NotImplementedError("setCameraPosition is not yet implemented.")
+
+    def setCameraZoom(self, zoom: float):
+        raise NotImplementedError("setCameraZoom is not yet implemented.")
+
+    def setCameraPose(self, pose: np.ndarray = np.eye(4)):
+        raise NotImplementedError("setcameraPose is not yet implemented.")
+
+    def disableCameraControl(self):
+        raise NotImplementedError("disableCameraControl is not yet implemented.")
+
+    def enableCameraControl(self):
+        raise NotImplementedError("enableCameraControl is not yet implemented.")

--- a/bindings/python/pinocchio/visualize/viser_visualizer.py
+++ b/bindings/python/pinocchio/visualize/viser_visualizer.py
@@ -199,10 +199,14 @@ class ViserVisualizer(BaseVisualizer):
                 opacity=color_override[3],
             )
         elif isinstance(geom, MESH_TYPES):
-            frame = self._add_mesh_from_path(name, geometry_object.meshPath, color_override)
+            frame = self._add_mesh_from_path(
+                name, geometry_object.meshPath, color_override
+            )
         elif isinstance(geom, hppfcl.Convex):
             if len(geometry_object.meshPath) > 0:
-                frame = self._add_mesh_from_path(name, geometry_object.meshPath, color_override)
+                frame = self._add_mesh_from_path(
+                    name, geometry_object.meshPath, color_override
+                )
             else:
                 frame = self._add_mesh_from_convex(name, geom, color_override)
         else:

--- a/bindings/python/pinocchio/visualize/visualizers.py
+++ b/bindings/python/pinocchio/visualize/visualizers.py
@@ -7,6 +7,7 @@ from .gepetto_visualizer import GepettoVisualizer
 from .meshcat_visualizer import MeshcatVisualizer
 from .panda3d_visualizer import Panda3dVisualizer
 from .rviz_visualizer import RVizVisualizer
+from .viser_visualizer import ViserVisualizer
 
 
 class Visualizer(Enum):
@@ -15,6 +16,7 @@ class Visualizer(Enum):
     MESHCAT = MeshcatVisualizer
     PANDA3D = Panda3dVisualizer
     RVIZ = RVizVisualizer
+    VISER = ViserVisualizer
 
     @classmethod
     def default(cls):
@@ -36,11 +38,12 @@ class Visualizer(Enum):
                 "- gepetto-viewer\n"
                 "- panda3d\n"
                 "- rviz\n"
+                "- viser\n"
             )
             raise ImportError(err)
 
         # Otherwise, use the first available
-        for v in ["meshcat", "gepetto", "panda3d_viewer", "rviz"]:
+        for v in ["meshcat", "gepetto", "panda3d_viewer", "rviz", "viser"]:
             if find_spec(v) is not None:
                 return getattr(cls, v.replace("_viewer", "").upper()).value
 
@@ -51,5 +54,6 @@ class Visualizer(Enum):
             "- gepetto-viewer\n"
             "- panda3d\n"
             "- rviz\n"
+            "- viser\n"
         )
         raise ImportError(err)

--- a/examples/viser-viewer.py
+++ b/examples/viser-viewer.py
@@ -29,10 +29,7 @@ try:
     viz = ViserVisualizer(model, collision_model, visual_model)
     viz.initViewer(open=True)
 except ImportError as err:
-    print(
-        "Error while initializing the viewer. "
-        "It seems you should install viser"
-    )
+    print("Error while initializing the viewer. It seems you should install viser")
     print(err)
     sys.exit(0)
 
@@ -81,6 +78,7 @@ viz.display()
 
 model.gravity.linear[:] = 0.0
 dt = 0.01
+
 
 def sim_loop():
     tau0 = np.zeros(model.nv)

--- a/examples/viser-viewer.py
+++ b/examples/viser-viewer.py
@@ -1,0 +1,105 @@
+# This examples shows how to load and move a robot in Viser.
+# Note: this feature requires Viser to be installed, this can be done using
+# pip install --user viser
+
+import sys
+from pathlib import Path
+
+import numpy as np
+import pinocchio as pin
+from pinocchio.visualize import ViserVisualizer
+
+# Load the URDF model.
+# Conversion with str seems to be necessary when executing this file with ipython
+pinocchio_model_dir = Path(__file__).parent.parent / "models"
+
+model_path = pinocchio_model_dir / "example-robot-data/robots"
+mesh_dir = pinocchio_model_dir
+# urdf_filename = "talos_reduced.urdf"
+# urdf_model_path = join(join(model_path,"talos_data/robots"),urdf_filename)
+urdf_filename = "solo.urdf"
+urdf_model_path = model_path / "solo_description/robots" / urdf_filename
+
+model, collision_model, visual_model = pin.buildModelsFromUrdf(
+    urdf_model_path, mesh_dir, pin.JointModelFreeFlyer()
+)
+
+# Start a new Viser server and client.
+try:
+    viz = ViserVisualizer(model, collision_model, visual_model)
+    viz.initViewer(open=True)
+except ImportError as err:
+    print(
+        "Error while initializing the viewer. "
+        "It seems you should install viser"
+    )
+    print(err)
+    sys.exit(0)
+
+# Create a convex shape from solo main body
+mesh = visual_model.geometryObjects[0].geometry
+mesh.buildConvexRepresentation(True)
+convex = mesh.convex
+
+# Place the convex object on the scene and display it
+if convex is not None:
+    placement = pin.SE3.Identity()
+    placement.translation[0] = 2.0
+    geometry = pin.GeometryObject("convex", 0, placement, convex)
+    geometry.meshColor = np.ones(4)
+    visual_model.addGeometryObject(geometry)
+    # After modifying the visual_model we must rebuild
+    # associated data inside the visualizer
+    viz.rebuildData()
+
+# Load the robot in the viewer.
+viz.loadViewerModel()
+
+# Display a robot configuration.
+q0 = pin.neutral(model)
+viz.display(q0)
+viz.displayVisuals(True)
+
+# Display another robot.
+viz2 = ViserVisualizer(model, collision_model, visual_model)
+viz2.initViewer(viz.viewer)
+viz2.loadViewerModel(rootNodeName="pinocchio2")
+q = q0.copy()
+q[1] = 1.0
+viz2.display(q)
+
+# standing config
+q1 = np.array(
+    [0.0, 0.0, 0.235, 0.0, 0.0, 0.0, 1.0, 0.8, -1.6, 0.8, -1.6, -0.8, 1.6, -0.8, 1.6]
+)
+
+v0 = np.random.randn(model.nv) * 2
+data = viz.data
+pin.forwardKinematics(model, data, q1, v0)
+frame_id = model.getFrameId("HR_FOOT")
+viz.display()
+
+model.gravity.linear[:] = 0.0
+dt = 0.01
+
+def sim_loop():
+    tau0 = np.zeros(model.nv)
+    qs = [q1]
+    vs = [v0]
+    nsteps = 100
+    for i in range(nsteps):
+        q = qs[i]
+        v = vs[i]
+        a1 = pin.aba(model, data, q, v, tau0)
+        vnext = v + dt * a1
+        qnext = pin.integrate(model, q, dt * vnext)
+        qs.append(qnext)
+        vs.append(vnext)
+        viz.display(qnext)
+    return qs, vs
+
+
+qs, vs = sim_loop()
+
+with viz.create_video_ctx("../leap.mp4"):
+    viz.play(qs, dt)


### PR DESCRIPTION
I've been enjoying the [Viser](https://github.com/nerfstudio-project/viser) visualizer quite a lot, so I decided to make an "official" Pinocchio model visualizer for it.

It's like Meshcat, except it's more modern, currently maintained, and has a lot more built-in interactive widgets!

It's still in early stages, but wanted to get it in front of the maintainers!

https://github.com/user-attachments/assets/2dcb00ae-ef8a-4ab5-9e83-e960d2d91403

Usage wise, it should behave quite similarly to meshcat:

```python
from pinocchio.visualize import ViserVisualizer

# ... make your Pinocchio model

viz = ViserVisualizer(model, collision_model, visual_model, data=data)
viz.initViewer(open=True, loadModel=True)
viz.displayCollisions(True)
viz.displayVisuals(True)
viz.displayFrames(True)

viz.display(pinocchio.neutral(model))
```