### PR TITLE
Add names for joints inside a composite joint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - ROS: added jrl_cmakemodules dependency ([#2789](https://github.com/stack-of-tasks/pinocchio/pull/2789))
 - Removed CMake < 3.22 details ([#2790](https://github.com/stack-of-tasks/pinocchio/pull/2790))
 
+### Added
+- Add names to joints that are inside a composite joint ([#2786](https://github.com/stack-of-tasks/pinocchio/pull/2786))
+
 ## [3.8.0] - 2025-09-17
 
 ### Added

--- a/include/pinocchio/bindings/python/multibody/joint/joints-models.hpp
+++ b/include/pinocchio/bindings/python/multibody/joint/joints-models.hpp
@@ -329,14 +329,14 @@ namespace pinocchio
     static context::JointModelComposite * init_proxy1(const context::JointModel & jmodel)
     {
       return boost::apply_visitor(
-        JointModelCompositeConstructorVisitor(context::SE3::Identity(), "joint_0"), jmodel);
+        JointModelCompositeConstructorVisitor(context::SE3::Identity(), "joint_1"), jmodel);
     }
 
     static context::JointModelComposite *
     init_proxy2(const context::JointModel & jmodel, const context::SE3 & joint_placement)
     {
       return boost::apply_visitor(
-        JointModelCompositeConstructorVisitor(joint_placement, "joint_0"), jmodel);
+        JointModelCompositeConstructorVisitor(joint_placement, "joint_1"), jmodel);
     }
 
     static context::JointModelComposite * init_proxy3(

--- a/include/pinocchio/bindings/python/multibody/joint/joints-models.hpp
+++ b/include/pinocchio/bindings/python/multibody/joint/joints-models.hpp
@@ -376,8 +376,11 @@ namespace pinocchio
         .def(
           "addJoint", &addJoint_proxy,
           (bp::arg("self"), bp::arg("joint_model"),
-           bp::arg("joint_placement") = context::SE3::Identity(), bp::arg("name") = ""),
+           bp::arg("joint_placement") = context::SE3::Identity(), bp::arg("name") = "joint_1"),
           "Add a joint to the vector of joints.", bp::return_internal_reference<>())
+        .def(
+          "getJointId", &context::JointModelComposite::getJointId, bp::args("joint_name"),
+          "Find the index of a joint inside a joint composite based on its name.")
 
 #ifndef PINOCCHIO_PYTHON_SKIP_COMPARISON_OPERATIONS
         .def(bp::self == bp::self)

--- a/include/pinocchio/multibody/joint/joint-composite.hpp
+++ b/include/pinocchio/multibody/joint/joint-composite.hpp
@@ -485,14 +485,14 @@ namespace pinocchio
       return res;
     }
 
-    int getJointIndex(const std::string & joint_name) const
+    JointIndex getJointId(const std::string & joint_name) const
     {
       auto it = std::find(jointNames.begin(), jointNames.end(), joint_name);
 
       if (it == jointNames.end())
-        return -1;
-      else
-        return static_cast<int>(std::distance(jointNames.begin(), it));
+        PINOCCHIO_THROW_PRETTY(std::invalid_argument, "JointComposite - joint_name not found");
+
+      return JointIndex(std::distance(jointNames.begin(), it));
     }
 
     /// \brief Vector of joints contained in the joint composite.

--- a/include/pinocchio/multibody/joint/joint-composite.hpp
+++ b/include/pinocchio/multibody/joint/joint-composite.hpp
@@ -241,7 +241,7 @@ namespace pinocchio
     JointModelCompositeTpl(
       const JointModelBase<JointModel> & jmodel,
       const SE3 & placement = SE3::Identity(),
-      const std::string & name = "joint_0")
+      const std::string & name = "joint_1")
     : joints(1, (JointModelVariant)jmodel.derived())
     , jointPlacements(1, placement)
     , m_nq(jmodel.nq())
@@ -309,7 +309,7 @@ namespace pinocchio
       std::string final_name = name;
       if (name.empty())
       {
-        final_name = "joint_" + std::to_string(njoints);
+        final_name = "joint_" + std::to_string(njoints + 1);
       }
       jointNames.push_back(final_name);
 

--- a/include/pinocchio/serialization/joints-model.hpp
+++ b/include/pinocchio/serialization/joints-model.hpp
@@ -29,6 +29,7 @@ namespace pinocchio
 
       ar & make_nvp("joints", joint.joints);
       ar & make_nvp("jointPlacements", joint.jointPlacements);
+      ar & make_nvp("jointNames", joint.jointNames);
     }
   };
 } // namespace pinocchio

--- a/unittest/joint-composite.cpp
+++ b/unittest/joint-composite.cpp
@@ -351,8 +351,9 @@ BOOST_AUTO_TEST_CASE(checkJointNames)
     .addJoint(JointModelRY(), SE3::Random(), "penultinum_joint")
     .addJoint(JointModelRX(), SE3::Random(), "last_joint");
 
-  BOOST_CHECK(jmodel_composite.getJointIndex("last_joint") == 2);
-  BOOST_CHECK(jmodel_composite.getJointIndex("penultinum_joint") == 1);
+  BOOST_CHECK(jmodel_composite.getJointId("last_joint") == 2);
+  BOOST_CHECK(jmodel_composite.getJointId("penultinum_joint") == 1);
+  BOOST_CHECK_THROW(jmodel_composite.getJointId("wrong_name"), std::invalid_argument);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/joint-composite.cpp
+++ b/unittest/joint-composite.cpp
@@ -344,4 +344,15 @@ BOOST_AUTO_TEST_CASE(test_kinematics)
   BOOST_CHECK(data.a.back().isApprox(data_c.a.back()));
 }
 
+BOOST_AUTO_TEST_CASE(checkJointNames)
+{
+  JointModelComposite jmodel_composite;
+  jmodel_composite.addJoint(JointModelRZ())
+    .addJoint(JointModelRY(), SE3::Random(), "penultinum_joint")
+    .addJoint(JointModelRX(), SE3::Random(), "last_joint");
+
+  BOOST_CHECK(jmodel_composite.getJointIndex("last_joint") == 2);
+  BOOST_CHECK(jmodel_composite.getJointIndex("penultinum_joint") == 1);
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Description

This pr adds a list of names that correspond to the joints inside a composite joints.
It's especially useful for people in biomechanics to track a joint evolution, even when it's inside a composite.
## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
