### PR TITLE
viser: apply <mesh scale> to vertices instead of translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Fixed
 
+- Fix Viser visualizer: apply URDF `<mesh scale>` to mesh vertices instead of scaling the link translation ([#2878](https://github.com/stack-of-tasks/pinocchio/pull/2878))
+
 - Fix build issue with g++ 12 ([#2890](https://github.com/stack-of-tasks/pinocchio/pull/2890))
 - Fix useless memory allocation in Python checkers ([#2897](https://github.com/stack-of-tasks/pinocchio/pull/2897))
 
 ### Changed
 
 - nix: switch to flakoboros ([#2882](https://github.com/stack-of-tasks/pinocchio/pull/2882))
+
 
 ## [4.0.0] - 2026-04-13
 

--- a/README.md
+++ b/README.md
@@ -304,6 +304,7 @@ In addition to the core dev team, the following people have also been involved i
 -   [Pierre Puchaud](https://github.com/ipuch): Ellipsoid Joint
 -   [Lucas Joseph](https://github.com/LucasJoseph): Ellipsoid Joint
 -   [Megane Millan](https://github.com/MegMll): core developer (MJCF, joint mimic, etc.)
+-   [Tingfan Wu](https://github.com/tingfan): Viser visualizer mesh-scale bug fix
 
 If you have participated in the development of **Pinocchio**, please add your name and contribution to this list.
 

--- a/bindings/python/pinocchio/visualize/viser_visualizer.py
+++ b/bindings/python/pinocchio/visualize/viser_visualizer.py
@@ -201,12 +201,18 @@ class ViserVisualizer(BaseVisualizer):
             )
         elif isinstance(geom, MESH_TYPES):
             frame = self._add_mesh_from_path(
-                name, geometry_object.meshPath, color_override
+                name,
+                geometry_object.meshPath,
+                color_override,
+                scale=geometry_object.meshScale,
             )
         elif isinstance(geom, coal.Convex):
             if len(geometry_object.meshPath) > 0:
                 frame = self._add_mesh_from_path(
-                    name, geometry_object.meshPath, color_override
+                    name,
+                    geometry_object.meshPath,
+                    color_override,
+                    scale=geometry_object.meshScale,
                 )
             else:
                 frame = self._add_mesh_from_convex(name, geom, color_override)
@@ -215,19 +221,31 @@ class ViserVisualizer(BaseVisualizer):
 
         self.frames[name] = frame
 
-    def _add_mesh_from_path(self, name, mesh_path, color):
+    def _add_mesh_from_path(self, name, mesh_path, color, scale=None):
         """
         Load a mesh from a file.
+
+        The URDF <mesh scale="x y z"/> attribute is stored on the geometry
+        object as ``meshScale``. Since viser scene nodes do not support a
+        per-node non-uniform scale, we bake the scale into the mesh vertices
+        at load time.
         """
         extension = Path(mesh_path).suffix.lower()
+        apply_scale = scale is not None and not np.allclose(scale, 1.0)
         if extension == ".dae" or color is None:
             mesh = trimesh.load_scene(mesh_path)
+            if apply_scale:
+                for g in mesh.geometry.values():
+                    g.vertices = g.vertices * np.asarray(scale)
             return self.viewer.scene.add_mesh_trimesh(name, mesh)
         else:
             mesh = trimesh.load_mesh(mesh_path)
+            vertices = mesh.vertices
+            if apply_scale:
+                vertices = vertices * np.asarray(scale)
             return self.viewer.scene.add_mesh_simple(
                 name,
-                mesh.vertices,
+                vertices,
                 mesh.faces,
                 color=color[:3],
                 opacity=color[3],
@@ -305,7 +323,7 @@ class ViserVisualizer(BaseVisualizer):
             # Update viewer configuration.
             frame_name = prefix + "/" + geometry_object.name
             frame = self.frames[frame_name]
-            frame.position = M.translation * geometry_object.meshScale
+            frame.position = M.translation
             frame.wxyz = pin.Quaternion(M.rotation).coeffs()[
                 [3, 0, 1, 2]
             ]  # Pinocchio uses xyzw

--- a/bindings/python/pinocchio/visualize/viser_visualizer.py
+++ b/bindings/python/pinocchio/visualize/viser_visualizer.py
@@ -221,31 +221,21 @@ class ViserVisualizer(BaseVisualizer):
 
         self.frames[name] = frame
 
-    def _add_mesh_from_path(self, name, mesh_path, color, scale=None):
+    def _add_mesh_from_path(self, name, mesh_path, color, scale):
         """
         Load a mesh from a file.
-
-        The URDF <mesh scale="x y z"/> attribute is stored on the geometry
-        object as ``meshScale``. Since viser scene nodes do not support a
-        per-node non-uniform scale, we bake the scale into the mesh vertices
-        at load time.
         """
         extension = Path(mesh_path).suffix.lower()
-        apply_scale = scale is not None and not np.allclose(scale, 1.0)
         if extension == ".dae" or color is None:
             mesh = trimesh.load_scene(mesh_path)
-            if apply_scale:
-                for g in mesh.geometry.values():
-                    g.vertices = g.vertices * np.asarray(scale)
+            mesh.apply_scale(scale)
             return self.viewer.scene.add_mesh_trimesh(name, mesh)
         else:
             mesh = trimesh.load_mesh(mesh_path)
-            vertices = mesh.vertices
-            if apply_scale:
-                vertices = vertices * np.asarray(scale)
+            mesh.apply_scale(scale)
             return self.viewer.scene.add_mesh_simple(
                 name,
-                vertices,
+                mesh.vertices,
                 mesh.faces,
                 color=color[:3],
                 opacity=color[3],

--- a/models/simple_humanoid_description/box.dae
+++ b/models/simple_humanoid_description/box.dae
@@ -1,0 +1,99 @@
+<COLLADA xmlns="http://www.collada.org/2005/11/COLLADASchema" version="1.4.1">
+  <asset>
+    <created>2026-06-04T00:00:00.000000</created>
+    <modified>2026-06-04T00:00:00.000000</modified>
+    <up_axis>Y_UP</up_axis>
+  </asset>
+  <library_effects>
+    <effect id="effect0" name="effect0">
+      <profile_COMMON>
+        <technique sid="common">
+          <phong>
+            <emission>
+              <color>0.0 0.0 0.0 1.0</color>
+            </emission>
+            <ambient>
+              <color>0.0 0.0 0.0 1.0</color>
+            </ambient>
+            <diffuse>
+              <color>0.0 0.0 0.0 1.0</color>
+            </diffuse>
+            <specular>
+              <color>0.0 0.0 0.0 1.0</color>
+            </specular>
+            <shininess>
+              <float>0.0</float>
+            </shininess>
+            <reflective>
+              <color>0.0 0.0 0.0 1.0</color>
+            </reflective>
+            <reflectivity>
+              <float>0.0</float>
+            </reflectivity>
+            <transparent>
+              <color>0.0 0.0 0.0 1.0</color>
+            </transparent>
+            <transparency>
+              <float>1.0</float>
+            </transparency>
+          </phong>
+        </technique>
+      </profile_COMMON>
+    </effect>
+  </library_effects>
+  <library_geometries>
+    <geometry id="geometry0" name="box">
+      <mesh>
+        <source id="verts-array">
+          <float_array count="24" id="verts-array-array">-0.5 -0.5 -0.5 -0.5 -0.5 0.5 -0.5 0.5 -0.5 -0.5 0.5 0.5 0.5 -0.5 -0.5 0.5 -0.5 0.5 0.5 0.5 -0.5 0.5 0.5 0.5</float_array>
+          <technique_common>
+            <accessor count="8" source="#verts-array-array" stride="3">
+              <param type="float" name="X" />
+              <param type="float" name="Y" />
+              <param type="float" name="Z" />
+            </accessor>
+          </technique_common>
+        </source>
+        <source id="normals-array">
+          <float_array count="24" id="normals-array-array">-0.5773503 -0.5773503 -0.5773503 -0.5773503 -0.5773503 0.5773503 -0.5773503 0.5773503 -0.5773503 -0.5773503 0.5773503 0.5773503 0.5773503 -0.5773503 -0.5773503 0.5773503 -0.5773503 0.5773503 0.5773503 0.5773503 -0.5773503 0.5773503 0.5773503 0.5773503</float_array>
+          <technique_common>
+            <accessor count="8" source="#normals-array-array" stride="3">
+              <param type="float" name="X" />
+              <param type="float" name="Y" />
+              <param type="float" name="Z" />
+            </accessor>
+          </technique_common>
+        </source>
+        <vertices id="verts-array-vertices">
+          <input semantic="POSITION" source="#verts-array" />
+        </vertices>
+        <triangles count="12" material="material0">
+          <input offset="0" semantic="VERTEX" source="#verts-array-vertices" />
+          <input offset="1" semantic="NORMAL" source="#normals-array" />
+          <p>1 1 3 3 0 0 4 4 1 1 0 0 0 0 3 3 2 2 2 2 4 4 0 0 1 1 7 7 3 3 5 5 1 1 4 4 5 5 7 7 1 1 3 3 7 7 2 2 6 6 4 4 2 2 2 2 7 7 6 6 6 6 5 5 4 4 7 7 5 5 6 6</p>
+        </triangles>
+      </mesh>
+    </geometry>
+  </library_geometries>
+  <library_materials>
+    <material id="material0" name="defaultmaterial">
+      <instance_effect url="#effect0" />
+    </material>
+  </library_materials>
+  <library_visual_scenes>
+    <visual_scene id="scene">
+      <node id="node0" name="node0">
+        <instance_geometry url="#geometry0">
+          <bind_material>
+            <technique_common>
+              <instance_material symbol="material0" target="#material0" />
+            </technique_common>
+          </bind_material>
+        </instance_geometry>
+      </node>
+    </visual_scene>
+  </library_visual_scenes>
+  <scene>
+    <instance_visual_scene url="#scene" />
+  </scene>
+</COLLADA>

--- a/unittest/python/CMakeLists.txt
+++ b/unittest/python/CMakeLists.txt
@@ -147,6 +147,7 @@ if(urdfdom_FOUND)
         bindings_urdf
         bindings_geometry_model_urdf
         bindings_contact_inverse_dynamics
+        bindings_viser_visualizer
     )
 endif(urdfdom_FOUND)
 

--- a/unittest/python/bindings_viser_visualizer.py
+++ b/unittest/python/bindings_viser_visualizer.py
@@ -2,8 +2,8 @@
 Tests for pinocchio.visualize.ViserVisualizer.
 
 Focused on the meshScale handling: URDF ``<mesh scale="..."/>`` must be
-baked into the mesh vertices at load time, and must NOT be multiplied
-into the frame translation in updatePlacements.
+baked into the mesh at load time, and must NOT be multiplied into the frame
+translation in updatePlacements.
 """
 
 import unittest
@@ -13,6 +13,7 @@ import numpy as np
 import pinocchio as pin
 
 try:
+    import trimesh
     import viser
     from pinocchio.visualize import ViserVisualizer
 
@@ -20,12 +21,20 @@ try:
 except ImportError:
     WITH_VISER = False
 
+try:
+    import collada  # pycollada, required by trimesh to load DAE files
 
-# Resolve the pinocchio repo's shipped test mesh.
+    WITH_PYCOLLADA = True
+except ImportError:
+    WITH_PYCOLLADA = False
+
+
+# Resolve the pinocchio repo's shipped test meshes.
 MODELS_DIR = (
     Path(__file__).resolve().parent.parent.parent / "models"
 )  # unittest/python/../../models -> models
 BOX_STL = MODELS_DIR / "simple_humanoid_description" / "box.stl"
+BOX_DAE = MODELS_DIR / "simple_humanoid_description" / "box.dae"
 
 
 URDF_WITH_SCALE = """<?xml version="1.0"?>
@@ -46,81 +55,85 @@ URDF_WITH_SCALE = """<?xml version="1.0"?>
 @unittest.skipUnless(pin.WITH_URDFDOM, "Needs URDFDOM")
 class TestViserVisualizerMeshScale(unittest.TestCase):
     def setUp(self):
-        if not BOX_STL.is_file():
-            self.skipTest(f"box.stl not found at {BOX_STL}")
+        self.server = viser.ViserServer(host="localhost", server_port=0)
 
-        self.model = pin.buildModelFromXML(URDF_WITH_SCALE)
-        self.visual_model = pin.buildGeomFromUrdfString(
-            self.model,
-            URDF_WITH_SCALE,
-            pin.GeometryType.VISUAL,
-            package_dirs=[str(BOX_STL.parent)],
-        )
-        # Reuse visual as collision; the ViserVisualizer updates both on load.
-        self.collision_model = self.visual_model
-        self.expected_scale = np.array([2.0, 3.0, 4.0])
-        self.expected_translation = np.array([1.0, 2.0, 3.0])
+    def tearDown(self):
+        self.server.stop()
 
-        geom = self.visual_model.geometryObjects[0]
-        np.testing.assert_allclose(geom.meshScale, self.expected_scale)
-
-    def _make_visualizer(self):
-        # A headless viser server on an ephemeral port.
-        server = viser.ViserServer(host="localhost", server_port=0)
+    def _make_visualizer(self, model=None, visual_model=None, collision_model=None):
+        if model is None:
+            model = pin.Model()
         viz = ViserVisualizer(
-            self.model,
-            collision_model=self.collision_model,
-            visual_model=self.visual_model,
+            model,
+            collision_model=collision_model,
+            visual_model=visual_model,
         )
-        viz.initViewer(viewer=server)
-        return server, viz
+        viz.initViewer(viewer=self.server)
+        return viz
 
-    def test_scale_is_forwarded_to_mesh_loader(self):
-        """
-        Check that ``_add_mesh_from_path`` receives the geometry meshScale.
-        """
-        captured = {}
-        orig = ViserVisualizer._add_mesh_from_path
+    def test_stl_path_with_scale(self):
+        """STL branch: scale must be baked into the mesh vertices."""
+        scale = np.array([2.0, 3.0, 4.0])
+        expected_vertices = trimesh.load_mesh(str(BOX_STL)).vertices * scale
 
-        def spy(self, name, mesh_path, color, scale=None):
-            captured["scale"] = None if scale is None else np.array(scale)
-            return orig(self, name, mesh_path, color, scale=scale)
+        viz = self._make_visualizer()
+        frame = viz._add_mesh_from_path(
+            "test_stl",
+            str(BOX_STL),
+            color=[1.0, 0.0, 0.0, 1.0],
+            scale=scale,
+        )
+        np.testing.assert_allclose(
+            np.array(frame.vertices), expected_vertices, atol=1e-5
+        )
 
-        ViserVisualizer._add_mesh_from_path = spy
-        try:
-            server, viz = self._make_visualizer()
-            try:
-                viz.loadViewerModel()
-            finally:
-                server.stop()
-        finally:
-            ViserVisualizer._add_mesh_from_path = orig
-
-        self.assertIsNotNone(captured.get("scale"))
-        np.testing.assert_allclose(captured["scale"], self.expected_scale)
+    @unittest.skipUnless(WITH_PYCOLLADA, "Needs pycollada")
+    def test_dae_path_with_scale(self):
+        """DAE branch: _add_mesh_from_path must accept a DAE file with scale."""
+        viz = self._make_visualizer()
+        frame = viz._add_mesh_from_path(
+            "test_dae",
+            str(BOX_DAE),
+            color=None,
+            scale=np.array([2.0, 3.0, 4.0]),
+        )
+        self.assertIsNotNone(frame)
 
     def test_translation_is_not_multiplied_by_mesh_scale(self):
         """
         Check that frame.position equals the link translation.
 
         After ``display(q)``, the viser frame translation must match the
-        URDF link origin, *not* origin * meshScale (the previous bug).
+        URDF link origin.
         """
-        server, viz = self._make_visualizer()
-        try:
-            viz.loadViewerModel()
-            viz.display(pin.neutral(self.model))
+        expected_scale = np.array([2.0, 3.0, 4.0])
+        expected_translation = np.array([1.0, 2.0, 3.0])
 
-            geom_name = self.visual_model.geometryObjects[0].name
-            frame = viz.frames[viz.viewerRootNodeName + "/visual/" + geom_name]
+        model = pin.buildModelFromXML(URDF_WITH_SCALE)
+        visual_model = pin.buildGeomFromUrdfString(
+            model,
+            URDF_WITH_SCALE,
+            pin.GeometryType.VISUAL,
+            package_dirs=[str(BOX_STL.parent)],
+        )
+        np.testing.assert_allclose(
+            visual_model.geometryObjects[0].meshScale, expected_scale
+        )
 
-            np.testing.assert_allclose(
-                np.asarray(frame.position), self.expected_translation, atol=1e-9
-            )
-            buggy = self.expected_translation * self.expected_scale
-            self.assertFalse(np.allclose(np.asarray(frame.position), buggy))
-        finally:
-            server.stop()
+        viz = self._make_visualizer(
+            model=model,
+            collision_model=visual_model,
+            visual_model=visual_model,
+        )
+        viz.loadViewerModel()
+        viz.display(pin.neutral(model))
+
+        geom_name = visual_model.geometryObjects[0].name
+        frame = viz.frames[viz.viewerRootNodeName + "/visual/" + geom_name]
+
+        np.testing.assert_allclose(
+            np.asarray(frame.position), expected_translation, atol=1e-9
+        )
 
 
 if __name__ == "__main__":

--- a/unittest/python/bindings_viser_visualizer.py
+++ b/unittest/python/bindings_viser_visualizer.py
@@ -1,0 +1,121 @@
+"""Tests for pinocchio.visualize.ViserVisualizer.
+
+Focused on the meshScale handling: URDF ``<mesh scale="..."/>`` must be
+baked into the mesh vertices at load time, and must NOT be multiplied
+into the frame translation in updatePlacements.
+"""
+
+import unittest
+from pathlib import Path
+
+import numpy as np
+import pinocchio as pin
+
+try:
+    import viser
+    from pinocchio.visualize import ViserVisualizer
+
+    WITH_VISER = True
+except ImportError:
+    WITH_VISER = False
+
+
+# Resolve the pinocchio repo's shipped test mesh.
+MODELS_DIR = (
+    Path(__file__).resolve().parent.parent.parent / "models"
+)  # unittest/python/../../models -> models
+BOX_STL = MODELS_DIR / "simple_humanoid_description" / "box.stl"
+
+
+URDF_WITH_SCALE = """<?xml version="1.0"?>
+<robot name="scaled_box">
+  <link name="base_link">
+    <visual>
+      <origin xyz="1 2 3" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="package://box.stl" scale="2 3 4"/>
+      </geometry>
+    </visual>
+  </link>
+</robot>
+"""
+
+
+@unittest.skipUnless(WITH_VISER, "Needs viser")
+@unittest.skipUnless(pin.WITH_URDFDOM, "Needs URDFDOM")
+class TestViserVisualizerMeshScale(unittest.TestCase):
+    def setUp(self):
+        if not BOX_STL.is_file():
+            self.skipTest(f"box.stl not found at {BOX_STL}")
+
+        self.model = pin.buildModelFromXML(URDF_WITH_SCALE)
+        self.visual_model = pin.buildGeomFromUrdfString(
+            self.model,
+            URDF_WITH_SCALE,
+            pin.GeometryType.VISUAL,
+            package_dirs=[str(BOX_STL.parent)],
+        )
+        # Reuse visual as collision; the ViserVisualizer updates both on load.
+        self.collision_model = self.visual_model
+        self.expected_scale = np.array([2.0, 3.0, 4.0])
+        self.expected_translation = np.array([1.0, 2.0, 3.0])
+
+        geom = self.visual_model.geometryObjects[0]
+        np.testing.assert_allclose(geom.meshScale, self.expected_scale)
+
+    def _make_visualizer(self):
+        # A headless viser server on an ephemeral port.
+        server = viser.ViserServer(host="localhost", server_port=0)
+        viz = ViserVisualizer(
+            self.model,
+            collision_model=self.collision_model,
+            visual_model=self.visual_model,
+        )
+        viz.initViewer(viewer=server)
+        return server, viz
+
+    def test_scale_is_forwarded_to_mesh_loader(self):
+        """``_add_mesh_from_path`` must receive the geometry meshScale."""
+        captured = {}
+        orig = ViserVisualizer._add_mesh_from_path
+
+        def spy(self, name, mesh_path, color, scale=None):
+            captured["scale"] = None if scale is None else np.array(scale)
+            return orig(self, name, mesh_path, color, scale=scale)
+
+        ViserVisualizer._add_mesh_from_path = spy
+        try:
+            server, viz = self._make_visualizer()
+            try:
+                viz.loadViewerModel()
+            finally:
+                server.stop()
+        finally:
+            ViserVisualizer._add_mesh_from_path = orig
+
+        self.assertIsNotNone(captured.get("scale"))
+        np.testing.assert_allclose(captured["scale"], self.expected_scale)
+
+    def test_translation_is_not_multiplied_by_mesh_scale(self):
+        """After ``display(q)``, frame.position must equal the link
+        translation, *not* translation * meshScale.
+        """
+        server, viz = self._make_visualizer()
+        try:
+            viz.loadViewerModel()
+            viz.display(pin.neutral(self.model))
+
+            geom_name = self.visual_model.geometryObjects[0].name
+            frame = viz.frames[viz.viewerRootNodeName + "/visual/" + geom_name]
+
+            np.testing.assert_allclose(
+                np.asarray(frame.position), self.expected_translation, atol=1e-9
+            )
+            buggy = self.expected_translation * self.expected_scale
+            self.assertFalse(np.allclose(np.asarray(frame.position), buggy))
+        finally:
+            server.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/unittest/python/bindings_viser_visualizer.py
+++ b/unittest/python/bindings_viser_visualizer.py
@@ -6,6 +6,7 @@ baked into the mesh at load time, and must NOT be multiplied into the frame
 translation in updatePlacements.
 """
 
+import importlib.util
 import unittest
 from pathlib import Path
 
@@ -21,12 +22,7 @@ try:
 except ImportError:
     WITH_VISER = False
 
-try:
-    import collada  # pycollada, required by trimesh to load DAE files
-
-    WITH_PYCOLLADA = True
-except ImportError:
-    WITH_PYCOLLADA = False
+WITH_PYCOLLADA = importlib.util.find_spec("collada") is not None
 
 
 # Resolve the pinocchio repo's shipped test meshes.

--- a/unittest/python/bindings_viser_visualizer.py
+++ b/unittest/python/bindings_viser_visualizer.py
@@ -7,6 +7,7 @@ translation in updatePlacements.
 """
 
 import importlib.util
+import io
 import unittest
 from pathlib import Path
 
@@ -86,14 +87,28 @@ class TestViserVisualizerMeshScale(unittest.TestCase):
     @unittest.skipUnless(WITH_PYCOLLADA, "Needs pycollada")
     def test_dae_path_with_scale(self):
         """DAE branch: _add_mesh_from_path must accept a DAE file with scale."""
+        scale = np.array([2.0, 3.0, 4.0])
+        # access original mesh
+        original_mesh = trimesh.load_scene(str(BOX_DAE)).to_mesh()
+
         viz = self._make_visualizer()
         frame = viz._add_mesh_from_path(
             "test_dae",
             str(BOX_DAE),
             color=None,
-            scale=np.array([2.0, 3.0, 4.0]),
+            scale=scale,
         )
-        self.assertIsNotNone(frame)
+
+        # mesh is not accessible from frame, we load glb data to access mesh
+        result_mesh = trimesh.load(
+            io.BytesIO(frame.glb_data), file_type="glb"
+        ).to_mesh()
+
+        np.testing.assert_allclose(
+            result_mesh.vertices,
+            original_mesh.vertices * scale,
+            atol=1e-5,
+        )
 
     def test_translation_is_not_multiplied_by_mesh_scale(self):
         """

--- a/unittest/python/bindings_viser_visualizer.py
+++ b/unittest/python/bindings_viser_visualizer.py
@@ -1,4 +1,5 @@
-"""Tests for pinocchio.visualize.ViserVisualizer.
+"""
+Tests for pinocchio.visualize.ViserVisualizer.
 
 Focused on the meshScale handling: URDF ``<mesh scale="..."/>`` must be
 baked into the mesh vertices at load time, and must NOT be multiplied
@@ -75,7 +76,9 @@ class TestViserVisualizerMeshScale(unittest.TestCase):
         return server, viz
 
     def test_scale_is_forwarded_to_mesh_loader(self):
-        """``_add_mesh_from_path`` must receive the geometry meshScale."""
+        """
+        Check that ``_add_mesh_from_path`` receives the geometry meshScale.
+        """
         captured = {}
         orig = ViserVisualizer._add_mesh_from_path
 
@@ -97,8 +100,11 @@ class TestViserVisualizerMeshScale(unittest.TestCase):
         np.testing.assert_allclose(captured["scale"], self.expected_scale)
 
     def test_translation_is_not_multiplied_by_mesh_scale(self):
-        """After ``display(q)``, frame.position must equal the link
-        translation, *not* translation * meshScale.
+        """
+        Check that frame.position equals the link translation.
+
+        After ``display(q)``, the viser frame translation must match the
+        URDF link origin, *not* origin * meshScale (the previous bug).
         """
         server, viz = self._make_visualizer()
         try:


### PR DESCRIPTION
Thanks for taking the time to make and fill out this pull request!

## Description

Fixes rendering of URDF meshes with a non-unit `<mesh scale="..."/>` attribute in the Viser visualizer.

**Before:** `ViserVisualizer._add_mesh_from_path` loaded mesh vertices at their native scale and ignored `GeometryObject.meshScale`. To compensate, `updatePlacements` multiplied the link translation by `meshScale` (`frame.position = M.translation * geometry_object.meshScale`). That is incorrect — the per-geometry scale is a *mesh* property, not a kinematic one. The net effect was: meshes rendered at the wrong size *and* wrong position, and different geometries on the same link were shifted apart from each other.

**After:** `meshScale` is baked into the mesh vertices at load time (matching how the `.dae` / `trimesh.Scene` branch works), and the link translation is passed through untouched. Viser scene nodes don't support a per-node non-uniform scale, so baking the scale into the vertices is the right place for it.

Added a regression test (`unittest/python/bindings_viser_visualizer.py`) that builds a one-link URDF with `<mesh scale="2 3 4"/>` at translation `(1, 2, 3)` and checks both:
- the scale is forwarded to `_add_mesh_from_path`, and
- after `display(q)`, the viser frame position equals `(1, 2, 3)` — not `(2, 6, 12)` as the old code produced.

No related issue on the tracker — happy to open one if preferred.

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation *(N/A — Python-only internals, no doxygen affected)*
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
