### PR TITLE
Fix axis of unaligned mimic joint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - CMake: Added support for `BUILD_STANDALONE_PYTHON_INTERFACE` ([#2714](https://github.com/stack-of-tasks/pinocchio/pull/2714))
 
 ### Fixed
+- Set axis of unaligned mimic joint ([#2763](https://github.com/stack-of-tasks/pinocchio/pull/2763))
 - Fixed explicit conversions to Scalar type in log.hxx ([#2730](https://github.com/stack-of-tasks/pinocchio/pull/2730))
 - Check row dimensions of input Jacobians when computing kinematics Jacobian ([#2684](https://github.com/stack-of-tasks/pinocchio/pull/2684))
 - Fix case joint_id == 0 in getJointKinematicHessian ([#2705](https://github.com/stack-of-tasks/pinocchio/pull/2705))

--- a/include/pinocchio/parsers/urdf/model.hxx
+++ b/include/pinocchio/parsers/urdf/model.hxx
@@ -540,7 +540,8 @@ namespace pinocchio
             return model.addJoint(
               frame.parentJoint,
               typename JointCollection::JointModelMimic(
-                TypeUnaligned(), mimicked_joint, mimic_info.multiplier, mimic_info.offset),
+                TypeUnaligned(mimic_info.axis.normalized()), mimicked_joint, mimic_info.multiplier,
+                mimic_info.offset),
               frame.placement * placement, joint_name, max_effort, max_velocity, min_config,
               max_config, friction, damping);
             break;


### PR DESCRIPTION
Thanks for taking the time to make and fill out this pull request!

## Description

When a mimic joint was unaligned, its axis was not set. 
It fixes #2761 

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
