### PR TITLE
Fix the useless copy of Model in Python checkers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Fixed
 
 - Fix build issue with g++ 12 ([#2890](https://github.com/stack-of-tasks/pinocchio/pull/2890))
+- Fix useless memory allocation in Python checkers ([#2897](https://github.com/stack-of-tasks/pinocchio/pull/2897))
 
 ### Changed
 

--- a/include/pinocchio/bindings/python/utils/model-checker.hpp
+++ b/include/pinocchio/bindings/python/utils/model-checker.hpp
@@ -32,7 +32,7 @@ namespace pinocchio
         // Convert the object to a tuple
         boost::python::tuple py_args = boost::python::extract<boost::python::tuple>(args);
 
-        const auto & model =
+        const context::Model & model =
           boost::python::extract<const context::Model &>(py_args[model_arg_list_idx]);
         if (!model.check(MimicChecker()))
         {

--- a/include/pinocchio/bindings/python/utils/model-checker.hpp
+++ b/include/pinocchio/bindings/python/utils/model-checker.hpp
@@ -32,8 +32,9 @@ namespace pinocchio
         // Convert the object to a tuple
         boost::python::tuple py_args = boost::python::extract<boost::python::tuple>(args);
 
-        context::Model m = boost::python::extract<context::Model>(py_args[model_arg_list_idx]);
-        if (!m.check(MimicChecker()))
+        const auto & model =
+          boost::python::extract<const context::Model &>(py_args[model_arg_list_idx]);
+        if (!model.check(MimicChecker()))
         {
           PyErr_SetString(PyExc_RuntimeError, m_error_message.c_str());
           return false;


### PR DESCRIPTION
Thanks for taking the time to make and fill out this pull request!

## Description

<!--
Please include a clear and concise description of the changes included in this pull request.
Explain what are you changing and why.

If applicable, link the related issue using "Fixes #issue_number".
-->

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation
- [ ] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
