### PR TITLE
MJCF constraint loading path with fixed bases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+- MJCF: load constraint models consistently across all build-model paths in the Python bindings, including fixed-base models.
+
 ## [3.9.0] - 2026-01-05
 
 ### Added

--- a/bindings/python/parsers/mjcf/model.cpp
+++ b/bindings/python/parsers/mjcf/model.cpp
@@ -15,18 +15,21 @@ namespace pinocchio
 
     namespace bp = boost::python;
 
-    Model buildModelFromMJCF(const bp::object & filename)
+    bp::tuple buildModelFromMJCF(const bp::object & filename)
     {
       Model model;
-      ::pinocchio::mjcf::buildModel(path(filename), model);
-      return model;
+      PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel) contact_models;
+      ::pinocchio::mjcf::buildModel(path(filename), model, contact_models);
+
+      return bp::make_tuple(model, contact_models);
     }
 
-    Model buildModelFromMJCF(const bp::object & filename, const JointModel & root_joint)
+    bp::tuple buildModelFromMJCF(const bp::object & filename, const JointModel & root_joint)
     {
       Model model;
-      ::pinocchio::mjcf::buildModel(path(filename), root_joint, model);
-      return model;
+      PINOCCHIO_STD_VECTOR_WITH_EIGEN_ALLOCATOR(RigidConstraintModel) contact_models;
+      ::pinocchio::mjcf::buildModel(path(filename), root_joint, model, contact_models);
+      return bp::make_tuple(model, contact_models);
     }
 
     bp::tuple buildModelFromMJCF(
@@ -45,16 +48,18 @@ namespace pinocchio
     {
       bp::def(
         "buildModelFromMJCF",
-        static_cast<Model (*)(const bp::object &)>(pinocchio::python::buildModelFromMJCF),
+        static_cast<bp::tuple (*)(const bp::object &)>(pinocchio::python::buildModelFromMJCF),
         bp::args("mjcf_filename"),
-        "Parse the MJCF file given in input and return a pinocchio Model.");
+        "Parse the MJCF file given in input and return a pinocchio Model as "
+        "well as a constraint list if some are present in the MJCF file.");
 
       bp::def(
         "buildModelFromMJCF",
-        static_cast<Model (*)(const bp::object &, const JointModel &)>(
+        static_cast<bp::tuple (*)(const bp::object &, const JointModel &)>(
           pinocchio::python::buildModelFromMJCF),
         bp::args("mjcf_filename", "root_joint"),
-        "Parse the MJCF file and return a pinocchio Model with the given root Joint.");
+        "Parse the MJCF file and return a pinocchio Model with the given root Joint as "
+        "well as a constraint list if some are present in the MJCF file.");
 
       bp::def(
         "buildModelFromMJCF",

--- a/bindings/python/pinocchio/shortcuts.py
+++ b/bindings/python/pinocchio/shortcuts.py
@@ -290,9 +290,9 @@ def _buildModelsFromMJCF(
 
     contact_models = []
     if root_joint is None:
-        model = pin.buildModelFromMJCF(filename)
+        model, contact_models = pin.buildModelFromMJCF(filename)
     elif root_joint is not None and root_joint_name is None:
-        model = pin.buildModelFromMJCF(filename, root_joint)
+        model, contact_models = pin.buildModelFromMJCF(filename, root_joint)
     else:
         model, contact_models = pin.buildModelFromMJCF(
             filename, root_joint, root_joint_name

--- a/unittest/python/CMakeLists.txt
+++ b/unittest/python/CMakeLists.txt
@@ -39,6 +39,7 @@ set(${PROJECT_NAME}_PYTHON_TESTS
     bindings_com_velocity_derivatives
     # Parsers
     bindings_sample_models
+    bindings_mjcf
     bindings_model_graph
     # Others
     robot_wrapper

--- a/unittest/python/bindings_mjcf.py
+++ b/unittest/python/bindings_mjcf.py
@@ -1,0 +1,27 @@
+import unittest
+from pathlib import Path
+
+import pinocchio as pin
+
+
+class TestMjcfBindings(unittest.TestCase):
+    def setUp(self):
+        self.model_path = Path(__file__).parent.parent / "models" / "closed_chain.xml"
+
+    def test_build_model_from_mjcf_returns_contacts_no_root_joint(self):
+        model, contact_models = pin.buildModelFromMJCF(self.model_path)
+
+        self.assertTrue(isinstance(model, pin.Model))
+        self.assertEqual(len(contact_models), 4)
+
+    def test_build_model_from_mjcf_returns_contacts_with_root_joint(self):
+        model, contact_models = pin.buildModelFromMJCF(
+            self.model_path, pin.JointModelFreeFlyer()
+        )
+
+        self.assertTrue(isinstance(model, pin.Model))
+        self.assertEqual(len(contact_models), 4)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Description

This PR exposes the necessary interfaces to load constraint models in all the MJCF build model paths in the python bindings, allowing to use fixed-base close-chain MJCF models in the python API. 

Fixes #2854.

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
