### PR TITLE
Fix mesh scaling in Viser visualizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 - Fix build issue with g++ 12 ([#2890](https://github.com/stack-of-tasks/pinocchio/pull/2890))
 - Fix useless memory allocation in Python checkers ([#2897](https://github.com/stack-of-tasks/pinocchio/pull/2897))
+- Fix mesh scaling in Viser visualizer ([#2903](https://github.com/stack-of-tasks/pinocchio/pull/2903))
 
 ### Changed
 

--- a/bindings/python/pinocchio/visualize/viser_visualizer.py
+++ b/bindings/python/pinocchio/visualize/viser_visualizer.py
@@ -201,12 +201,18 @@ class ViserVisualizer(BaseVisualizer):
             )
         elif isinstance(geom, MESH_TYPES):
             frame = self._add_mesh_from_path(
-                name, geometry_object.meshPath, color_override
+                name,
+                geometry_object.meshPath,
+                color_override,
+                geometry_object.meshScale,
             )
         elif isinstance(geom, coal.Convex):
             if len(geometry_object.meshPath) > 0:
                 frame = self._add_mesh_from_path(
-                    name, geometry_object.meshPath, color_override
+                    name,
+                    geometry_object.meshPath,
+                    color_override,
+                    geometry_object.meshScale,
                 )
             else:
                 frame = self._add_mesh_from_convex(name, geom, color_override)
@@ -215,16 +221,18 @@ class ViserVisualizer(BaseVisualizer):
 
         self.frames[name] = frame
 
-    def _add_mesh_from_path(self, name, mesh_path, color):
+    def _add_mesh_from_path(self, name, mesh_path, color, scale):
         """
         Load a mesh from a file.
         """
         extension = Path(mesh_path).suffix.lower()
         if extension == ".dae" or color is None:
             mesh = trimesh.load_scene(mesh_path)
+            mesh.apply_scale(scale)
             return self.viewer.scene.add_mesh_trimesh(name, mesh)
         else:
             mesh = trimesh.load_mesh(mesh_path)
+            mesh.apply_scale(scale)
             return self.viewer.scene.add_mesh_simple(
                 name,
                 mesh.vertices,
@@ -305,7 +313,7 @@ class ViserVisualizer(BaseVisualizer):
             # Update viewer configuration.
             frame_name = prefix + "/" + geometry_object.name
             frame = self.frames[frame_name]
-            frame.position = M.translation * geometry_object.meshScale
+            frame.position = M.translation
             frame.wxyz = pin.Quaternion(M.rotation).coeffs()[
                 [3, 0, 1, 2]
             ]  # Pinocchio uses xyzw


### PR DESCRIPTION
## Description

This PR fixes the `ViserVisualizer` to correctly apply mesh scaling specified in URDF files.
@eholum FYI

Before:
<img width="1756" height="1126" alt="image" src="https://github.com/user-attachments/assets/17a3709c-53a1-4866-b6f2-07e608c16067" />

After:
<img width="1671" height="1118" alt="image" src="https://github.com/user-attachments/assets/204cf319-9561-4cf2-84e0-5865bc1d3d52" />

... and after removing the extra `geometry_object.meshScale` in `updatePlacements()`, which was covering the mesh loading bug.
<img width="1892" height="1290" alt="image" src="https://github.com/user-attachments/assets/0e03e8a9-2a7d-4a09-b50a-e9930b3d74b5" />


## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
