### PR TITLE
Use VS2022 in CI

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-# GitHub syntax highlighting
-pixi.lock linguist-language=YAML linguist-generated=true
+# SCM syntax highlighting & preventing 3-way merges
+pixi.lock merge=binary linguist-language=YAML linguist-generated=true -diff

--- a/.github/workflows/macos-linux-windows-pixi.yml
+++ b/.github/workflows/macos-linux-windows-pixi.yml
@@ -66,11 +66,11 @@ jobs:
             BUILD_ADVANCED_TESTING: OFF
           - os: macos-15-intel
             BUILD_ADVANCED_TESTING: OFF
-          - os: windows-latest
+          - os: windows-2022
             environment: all
             build_type: Release
             BUILD_ADVANCED_TESTING: OFF
-          - os: windows-latest
+          - os: windows-2022
             environment: all-clang-cl
             build_type: Release
             BUILD_ADVANCED_TESTING: OFF
@@ -163,7 +163,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel, windows-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest, macos-15-intel, windows-2022]
         environment: [all]
 
     steps:
@@ -251,7 +251,7 @@ jobs:
   #   strategy:
   #     fail-fast: false
   #     matrix:
-  #       os: [ubuntu-latest, macos-latest, macos-15-intel, windows-latest]
+  #       os: [ubuntu-latest, macos-latest, macos-15-intel, windows-2022]
 
   #   steps:
   #     - uses: actions/checkout@v6


### PR DESCRIPTION
## Description

- Github migrate windows-latest to windows image using vs2026. Right now, it's not the default compiler used by conda and workflow will fail.
- Update pixi.lock gitattributes.

## Checklist

- [ ] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation
- [ ] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
