### PR TITLE
Fix ViserVisualizer import without hppfcl

### DIFF
--- a/bindings/python/pinocchio/visualize/__init__.py
+++ b/bindings/python/pinocchio/visualize/__init__.py
@@ -1,8 +1,13 @@
 # ruff: noqa: F401
+from importlib.util import find_spec
+
 from .base_visualizer import BaseVisualizer
 from .gepetto_visualizer import GepettoVisualizer
 from .meshcat_visualizer import MeshcatVisualizer
 from .panda3d_visualizer import Panda3dVisualizer
 from .rviz_visualizer import RVizVisualizer
-from .viser_visualizer import ViserVisualizer
+
+if find_spec("hppfcl") is not None:
+    from .viser_visualizer import ViserVisualizer
+
 from .visualizers import Visualizer

--- a/bindings/python/pinocchio/visualize/visualizers.py
+++ b/bindings/python/pinocchio/visualize/visualizers.py
@@ -7,7 +7,13 @@ from .gepetto_visualizer import GepettoVisualizer
 from .meshcat_visualizer import MeshcatVisualizer
 from .panda3d_visualizer import Panda3dVisualizer
 from .rviz_visualizer import RVizVisualizer
-from .viser_visualizer import ViserVisualizer
+
+if find_spec("hppfcl") is not None:
+    from .viser_visualizer import ViserVisualizer
+else:
+
+    class ViserVisualizer:
+        pass
 
 
 class Visualizer(Enum):

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -122,6 +122,7 @@ if(BUILD_PYTHON_INTERFACE)
         ${PROJECT_NAME}_PYTHON_EXAMPLES
         meshcat-viewer
         meshcat-viewer-dae
+        viser-viewer
         collisions
         collision-with-point-clouds
         append-urdf-model-with-another-model


### PR DESCRIPTION
Thanks for taking the time to make and fill out this pull request!

## Description

<!--
Please include a clear and concise description of the changes included in this pull request.
Explain what are you changing and why.

If applicable, link the related issue using "Fixes #issue_number".
-->
ViserVisualizer is imported in visualize/__init__.py and visualize/visualizers.py but the import fail if pinocchio is not built with hppfcl.
This PR change these files to only import ViserVisualizer when hppfcl is available.

Also, this PR add examples/viser-viewer.py to the list of unit test to avoid regression.

There is no changelog modification because the issue was not released.

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation
- [ ] I have added tests that prove my fix or feature works
- [ ] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
