### PR TITLE
Add continuous joint as mimic in urdf parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
+- Continuous joints can now be parsed as mimic from a urdf file ([#2756](https://github.com/stack-of-tasks/pinocchio/pull/2756))
 - Beta version of Viser visualizer ([#2718](https://github.com/stack-of-tasks/pinocchio/pull/2718))
 - Add `pinocchio::graph::ModelGraph` class
   - Simple API to build a model

--- a/include/pinocchio/multibody/joint/joint-mimic.hpp
+++ b/include/pinocchio/multibody/joint/joint-mimic.hpp
@@ -606,9 +606,16 @@ namespace pinocchio
     , m_nqExtended(jmodel_mimicking.nq())
     , m_nvExtended(jmodel_mimicking.nvExtended())
     {
-      assert(jmodel_mimicking.nq() == jmodel_mimicked.nq());
-      assert(jmodel_mimicking.nv() == jmodel_mimicked.nv());
-      assert(jmodel_mimicking.nvExtended() == jmodel_mimicked.nvExtended());
+      // Throw in case nq and nv from mimicking and mimicked are different
+      PINOCCHIO_CHECK_ARGUMENT_SIZE(
+        jmodel_mimicking.nq(), jmodel_mimicked.nq(),
+        "Mimicking and mimicked configuration spaces have different sizes");
+      PINOCCHIO_CHECK_ARGUMENT_SIZE(
+        jmodel_mimicking.nv(), jmodel_mimicked.nv(),
+        "Mimicking and mimicked tangent spaces have different sizes");
+      PINOCCHIO_CHECK_ARGUMENT_SIZE(
+        jmodel_mimicking.nvExtended(), jmodel_mimicked.nvExtended(),
+        "Mimicking and mimicked extended tangent spaces have different sizes");
 
       setMimicIndexes(
         jmodel_mimicked.id(), jmodel_mimicked.idx_q(), jmodel_mimicked.idx_v(),

--- a/include/pinocchio/parsers/urdf/model.hxx
+++ b/include/pinocchio/parsers/urdf/model.hxx
@@ -314,6 +314,15 @@ namespace pinocchio
                   frame, placement, joint_name, max_effort, max_velocity, min_config, max_config,
                   friction, damping, *mimic_info);
                 break;
+              case Base::CONTINUOUS:
+                joint_id = addMimicJoint<
+                  typename JointCollection::JointModelRUBX,
+                  typename JointCollection::JointModelRUBY,
+                  typename JointCollection::JointModelRUBZ,
+                  typename JointCollection::JointModelRevoluteUnboundedUnaligned>(
+                  frame, placement, joint_name, max_effort, max_velocity, min_config, max_config,
+                  friction, damping, *mimic_info);
+                break;
               default:
                 PINOCCHIO_CHECK_INPUT_ARGUMENT(
                   false, "Cannot mimic this type. Only revolute, prismatic and helicoidal can be "

--- a/src/parsers/urdf/model.cpp
+++ b/src/parsers/urdf/model.cpp
@@ -187,9 +187,30 @@ namespace pinocchio
               damping << joint->dynamics->damping;
             }
 
-            model.addJointAndBody(
-              UrdfVisitorBase::CONTINUOUS, axis, parentFrameId, jointPlacement, joint->name, Y,
-              link->name, max_effort, max_velocity, min_config, max_config, friction, damping);
+            if (joint->mimic && mimic)
+            {
+              max_effort = Vector::Constant(0, infty);
+              max_velocity = Vector::Constant(0, infty);
+              min_config = Vector::Constant(0, -infty);
+              max_config = Vector::Constant(0, infty);
+
+              friction = Vector::Constant(0, 0.);
+              damping = Vector::Constant(0, 0.);
+
+              MimicInfo_ mimic_info(
+                joint->mimic->joint_name, joint->mimic->multiplier, joint->mimic->offset, axis,
+                UrdfVisitorBase::CONTINUOUS);
+
+              model.addJointAndBody(
+                UrdfVisitorBase::MIMIC, axis, parentFrameId, jointPlacement, joint->name, Y,
+                link->name, max_effort, max_velocity, min_config, max_config, friction, damping,
+                mimic_info);
+            }
+            else
+              model.addJointAndBody(
+                UrdfVisitorBase::CONTINUOUS, axis, parentFrameId, jointPlacement, joint->name, Y,
+                link->name, max_effort, max_velocity, min_config, max_config, friction, damping);
+
             break;
 
           case ::urdf::Joint::PRISMATIC:

--- a/unittest/urdf.cpp
+++ b/unittest/urdf.cpp
@@ -356,11 +356,11 @@ BOOST_AUTO_TEST_CASE(test_mimic_parsing)
   BOOST_CHECK(model.nvExtended == 4);
 
   BOOST_CHECK(
-    model.joints[model.getJointId("joint2")].idx_q()
-    == model.joints[model.getJointId("joint1")].idx_q());
+    model.joints[model.getJointId("joint_2")].idx_q()
+    == model.joints[model.getJointId("joint_1")].idx_q());
   BOOST_CHECK(
-    model.joints[model.getJointId("joint4")].idx_q()
-    == model.joints[model.getJointId("joint3")].idx_q());
+    model.joints[model.getJointId("joint_4")].idx_q()
+    == model.joints[model.getJointId("joint_3")].idx_q());
 
   // Check non possible mimic pair
   std::string filestr1(R"(<?xml version="1.0" encoding="utf-8"?>

--- a/unittest/urdf.cpp
+++ b/unittest/urdf.cpp
@@ -311,42 +311,42 @@ BOOST_AUTO_TEST_CASE(test_getFrameId_identical_link_and_joint_name)
 BOOST_AUTO_TEST_CASE(test_mimic_parsing)
 {
   // Read file as XML
-  std::string filestr("<?xml version=\"1.0\" encoding=\"utf-8\"?>"
-                      "<robot name=\"test\">"
-                      "  <link name=\"base_link\"/>"
-                      "  <link name=\"link_1\"/>"
-                      "  <link name=\"link_2\"/>"
-                      "  <link name=\"link_3\"/>"
-                      "  <link name=\"link_4\"/>"
-                      "  <joint name=\"joint_1\" type=\"revolute\">"
-                      "    <origin xyz=\"1 0 0\"/>"
-                      "    <axis xyz=\"0 0 1\"/>"
-                      "    <parent link=\"base_link\"/>"
-                      "    <child link=\"link_1\"/>"
-                      "    <limit effort=\"50\" lower=\"0.0\" upper=\"0.8\" velocity=\"0.5\"/>"
-                      "  </joint>"
-                      "  <joint name=\"joint_2\" type=\"revolute\">"
-                      "    <origin xyz=\"0 1 0\"/>"
-                      "    <axis xyz=\"0 0 1\"/>"
-                      "    <parent link=\"link_1\"/>"
-                      "    <child link=\"link_2\"/>"
-                      "    <mimic joint=\"joint_1\" multiplier=\"-1\"/>"
-                      "    <limit effort=\"50\" lower=\"0.0\" upper=\"0.8\" velocity=\"0.5\"/>"
-                      "  </joint>"
-                      "  <joint name=\"joint_3\" type=\"continuous\">"
-                      "    <origin xyz=\"1 0 0\"/>"
-                      "    <axis xyz=\"0 0 1\"/>"
-                      "    <parent link=\"link_2\"/>"
-                      "    <child link=\"link_3\"/>"
-                      "  </joint>"
-                      "  <joint name=\"joint_4\" type=\"continuous\">"
-                      "    <origin xyz=\"0 1 0\"/>"
-                      "    <axis xyz=\"0 0 1\"/>"
-                      "    <parent link=\"link_3\"/>"
-                      "    <child link=\"link_4\"/>"
-                      "    <mimic joint=\"joint_3\" multiplier=\"-2\"/>"
-                      "  </joint>"
-                      "</robot>");
+  std::string filestr(R"(<?xml version="1.0" encoding="utf-8"?>
+                      <robot name="test">
+                        <link name="base_link"/>
+                        <link name="link_1"/>
+                        <link name="link_2"/>
+                        <link name="link_3"/>
+                        <link name="link_4"/>
+                        <joint name="joint_1" type="revolute">
+                          <origin xyz="1 0 0"/>
+                          <axis xyz="0 0 1"/>
+                          <parent link="base_link"/>
+                          <child link="link_1"/>
+                          <limit effort="50" lower="0.0" upper="0.8" velocity="0.5"/>
+                        </joint>
+                        <joint name="joint_2" type="revolute">
+                          <origin xyz="0 1 0"/>
+                          <axis xyz="0 0 1"/>
+                          <parent link="link_1"/>
+                          <child link="link_2"/>
+                          <mimic joint="joint_1" multiplier="-1"/>
+                          <limit effort="50" lower="0.0" upper="0.8" velocity="0.5"/>
+                        </joint>
+                        <joint name="joint_3" type="continuous">
+                          <origin xyz="1 0 0"/>
+                          <axis xyz="0 0 1"/>
+                          <parent link="link_2"/>
+                          <child link="link_3"/>
+                        </joint>
+                        <joint name="joint_4" type="continuous">
+                          <origin xyz="0 1 0"/>
+                          <axis xyz="0 0 1"/>
+                          <parent link="link_3"/>
+                          <child link="link_4"/>
+                          <mimic joint="joint_3" multiplier="-2"/>
+                        </joint>
+                      </robot>)");
 
   pinocchio::Model model;
   pinocchio::urdf::buildModelFromXML(filestr, model, false, true);
@@ -361,6 +361,31 @@ BOOST_AUTO_TEST_CASE(test_mimic_parsing)
   BOOST_CHECK(
     model.joints[model.getJointId("joint4")].idx_q()
     == model.joints[model.getJointId("joint3")].idx_q());
+
+  // Check non possible mimic pair
+  std::string filestr1(R"(<?xml version="1.0" encoding="utf-8"?>
+                    <robot name="test">
+                      <link name="base_link"/>
+                      <link name="link_1"/>
+                      <link name="link_2"/>
+                      <joint name="joint_1" type="revolute">
+                        <origin xyz="1 0 0"/>
+                        <axis xyz="0 0 1"/>
+                        <parent link="base_link"/>
+                        <child link="link_1"/>
+                        <limit effort="50" lower="0.0" upper="0.8" velocity="0.5"/>
+                      </joint>
+                      <joint name="joint_4" type="continuous">
+                        <origin xyz="0 1 0"/>
+                        <axis xyz="0 0 1"/>
+                        <parent link="link_1"/>
+                        <child link="link_2"/>
+                        <mimic joint="joint_1" multiplier="-2"/>
+                      </joint>
+                    </robot>)");
+  pinocchio::Model model1;
+  BOOST_CHECK_THROW(
+    pinocchio::urdf::buildModelFromXML(filestr1, model1, false, true), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/urdf.cpp
+++ b/unittest/urdf.cpp
@@ -308,4 +308,59 @@ BOOST_AUTO_TEST_CASE(test_getFrameId_identical_link_and_joint_name)
   BOOST_CHECK(model.getFrameId("base", pinocchio::FrameType::FIXED_JOINT) == 2);
 }
 
+BOOST_AUTO_TEST_CASE(test_mimic_parsing)
+{
+  // Read file as XML
+  std::string filestr("<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                      "<robot name=\"test\">"
+                      "  <link name=\"base_link\"/>"
+                      "  <link name=\"link_1\"/>"
+                      "  <link name=\"link_2\"/>"
+                      "  <link name=\"link_3\"/>"
+                      "  <link name=\"link_4\"/>"
+                      "  <joint name=\"joint_1\" type=\"revolute\">"
+                      "    <origin xyz=\"1 0 0\"/>"
+                      "    <axis xyz=\"0 0 1\"/>"
+                      "    <parent link=\"base_link\"/>"
+                      "    <child link=\"link_1\"/>"
+                      "    <limit effort=\"50\" lower=\"0.0\" upper=\"0.8\" velocity=\"0.5\"/>"
+                      "  </joint>"
+                      "  <joint name=\"joint_2\" type=\"revolute\">"
+                      "    <origin xyz=\"0 1 0\"/>"
+                      "    <axis xyz=\"0 0 1\"/>"
+                      "    <parent link=\"link_1\"/>"
+                      "    <child link=\"link_2\"/>"
+                      "    <mimic joint=\"joint_1\" multiplier=\"-1\"/>"
+                      "    <limit effort=\"50\" lower=\"0.0\" upper=\"0.8\" velocity=\"0.5\"/>"
+                      "  </joint>"
+                      "  <joint name=\"joint_3\" type=\"continuous\">"
+                      "    <origin xyz=\"1 0 0\"/>"
+                      "    <axis xyz=\"0 0 1\"/>"
+                      "    <parent link=\"link_2\"/>"
+                      "    <child link=\"link_3\"/>"
+                      "  </joint>"
+                      "  <joint name=\"joint_4\" type=\"continuous\">"
+                      "    <origin xyz=\"0 1 0\"/>"
+                      "    <axis xyz=\"0 0 1\"/>"
+                      "    <parent link=\"link_3\"/>"
+                      "    <child link=\"link_4\"/>"
+                      "    <mimic joint=\"joint_3\" multiplier=\"-2\"/>"
+                      "  </joint>"
+                      "</robot>");
+
+  pinocchio::Model model;
+  pinocchio::urdf::buildModelFromXML(filestr, model, false, true);
+
+  BOOST_CHECK(model.nq == 3);
+  BOOST_CHECK(model.nv == 2);
+  BOOST_CHECK(model.nvExtended == 4);
+
+  BOOST_CHECK(
+    model.joints[model.getJointId("joint2")].idx_q()
+    == model.joints[model.getJointId("joint1")].idx_q());
+  BOOST_CHECK(
+    model.joints[model.getJointId("joint4")].idx_q()
+    == model.joints[model.getJointId("joint3")].idx_q());
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Thanks for taking the time to make and fill out this pull request!

## Description

Change in the urdf parser to have possibility to mimic continuous joints. Change an assert into a throw to avoid nq and nv mismatch when creating a mimic joint. 
Mimic test case for urdf parser. 

Will close https://github.com/stack-of-tasks/pinocchio/issues/2753

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
