### PR TITLE
Fix dangling-reference warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix Viser visualizer: apply URDF `<mesh scale>` to mesh vertices instead of scaling the link translation ([#2878](https://github.com/stack-of-tasks/pinocchio/pull/2878))
 
 - Fix build issue with g++ 12 ([#2890](https://github.com/stack-of-tasks/pinocchio/pull/2890))
-- Fix useless memory allocation in Python checkers ([#2897](https://github.com/stack-of-tasks/pinocchio/pull/2897))
+- Fix useless memory allocation in Python checkers ([#2897](https://github.com/stack-of-tasks/pinocchio/pull/2897) and [#2907](https://github.com/stack-of-tasks/pinocchio/pull/2907))
 
 ### Changed
 

--- a/include/pinocchio/bindings/python/utils/model-checker.hpp
+++ b/include/pinocchio/bindings/python/utils/model-checker.hpp
@@ -32,9 +32,8 @@ namespace pinocchio
         // Convert the object to a tuple
         boost::python::tuple py_args = boost::python::extract<boost::python::tuple>(args);
 
-        const context::Model & model =
-          boost::python::extract<const context::Model &>(py_args[model_arg_list_idx]);
-        if (!model.check(MimicChecker()))
+        boost::python::extract<const context::Model &> get_model(py_args[model_arg_list_idx]);
+        if (!get_model().check(MimicChecker()))
         {
           PyErr_SetString(PyExc_RuntimeError, m_error_message.c_str());
           return false;


### PR DESCRIPTION
Thanks for taking the time to make and fill out this pull request!

## Description

#2897 introduce a read to a temporary object. This PR prevent this.

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation
- [ ] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
