### PR TITLE
Don't trigger CI on push and pull_request event #756

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -2,6 +2,8 @@ name: CI - Linux via APT
 
 on:
   push:
+    branches:
+      - devel
     paths-ignore:
       - doc/**
       - .gitlab-ci.yml
@@ -31,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
     strategy:
+      fail-fast: false
       matrix:
         container: ['ubuntu:22.04', 'ubuntu:24.04']
 

--- a/.github/workflows/macos-linux-windows-pixi.yml
+++ b/.github/workflows/macos-linux-windows-pixi.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '0 0 * * 1'
   push:
+    branches:
+      - devel
     paths-ignore:
       - doc/**
       - .gitlab-ci.yml

--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -3,17 +3,14 @@ name: "CI - Nix"
 on:
   push:
     branches:
-      - master
       - devel
   pull_request:
-    branches:
-      - master
-      - devel
 
 jobs:
   nix-full:
     runs-on: "${{ matrix.os }}-latest"
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu, macos]
     steps:

--- a/.github/workflows/ros_ci.yml
+++ b/.github/workflows/ros_ci.yml
@@ -6,6 +6,8 @@ name: CI - Linux via ROS
 # This determines when this workflow is run
 on:
   push:
+    branches:
+      - devel
     paths-ignore:
       - doc/**
       - .gitlab-ci.yml
@@ -32,6 +34,7 @@ concurrency:
 jobs:
   CI:
     strategy:
+      fail-fast: false
       matrix:
         env:
           - {ROS_DISTRO: humble}


### PR DESCRIPTION
Thanks for taking the time to make and fill out this pull request!

## Description

This will avoid building 2 time the same commit.
Also, try to homogenize workflows.

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
