### PR TITLE
Fix missing argument in exposeDelassus() pybind definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `JointModelMimic::hasConfigurationLimit()` to return empty vector instead of delegating to mimicking joint ([#2715](https://github.com/stack-of-tasks/pinocchio/pull/2715))
 - Fix check mimic_subtree_joint ([#2716](https://github.com/stack-of-tasks/pinocchio/pull/2716))
 - Fix mimic patch for crba ([#2716](https://github.com/stack-of-tasks/pinocchio/pull/2716))
+- Fix missing argument in exposeDelassus() pybind definition ([#2731](https://github.com/stack-of-tasks/pinocchio/pull/2731))
 
 ### Changed
 - Disable coal/hpp-fcl warnings when building Pinocchio ([#2686](https://github.com/stack-of-tasks/pinocchio/pull/2686))

--- a/bindings/python/algorithm/expose-delassus.cpp
+++ b/bindings/python/algorithm/expose-delassus.cpp
@@ -67,7 +67,7 @@ namespace pinocchio
       bp::def(
         "computeDampedDelassusMatrixInverse", computeDampedDelassusMatrixInverse_proxy,
         (bp::arg("model"), bp::arg("data"), bp::arg("q"), bp::arg("contact_models"),
-         bp::arg("contact_datas"), bp::arg("mu") = 0),
+         bp::arg("contact_datas"), bp::arg("mu") = 0.0, bp::arg("scaled") = false),
         "Computes the inverse of the Delassus matrix associated to a set of given constraints.",
         mimic_not_supported_function<>(0));
     }


### PR DESCRIPTION
Hello,
I noticed that when you are binding the `computeDampedDelassusMatrixInverse()` function from C++ to Python, the `scaled = false` argument from the C++ function signature is not reflected in the Python binding. This results in an argument mismatch when calling the function from Python.

This pull request adds the missing argument to ensure the binding matches the C++ function signature and prevents runtime errors in downstream Python code.

Let me know if this fix the issue.