### PR TITLE
Add color support for robot meshes in Viser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - ROS: added jrl_cmakemodules dependency ([#2789](https://github.com/stack-of-tasks/pinocchio/pull/2789))
 - Add docker images ([#2776](https://github.com/stack-of-tasks/pinocchio/pull/2776))
 - Add names to joints that are inside a composite joint ([#2786](https://github.com/stack-of-tasks/pinocchio/pull/2786))
+- Add color support for robot meshes in Viser ([#2793](https://github.com/stack-of-tasks/pinocchio/pull/2793))
 
 ### Changed
 - Python version update ([#2802](https://github.com/stack-of-tasks/pinocchio/pull/2802)):

--- a/README.md
+++ b/README.md
@@ -287,6 +287,7 @@ In addition to the core dev team, the following people have also been involved i
 -   [Sebastian Castro](https://roboticseabass.com) (RAI Institute): Viser visualizer and MeshCat visualizer feature extension
 -   [Lev Kozlov](https://github.com/lvjonok): Kinetic and potential energy regressors
 -   [Simeon Nedelchev](https://github.com/simeon-ned): Pseudo inertia and Log-Cholesky parametrization
+-   [Alexy Legrand](https://www.linkedin.com/in/alexy-legrand-125889232/): Viser color bug fixes
 
 If you have participated in the development of **Pinocchio**, please add your name and contribution to this list.
 


### PR DESCRIPTION
Thanks for taking the time to make and fill out this pull request!

## Description

This PR adds support for loading and displaying mesh colors in Viser, improving the visual fidelity of robot models.

<!--
## What am I changing?

I'm adding color support to the ViserVisualizer by implementing COLLADA (.dae) file parsing to extract and apply material colors to robot meshes.

## Why?

Currently, ViserVisualizer loads all meshes without their original colors, making robots appear uniform and less visually distinctive. This makes it harder to distinguish different parts and reduces visual fidelity compared to other visualizers like GepettoViewer or MeshCat.

By parsing COLLADA files and extracting material information (diffuse colors and opacity), robots now display with their intended colors, improving:
- Visual clarity and part identification
- Consistency with other Pinocchio visualizers
- Overall user experience when working with robot models

## How?

The `_add_mesh_from_path` method now:
1. Detects COLLADA (.dae) files
2. Parses geometries and their associated material effects
3. Extracts diffuse color and opacity from each material
4. Creates meshes with proper colors using the existing `add_mesh_simple` API
5. Falls back to standard trimesh loading when color data is unavailable or parsing fails

This maintains full backward compatibility with existing STL and other mesh formats.

If applicable, link the related issue using "Fixes #2792".
-->

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation
- [ ] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
