### PR TITLE
Fix build issue with g++ 12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
-- nix: switch to flakoboros
+### Fixed
+
+- Fix build issue with g++ 12 ([#2890](https://github.com/stack-of-tasks/pinocchio/pull/2890))
+
+### Changed
+
+- nix: switch to flakoboros ([#2882](https://github.com/stack-of-tasks/pinocchio/pull/2882))
 
 ## [4.0.0] - 2026-04-13
 

--- a/include/pinocchio/src/constraints/utils.hxx
+++ b/include/pinocchio/src/constraints/utils.hxx
@@ -943,12 +943,12 @@ namespace pinocchio
         PINOCCHIO_UNUSED_VARIABLE(dispatcher);
 
         // For some reason this assert is always evaluated when building
-        // with g++ 11.
-        // TODO Remove when Ubuntu 22.04 is no more supported.
-#if !defined(__GNUC__) || __GNUC__ >= 12
+        // with g++ 11 and 12.
+        // TODO Remove when Ubuntu 22.04 and Debian 12 (ROS) is no more supported.
+#if !defined(__GNUC__) || __GNUC__ >= 13
         static_assert(
           false, "ComputeBlockDiagonalPatternImpl not implemented for this constraint.");
-#endif // !defined(__GNUC__) || __GNUC__ >= 12
+#endif // !defined(__GNUC__) || __GNUC__ >= 13
       }
     };
 


### PR DESCRIPTION
## Description

A build issue found in g++ 11 is also present in g++ 12. This PR extend the fix to this version.

Close #2887 

## Checklist

- [ ] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation
- [ ] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
