### PR TITLE
CMake: dont require mathjax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Changed
 
 - nix: switch to flakoboros ([#2882](https://github.com/stack-of-tasks/pinocchio/pull/2882))
+- CMake: optionalize `DOXYGEN_USE_MATHJAX` ([#2915](https://github.com/stack-of-tasks/pinocchio/pull/2915))
 
 
 ## [4.0.0] - 2026-04-13

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,6 +30,7 @@ set(CMAKE_VERBOSE_MAKEFILE True)
 # Need to be set before including base.cmake
 # ----------------------------------------------------
 option(INSTALL_DOCUMENTATION "Generate and install the documentation" OFF)
+option(PINOCCHIO_DOXYGEN_USE_MATHJAX "Avoid latex at build time" ON)
 
 # Check if the submodule cmake have been initialized
 set(JRL_CMAKE_MODULES "${CMAKE_CURRENT_LIST_DIR}/cmake")
@@ -62,7 +63,9 @@ else()
     endif()
 endif()
 
-set(DOXYGEN_USE_MATHJAX YES)
+if(PINOCCHIO_DOXYGEN_USE_MATHJAX)
+  set(DOXYGEN_USE_MATHJAX YES)
+endif()
 
 # ----------------------------------------------------
 # --- Policy -----------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,7 +64,7 @@ else()
 endif()
 
 if(PINOCCHIO_DOXYGEN_USE_MATHJAX)
-  set(DOXYGEN_USE_MATHJAX YES)
+    set(DOXYGEN_USE_MATHJAX YES)
 endif()
 
 # ----------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CMAKE_VERBOSE_MAKEFILE True)
 # Need to be set before including base.cmake
 # ----------------------------------------------------
 option(INSTALL_DOCUMENTATION "Generate and install the documentation" OFF)
-option(PINOCCHIO_DOXYGEN_USE_MATHJAX "Avoid latex at build time" ON)
+option(PINOCCHIO_DOXYGEN_USE_MATHJAX "Avoid latex at build time" OFF)
 
 # Check if the submodule cmake have been initialized
 set(JRL_CMAKE_MODULES "${CMAKE_CURRENT_LIST_DIR}/cmake")


### PR DESCRIPTION
## Description

Mathjax is nice, but I think it should not be activated *unconditionally*. 

I believe it is the responsibility of the package maintainer to decide if docs should be build with nice latex svgs, or if mathjax should be bundled.

Currently, even with `-DDOXYGEN_USE_MATHJAX=OFF`, I get 23MB in the `share/doc/pinocchio/doxygen-html/MathJax`, so it won't even be re-used by other packages and would have to be duplicated.

For this reason, I think it should be OFF (or not set, as in the current state of this PR) by default.

Actually, I do not see any reason to turn this ON unless the user is not able to use a proper package manager, which is hopefuly a very rare case nowadays.


## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [ ] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation
- [ ] I have added tests that prove my fix or feature works
- [ ] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
