### PR TITLE
Topic/aba second order derivatives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Add second-order partial derivatives of the Articulated Body Algorithm (forward dynamics) with respect to joint configuration, velocity and torque ([#2891](https://github.com/stack-of-tasks/pinocchio/pull/2891))
+
 ## [4.1.0] - 2026-07-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ In addition to the core dev team, the following people have also been involved i
 -   [François Keith](https://scholar.google.fr/citations?user=cxSxXiQAAAAJ&hl=en) (CEA): Windows support
 -   [Sarah El Kazdadi](https://github.com/sarah-ek) (Inria): multi-precision arithmetic support
 -   [Nicolas Torres Alberto](https://scholar.google.com/citations?user=gYNLhEIAAAAJ&hl=en) (Inria): features extension
--   [Shubham Singh](https://github.com/shubhamsingh91) (UT Austin): second-order inverse dynamics derivatives
+-   [Shubham Singh](https://github.com/shubhamsingh91) (UT Austin): second-order inverse and forward dynamics derivatives
 -   [Sebastian Castro](https://roboticseabass.com): Viser visualizer and MeshCat visualizer feature extension
 -   [Lev Kozlov](https://github.com/lvjonok): Kinetic and potential energy regressors
 -   [Simeon Nedelchev](https://github.com/simeon-ned): Pseudo inertia and Log-Cholesky parametrization

--- a/benchmark/timings-derivatives.cpp
+++ b/benchmark/timings-derivatives.cpp
@@ -9,6 +9,7 @@
 #include "pinocchio/algorithm/kinematics-derivatives.hpp"
 #include "pinocchio/algorithm/rnea-derivatives.hpp"
 #include "pinocchio/algorithm/rnea-second-order-derivatives.hpp"
+#include "pinocchio/algorithm/aba-second-order-derivatives.hpp"
 #include "pinocchio/algorithm/aba-derivatives.hpp"
 #include "pinocchio/algorithm/aba.hpp"
 #include "pinocchio/algorithm/rnea.hpp"
@@ -133,6 +134,15 @@ struct DerivativesFixture : ModelFixture
     dtau2_dv.setZero();
     dtau2_dqv.setZero();
     dtau_dadq.setZero();
+
+    d2ddq_dqdq = Tensor3x(model.nv, model.nv, model.nv);
+    d2ddq_dvdv = Tensor3x(model.nv, model.nv, model.nv);
+    d2ddq_dqdv = Tensor3x(model.nv, model.nv, model.nv);
+    d2ddq_dtaudq = Tensor3x(model.nv, model.nv, model.nv);
+    d2ddq_dqdq.setZero();
+    d2ddq_dvdv.setZero();
+    d2ddq_dqdv.setZero();
+    d2ddq_dtaudq.setZero();
   }
 
   PINOCCHIO_EIGEN_PLAIN_COLUMN_MAJOR_TYPE(Eigen::MatrixXd) drnea_dq;
@@ -147,6 +157,11 @@ struct DerivativesFixture : ModelFixture
   Tensor3x dtau2_dv;
   Tensor3x dtau2_dqv;
   Tensor3x dtau_dadq;
+
+  Tensor3x d2ddq_dqdq;
+  Tensor3x d2ddq_dvdv;
+  Tensor3x d2ddq_dqdv;
+  Tensor3x d2ddq_dtaudq;
 
   void TearDown(benchmark::State & st)
   {
@@ -271,6 +286,33 @@ BENCHMARK_DEFINE_F(DerivativesFixture, COMUTE_RNEA_SECOND_ORDER_DERIVATIVES)(ben
   }
 }
 BENCHMARK_REGISTER_F(DerivativesFixture, COMUTE_RNEA_SECOND_ORDER_DERIVATIVES)
+  ->Apply(CustomArguments);
+
+// COMPUTE_ABA_SECOND_ORDER_DERIVATIVES
+
+PINOCCHIO_DONT_INLINE static void computeABASecondOrderDerivativesCall(
+  const pinocchio::Model & model,
+  pinocchio::Data & data,
+  const Eigen::VectorXd & q,
+  const Eigen::VectorXd & v,
+  const Eigen::VectorXd & tau,
+  const Tensor3x & d2ddq_dqdq,
+  const Tensor3x & d2ddq_dvdv,
+  const Tensor3x & d2ddq_dqdv,
+  const Tensor3x & d2ddq_dtaudq)
+{
+  ComputeABASecondOrderDerivatives(
+    model, data, q, v, tau, d2ddq_dqdq, d2ddq_dvdv, d2ddq_dqdv, d2ddq_dtaudq);
+}
+BENCHMARK_DEFINE_F(DerivativesFixture, COMPUTE_ABA_SECOND_ORDER_DERIVATIVES)(benchmark::State & st)
+{
+  for (auto _ : st)
+  {
+    computeABASecondOrderDerivativesCall(
+      model, data, q, v, tau, d2ddq_dqdq, d2ddq_dvdv, d2ddq_dqdv, d2ddq_dtaudq);
+  }
+}
+BENCHMARK_REGISTER_F(DerivativesFixture, COMPUTE_ABA_SECOND_ORDER_DERIVATIVES)
   ->Apply(CustomArguments);
 
 // COMPUTE_RNEA_FD_DERIVATIVES

--- a/include/pinocchio/algorithm/aba-second-order-derivatives.hpp
+++ b/include/pinocchio/algorithm/aba-second-order-derivatives.hpp
@@ -1,0 +1,174 @@
+//
+// Copyright (c) 2018-2024 INRIA
+//
+
+#pragma once
+
+// IWYU pragma: begin_keep
+#include <Eigen/Core>
+
+#include <cassert>
+#include <cstddef>
+#include <type_traits>
+#include <vector>
+
+#include "pinocchio/macros.hpp"
+#include "pinocchio/eigen-common.hpp"
+#include "pinocchio/fwd.hpp"
+
+#include "pinocchio/math.hpp"
+
+#include "pinocchio/spatial.hpp"
+
+#include "pinocchio/multibody.hpp"
+#include "pinocchio/multibody/joint.hpp"
+#include "pinocchio/multibody/visitor.hpp"
+
+#include "pinocchio/algorithm/check.hpp"
+#include "pinocchio/algorithm/aba.hpp"
+#include "pinocchio/algorithm/aba-derivatives.hpp"
+#include "pinocchio/algorithm/rnea-second-order-derivatives.hpp"
+// IWYU pragma: end_keep
+
+namespace pinocchio
+{
+  ///
+  /// \brief Computes the Second-Order partial derivatives of the Articulated Body
+  /// Algorithm (forward dynamics) with respect to the joint configuration, the joint
+  /// velocity and the joint torque.
+  ///
+  /// \tparam JointCollectionTpl Collection of Joint types.
+  /// \tparam ConfigVectorType Type of the joint configuration vector.
+  /// \tparam TangentVectorType1 Type of the joint velocity vector.
+  /// \tparam TangentVectorType2 Type of the joint torque vector.
+  /// \tparam Tensor1 Type of the 3D-Tensor containing the SO partial derivative
+  /// with respect to the joint configuration vector. The elements of the joint
+  /// acceleration vector are along the 1st dim, and joint configuration along
+  /// the 2nd and 3rd dimensions.
+  /// \tparam Tensor2 Type of the 3D-Tensor containing the Second-Order partial
+  /// derivative with respect to the joint velocity vector. The elements of the
+  /// joint acceleration vector are along the 1st dim, and the velocity along
+  /// the 2nd and 3rd dimensions.
+  /// \tparam Tensor3 Type of the 3D-Tensor containing the cross Second-Order
+  /// partial derivative with respect to the joint configuration and velocity
+  /// vector. The elements of the joint acceleration vector are along the 1st
+  /// dim, the velocity vector along the 2nd dimension, and the configuration
+  /// vector along the 3rd dimension.
+  /// \tparam Tensor4 Type of the 3D-Tensor containing the cross Second-Order
+  /// partial derivative with respect to the joint torque and joint
+  /// configuration vector. The elements of the joint acceleration vector are
+  /// along the 1st dim, the torque vector along the 2nd dimension, and the
+  /// configuration vector along the 3rd dimension.
+  ///
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  /// \param[in] q The joint configuration vector (dim model.nq).
+  /// \param[in] v The joint velocity vector (dim model.nv).
+  /// \param[in] tau The joint torque vector (dim model.nv).
+  /// \param[out] d2ddq_dqdq Second-Order Partial derivative of the joint
+  /// acceleration vector with respect to the joint configuration.
+  /// \param[out] d2ddq_dvdv Second-Order Partial derivative of the joint
+  /// acceleration vector with respect to the joint velocity.
+  /// \param[out] d2ddq_dqdv Cross Second-Order Partial derivative of the joint
+  /// acceleration vector with respect to the joint configuration and joint
+  /// velocity.
+  /// \param[out] d2ddq_dtaudq Cross Second-Order Partial derivative of the
+  /// joint acceleration vector with respect to the joint torque and joint
+  /// configuration.
+  ///
+  /// \remarks The output tensors are fully overwritten by this call, so no
+  /// pre-initialization is required. The storage order of the 3D-tensor
+  /// derivatives mirrors the convention used for the SO RNEA derivatives:
+  /// rows index the output joint-acceleration component, columns index the
+  /// inner derivative variable, and pages index the outer derivative
+  /// variable. For example, d2ddq_dqdv equals d(dqdd/dv)/dq, so the velocity
+  /// indices vary along the columns and the configuration indices vary along
+  /// the pages.
+  ///
+  /// \note This algorithm reuses pinocchio::computeABADerivatives and
+  /// pinocchio::ComputeRNEASecondOrderDerivatives. After the call, the
+  /// first-order ABA derivatives are also available in data.ddq_dq, data.ddq_dv
+  /// and data.Minv, and the second-order RNEA derivatives in data.d2tau_*.
+  ///
+  /// \sa pinocchio::ComputeRNEASecondOrderDerivatives,
+  ///     pinocchio::computeABADerivatives.
+  ///
+  template<
+    typename Scalar,
+    int Options,
+    template<typename, int> class JointCollectionTpl,
+    typename ConfigVectorType,
+    typename TangentVectorType1,
+    typename TangentVectorType2,
+    typename Tensor1,
+    typename Tensor2,
+    typename Tensor3,
+    typename Tensor4>
+  inline void ComputeABASecondOrderDerivatives(
+    const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
+    DataTpl<Scalar, Options, JointCollectionTpl> & data,
+    const Eigen::MatrixBase<ConfigVectorType> & q,
+    const Eigen::MatrixBase<TangentVectorType1> & v,
+    const Eigen::MatrixBase<TangentVectorType2> & tau,
+    const Tensor1 & d2ddq_dqdq,
+    const Tensor2 & d2ddq_dvdv,
+    const Tensor3 & d2ddq_dqdv,
+    const Tensor4 & d2ddq_dtaudq);
+
+  ///
+  /// \brief Computes the Second-Order partial derivatives of the Articulated
+  /// Body Algorithm (forward dynamics) with respect to the joint configuration,
+  /// the joint velocity and the joint torque.
+  ///
+  /// \tparam JointCollectionTpl Collection of Joint types.
+  /// \tparam ConfigVectorType Type of the joint configuration vector.
+  /// \tparam TangentVectorType1 Type of the joint velocity vector.
+  /// \tparam TangentVectorType2 Type of the joint torque vector.
+  ///
+  /// \param[in] model The model structure of the rigid body system.
+  /// \param[in] data The data structure of the rigid body system.
+  /// \param[in] q The joint configuration vector (dim model.nq).
+  /// \param[in] v The joint velocity vector (dim model.nv).
+  /// \param[in] tau The joint torque vector (dim model.nv).
+  ///
+  /// \note The results are stored in data.d2ddq_dqdq, data.d2ddq_dvdv,
+  /// data.d2ddq_dqdv and data.d2ddq_dtaudq, which respectively correspond to
+  /// the Second-Order partial derivatives of the joint acceleration vector
+  /// with respect to the joint configuration, joint velocity, and the cross
+  /// Second-Order partial derivatives with respect to (configuration,velocity)
+  /// and (torque,configuration). The first-order ABA derivatives are also
+  /// available in data.ddq_dq, data.ddq_dv and data.Minv, and the second-order
+  /// RNEA derivatives in data.d2tau_*.
+  ///
+  /// \sa pinocchio::ComputeRNEASecondOrderDerivatives,
+  ///     pinocchio::computeABADerivatives.
+  ///
+  template<
+    typename Scalar,
+    int Options,
+    template<typename, int> class JointCollectionTpl,
+    typename ConfigVectorType,
+    typename TangentVectorType1,
+    typename TangentVectorType2>
+  inline void ComputeABASecondOrderDerivatives(
+    const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
+    DataTpl<Scalar, Options, JointCollectionTpl> & data,
+    const Eigen::MatrixBase<ConfigVectorType> & q,
+    const Eigen::MatrixBase<TangentVectorType1> & v,
+    const Eigen::MatrixBase<TangentVectorType2> & tau)
+  {
+    (data.d2ddq_dqdq).setZero();
+    (data.d2ddq_dvdv).setZero();
+    (data.d2ddq_dqdv).setZero();
+    (data.d2ddq_dtaudq).setZero();
+
+    ComputeABASecondOrderDerivatives(
+      model, data, q.derived(), v.derived(), tau.derived(), data.d2ddq_dqdq, data.d2ddq_dvdv,
+      data.d2ddq_dqdv, data.d2ddq_dtaudq);
+  }
+
+} // namespace pinocchio
+
+// IWYU pragma: begin_exports
+#include "pinocchio/src/algorithm/aba-second-order-derivatives.hxx"
+// IWYU pragma: end_exports

--- a/include/pinocchio/src/algorithm/aba-second-order-derivatives.hxx
+++ b/include/pinocchio/src/algorithm/aba-second-order-derivatives.hxx
@@ -1,0 +1,321 @@
+//
+// Copyright (c) 2018-2024 INRIA
+//
+
+#pragma once
+
+// IWYU pragma: private, include "pinocchio/algorithm/aba-second-order-derivatives.hpp"
+
+#ifdef PINOCCHIO_LSP
+  #undef PINOCCHIO_LSP
+  #include "pinocchio/algorithm/aba-second-order-derivatives.hpp"
+#endif // PINOCCHIO_LSP
+
+#include "pinocchio/spatial/act-on-set.hpp"
+
+namespace pinocchio
+{
+
+  // Forward sweep used by ComputeABASecondOrderDerivatives to propagate the
+  // input acceleration `a` through the chain. Only acceleration-dependent
+  // quantities are recomputed per call:
+  //   - data.oa[i]: spatial acceleration with zero gravity at the root, so
+  //     the backward sweep yields (dM/dq)*a only (no gravity contribution).
+  //   - ddJ_cols = oa x J_cols.
+  //   - data.of[i] = oYcrb_leaf[i] * oa, the spatial force at body i.
+  //   - data.oYcrb[i] is reset to oYcrb_leaf[i], since the backward sweep
+  //     composites oYcrb in place and we need the leaf values at the start
+  //     of each per-column iteration.
+  // q-dependent quantities (data.oMi, data.liMi, data.J, data.joints[i] with
+  // a valid jdata.S(), and the world-frame leaf inertia oYcrb_leaf cached by
+  // the caller) are assumed to already be set by the prior computeABADerivatives
+  // and ComputeRNEASecondOrderDerivatives calls, so we deliberately skip
+  // jmodel.calc and the liMi/oMi/J_cols updates that a standard ABA forward
+  // sweep would perform.
+  template<
+    typename Scalar,
+    int Options,
+    template<typename, int> class JointCollectionTpl,
+    typename InputAccType>
+  struct ComputeABASecondOrderDerivativesInnerForwardStep
+  : public fusion::JointUnaryVisitorBase<ComputeABASecondOrderDerivativesInnerForwardStep<
+      Scalar,
+      Options,
+      JointCollectionTpl,
+      InputAccType>>
+  {
+    typedef ModelTpl<Scalar, Options, JointCollectionTpl> Model;
+    typedef DataTpl<Scalar, Options, JointCollectionTpl> Data;
+    typedef typename Data::Inertia Inertia;
+    typedef std::vector<Inertia> InertiaVector;
+
+    typedef boost::fusion::
+      vector<const Model &, Data &, const InputAccType &, const InertiaVector &>
+        ArgsType;
+
+    template<typename JointModel>
+    static void algo(
+      const JointModelBase<JointModel> & jmodel,
+      JointDataBase<typename JointModel::JointDataDerived> & jdata,
+      const Model & model,
+      Data & data,
+      const Eigen::MatrixBase<InputAccType> & a,
+      const InertiaVector & oYcrb_leaf)
+    {
+      typedef typename Model::JointIndex JointIndex;
+      typedef typename Data::Motion Motion;
+
+      const JointIndex i = jmodel.id();
+      const JointIndex parent = model.parents[i];
+      Motion & oa = data.oa[i];
+
+      if (parent > 0)
+        oa = data.oa[parent];
+      else
+        oa.setZero(); // zero gravity: result is (dM/dq)*a, not (dM/dq)*a + dh/dq
+
+      typedef
+        typename SizeDepType<JointModel::NV>::template ColsReturn<typename Data::Matrix6x>::Type
+          ColsBlock;
+      ColsBlock J_cols = jmodel.jointCols(data.J);
+      ColsBlock ddJ_cols = jmodel.jointCols(data.ddJ);
+
+      motionSet::motionAction(oa, J_cols, ddJ_cols);
+      oa += data.oMi[i].act(jdata.S() * jmodel.jointVelocitySelector(a));
+
+      data.oYcrb[i] = oYcrb_leaf[i];
+      data.of[i] = data.oYcrb[i] * oa;
+    }
+  };
+
+  // Backward sweep companion to ComputeABASecondOrderDerivativesInnerForwardStep.
+  // Fills `dM_a_dq(j, k) = d/dq_k ( M(q) * a )_j` using `Ftmp1` and `Ftmp3`
+  // as accumulation workspace (each sized 6 x model.nv).
+  template<
+    typename Scalar,
+    int Options,
+    template<typename, int> class JointCollectionTpl,
+    typename FtmpType,
+    typename OutputMatrixType>
+  struct ComputeABASecondOrderDerivativesInnerBackwardStep
+  : public fusion::JointUnaryVisitorBase<ComputeABASecondOrderDerivativesInnerBackwardStep<
+      Scalar,
+      Options,
+      JointCollectionTpl,
+      FtmpType,
+      OutputMatrixType>>
+  {
+    typedef ModelTpl<Scalar, Options, JointCollectionTpl> Model;
+    typedef DataTpl<Scalar, Options, JointCollectionTpl> Data;
+
+    typedef boost::fusion::vector<const Model &, Data &, FtmpType &, FtmpType &, OutputMatrixType &>
+      ArgsType;
+
+    template<typename JointModel>
+    static void algo(
+      const JointModelBase<JointModel> & jmodel,
+      const Model & model,
+      Data & data,
+      FtmpType & Ftmp1,
+      FtmpType & Ftmp3,
+      OutputMatrixType & dM_a_dq)
+    {
+      typedef typename Model::JointIndex JointIndex;
+
+      const JointIndex i = jmodel.id();
+      const JointIndex parent = model.parents[i];
+
+      typedef
+        typename SizeDepType<JointModel::NV>::template ColsReturn<typename Data::Matrix6x>::Type
+          ColsBlock;
+      ColsBlock J_cols = jmodel.jointCols(data.J);
+      ColsBlock ddJ_cols = jmodel.jointCols(data.ddJ);
+      ColsBlock tmp1 = jmodel.jointCols(Ftmp1);
+      ColsBlock tmp3 = jmodel.jointCols(Ftmp3);
+
+      const Eigen::Index joint_idx = (Eigen::Index)jmodel.idx_v();
+      const Eigen::Index joint_dofs = (Eigen::Index)jmodel.nv();
+      const Eigen::Index subtree_dofs = (Eigen::Index)data.nvSubtree[i];
+      const Eigen::Index successor_idx = joint_idx + joint_dofs;
+      const Eigen::Index successor_dofs = subtree_dofs - joint_dofs;
+
+      typename Data::Inertia & oYcrb = data.oYcrb[i];
+      motionSet::inertiaAction(oYcrb, J_cols, tmp1);
+      motionSet::inertiaAction<ADDTO>(oYcrb, ddJ_cols, tmp3);
+      motionSet::act<ADDTO>(J_cols, data.of[i], tmp3);
+
+      if (successor_dofs > 0)
+        dM_a_dq.block(joint_idx, successor_idx, joint_dofs, successor_dofs).noalias() =
+          J_cols.transpose() * Ftmp3.middleCols(successor_idx, successor_dofs);
+
+      dM_a_dq.block(joint_idx, joint_idx, subtree_dofs, joint_dofs).noalias() =
+        Ftmp1.middleCols(joint_idx, subtree_dofs).transpose() * ddJ_cols;
+
+      if (parent > 0)
+      {
+        data.oYcrb[parent] += data.oYcrb[i];
+        data.of[parent] += data.of[i];
+      }
+    }
+  };
+
+  template<
+    typename Scalar,
+    int Options,
+    template<typename, int> class JointCollectionTpl,
+    typename ConfigVectorType,
+    typename TangentVectorType1,
+    typename TangentVectorType2,
+    typename Tensor1,
+    typename Tensor2,
+    typename Tensor3,
+    typename Tensor4>
+  inline void ComputeABASecondOrderDerivatives(
+    const ModelTpl<Scalar, Options, JointCollectionTpl> & model,
+    DataTpl<Scalar, Options, JointCollectionTpl> & data,
+    const Eigen::MatrixBase<ConfigVectorType> & q,
+    const Eigen::MatrixBase<TangentVectorType1> & v,
+    const Eigen::MatrixBase<TangentVectorType2> & tau,
+    const Tensor1 & d2ddq_dqdq,
+    const Tensor2 & d2ddq_dvdv,
+    const Tensor3 & d2ddq_dqdv,
+    const Tensor4 & d2ddq_dtaudq)
+  {
+    PINOCCHIO_CHECK_ARGUMENT_SIZE(q.size(), model.nq);
+    PINOCCHIO_CHECK_ARGUMENT_SIZE(v.size(), model.nv);
+    PINOCCHIO_CHECK_ARGUMENT_SIZE(tau.size(), model.nv);
+    PINOCCHIO_CHECK_ARGUMENT_SIZE(d2ddq_dqdq.dimension(0), model.nv);
+    PINOCCHIO_CHECK_ARGUMENT_SIZE(d2ddq_dqdq.dimension(1), model.nv);
+    PINOCCHIO_CHECK_ARGUMENT_SIZE(d2ddq_dqdq.dimension(2), model.nv);
+    PINOCCHIO_CHECK_ARGUMENT_SIZE(d2ddq_dvdv.dimension(0), model.nv);
+    PINOCCHIO_CHECK_ARGUMENT_SIZE(d2ddq_dvdv.dimension(1), model.nv);
+    PINOCCHIO_CHECK_ARGUMENT_SIZE(d2ddq_dvdv.dimension(2), model.nv);
+    PINOCCHIO_CHECK_ARGUMENT_SIZE(d2ddq_dqdv.dimension(0), model.nv);
+    PINOCCHIO_CHECK_ARGUMENT_SIZE(d2ddq_dqdv.dimension(1), model.nv);
+    PINOCCHIO_CHECK_ARGUMENT_SIZE(d2ddq_dqdv.dimension(2), model.nv);
+    PINOCCHIO_CHECK_ARGUMENT_SIZE(d2ddq_dtaudq.dimension(0), model.nv);
+    PINOCCHIO_CHECK_ARGUMENT_SIZE(d2ddq_dtaudq.dimension(1), model.nv);
+    PINOCCHIO_CHECK_ARGUMENT_SIZE(d2ddq_dtaudq.dimension(2), model.nv);
+    assert(model.check(data) && "data is not consistent with model.");
+    assert(model.check(MimicChecker()) && "Function does not support mimic joints");
+
+    typedef ModelTpl<Scalar, Options, JointCollectionTpl> Model;
+    typedef DataTpl<Scalar, Options, JointCollectionTpl> Data;
+    typedef typename Data::MatrixXs MatrixXs;
+    typedef typename Data::VectorXs VectorXs;
+    typedef typename Data::Matrix6x Matrix6x;
+    typedef typename Data::Tensor3x Tensor3x;
+    typedef typename Model::JointIndex JointIndex;
+
+    const Eigen::Index nv = model.nv;
+    const Eigen::Index nv2 = nv * nv;
+
+    // 1) First-order ABA derivatives: fills data.ddq, data.ddq_dq, data.ddq_dv
+    //    and (upper triangle of) data.Minv.
+    computeABADerivatives(model, data, q.derived(), v.derived(), tau.derived());
+    // Symmetrize Minv: computeABADerivatives only fills the upper triangle
+    data.Minv.template triangularView<Eigen::StrictlyLower>() =
+      data.Minv.transpose().template triangularView<Eigen::StrictlyLower>();
+
+    // 2) Second-order RNEA derivatives at (q, v, ddq). d2tau_dadq holds the
+    //    pages of dM/dq.
+    ComputeRNEASecondOrderDerivatives(
+      model, data, q.derived(), v.derived(), data.ddq, data.d2tau_dqdq, data.d2tau_dvdv,
+      data.d2tau_dqdv, data.d2tau_dadq);
+
+    // 3) Inner-Term: for each column w of (ddq_dq, ddq_dv, Minv), compute
+    //    (dM/dq) * column and store as page w of the corresponding tensor.
+    //
+    // The per-column forward sweep below is the acceleration-only pass; it
+    // reuses the q-dependent kinematics (data.oMi, data.J, data.joints[i])
+    // already populated by computeABADerivatives and SO RNEA, and the leaf
+    // body inertias cached in oYcrb_leaf right below.
+    typedef ComputeABASecondOrderDerivativesInnerForwardStep<
+      Scalar, Options, JointCollectionTpl, VectorXs>
+      InnerPass1;
+    typedef ComputeABASecondOrderDerivativesInnerBackwardStep<
+      Scalar, Options, JointCollectionTpl, Matrix6x, MatrixXs>
+      InnerPass2;
+
+    // Cache the world-frame leaf body inertia once. SO RNEA leaves
+    // data.oYcrb in its composited state, and the inner-term backward sweep
+    // mutates data.oYcrb again per call, so we restore the leaf values at
+    // the start of each per-column forward pass.
+    typename InnerPass1::InertiaVector oYcrb_leaf((std::size_t)model.njoints);
+    for (JointIndex i = 1; i < (JointIndex)model.njoints; ++i)
+      oYcrb_leaf[i] = data.oMi[i].act(model.inertias[i]);
+
+    // TODO: preallocate these scratch buffers (three nv-cubed tensors, two
+    // 6-by-nv matrices, one nv-by-nv matrix, plus the two nv-by-4*nv^2
+    // matrices in step 4) as Data fields to avoid the per-call allocations
+    // (relevant for trajectory-optimization loops that call this per knot
+    // point).
+    Tensor3x prodq(nv, nv, nv), prodv(nv, nv, nv), prodqdd(nv, nv, nv);
+    Matrix6x Ftmp1 = Matrix6x::Zero(6, nv);
+    Matrix6x Ftmp3 = Matrix6x::Zero(6, nv);
+    MatrixXs inner_out(nv, nv);
+
+    auto fill_inner = [&](const auto & input_columns, Tensor3x & out_tensor) {
+      for (Eigen::Index w = 0; w < nv; ++w)
+      {
+        VectorXs a_input = input_columns.col(w);
+        for (JointIndex i = 1; i < (JointIndex)model.njoints; ++i)
+          InnerPass1::run(
+            model.joints[i], data.joints[i],
+            typename InnerPass1::ArgsType(model, data, a_input, oYcrb_leaf));
+
+        Ftmp1.setZero();
+        Ftmp3.setZero();
+        inner_out.setZero();
+        for (JointIndex i = (JointIndex)(model.njoints - 1); i > 0; --i)
+          InnerPass2::run(
+            model.joints[i], typename InnerPass2::ArgsType(model, data, Ftmp1, Ftmp3, inner_out));
+
+        Eigen::Map<MatrixXs>(out_tensor.data() + w * nv2, nv, nv) = inner_out;
+      }
+    };
+
+    fill_inner(data.ddq_dq, prodq);
+    fill_inner(data.ddq_dv, prodv);
+    fill_inner(data.Minv, prodqdd);
+
+    // 4) Outer-Term: build term_in (nv x 4*nv*nv) and take a single dense
+    //    -M^{-1} * term_in product. Singh, Russell & Wensing (2023),
+    //    Fig. 14b: at practical robotics sizes the BLAS-3 GEMM beats the
+    //    AZA recursion on the Outer-Term.
+    MatrixXs term_in(nv, 4 * nv2);
+    for (Eigen::Index u = 0; u < nv; ++u)
+    {
+      for (Eigen::Index i = 0; i < nv; ++i)
+      {
+        for (Eigen::Index n = 0; n < nv; ++n)
+        {
+          term_in(n, (4 * u + 0) * nv + i) =
+            data.d2tau_dqdq(n, i, u) + prodq(n, u, i) + prodq(n, i, u);
+          term_in(n, (4 * u + 1) * nv + i) = data.d2tau_dvdv(n, i, u);
+          term_in(n, (4 * u + 2) * nv + i) = data.d2tau_dqdv(n, i, u) + prodv(n, i, u);
+          term_in(n, (4 * u + 3) * nv + i) = prodqdd(n, u, i);
+        }
+      }
+    }
+
+    MatrixXs term_out(nv, 4 * nv2);
+    term_out.noalias() = -data.Minv * term_in;
+
+    // 5) Scatter term_out into the four output tensors.
+    for (Eigen::Index u = 0; u < nv; ++u)
+    {
+      for (Eigen::Index i = 0; i < nv; ++i)
+      {
+        for (Eigen::Index n = 0; n < nv; ++n)
+        {
+          const_cast<Tensor1 &>(d2ddq_dqdq)(n, i, u) = term_out(n, (4 * u + 0) * nv + i);
+          const_cast<Tensor2 &>(d2ddq_dvdv)(n, i, u) = term_out(n, (4 * u + 1) * nv + i);
+          const_cast<Tensor3 &>(d2ddq_dqdv)(n, i, u) = term_out(n, (4 * u + 2) * nv + i);
+          const_cast<Tensor4 &>(d2ddq_dtaudq)(n, i, u) = term_out(n, (4 * u + 3) * nv + i);
+        }
+      }
+    }
+  }
+
+} // namespace pinocchio

--- a/include/pinocchio/src/multibody/data.hxx
+++ b/include/pinocchio/src/multibody/data.hxx
@@ -574,6 +574,22 @@ namespace pinocchio
     /// configuration.
     Tensor3x d2tau_dadq;
 
+    /// \brief SO Partial derivative of the joint acceleration vector with
+    /// respect to the joint configuration.
+    Tensor3x d2ddq_dqdq;
+
+    /// \brief SO Partial derivative of the joint acceleration vector with
+    /// respect to the joint velocity.
+    Tensor3x d2ddq_dvdv;
+
+    /// \brief SO Cross-Partial derivative of the joint acceleration vector
+    /// with respect to the joint configuration/velocity.
+    Tensor3x d2ddq_dqdv;
+
+    /// \brief SO Cross-Partial derivative of the joint acceleration vector
+    /// with respect to the joint torque/configuration.
+    Tensor3x d2ddq_dtaudq;
+
 #if defined(_MSC_VER)
   #pragma warning(default : 4554) // C4554 enabled after tensor definition
 #endif
@@ -775,6 +791,10 @@ namespace pinocchio
   , d2tau_dvdv(model.nv, model.nv, model.nv)
   , d2tau_dqdv(model.nv, model.nv, model.nv)
   , d2tau_dadq(model.nv, model.nv, model.nv)
+  , d2ddq_dqdq(model.nv, model.nv, model.nv)
+  , d2ddq_dvdv(model.nv, model.nv, model.nv)
+  , d2ddq_dqdv(model.nv, model.nv, model.nv)
+  , d2ddq_dtaudq(model.nv, model.nv, model.nv)
   , extended_motion_propagator((std::size_t)model.njoints, Matrix6::Zero())
   , extended_motion_propagator2((std::size_t)model.njoints, Matrix6::Zero())
   , spatial_inv_inertia((std::size_t)model.njoints, Matrix6::Zero())
@@ -826,6 +846,10 @@ namespace pinocchio
     d2tau_dvdv.setZero();
     d2tau_dqdv.setZero();
     d2tau_dadq.setZero();
+    d2ddq_dqdq.setZero();
+    d2ddq_dvdv.setZero();
+    d2ddq_dqdv.setZero();
+    d2ddq_dtaudq.setZero();
   }
   PINOCCHIO_COMPILER_DIAGNOSTIC_POP
 
@@ -1059,7 +1083,11 @@ namespace pinocchio
              && Tensor<bool, 0>((data1.d2tau_dqdq == data2.d2tau_dqdq).all())(0)
              && Tensor<bool, 0>((data1.d2tau_dvdv == data2.d2tau_dvdv).all())(0)
              && Tensor<bool, 0>((data1.d2tau_dqdv == data2.d2tau_dqdv).all())(0)
-             && Tensor<bool, 0>((data1.d2tau_dadq == data2.d2tau_dadq).all())(0);
+             && Tensor<bool, 0>((data1.d2tau_dadq == data2.d2tau_dadq).all())(0)
+             && Tensor<bool, 0>((data1.d2ddq_dqdq == data2.d2ddq_dqdq).all())(0)
+             && Tensor<bool, 0>((data1.d2ddq_dvdv == data2.d2ddq_dvdv).all())(0)
+             && Tensor<bool, 0>((data1.d2ddq_dqdv == data2.d2ddq_dqdv).all())(0)
+             && Tensor<bool, 0>((data1.d2ddq_dtaudq == data2.d2ddq_dtaudq).all())(0);
 
     return value;
   }

--- a/include/pinocchio/src/serialization/data.hxx
+++ b/include/pinocchio/src/serialization/data.hxx
@@ -145,6 +145,10 @@ namespace boost
       PINOCCHIO_MAKE_DATA_NVP(ar, data, d2tau_dvdv);
       PINOCCHIO_MAKE_DATA_NVP(ar, data, d2tau_dqdv);
       PINOCCHIO_MAKE_DATA_NVP(ar, data, d2tau_dadq);
+      PINOCCHIO_MAKE_DATA_NVP(ar, data, d2ddq_dqdq);
+      PINOCCHIO_MAKE_DATA_NVP(ar, data, d2ddq_dvdv);
+      PINOCCHIO_MAKE_DATA_NVP(ar, data, d2ddq_dqdv);
+      PINOCCHIO_MAKE_DATA_NVP(ar, data, d2ddq_dtaudq);
       PINOCCHIO_MAKE_DATA_NVP(ar, data, kinematic_hessians);
       PINOCCHIO_MAKE_DATA_NVP(ar, data, primal_dual_contact_solution);
 

--- a/unittest/CMakeLists.txt
+++ b/unittest/CMakeLists.txt
@@ -266,6 +266,7 @@ add_pinocchio_unit_test(contact-dynamics-derivatives)
 # endif()
 add_pinocchio_unit_test(impulse-dynamics-derivatives)
 add_pinocchio_unit_test(rnea-second-order-derivatives)
+add_pinocchio_unit_test(aba-second-order-derivatives)
 
 # # Pinocchio features
 add_pinocchio_unit_test(spatial)

--- a/unittest/aba-second-order-derivatives.cpp
+++ b/unittest/aba-second-order-derivatives.cpp
@@ -1,0 +1,162 @@
+//
+// Copyright (c) 2018-2024 INRIA
+//
+
+#include "pinocchio/multibody.hpp"
+
+#include "pinocchio/algorithm/aba-second-order-derivatives.hpp"
+#include "pinocchio/algorithm/aba-derivatives.hpp"
+#include "pinocchio/multibody/sample-models.hpp"
+
+#include <boost/test/unit_test.hpp>
+#include <boost/utility/binary.hpp>
+
+BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
+
+namespace
+{
+  inline void symmetrizeUpper(Eigen::MatrixXd & m)
+  {
+    m.triangularView<Eigen::StrictlyLower>() = m.transpose().triangularView<Eigen::StrictlyLower>();
+  }
+} // namespace
+
+BOOST_AUTO_TEST_CASE(test_aba_derivatives_SO)
+{
+  using namespace Eigen;
+  using namespace pinocchio;
+
+  Model model;
+  buildModels::humanoidRandom(model);
+
+  Data data(model), data_fd(model);
+
+  model.lowerPositionLimit.head<3>().fill(-1.);
+  model.upperPositionLimit.head<3>().fill(1.);
+
+  VectorXd q = randomConfiguration(model);
+  VectorXd v(VectorXd::Random(model.nv));
+  VectorXd tau(VectorXd::Random(model.nv));
+
+  // 1) Analytical second-order ABA derivatives.
+  Data::Tensor3x d2ddq_dqdq(model.nv, model.nv, model.nv);
+  Data::Tensor3x d2ddq_dvdv(model.nv, model.nv, model.nv);
+  Data::Tensor3x d2ddq_dqdv(model.nv, model.nv, model.nv);
+  Data::Tensor3x d2ddq_dtaudq(model.nv, model.nv, model.nv);
+  d2ddq_dqdq.setZero();
+  d2ddq_dvdv.setZero();
+  d2ddq_dqdv.setZero();
+  d2ddq_dtaudq.setZero();
+
+  ComputeABASecondOrderDerivatives(
+    model, data, q, v, tau, d2ddq_dqdq, d2ddq_dvdv, d2ddq_dqdv, d2ddq_dtaudq);
+
+  // 2) Finite-difference reference, computed by perturbing q and v and re-running
+  //    the first-order ABA derivatives.
+  Data::Tensor3x d2ddq_dqdq_fd(model.nv, model.nv, model.nv);
+  Data::Tensor3x d2ddq_dvdv_fd(model.nv, model.nv, model.nv);
+  Data::Tensor3x d2ddq_dqdv_fd(model.nv, model.nv, model.nv);
+  Data::Tensor3x d2ddq_dtaudq_fd(model.nv, model.nv, model.nv);
+  d2ddq_dqdq_fd.setZero();
+  d2ddq_dvdv_fd.setZero();
+  d2ddq_dqdv_fd.setZero();
+  d2ddq_dtaudq_fd.setZero();
+
+  MatrixXd ddq_dq_base(MatrixXd::Zero(model.nv, model.nv));
+  MatrixXd ddq_dv_base(MatrixXd::Zero(model.nv, model.nv));
+  MatrixXd ddq_dtau_base(MatrixXd::Zero(model.nv, model.nv));
+
+  computeABADerivatives(model, data, q, v, tau, ddq_dq_base, ddq_dv_base, ddq_dtau_base);
+  symmetrizeUpper(ddq_dtau_base);
+
+  MatrixXd ddq_dq_plus(MatrixXd::Zero(model.nv, model.nv));
+  MatrixXd ddq_dv_plus(MatrixXd::Zero(model.nv, model.nv));
+  MatrixXd ddq_dtau_plus(MatrixXd::Zero(model.nv, model.nv));
+
+  MatrixXd temp_dq(MatrixXd::Zero(model.nv, model.nv));
+  MatrixXd temp_dv(MatrixXd::Zero(model.nv, model.nv));
+  MatrixXd temp_dtau(MatrixXd::Zero(model.nv, model.nv));
+
+  VectorXd v_eps(VectorXd::Zero(model.nv));
+  VectorXd q_plus(model.nq);
+  VectorXd v_plus(model.nv);
+
+  const double alpha = 1e-7;
+
+  // 2a) Perturb q (configuration). This populates d2ddq_dqdq_fd and
+  //     d2ddq_dtaudq_fd.
+  for (int k = 0; k < model.nv; ++k)
+  {
+    v_eps[k] += alpha;
+    q_plus = integrate(model, q, v_eps);
+    computeABADerivatives(model, data_fd, q_plus, v, tau, ddq_dq_plus, ddq_dv_plus, ddq_dtau_plus);
+    symmetrizeUpper(ddq_dtau_plus);
+
+    temp_dq = (ddq_dq_plus - ddq_dq_base) / alpha;
+    temp_dtau = (ddq_dtau_plus - ddq_dtau_base) / alpha;
+
+    for (int ii = 0; ii < model.nv; ++ii)
+    {
+      for (int jj = 0; jj < model.nv; ++jj)
+      {
+        d2ddq_dqdq_fd(jj, ii, k) = temp_dq(jj, ii);
+        d2ddq_dtaudq_fd(jj, ii, k) = temp_dtau(jj, ii);
+      }
+    }
+    v_eps[k] -= alpha;
+  }
+
+  // 2b) Perturb v. This populates d2ddq_dvdv_fd and d2ddq_dqdv_fd.
+  for (int k = 0; k < model.nv; ++k)
+  {
+    v_eps[k] += alpha;
+    v_plus = v + v_eps;
+    computeABADerivatives(model, data_fd, q, v_plus, tau, ddq_dq_plus, ddq_dv_plus, ddq_dtau_plus);
+
+    temp_dv = (ddq_dv_plus - ddq_dv_base) / alpha;
+    temp_dq = (ddq_dq_plus - ddq_dq_base) / alpha;
+
+    for (int ii = 0; ii < model.nv; ++ii)
+    {
+      for (int jj = 0; jj < model.nv; ++jj)
+      {
+        d2ddq_dvdv_fd(jj, ii, k) = temp_dv(jj, ii);
+        d2ddq_dqdv_fd(jj, ii, k) = temp_dq(jj, ii);
+      }
+    }
+    v_eps[k] -= alpha;
+  }
+
+  // 3) Compare analytic against finite-difference reference.
+  Map<VectorXd> mqq(d2ddq_dqdq.data(), d2ddq_dqdq.size());
+  Map<VectorXd> mvv(d2ddq_dvdv.data(), d2ddq_dvdv.size());
+  Map<VectorXd> mqv(d2ddq_dqdv.data(), d2ddq_dqdv.size());
+  Map<VectorXd> mtq(d2ddq_dtaudq.data(), d2ddq_dtaudq.size());
+
+  Map<VectorXd> mqq_fd(d2ddq_dqdq_fd.data(), d2ddq_dqdq_fd.size());
+  Map<VectorXd> mvv_fd(d2ddq_dvdv_fd.data(), d2ddq_dvdv_fd.size());
+  Map<VectorXd> mqv_fd(d2ddq_dqdv_fd.data(), d2ddq_dqdv_fd.size());
+  Map<VectorXd> mtq_fd(d2ddq_dtaudq_fd.data(), d2ddq_dtaudq_fd.size());
+
+  BOOST_CHECK(mqq.isApprox(mqq_fd, sqrt(alpha)));
+  BOOST_CHECK(mvv.isApprox(mvv_fd, sqrt(alpha)));
+  BOOST_CHECK(mqv.isApprox(mqv_fd, sqrt(alpha)));
+  BOOST_CHECK(mtq.isApprox(mtq_fd, sqrt(alpha)));
+
+  // 4) The Data-member overload should produce the same result as the
+  //    explicit-output overload.
+  Data data2(model);
+  ComputeABASecondOrderDerivatives(model, data2, q, v, tau);
+
+  Map<VectorXd> mqq2(data2.d2ddq_dqdq.data(), data2.d2ddq_dqdq.size());
+  Map<VectorXd> mvv2(data2.d2ddq_dvdv.data(), data2.d2ddq_dvdv.size());
+  Map<VectorXd> mqv2(data2.d2ddq_dqdv.data(), data2.d2ddq_dqdv.size());
+  Map<VectorXd> mtq2(data2.d2ddq_dtaudq.data(), data2.d2ddq_dtaudq.size());
+
+  BOOST_CHECK(mqq.isApprox(mqq2));
+  BOOST_CHECK(mvv.isApprox(mvv2));
+  BOOST_CHECK(mqv.isApprox(mqv2));
+  BOOST_CHECK(mtq.isApprox(mtq2));
+}
+
+BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Thanks for taking the time to make and fill out this pull request!

## Description

This PR (discussed in #2691) adds the second-order derivatives of the **unconstrained Articulated Body Algorithm** as derived in this paper (https://ieeexplore.ieee.org/abstract/document/10449483). 
The specific algorithm is from Eq~46 from the paper, and more details can be found in Fig.13. Note that this algorithm uses the **rnea-second-order-derivatives**, which were contributed previously as a part of #1860.

Paper can be accessed directly on [researchGate](https://www.researchgate.net/publication/368473734_On_Second-Order_Derivatives_of_Rigid-Body_Dynamics_Theory_Implementation). 

Output of timings-derivatives:
```  --------------------------------------------------------------------------------------------------
  Benchmark                                                        Time             CPU   Iterations
  --------------------------------------------------------------------------------------------------
  DerivativesFixture/FORWARD_KINEMATICS_Q_V_A                   3688 ns         3687 ns       189116
  DerivativesFixture/FORWARD_KINEMATICS_DERIVATIVES             4792 ns         4792 ns       152272
  DerivativesFixture/RNEA                                       5254 ns         5250 ns       132336
  DerivativesFixture/COMPUTE_RNEA_DERIVATIVES                  22267 ns        22267 ns        31468
  DerivativesFixture/COMUTE_RNEA_SECOND_ORDER_DERIVATIVES     164514 ns       164474 ns         4248
  DerivativesFixture/COMPUTE_ABA_SECOND_ORDER_DERIVATIVES    3486243 ns      3486084 ns          203
  DerivativesFixture/COMPUTE_RNEA_FD_DERIVATIVES              406536 ns       406510 ns         1724
  DerivativesFixture/ABA_LOCAL                                 13172 ns        13166 ns        51339
  DerivativesFixture/COMPUTE_ABA_DERIVATIVES                   49715 ns        49713 ns        14036
  DerivativesFixture/COMPUTE_ABA_DERIVATIVES_NO_Q_V_TAU        41965 ns        41963 ns        16760
  DerivativesFixture/COMPUTE_ABA_FD_DERIVATIVES               946073 ns       946021 ns          741
  DerivativesFixture/COMPUTE_M_INVERSE_Q                       10507 ns        10500 ns        66520
  DerivativesFixture/COMPUTE_M_INVERSE                          5036 ns         5036 ns       139458
  DerivativesFixture/COMPUTE_CHOLESKY_M_INVERSE                17365 ns        17364 ns        40261
```

Close #2691 

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
