### PR TITLE
Fix doxygen document hierarchy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 - Remove pixi 0.57 warnings ([#2802](https://github.com/stack-of-tasks/pinocchio/pull/2802))
 - CMake: use `sdformat.cmake` from `jrl-cmakemodules` ([#2800](https://github.com/stack-of-tasks/pinocchio/pull/2800))
+- Fix doxygen document hierarchy ([#2811](https://github.com/stack-of-tasks/pinocchio/pull/2811))
 
 ### Removed
 - Remove CMake < 3.22 details ([#2790](https://github.com/stack-of-tasks/pinocchio/pull/2790))

--- a/doc/a-features/a-spatial.md
+++ b/doc/a-features/a-spatial.md
@@ -1,4 +1,4 @@
-\page md_doc_a-features_a-spatial Spatial algebra
+# Spatial algebra  {#md_doc_a-features_a-spatial}
 
 Spatial algebra is a mathematical notation commonly employed in rigid body
 dynamics to represent and manipulate physical quantities such as velocities,

--- a/doc/a-features/b-model-data.md
+++ b/doc/a-features/b-model-data.md
@@ -1,4 +1,4 @@
-\page md_doc_a-features_b-model-data Model and data
+# Model and data {#md_doc_a-features_b-model-data}
 
 A fundamental paradigm of Pinocchio is the strict separation between
 *model* and *data*. By *model*, we mean the physical description of the

--- a/doc/a-features/c-joints.md
+++ b/doc/a-features/c-joints.md
@@ -1,4 +1,4 @@
-\page md_doc_a-features_c-joints Joints
+# Joints {#md_doc_a-features_c-joints}
 
 Within a model, a robot is represented as a kinematic tree, containing a
 collection of all the joints, information about their connectivity, and,

--- a/doc/a-features/d-model.md
+++ b/doc/a-features/d-model.md
@@ -1,4 +1,4 @@
-\page md_doc_a-features_d-model Geometric and collision models
+# Geometric and collision models {#md_doc_a-features_d-model}
 
 Aside from the kinematic model, Pinocchio defines a geometric model, i.e. the
 volumes attached to the kinematic tree. This model can be used for displaying

--- a/doc/a-features/e-lie.md
+++ b/doc/a-features/e-lie.md
@@ -1,4 +1,4 @@
-\page md_doc_a-features_e-lie Dealing with Lie-group geometry
+# Dealing with Lie-group geometry {#md_doc_a-features_e-lie}
 
 Pinocchio relies heavily on Lie groups and Lie algebras to handle motions and more specifically rotations.
 For this reason it supports the following special groups \\( SO(2), SO(3), SE(2), SE(3) \\) and implements their associated algebras
@@ -8,7 +8,7 @@ or the motion of the robot links. The later is particularly useful for collision
 It is also interesting to have general vector space over which a Lie algebra is defined.
 
 
-## Using \\( SE(2) \\) with pinocchio in C++
+## Using SE(2) with pinocchio in C++
 
 As a motivating example let us consider a mobile robot evolving in a plane \f$(\mathbb{R}^2 \times \mathbb{S}^1 \f$).
 ![SE2MotivatingExample](SE2MotivatingExample.svg)
@@ -72,7 +72,7 @@ The result is indeed:
 -1
 \endcode
 
-## Using \f$ SE(3) \f$ with pinocchio in C++
+## Using SE(3) with pinocchio in C++
 
 Our mobile robot is not in a plane but in a 3-dimensional space. So let's consider a object in our physical space. This is actually almost the same case, we want the object from one position to an other position. The difficulty lies in the fact that we now have three dimensions so the object has six degrees of freedom, three corresponding to its translation and three to its rotation.
 

--- a/doc/a-features/f-kinematic.md
+++ b/doc/a-features/f-kinematic.md
@@ -1,4 +1,4 @@
-\page md_doc_a-features_f-kinematic Kinematics algorithms
+# Kinematics algorithms {#md_doc_a-features_f-kinematic}
 
 ## Forward kinematics
 

--- a/doc/a-features/g-dynamic.md
+++ b/doc/a-features/g-dynamic.md
@@ -1,4 +1,4 @@
-\page md_doc_a-features_g-dynamic Dynamics algorithms
+# Dynamics algorithms {#md_doc_a-features_g-dynamic}
 
 ## Inverse dynamics
 

--- a/doc/a-features/h-frames.md
+++ b/doc/a-features/h-frames.md
@@ -1,4 +1,4 @@
-\page md_doc_a-features_h-frames Operational frames
+# Operational frames {#md_doc_a-features_h-frames}
 
 TODO: as frames are not necessary to understand the previous sections, it could
 be a good idea to treat them

--- a/doc/a-features/intro.md
+++ b/doc/a-features/intro.md
@@ -1,0 +1,1 @@
+# Feature {#md_doc_a-features_intro}

--- a/doc/a-features/j-analytical-derivatives.md
+++ b/doc/a-features/j-analytical-derivatives.md
@@ -1,4 +1,4 @@
-\page md_doc_a-features_j-analytical-derivatives Analytical derivatives
+# Analytical derivatives {#md_doc_a-features_j-analytical-derivatives}
 
 Beside proposing standard forward and inverse dynamics algorithms, Pinocchio
 also provides efficient implementations of their analytical derivatives. These

--- a/doc/a-features/k-automatic-differentiation.md
+++ b/doc/a-features/k-automatic-differentiation.md
@@ -1,4 +1,4 @@
-\page md_doc_a-features_k-automatic-differentiation Automatic differentiation and source code generation
+# Automatic differentiation and source code generation {#md_doc_a-features_k-automatic-differentiation}
 
 In addition to analytical derivatives, Pinocchio supports automatic
 differentiation. This is made possible through the full *scalar*

--- a/doc/a-features/l-python.md
+++ b/doc/a-features/l-python.md
@@ -1,3 +1,3 @@
-\page md_doc_a-features_l-python Python bindings
+# Python bindings {#md_doc_a-features_l-python}
 
 TODO: ...

--- a/doc/a-features/m-tests.md
+++ b/doc/a-features/m-tests.md
@@ -1,3 +1,3 @@
-\page md_doc_a-features_m-tests Unit tests
+# Unit tests {#md_doc_a-features_m-tests}
 
 TODO: ...

--- a/doc/b-examples/a-model.md
+++ b/doc/b-examples/a-model.md
@@ -1,4 +1,4 @@
-# Loading the model
+# Loading the model {#md_doc_b-examples_a-model}
 
 ## Python
 \include overview-urdf.py

--- a/doc/b-examples/ab-geometry-models.md
+++ b/doc/b-examples/ab-geometry-models.md
@@ -1,4 +1,4 @@
-# Geometry models
+# Geometry models {#md_doc_b-examples_ab-geometry-models}
 
 ## Python
 \include geometry-models.py

--- a/doc/b-examples/b-display.md
+++ b/doc/b-examples/b-display.md
@@ -1,4 +1,4 @@
-# Load and display a model
+# Load and display a model {#md_doc_b-examples_b-display}
 
 Pinocchio does not feature a built-in viewer and you will have to rely on external libraries.
 However, Pinocchio offers Python support for a few external tools in order to ease the display of a given model.

--- a/doc/b-examples/c-collisions.md
+++ b/doc/b-examples/c-collisions.md
@@ -1,4 +1,4 @@
-# Collision detection and distances
+# Collision detection and distances {#md_doc_b-examples_c-collisions}
 
 ## Python
 \include collisions.py

--- a/doc/b-examples/d-inverse-kinematics.md
+++ b/doc/b-examples/d-inverse-kinematics.md
@@ -1,4 +1,4 @@
-# Inverse kinematics (clik)
+# Inverse kinematics (clik) {#md_doc_b-examples_d-inverse-kinematics}
 
 This example shows how to position the end effector of a manipulator robot to a given pose (position and orientation).
 The example employs a simple Jacobian-based iterative algorithm, which is called closed-loop inverse kinematics (CLIK).

--- a/doc/b-examples/display/a-gepetto-viewer.md
+++ b/doc/b-examples/display/a-gepetto-viewer.md
@@ -1,3 +1,3 @@
-# Display a model using GepettoViewer
+# Display a model using GepettoViewer {#md_doc_b-examples_display_a-gepetto-viewer}
 
 \include gepetto-viewer.py

--- a/doc/b-examples/display/b-meshcat-viewer.md
+++ b/doc/b-examples/display/b-meshcat-viewer.md
@@ -1,3 +1,3 @@
-# Display a model using Meshcat
+# Display a model using Meshcat {#md_doc_b-examples_display_b-meshcat-viewer}
 
 \include meshcat-viewer.py

--- a/doc/b-examples/display/c-robot-wrapper-viewer.md
+++ b/doc/b-examples/display/c-robot-wrapper-viewer.md
@@ -1,4 +1,4 @@
-# Display a model using RobotWrapper
+# Display a model using RobotWrapper {#md_doc_b-examples_display_c-robot-wrapper-viewer}
 
 `RobotWrapper` is a wrapper class written in Python holding Pinocchio models and data.
 It also includes wrapper functions for a few common methods.

--- a/doc/b-examples/e-reduced-model.md
+++ b/doc/b-examples/e-reduced-model.md
@@ -1,4 +1,4 @@
-# Build reduced model
+# Build reduced model {#md_doc_b-examples_e-reduced-model}
 
 This example shows how to build a reduced robot model from an existing URDF model by fixing the desired joints at a specified position.
 

--- a/doc/b-examples/f-update-model.md
+++ b/doc/b-examples/f-update-model.md
@@ -1,4 +1,4 @@
-# Update model after loading its URDF
+# Update model after loading its URDF {#md_doc_b-examples_f-update-model}
 
 This example shows how to update a robot model after loading it from a URDF description.
 

--- a/doc/b-examples/intro.md
+++ b/doc/b-examples/intro.md
@@ -1,1 +1,1 @@
-# Examples
+# Examples {#md_doc_b-examples_intro}

--- a/doc/c-maths/a-rigid-bodies.md
+++ b/doc/c-maths/a-rigid-bodies.md
@@ -1,4 +1,4 @@
-# Rigid Bodies
+# Rigid Bodies {#md_doc_c-maths_a-rigid-bodies}
 
 ## Geometry
 

--- a/doc/c-maths/b-joints.md
+++ b/doc/c-maths/b-joints.md
@@ -1,4 +1,4 @@
-# Joint dynamics
+# Joint dynamics {#md_doc_c-maths_b-joints}
 
 ## Geometry
 

--- a/doc/c-maths/intro.md
+++ b/doc/c-maths/intro.md
@@ -1,3 +1,3 @@
-# Mathematical formulation
+# Mathematical formulation {#md_doc_c-maths_intro}
 
 This section describes the mathematical formulation used by Pinocchio, which is the base for Featherstone's algorithms.

--- a/doc/c-maths/se3.md
+++ b/doc/c-maths/se3.md
@@ -1,4 +1,4 @@
-# CheatSheet: SE(3) operations
+# CheatSheet: SE(3) operations {#md_doc_c-maths_se3}
 
 <div class="center">
 

--- a/doc/d-practical-exercises/1-directgeom.md
+++ b/doc/d-practical-exercises/1-directgeom.md
@@ -1,4 +1,4 @@
-# 1) Move your body (aka direct geometry)
+# 1) Move your body (aka direct geometry) {#md_doc_d-practical-exercises_1-directgeom}
 
 ## Objective
 

--- a/doc/d-practical-exercises/2-invgeom.md
+++ b/doc/d-practical-exercises/2-invgeom.md
@@ -1,4 +1,4 @@
-# 2) Grasp an object (aka inverse Geometry)
+# 2) Grasp an object (aka inverse Geometry) {#md_doc_d-practical-exercises_2-invgeom}
 
 ## Objectives
 

--- a/doc/d-practical-exercises/3-invkine.md
+++ b/doc/d-practical-exercises/3-invkine.md
@@ -1,4 +1,4 @@
-# 3) Drag and Drop (aka Inverse kinematics)
+# 3) Drag and Drop (aka Inverse kinematics) {#md_doc_d-practical-exercises_3-invkine}
 
 ## Objectives
 

--- a/doc/d-practical-exercises/4-dyn.md
+++ b/doc/d-practical-exercises/4-dyn.md
@@ -1,4 +1,4 @@
-# 4) Snap your fingers (aka direct and inverse dynamics)
+# 4) Snap your fingers (aka direct and inverse dynamics) {#md_doc_d-practical-exercises_4-dyn}
 
 ## Objectives
 

--- a/doc/d-practical-exercises/5-planner.md
+++ b/doc/d-practical-exercises/5-planner.md
@@ -1,4 +1,4 @@
-# 5) Look ahead (aka motion planning)
+# 5) Look ahead (aka motion planning) {#md_doc_d-practical-exercises_5-planner}
 
 ## Objective
 

--- a/doc/d-practical-exercises/6-wpg.md
+++ b/doc/d-practical-exercises/6-wpg.md
@@ -1,4 +1,4 @@
-# 6) Take a walk (aka optimal control)
+# 6) Take a walk (aka optimal control) {#md_doc_d-practical-exercises_6-wpg}
 
 ## Objective
 

--- a/doc/d-practical-exercises/7-learn.md
+++ b/doc/d-practical-exercises/7-learn.md
@@ -1,4 +1,4 @@
-# 7) Learning to fly (aka policy learning)
+# 7) Learning to fly (aka policy learning) {#md_doc_d-practical-exercises_7-learn}
 
 ## Objective
 

--- a/doc/d-practical-exercises/intro.md
+++ b/doc/d-practical-exercises/intro.md
@@ -1,3 +1,3 @@
-# Practical Exercises
+# Practical Exercises {#md_doc_d-practical-exercises_intro}
 
 This section contains complete exercices to understand Pinocchio.

--- a/doc/treeview.dox
+++ b/doc/treeview.dox
@@ -39,6 +39,7 @@ namespace pinocchio {
         - \subpage md_doc_b-examples_c-collisions
         - \subpage md_doc_b-examples_d-inverse-kinematics
         - \subpage md_doc_b-examples_e-reduced-model
+        - \subpage md_doc_b-examples_f-update-model
   */
 
   /** \page md_doc_b-examples_b-display
@@ -48,14 +49,8 @@ namespace pinocchio {
   */
 
   /** \page md_doc_c-maths_intro Mathematical Formulation
-        - \subpage md_doc_c-maths_a-overview
-        - \subpage md_doc_c-maths_b-rigid-bodies
-        - \subpage md_doc_c-maths_c-joints
-        - \subpage md_doc_c-maths_d-articulated
-        - \subpage md_doc_c-maths_dynamics
-        - \subpage md_doc_c-maths_e-collisions
-        - \subpage md_doc_c-maths_e-miscs
-        - \subpage md_doc_c-maths_f-algorithms
+        - \subpage md_doc_c-maths_a-rigid-bodies
+        - \subpage md_doc_c-maths_b-joints
         - \subpage md_doc_c-maths_se3
   */
 
@@ -105,7 +100,4 @@ namespace pinocchio {
 
   /// \namespace pinocchio::srdf
   /// \brief SRDF parsing
-
-  /// \namespace pinocchio::lua
-  /// \brief Lua parsing
 }


### PR DESCRIPTION
## Description

Fix Doxygen document hierarchy.
Doxygen side panel should be less messy.

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [ ] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
