### PR TITLE
examples: fix more use of system example-robot-data

### DIFF
--- a/examples/capsule-approximation.py
+++ b/examples/capsule-approximation.py
@@ -5,6 +5,7 @@ https://tel.archives-ouvertes.fr/file/index/docid/833019/filename/thesis.pdf
 Section 3.8.1 Computing minimum bounding capsules
 """
 
+import os
 from pathlib import Path
 
 import hppfcl
@@ -167,9 +168,7 @@ if __name__ == "__main__":
     # This path refers to Pinocchio source code but you can define your own directory
     # here.
 
-    pinocchio_model_dir = Path(__file__).parent.parent / "models"
-    urdf_filename = (
-        pinocchio_model_dir
-        + "models/example-robot-data/robots/ur_description/urdf/ur5_gripper.urdf"
-    )
-    parse_urdf(urdf_filename, "ur5_gripper_with_capsules.urdf")
+    model_path = Path(os.environ.get("EXAMPLE_ROBOT_DATA_MODEL_DIR"))
+    urdf_filename = "ur5_gripper.urdf"
+    urdf_model_path = model_path / "ur_description/urdf" / urdf_filename
+    parse_urdf(urdf_model_path, "ur5_gripper_with_capsules.urdf")

--- a/examples/contact-cholesky.py
+++ b/examples/contact-cholesky.py
@@ -1,13 +1,12 @@
+import os
 from pathlib import Path
 
 import pinocchio as pin
 
-pinocchio_model_dir = Path(__file__).parent.parent / "models"
-urdf_filename = (
-    pinocchio_model_dir
-    / "example-robot-data/robots/anymal_b_simple_description/robots/anymal.urdf"
-)
-model = pin.buildModelFromUrdf(urdf_filename)
+model_path = Path(os.environ.get("EXAMPLE_ROBOT_DATA_MODEL_DIR"))
+urdf_filename = "anymal.urdf"
+urdf_model_path = model_path / "anymal_b_simple_description/robots" / urdf_filename
+model = pin.buildModelFromUrdf(urdf_model_path)
 data = model.createData()
 
 q0 = pin.neutral(model)


### PR DESCRIPTION
ref. #2728


## Description

fix for system example-robot-data eg. 
```python
58/80 Test #65: pinocchio-example-py-contact-cholesky ........................***Failed    0.32 sec
Error:   File /build/source/models/example-robot-data/robots/anymal_b_simple_description/robots/anymal.urdf does not exist
          at line 56 in /build/source/urdf_parser/src/model.cpp
Traceback (most recent call last):
   File "/build/source/examples/contact-cholesky.py", line 10, in <module>
     model = pin.buildModelFromUrdf(urdf_filename)
ValueError: The file /build/source/models/example-robot-data/robots/anymal_b_simple_description/robots/anymal.urdf does not contain a valid URDF model.
```

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation
- [ ] I have added tests that prove my fix or feature works
- [ ] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
