### PR TITLE
[ROS-O] Remove unused ROS_VERSION condition in package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,7 @@
   <depend>ros_environment</depend>
   <depend>python3</depend>
   <depend>python3-numpy</depend>
-  <depend condition="$ROS_VERSION == 2">urdfdom</depend>
+  <depend>urdfdom</depend>
   <depend>eigen</depend>
   <depend>boost</depend>
   <depend>eigenpy</depend>

--- a/pixi.lock
+++ b/pixi.lock
@@ -27994,7 +27994,7 @@ packages:
   timestamp: 1764330112083
 - conda: .
   name: pinocchio
-  version: 3.8.0
+  version: 3.9.0
   build: h0dc7051_0
   subdir: osx-64
   variants:
@@ -28012,7 +28012,7 @@ packages:
   - urdfdom >=4.0.1,<4.1.0a0
 - conda: .
   name: pinocchio
-  version: 3.8.0
+  version: 3.9.0
   build: h2433df5_0
   subdir: win-64
   variants:
@@ -28033,7 +28033,7 @@ packages:
   - urdfdom >=4.0.1,<4.1.0a0
 - conda: .
   name: pinocchio
-  version: 3.8.0
+  version: 3.9.0
   build: h60d57d3_0
   subdir: osx-arm64
   variants:
@@ -28051,7 +28051,7 @@ packages:
   - urdfdom >=4.0.1,<4.1.0a0
 - conda: .
   name: pinocchio
-  version: 3.8.0
+  version: 3.9.0
   build: hb0f4dca_0
   subdir: linux-64
   variants:
@@ -28070,7 +28070,7 @@ packages:
   - urdfdom >=4.0.1,<4.1.0a0
 - conda: .
   name: pinocchio
-  version: 3.8.0
+  version: 3.9.0
   build: he8cfe8b_0
   subdir: linux-aarch64
   variants:

--- a/pixi.lock
+++ b/pixi.lock
@@ -16784,7 +16784,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/win-64/zlib-1.3.1-h2466b09_2.conda
       - conda: https://conda.anaconda.org/conda-forge/win-64/zstd-1.5.7-h534d264_6.conda
       - conda: .
-        build: h2433df5_0
+        build: h659f713_0
 packages:
 - conda: https://conda.anaconda.org/conda-forge/linux-64/_libgcc_mutex-0.1-conda_forge.tar.bz2
   sha256: fe51de6107f9edc7aa4f786a70f4a883943bc9d39b3bb7307c04c41410990726
@@ -28013,17 +28013,14 @@ packages:
 - conda: .
   name: pinocchio
   version: 3.9.0
-  build: h2433df5_0
-  subdir: win-64
+  build: h60d57d3_0
+  subdir: osx-arm64
   variants:
-    cxx_compiler: vs2019
-    target_platform: win-64
+    target_platform: osx-arm64
   depends:
   - libboost-devel >=1.80.0
   - libboost-python-devel >=1.80.0
-  - vc >=14.2,<15
-  - vc14_runtime >=14.29.30139
-  - ucrt >=10.0.20348.0
+  - libcxx >=21
   - hpp-fcl >=3.0.2,<3.0.3.0a0
   - libboost >=1.88.0,<1.89.0a0
   - libboost-python >=1.88.0,<1.89.0a0
@@ -28034,14 +28031,17 @@ packages:
 - conda: .
   name: pinocchio
   version: 3.9.0
-  build: h60d57d3_0
-  subdir: osx-arm64
+  build: h659f713_0
+  subdir: win-64
   variants:
-    target_platform: osx-arm64
+    cxx_compiler: vs2022
+    target_platform: win-64
   depends:
   - libboost-devel >=1.80.0
   - libboost-python-devel >=1.80.0
-  - libcxx >=21
+  - vc >=14.3,<15
+  - vc14_runtime >=14.44.35208
+  - ucrt >=10.0.20348.0
   - hpp-fcl >=3.0.2,<3.0.3.0a0
   - libboost >=1.88.0,<1.89.0a0
   - libboost-python >=1.88.0,<1.89.0a0

--- a/pixi.toml
+++ b/pixi.toml
@@ -34,7 +34,7 @@ name = { workspace = true }
 version = { workspace = true }
 
 [package.build]
-backend = { name = "pixi-build-cmake", version = "0.3.*" }
+backend = { name = "pixi-build-cmake", version = "*" }
 
 [package.build.config]
 extra-args = [


### PR DESCRIPTION
The ROS1 alternative was removed from the package.xml [here](https://github.com/stack-of-tasks/pinocchio/commit/8ca2ca37e2cbc3b830348d7e87216143daddd99f) which broke the dependency in ROS-O.
But the `urdfdom` dependency works great with ROS-O and ROS2 as well, so the conditional is not just obsolete, but actually harmful and breaks builds.