### PR TITLE
Update SDF support include path in CMakeLists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - ROS: added jrl_cmakemodules dependency ([#2789](https://github.com/stack-of-tasks/pinocchio/pull/2789))
 - Removed CMake < 3.22 details ([#2790](https://github.com/stack-of-tasks/pinocchio/pull/2790))
 - Python : add overload of `BaseVisualizer::play()` to `VisualizerPythonVisitor` ([#2796](https://github.com/stack-of-tasks/pinocchio/pull/2796))
+- CMake: use `sdformat.cmake` from `jrl-cmakemodules` ([#2800](https://github.com/stack-of-tasks/pinocchio/pull/2800))
 
 ### Added
 - Add names to joints that are inside a composite joint ([#2786](https://github.com/stack-of-tasks/pinocchio/pull/2786))

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -229,7 +229,7 @@ if(BUILD_WITH_URDF_SUPPORT)
 endif()
 
 if(BUILD_WITH_SDF_SUPPORT)
-  include(${CMAKE_CURRENT_LIST_DIR}/cmake/sdformat.cmake)
+  include(${JRL_CMAKE_MODULES}/sdformat.cmake)
   search_for_sdformat(REQUIRED)
   if(SDFormat_FOUND)
     check_minimal_cxx_standard(11 REQUIRED)


### PR DESCRIPTION
JRL gets fetched but then its cmake file for sdformat is not used.

TODO:
- [x] check if it's ok for a ROS installation
  Note: this may require an if/else depending on the detection of a ROS 2 build (e.g. via colcon)?

## Description

source build (non-ROS workspace) - build fails as the `sdformat.cmake` is expected in an inexistent position in source folder.

## Checklist

- [ ] I have run `pre-commit run --all-files` or `pixi run lint`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation
- [ ] I have added tests that prove my fix or feature works
- [ ] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
