### PR TITLE
Add RoboPlan, PlaCo, and CRISP controllers to open source projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,10 +304,13 @@ If you have participated in the development of **Pinocchio**, please add your na
 -   [TriFingerSimulation](https://github.com/open-dynamic-robot-initiative/trifinger_simulation): TriFinger Robot Simulation (a Robot to perform RL on manipulation).
 -   [Casadi_Kin_Dyn](https://github.com/ADVRHumanoids/casadi_kin_dyn): IIT Package for generation of symbolic (SX) expressions of robot kinematics and dynamics.
 -   [PyRoboPlan](https://github.com/sea-bass/pyroboplan): An educational Python library for manipulator motion planning using the Pinocchio Python bindings.
+-   [RoboPlan](https://github.com/open-planning/roboplan): A modern robot motion planning library based on Pinocchio, built in C++ with Python bindings (successor to PyRoboPlan).
 -   [ProxSuite-NLP](https://github.com/Simple-Robotics/proxsuite-nlp): A primal-dual augmented Lagrangian solver for nonlinear programming on manifolds.
 -   [Aligator](https://github.com/Simple-Robotics/aligator): A versatile and efficient framework for constrained trajectory optimization.
 -   [Simple](https://github.com/Simple-Robotics/Simple): The Simple Simulator: Simulation Made Simple.
 -   [LoIK](https://github.com/Simple-Robotics/LoIK): Low-Complexity Inverse Kinematics.
+-   [PlaCo](https://github.com/Rhoban/placo): Rhoban's planning and control library, featuring task-space inverse kinematics and dynamics high-level API for whole-body control tasks.
+-   [CRISP controllers](https://github.com/utiasDSL/crisp_controllers): Collection of real-time, C++ controllers for compliant torque-based control for manipulators compatible with `ros2_control`.
 
 ## Acknowledgments
 


### PR DESCRIPTION
## Description

Adds [RoboPlan](https://github.com/open-planning/roboplan) (which is my project) to the README of open-source projects, as well as 2 other cool projects I'm aware of that use Pinocchio but are not yet on this list.

No CHANGELOG needed.

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
