### PR TITLE
bindings/python/visualizers : add overload for `BaseVisualizer::play()` in `VisualizerPythonVisitor`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add docker images ([#2776](https://github.com/stack-of-tasks/pinocchio/pull/2776))
 - ROS: added jrl_cmakemodules dependency ([#2789](https://github.com/stack-of-tasks/pinocchio/pull/2789))
 - Removed CMake < 3.22 details ([#2790](https://github.com/stack-of-tasks/pinocchio/pull/2790))
-- Python headers : also expose overload of `BaseVisualizer::play()` in `VisualizerPythonVisitor`
+- Python : add overload of `BaseVisualizer::play()` to `VisualizerPythonVisitor` ([#2796](https://github.com/stack-of-tasks/pinocchio/pull/2796))
 
 ### Added
 - Add names to joints that are inside a composite joint ([#2786](https://github.com/stack-of-tasks/pinocchio/pull/2786))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Add docker images ([#2776](https://github.com/stack-of-tasks/pinocchio/pull/2776))
 - ROS: added jrl_cmakemodules dependency ([#2789](https://github.com/stack-of-tasks/pinocchio/pull/2789))
 - Removed CMake < 3.22 details ([#2790](https://github.com/stack-of-tasks/pinocchio/pull/2790))
+- Python headers : also expose overload of `BaseVisualizer::play()` in `VisualizerPythonVisitor`
 
 ### Added
 - Add names to joints that are inside a composite joint ([#2786](https://github.com/stack-of-tasks/pinocchio/pull/2786))

--- a/include/pinocchio/bindings/python/visualizers/visualizer-visitor.hpp
+++ b/include/pinocchio/bindings/python/visualizers/visualizer-visitor.hpp
@@ -38,6 +38,7 @@ namespace pinocchio
         Visualizer & vis, const std::vector<visualizers::VectorXs> & qs, context::Scalar dt)
       {
         std::vector<visualizers::ConstVectorRef> qs_;
+        qs_.reserve(qs.size());
         for (size_t i = 0; i < qs.size(); i++)
         {
           qs_.emplace_back(qs[i]);

--- a/include/pinocchio/bindings/python/visualizers/visualizer-visitor.hpp
+++ b/include/pinocchio/bindings/python/visualizers/visualizer-visitor.hpp
@@ -8,6 +8,7 @@
 #include "pinocchio/bindings/python/fwd.hpp"
 
 #include <eigenpy/optional.hpp>
+#include <eigenpy/std-vector.hpp>
 
 namespace pinocchio
 {
@@ -19,7 +20,6 @@ namespace pinocchio
     struct VisualizerPythonVisitor : bp::def_visitor<VisualizerPythonVisitor<Visualizer>>
     {
       typedef ::pinocchio::visualizers::BaseVisualizer Base;
-      typedef ::pinocchio::visualizers::ConstMatrixRef ConstMatrixRef;
       static_assert(
         std::is_base_of<Base, Visualizer>::value,
         "Visualizer class must be derived from pinocchio::visualizers::BaseVisualizer.");
@@ -34,7 +34,19 @@ namespace pinocchio
         vis.setCameraPose(pose);
       }
 
-      static void play_proxy2(Visualizer & vis, const ConstMatrixRef & qs, context::Scalar dt)
+      static void play_proxy(
+        Visualizer & vis, const std::vector<visualizers::VectorXs> & qs, context::Scalar dt)
+      {
+        std::vector<visualizers::ConstVectorRef> qs_;
+        for (size_t i = 0; i < qs.size(); i++)
+        {
+          qs_.emplace_back(qs[i]);
+        }
+        vis.play(qs_, dt);
+      }
+
+      static void
+      play_proxy2(Visualizer & vis, const visualizers::ConstMatrixRef & qs, context::Scalar dt)
       {
         vis.play(qs, dt);
       }
@@ -58,6 +70,7 @@ namespace pinocchio
           .def(
             "display", +[](Visualizer & v, const ConstVectorRef & q) { v.display(q); },
             (bp::arg("self"), bp::arg("q") = boost::none))
+          .def("play", play_proxy, (bp::arg("self"), "qs", "dt"))
           .def("play", play_proxy2, (bp::arg("self"), "qs", "dt"))
           .def("setCameraTarget", &Visualizer::setCameraTarget, (bp::arg("self"), "target"))
           .def("setCameraPosition", &Visualizer::setCameraPosition, (bp::arg("self"), "position"))


### PR DESCRIPTION
## Description

This PR enables calling `viz.play(qs)` when `viz` is an expose subclass of the C++ `pinocchio::visualizers::BaseVisualizer` class and `qs` is a list of NumPy arrays (instead of a `(T, nq)` NumPy array which was the only allowed signature before).

<!--
Please include a clear and concise description of the changes included in this pull request.
Explain what are you changing and why.

If applicable, link the related issue using "Fixes #issue_number".
-->

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
