### PR TITLE
Fix Viser visualizer loading DAE files as trimesh.Scene

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
   - Convert configuration or tangent vector from two model with different root
   - [C++ example](./examples/model-configuration-converter.cpp)
   - [Python example](./examples/model-configuration-converter.py)
+- Fix Viser visualizer loading DAE files as trimesh.Scene ([#2748](https://github.com/stack-of-tasks/pinocchio/pull/2748))
 
 ### Fixed
 - Fixed explicit conversions to Scalar type in log.hxx ([#2730](https://github.com/stack-of-tasks/pinocchio/pull/2730))

--- a/bindings/python/pinocchio/visualize/viser_visualizer.py
+++ b/bindings/python/pinocchio/visualize/viser_visualizer.py
@@ -218,7 +218,7 @@ class ViserVisualizer(BaseVisualizer):
         """
         Load a mesh from a file.
         """
-        mesh = trimesh.load(mesh_path)
+        mesh = trimesh.load_mesh(mesh_path)
         if color is None:
             return self.viewer.scene.add_mesh_trimesh(name, mesh)
         else:


### PR DESCRIPTION
## Description

Fix Viser visualizer loading DAE files as trimesh.Scene. To reproduce run https://gist.github.com/JafarAbdi/4e33d485491c336d5d01f7cf6f2865bf with `uv run` (See _add_mesh_from_path function)

@sea-bass fyi

## Checklist

- [ ] I have run `pre-commit run --all-files` or `pixi run lint`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation
- [ ] I have added tests that prove my fix or feature works
- [ ] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
