### PR TITLE
Update `package-xml` to introduce colcon dependency over "coal" package

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -25,7 +25,7 @@
   <depend>eigen</depend>
   <depend>boost</depend>
   <depend>eigenpy</depend>
-  <depend>hpp-fcl</depend>
+  <depend>coal</depend>
 
   <!-- Compiling Pinocchio with clang reduces build time, required memory, and results in faster runtime. Note: This only specifies the build dependency, it does not auto-select the compiler - this needs to be specified manually -->
   <buildtool_depend>clang</buildtool_depend>


### PR DESCRIPTION
Maybe related to https://github.com/stack-of-tasks/pinocchio/issues/2480

When building `pinocchio` in a Colcon workspace (the ROS 2 way), a dependency on `hpp-fcl` is declared in `package.xml`. However, `hpp-fcl` is now `coal`.

`coal` needs to be built with retrocompatibility enabled. A specific CMake helper is installed only when `COAL_BACKWARD_COMPATIBILITY_WITH_HPP_FCL=ON`, thus the full command line has to be (assuming this patch is applied, to tell colcon that `pinocchio` package needs to wait for `coal` build):

```
colcon build --packages-select coal pinocchio --cmake-args -DCOAL_BACKWARD_COMPATIBILITY_WITH_HPP_FCL=ON -DBUILD_WITH_COLLISION_SUPPORT=ON
```

Wouldn't be better then also to update `find_package( )` directives to actively look for `coal` instead of `hpp-fcl`?