### PR TITLE
update doc links

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://opensource.org/licenses/BSD-2-Clause"><img src="https://img.shields.io/badge/License-BSD%202--Clause-green.svg" alt="License"/></a>
-  <a href="https://gepettoweb.laas.fr/doc/stack-of-tasks/pinocchio/devel/doxygen-html/"><img src="https://img.shields.io/badge/docs-online-brightgreen" alt="Documentation"/></a>
+  <a href="https://gepetto.github.io/doc/pinocchio/doxygen-html/"><img src="https://img.shields.io/badge/docs-online-brightgreen" alt="Documentation"/></a>
   <a href="https://deepwiki.com/stack-of-tasks/pinocchio"><img src="https://deepwiki.com/badge.svg" alt="Ask DeepWiki"/></a>
   <a href="http://projects.laas.fr/gepetto/doc/stack-of-tasks/pinocchio/devel/coverage/"><img src="https://gepgitlab.laas.fr/stack-of-tasks/pinocchio/badges/devel/coverage.svg?job=doc-coverage" alt="Coverage Report"/></a>
   <a href="https://anaconda.org/conda-forge/pinocchio"><img src="https://img.shields.io/conda/dn/conda-forge/pinocchio.svg" alt="Conda Downloads"/></a>
@@ -33,7 +33,7 @@ It is built upon Eigen for linear algebra and **coal** for collision detection. 
 **Pinocchio** is now at the heart of various robotics software as [Aligator](https://github.com/Simple-Robotics/Aligator), [Crocoddyl](https://github.com/loco-3d/crocoddyl), an open-source and efficient Differential Dynamic Programming solver for robotics, the [Stack-of-Tasks](http://stack-of-tasks.github.io), an open-source and versatile hierarchical controller framework, or the [Humanoid Path Planner](https://humanoid-path-planner.github.io/hpp-doc), open-source software for Motion and Manipulation Planning.
 **Pinocchio** is also a primary source of inspiration for the [Kamino](https://disneyresearch.github.io/kamino/) simulator developed by Disney Research, which populates the Newton physics engine.
 
-If you want to learn more about **Pinocchio** internal behaviors and main features, we invite you to read the related [paper](https://hal-laas.archives-ouvertes.fr/hal-01866228) and the online [documentation](https://gepettoweb.laas.fr/doc/stack-of-tasks/pinocchio/devel/doxygen-html/) or [DeepWiki](https://deepwiki.com/stack-of-tasks/pinocchio).
+If you want to learn more about **Pinocchio** internal behaviors and main features, we invite you to read the related [paper](https://hal-laas.archives-ouvertes.fr/hal-01866228) and the online [documentation](https://gepetto.github.io/doc/pinocchio/doxygen-html/) or [DeepWiki](https://deepwiki.com/stack-of-tasks/pinocchio).
 
 If you want to dive into **Pinocchio** directly, only one single line is sufficient (assuming you have Conda):
 
@@ -110,18 +110,18 @@ or via pip (currently only available on Linux):
 
 ## Documentation
 
-The online documentation for the latest release of **Pinocchio** is available [here](https://gepettoweb.laas.fr/doc/stack-of-tasks/pinocchio/devel/doxygen-html/). A cheat sheet pdf with the main functions and algorithms can be found [here](https://github.com/stack-of-tasks/pinocchio/blob/devel/doc/pinocchio_cheat_sheet.pdf).
+The online documentation for the latest release of **Pinocchio** is available [here](https://gepetto.github.io/doc/pinocchio/doxygen-html/). A cheat sheet pdf with the main functions and algorithms can be found [here](https://github.com/stack-of-tasks/pinocchio/blob/devel/doc/pinocchio_cheat_sheet.pdf).
 
 ## Examples
 
 In the [examples](https://github.com/stack-of-tasks/pinocchio/tree/devel/examples) directory, we provide some basic examples of using Pinocchio in Python.
-Additional examples introducing **Pinocchio** are also available in the [documentation](https://gepettoweb.laas.fr/doc/stack-of-tasks/pinocchio/devel/doxygen-html/md_doc_d-practical-exercises_intro.html).
+Additional examples introducing **Pinocchio** are also available in the [documentation](https://gepetto.github.io/doc/pinocchio/doxygen-html/md_doc_d-practical-exercises_intro.html).
 
 ## Tutorials
 
 **Pinocchio** comes with a large set of tutorials that introduce the basic tools for robot control.
-Tutorial and training documents are listed [here](https://gepettoweb.laas.fr/doc/stack-of-tasks/pinocchio/devel/doxygen-html/index.html#OverviewConclu).
-You can also consider the interactive Jupyter notebook [set of tutorials](https://github.com/ymontmarin/_tps_robotique) developed by [Nicolas Mansard](https://gepettoweb.laas.fr/index.php/Members/NicolasMansard) and [Yann de Mont-Marin](https://github.com/ymontmarin).
+Tutorial and training documents are listed [here](https://gepetto.github.io/doc/pinocchio/doxygen-html/index.html#OverviewConclu).
+You can also consider the interactive Jupyter notebook [set of tutorials](https://github.com/ymontmarin/_tps_robotique) developed by [Nicolas Mansard](https://www.laas.fr/fr/annuaire/223) and [Yann de Mont-Marin](https://github.com/ymontmarin).
 
 ## Pinocchio continuous integrations
 

--- a/development/contributing.md
+++ b/development/contributing.md
@@ -19,7 +19,7 @@ Please try to include as much information as you can. Details like these are inc
   * Anything unusual about your environment or deployment
 
 ## Contributing via Pull Requests
-The following guidance should be up-to-date, but the documentation as found [here](https://gepettoweb.laas.fr/doc/stack-of-tasks/pinocchio/devel/doxygen-html/) should prove as the final say.
+The following guidance should be up-to-date, but the documentation as found [here](https://gepetto.github.io/doc/pinocchio/doxygen-html/) should prove as the final say.
 
 Contributions via pull requests are much appreciated.
 Before sending us a pull request, please ensure that:

--- a/doc/e-development/Implement_a_new_joint.md
+++ b/doc/e-development/Implement_a_new_joint.md
@@ -1040,7 +1040,7 @@ Use this checklist to track your implementation progress:
 ## Additional Resources
 
 - **Featherstone's Book**: *Rigid Body Dynamics Algorithms* (2008) - The definitive reference for spatial algebra
-- **Pinocchio Documentation**: https://gepettoweb.laas.fr/doc/stack-of-tasks/pinocchio/master/doxygen-html/
+- **Pinocchio Documentation**: https://gepetto.github.io/doc/pinocchio/doxygen-html/
 - **Existing Joint Implementations**: Study `joint-revolute.hpp`, `joint-spherical-ZYX.hpp`, `joint-free-flyer.hpp` for examples
 - **SymPy for symbolic math**: https://www.sympy.org/
 


### PR DESCRIPTION
## Description

gepettoweb is deprecated.


## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation
- [ ] I have added tests that prove my fix or feature works
- [ ] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
