### PR TITLE
Change MimicChecker return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `appendModel` issues ([#2807](https://github.com/stack-of-tasks/pinocchio/pull/2807)):
   - Bad inertia transformation when multiple frame with inertia have non null placement
   - Undefined behavior when more than two frame was attached to universe
+- Fix MimicChecker condition ([#2814](https://github.com/stack-of-tasks/pinocchio/pull/2814))
 
 ### Removed
 - Remove CMake < 3.22 details ([#2790](https://github.com/stack-of-tasks/pinocchio/pull/2790))

--- a/include/pinocchio/algorithm/check-model.hxx
+++ b/include/pinocchio/algorithm/check-model.hxx
@@ -60,10 +60,7 @@ namespace pinocchio
   inline bool
   MimicChecker::checkModel_impl(const ModelTpl<Scalar, Options, JointCollectionTpl> & model) const
   {
-    if (!model.mimicking_joints.empty())
-      return false;
-
-    return true;
+    return (model.mimicking_joints.empty() == false);
   }
 
   template<class... T>

--- a/unittest/algo-check.cpp
+++ b/unittest/algo-check.cpp
@@ -55,7 +55,7 @@ BOOST_AUTO_TEST_CASE(test_check)
   pinocchio::Model model_mimic;
   buildModels::humanoidRandom(model_mimic, false, true);
   pinocchio::Data data_mimic(model_mimic);
-  BOOST_CHECK(!model_mimic.check(MimicChecker()));
+  BOOST_CHECK(model_mimic.check(MimicChecker()));
   BOOST_CHECK(model_mimic.check(data_mimic));
 }
 

--- a/unittest/model.cpp
+++ b/unittest/model.cpp
@@ -1169,4 +1169,70 @@ BOOST_AUTO_TEST_CASE(test_append_model_universe_with_inertia_issue_2805)
   BOOST_CHECK(new_model.inertias[1].isApprox(expected_model.inertias[1]));
 }
 
+BOOST_AUTO_TEST_CASE(test_mimic_check)
+{
+  {
+    Model manipulator_no_mimic;
+    const bool using_mimic = false;
+    buildModels::manipulator(manipulator_no_mimic, using_mimic);
+    BOOST_CHECK(manipulator_no_mimic.mimicked_joints.size() == 0);
+    BOOST_CHECK(manipulator_no_mimic.mimicking_joints.size() == 0);
+    BOOST_CHECK(manipulator_no_mimic.check(MimicChecker()) == false);
+  }
+  {
+    Model manipulator_mimic;
+    const bool using_mimic = true;
+    buildModels::manipulator(manipulator_mimic, using_mimic);
+    BOOST_CHECK(manipulator_mimic.mimicked_joints.size() > 0);
+    BOOST_CHECK(manipulator_mimic.mimicking_joints.size() > 0);
+    BOOST_CHECK(manipulator_mimic.check(MimicChecker()) == true);
+  }
+  {
+    Model humanoid_ff_no_mimic;
+    const bool using_free_flyer = true;
+    const bool using_mimic = false;
+    buildModels::humanoidRandom(humanoid_ff_no_mimic, using_free_flyer, using_mimic);
+    BOOST_CHECK(humanoid_ff_no_mimic.mimicked_joints.size() == 0);
+    BOOST_CHECK(humanoid_ff_no_mimic.mimicking_joints.size() == 0);
+    BOOST_CHECK(humanoid_ff_no_mimic.check(MimicChecker()) == false);
+  }
+  {
+    Model humanoid_ff_mimic;
+    const bool using_free_flyer = true;
+    const bool using_mimic = true;
+    buildModels::humanoidRandom(humanoid_ff_mimic, using_free_flyer, using_mimic);
+    BOOST_CHECK(humanoid_ff_mimic.mimicked_joints.size() > 0);
+    BOOST_CHECK(humanoid_ff_mimic.mimicking_joints.size() > 0);
+    BOOST_CHECK(humanoid_ff_mimic.check(MimicChecker()) == true);
+  }
+  {
+    Model humanoid_no_ff_no_mimic;
+    const bool using_free_flyer = false;
+    const bool using_mimic = false;
+    buildModels::humanoidRandom(humanoid_no_ff_no_mimic, using_free_flyer, using_mimic);
+    BOOST_CHECK(humanoid_no_ff_no_mimic.mimicked_joints.size() == 0);
+    BOOST_CHECK(humanoid_no_ff_no_mimic.mimicking_joints.size() == 0);
+    BOOST_CHECK(humanoid_no_ff_no_mimic.check(MimicChecker()) == false);
+  }
+  {
+    Model humanoid_no_ff_mimic;
+    const bool using_free_flyer = false;
+    const bool using_mimic = true;
+    buildModels::humanoidRandom(humanoid_no_ff_mimic, using_free_flyer, using_mimic);
+    BOOST_CHECK(humanoid_no_ff_mimic.mimicked_joints.size() > 0);
+    BOOST_CHECK(humanoid_no_ff_mimic.mimicking_joints.size() > 0);
+    BOOST_CHECK(humanoid_no_ff_mimic.check(MimicChecker()) == true);
+  }
+  {
+    Model custom_model;
+    custom_model.addJoint(0, JointModelRX(), SE3::Identity(), "j1");
+    custom_model.addJoint(1, JointModelRX(), SE3::Identity(), "j2");
+    custom_model.addJoint(
+      2, JointModelMimic(JointModelRX(), custom_model.joints[1], 1., 0.), SE3::Identity(), "j3");
+    BOOST_CHECK(custom_model.mimicked_joints.size() > 0);
+    BOOST_CHECK(custom_model.mimicking_joints.size() > 0);
+    BOOST_CHECK(custom_model.check(MimicChecker()) == true);
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
## Description

Changes condition in `MimicChecker`, where it did the exact opposite of what I think it was meant to do.

Before: MimicChecker returned false if the model has mimic joints.

After: MimicChecker checks that the models has mimic joints.

Alternative: rename it to NoMimicChecker

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
