### PR TITLE
Add site attached to a fixed body in MJCF parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix mimic patch for crba ([#2716](https://github.com/stack-of-tasks/pinocchio/pull/2716))
 - Fix missing argument in exposeDelassus() pybind definition ([#2731](https://github.com/stack-of-tasks/pinocchio/pull/2731))
 - Fix copy of Model.armature in buidlReducedModel(...) ([#2749](https://github.com/stack-of-tasks/pinocchio/pull/2749))
+- Add site attached to a fixed body in MJCF parse ([#2754](https://github.com/stack-of-tasks/pinocchio/pull/2754))
 
 ### Changed
 - Disable coal/hpp-fcl warnings when building Pinocchio ([#2686](https://github.com/stack-of-tasks/pinocchio/pull/2686))

--- a/src/parsers/mjcf/mjcf-graph.cpp
+++ b/src/parsers/mjcf/mjcf-graph.cpp
@@ -996,6 +996,16 @@ namespace pinocchio
           urdfVisitor << jointName << " being parsed." << '\n';
 
           urdfVisitor.addFixedJointAndBody(parentFrameId, bodyPose, jointName, inert, nameOfBody);
+
+          // Attach child site frame to parent joint
+          FrameIndex bodyId = urdfVisitor.model.getFrameId(nameOfBody, BODY);
+          JointIndex parentJoint = urdfVisitor.model.frames[bodyId].parentJoint;
+          for (const auto & site : currentBody.siteChildren)
+          {
+            SE3 placement = bodyPose * site.sitePlacement;
+            urdfVisitor.model.addFrame(
+              Frame(site.siteName, parentJoint, bodyId, placement, OP_FRAME));
+          }
           return;
         }
 
@@ -1083,6 +1093,7 @@ namespace pinocchio
             rangeCompo.armature;
         }
 
+        // Attach child site frame to parent joint
         FrameIndex bodyId = urdfVisitor.model.getFrameId(nameOfBody, BODY);
         frame = urdfVisitor.model.frames[bodyId];
         for (const auto & site : currentBody.siteChildren)


### PR DESCRIPTION
## Description

Close #2747

Add site attached to a fixed body in ModelTpl::frames as OP_FRAME.

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [ ] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
