### PR TITLE
CMake: updates for CMake >= 3.22

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Homogenize python viewers examples ([#2771](https://github.com/stack-of-tasks/pinocchio/pull/2771))
 - Add docker images ([#2776](https://github.com/stack-of-tasks/pinocchio/pull/2776))
 - ROS: added jrl_cmakemodules dependency ([#2789](https://github.com/stack-of-tasks/pinocchio/pull/2789))
+- Removed CMake < 3.22 details ([#2790](https://github.com/stack-of-tasks/pinocchio/pull/2790))
 
 ## [3.8.0] - 2025-09-17
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,22 +86,10 @@ include("${JRL_CMAKE_MODULES}/python.cmake")
 include("${JRL_CMAKE_MODULES}/boost.cmake")
 include("${JRL_CMAKE_MODULES}/ide.cmake")
 include("${JRL_CMAKE_MODULES}/apple.cmake")
-if(APPLE) # Use the handmade approach
-  if(${CMAKE_VERSION} VERSION_LESS "3.18.0") # Need to find the right version
-    set(CMAKE_MODULE_PATH ${JRL_CMAKE_MODULES}/find-external/OpenMP ${CMAKE_MODULE_PATH})
-  endif()
-elseif(UNIX)
-  if(${CMAKE_VERSION} VERSION_EQUAL "3.20.0")
-    set(CMAKE_MODULE_PATH ${JRL_CMAKE_MODULES}/find-external/OpenMP ${CMAKE_MODULE_PATH})
-  endif()
-endif()
 include(CMakeDependentOption)
 
 # If needed, set CMake policy for APPLE systems
 apply_default_apple_configuration()
-if(CMAKE_VERSION VERSION_GREATER "3.12")
-  cmake_policy(SET CMP0074 NEW)
-endif()
 
 # Force C++ standard to be C++11 at least
 check_minimal_cxx_standard(11 ENFORCE)

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
             default = self'.packages.pinocchio;
             pinocchio = pkgs.python3Packages.pinocchio.overrideAttrs (super: {
               propagatedBuildInputs = super.propagatedBuildInputs ++ [ pkgs.example-robot-data ];
+              nativeCheckInputs = [ pkgs.python3Packages.pybind11 ];
               src = pkgs.lib.fileset.toSource {
                 root = ./.;
                 fileset = pkgs.lib.fileset.unions [
@@ -78,6 +79,7 @@
                 pkgs.example-robot-data
                 self'.packages.libpinocchio
               ];
+              nativeCheckInputs = [ pkgs.python3Packages.pybind11 ];
               src = pkgs.lib.fileset.toSource {
                 root = ./.;
                 fileset = pkgs.lib.fileset.unions [

--- a/unittest/packaging/cmake/CMakeLists.txt
+++ b/unittest/packaging/cmake/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.22)
 
 project(ExtraLib CXX)
 

--- a/unittest/packaging/external/CMakeLists.txt
+++ b/unittest/packaging/external/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.11)
+cmake_minimum_required(VERSION 3.22)
 
 project(ExtraLib CXX)
 

--- a/unittest/packaging/pinocchio_header/CMakeLists.txt
+++ b/unittest/packaging/pinocchio_header/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 3.22)
 
 project(ExtraLib CXX)
 find_package(pinocchio REQUIRED)

--- a/unittest/packaging/pkgconfig/CMakeLists.txt
+++ b/unittest/packaging/pkgconfig/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.22)
 
 project(ExtraLib CXX)
 find_package(PkgConfig REQUIRED)

--- a/unittest/python/CMakeLists.txt
+++ b/unittest/python/CMakeLists.txt
@@ -164,6 +164,5 @@ endif()
 if(NOT WIN32)
   pinocchio_add_python_cpp_module(bindings_visualizer PIN_TARGETS pinocchio::pinocchio_visualizers)
   pinocchio_add_lib_unit_test(bindings_visualizer)
+  add_subdirectory(pybind11)
 endif()
-
-add_subdirectory(pybind11)

--- a/unittest/python/pybind11/CMakeLists.txt
+++ b/unittest/python/pybind11/CMakeLists.txt
@@ -1,36 +1,38 @@
-include(FetchContent)
-FetchContent_Declare(
-  pybind11
-  GIT_REPOSITORY https://github.com/pybind/pybind11
-  GIT_TAG v3.0.1)
-FetchContent_GetProperties(pybind11)
-if(NOT pybind11_POPULATED)
-  FetchContent_Populate(pybind11)
-  add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
-
-  # pybind11_add_module(cpp2pybind11 cpp2pybind11.cpp)
-  #
-  # BUG: might not work out of the box on OSX with conda:
-  # https://github.com/pybind/pybind11/issues/3081
-  if(NOT BUILD_TESTING)
-    add_library(cpp2pybind11 MODULE EXCLUDE_FROM_ALL cpp2pybind11.cpp)
-  else()
-    add_library(cpp2pybind11 MODULE cpp2pybind11.cpp)
+find_package(pybind11 CONFIG QUIET)
+if(NOT TARGET pybind11::module)
+  include(FetchContent)
+  FetchContent_Declare(
+    pybind11
+    GIT_REPOSITORY https://github.com/pybind/pybind11
+    GIT_TAG v3.0.1)
+  FetchContent_GetProperties(pybind11)
+  if(NOT pybind11_POPULATED)
+    FetchContent_Populate(pybind11)
+    add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
   endif()
-  add_dependencies(build_tests cpp2pybind11)
-  target_link_libraries(cpp2pybind11 PRIVATE pinocchio_pywrap_default pybind11::module
-                                             Eigen3::Eigen)
-  set_target_properties(cpp2pybind11 PROPERTIES PREFIX "" SUFFIX ${PYTHON_EXT_SUFFIX})
-
-  if(CMAKE_CXX_STANDARD LESS 14)
-    message(STATUS "CXX_STANDARD for cpp2pybind11 changed from ${CMAKE_CXX_STANDARD} to 14")
-    set_target_properties(cpp2pybind11 PROPERTIES CXX_STANDARD 14)
-  endif()
-
-  if(WIN32)
-    target_compile_definitions(cpp2pybind11 PRIVATE -DNOMINMAX)
-  endif(WIN32)
-
-  add_python_unit_test("test-py-cpp2pybind11" "unittest/python/pybind11/test-cpp2pybind11.py"
-                       "bindings/python" "unittest/python/pybind11")
 endif()
+
+# pybind11_add_module(cpp2pybind11 cpp2pybind11.cpp)
+#
+# BUG: might not work out of the box on OSX with conda:
+# https://github.com/pybind/pybind11/issues/3081
+if(NOT BUILD_TESTING)
+  add_library(cpp2pybind11 MODULE EXCLUDE_FROM_ALL cpp2pybind11.cpp)
+else()
+  add_library(cpp2pybind11 MODULE cpp2pybind11.cpp)
+endif()
+add_dependencies(build_tests cpp2pybind11)
+target_link_libraries(cpp2pybind11 PRIVATE pinocchio_pywrap_default pybind11::module Eigen3::Eigen)
+set_target_properties(cpp2pybind11 PROPERTIES PREFIX "" SUFFIX ${PYTHON_EXT_SUFFIX})
+
+if(CMAKE_CXX_STANDARD LESS 14)
+  message(STATUS "CXX_STANDARD for cpp2pybind11 changed from ${CMAKE_CXX_STANDARD} to 14")
+  set_target_properties(cpp2pybind11 PROPERTIES CXX_STANDARD 14)
+endif()
+
+if(WIN32)
+  target_compile_definitions(cpp2pybind11 PRIVATE -DNOMINMAX)
+endif(WIN32)
+
+add_python_unit_test("test-py-cpp2pybind11" "unittest/python/pybind11/test-cpp2pybind11.py"
+                     "bindings/python" "unittest/python/pybind11")

--- a/unittest/python/pybind11/CMakeLists.txt
+++ b/unittest/python/pybind11/CMakeLists.txt
@@ -1,38 +1,36 @@
-if(CMAKE_VERSION VERSION_GREATER 4.11)
-  include(FetchContent)
-  FetchContent_Declare(
-    pybind11
-    GIT_REPOSITORY https://github.com/pybind/pybind11
-    GIT_TAG v2.10.0)
-  FetchContent_GetProperties(pybind11)
-  if(NOT pybind11_POPULATED)
-    FetchContent_Populate(pybind11)
-    add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
+include(FetchContent)
+FetchContent_Declare(
+  pybind11
+  GIT_REPOSITORY https://github.com/pybind/pybind11
+  GIT_TAG v3.0.1)
+FetchContent_GetProperties(pybind11)
+if(NOT pybind11_POPULATED)
+  FetchContent_Populate(pybind11)
+  add_subdirectory(${pybind11_SOURCE_DIR} ${pybind11_BINARY_DIR})
 
-    # pybind11_add_module(cpp2pybind11 cpp2pybind11.cpp)
-    #
-    # BUG: might not work out of the box on OSX with conda:
-    # https://github.com/pybind/pybind11/issues/3081
-    if(NOT BUILD_TESTING)
-      add_library(cpp2pybind11 MODULE EXCLUDE_FROM_ALL cpp2pybind11.cpp)
-    else()
-      add_library(cpp2pybind11 MODULE cpp2pybind11.cpp)
-    endif()
-    add_dependencies(build_tests cpp2pybind11)
-    target_link_libraries(cpp2pybind11 PRIVATE pinocchio_pywrap_default pybind11::module)
-    target_include_directories(cpp2pybind11 SYSTEM PUBLIC ${EIGEN3_INCLUDE_DIR})
-    set_target_properties(cpp2pybind11 PROPERTIES PREFIX "" SUFFIX ${PYTHON_EXT_SUFFIX})
-
-    if(CMAKE_CXX_STANDARD LESS 14)
-      message(STATUS "CXX_STANDARD for cpp2pybind11 changed from ${CMAKE_CXX_STANDARD} to 14")
-      set_target_properties(cpp2pybind11 PROPERTIES CXX_STANDARD 14)
-    endif()
-
-    if(WIN32)
-      target_compile_definitions(cpp2pybind11 PRIVATE -DNOMINMAX)
-    endif(WIN32)
-
-    add_python_unit_test("test-py-cpp2pybind11" "unittest/python/pybind11/test-cpp2pybind11.py"
-                         "bindings/python" "unittest/python/pybind11")
+  # pybind11_add_module(cpp2pybind11 cpp2pybind11.cpp)
+  #
+  # BUG: might not work out of the box on OSX with conda:
+  # https://github.com/pybind/pybind11/issues/3081
+  if(NOT BUILD_TESTING)
+    add_library(cpp2pybind11 MODULE EXCLUDE_FROM_ALL cpp2pybind11.cpp)
+  else()
+    add_library(cpp2pybind11 MODULE cpp2pybind11.cpp)
   endif()
+  add_dependencies(build_tests cpp2pybind11)
+  target_link_libraries(cpp2pybind11 PRIVATE pinocchio_pywrap_default pybind11::module
+                                             Eigen3::Eigen)
+  set_target_properties(cpp2pybind11 PROPERTIES PREFIX "" SUFFIX ${PYTHON_EXT_SUFFIX})
+
+  if(CMAKE_CXX_STANDARD LESS 14)
+    message(STATUS "CXX_STANDARD for cpp2pybind11 changed from ${CMAKE_CXX_STANDARD} to 14")
+    set_target_properties(cpp2pybind11 PROPERTIES CXX_STANDARD 14)
+  endif()
+
+  if(WIN32)
+    target_compile_definitions(cpp2pybind11 PRIVATE -DNOMINMAX)
+  endif(WIN32)
+
+  add_python_unit_test("test-py-cpp2pybind11" "unittest/python/pybind11/test-cpp2pybind11.py"
+                       "bindings/python" "unittest/python/pybind11")
 endif()


### PR DESCRIPTION
Hi,

Looking for `VERSION` in CMake following https://github.com/coal-library/coal/pull/770 I found a few inconsistencies, which are cleaned in this PR