### PR TITLE
Ignore non-source files in Nix CI job

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -4,7 +4,25 @@ on:
   push:
     branches:
       - devel
+    paths-ignore:
+      - doc/**
+      - .gitlab-ci.yml
+      - .gitignore
+      - '**.md'
+      - CITATION.*
+      - COPYING.LESSER
+      - colcon.pkg
+      - .pre-commit-config.yaml
   pull_request:
+    paths-ignore:
+      - doc/**
+      - .gitlab-ci.yml
+      - .gitignore
+      - '**.md'
+      - CITATION.*
+      - COPYING.LESSER
+      - colcon.pkg
+      - .pre-commit-config.yaml
 
 jobs:
   nix-full:


### PR DESCRIPTION
## Description

I noticed that a README change in https://github.com/stack-of-tasks/pinocchio/pull/2831 caused the Nix jobs to run even though other source-build ones were bypassed... so I just copy-pasted the pattern in other jobs here too, for example [this](https://github.com/stack-of-tasks/pinocchio/blob/4a0e2c40e6991173a40e587e1adff7f974172df3/.github/workflows/linux.yml#L4-L25).

No CHANGELOG needed here.

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
