### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ or via pip (currently only available on Linux):
 
 ## Documentation
 
-The online documentation for the latest release of ** Pinocchio ** is available [here](https://gepettoweb.laas.fr/doc/stack-of-tasks/pinocchio/devel/doxygen-html/). A cheat sheet pdf with the main functions and algorithms can be found [here](https://github.com/stack-of-tasks/pinocchio/blob/devel/doc/pinocchio_cheat_sheet.pdf).
+The online documentation for the latest release of **Pinocchio** is available [here](https://gepettoweb.laas.fr/doc/stack-of-tasks/pinocchio/devel/doxygen-html/). A cheat sheet pdf with the main functions and algorithms can be found [here](https://github.com/stack-of-tasks/pinocchio/blob/devel/doc/pinocchio_cheat_sheet.pdf).
 
 ## Examples
 


### PR DESCRIPTION
Fix typo for bold markup in README
<!--
Please include a clear and concise description of the changes included in this pull request.
Explain what are you changing and why.

If applicable, link the related issue using "Fixes #issue_number".
-->

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
