### PR TITLE
Improve v3 to v4 deprecation documation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+- Add `DataTpl::lastChild` deprecation notice in Python binding
+
 ## [4.1.0] - 2026-07-07
 
 ### Added

--- a/doc/_porting/porting-3-to-4.md
+++ b/doc/_porting/porting-3-to-4.md
@@ -54,9 +54,12 @@ ConstraintCholeskyDecompositionTpl changes :
 - Deprecate `ConstraintCholeskyDecompositionTpl::allocate` replaced by `ConstraintCholeskyDecompositionTpl::rebuild`
   - Add `std::vector<ConstraintModel, ConstraintModelAllocator>`
   - Add `std::vector<ConstraintData, ConstraintDataAllocator>`
+  - `constraint_datas` should be computed by the associated model
 - ConstraintCholeskyDecompositionTpl constructor :
   - Add `DataTpl<S1, O1, JointCollectionTpl>`
   - Add `std::vector<ConstraintData, ConstraintDataAllocator>`
+- `ConstraintCholeskyDecompositionTpl::compute`:
+  - `constraint_datas` should be computed by the associated model
 
 Utility API changes:
 - Remove `gettimeofday` definition on Windows

--- a/doc/_porting/porting-3-to-4.md
+++ b/doc/_porting/porting-3-to-4.md
@@ -63,6 +63,9 @@ Utility API changes:
 - Remove `deprecated-macros.hpp` and `deprecated-namespaces.hpp`
 - Remove `pinocchio/deprecation.hpp` replaced by `pinocchio/deprecated.hpp`
 
+DataTpl API changes:
+- Deprecate `DataTpl::lastChild` replaced by `ModelTpl::children` last value
+
 Python bindings API changes:
 - Deprecate `pinocchio/bindings/python/multibody/joint/joint.hpp` replaced by `pinocchio/bindings/python/multibody/joint/joint-model.hpp`
 - Deprecate Python bindings headers already implemented in eigenpy:

--- a/doc/_porting/porting-3-to-4.md
+++ b/doc/_porting/porting-3-to-4.md
@@ -68,7 +68,9 @@ Utility API changes:
 - Remove `pinocchio/deprecation.hpp` replaced by `pinocchio/deprecated.hpp`
 
 DataTpl API changes:
-- Deprecate `DataTpl::lastChild` replaced by `ModelTpl::children` last value
+- Deprecate `DataTpl::lastChild` replaced by `ModelTpl::children`:
+  - If joint `index` doesn't have any child it can be checked with `model.children[index].empty()`
+  - In other case `data.lastChild[index]` can be replaced by `model.children[index].back()`
 
 Python bindings API changes:
 - Deprecate `pinocchio/bindings/python/multibody/joint/joint.hpp` replaced by `pinocchio/bindings/python/multibody/joint/joint-model.hpp`

--- a/doc/_porting/porting-3-to-4.md
+++ b/doc/_porting/porting-3-to-4.md
@@ -39,6 +39,7 @@ HPP-FCL has been replaced by coal:
 Constraints API changes:
   - Add `std::vector<ConstraintData, ConstraintDataAllocator> contact_datas` in `initConstraintDynamics` method
   - Change `BaumgarteCorrectorParametersTpl` constructor: scalars are used for the gains instead of vectors
+  - `constraint_data` should be computed by `constaint_model.calc` call before calling `getConstraintJacobian`
 
 `RigidConstraintModel` internal API has changed:
   - Remove `colwise_joint1_sparsity`

--- a/include/pinocchio/bindings/python/multibody/data.hpp
+++ b/include/pinocchio/bindings/python/multibody/data.hpp
@@ -157,12 +157,24 @@ namespace pinocchio
             bp::make_function(
               +[](const Data & self) { return self.lastChild; },
               eigenpy::deprecated_member<>(
-                "Deprecated member. Use model.children last value instead.")),
+                "Deprecated member. Use model.children instead:\n"
+                "- If joint `index` doesn't have any child it can be checked with"
+                "len(model.children[index]) > 0`\n"
+                "- In other case `data.lastChild[index]` can be replaced by "
+                "`model.children[index][-1]`")),
             bp::make_function(
               +[](Data & self, const std::vector<int> & lastChild) { self.lastChild = lastChild; },
               eigenpy::deprecated_member<>(
-                "Deprecated member. Use model.children last value instead.")),
-            "Deprecated member. Use model.children last value instead.")
+                "Deprecated member. Use model.children instead:\n"
+                "- If joint `index` doesn't have any child it can be checked with"
+                "len(model.children[index]) > 0`\n"
+                "- In other case `data.lastChild[index]` can be replaced by "
+                "`model.children[index][-1]`")),
+            "Deprecated member. Use model.children instead:\n"
+            "- If joint `index` doesn't have any child it can be checked with"
+            "len(model.children[index]) > 0`\n"
+            "- In other case `data.lastChild[index]` can be replaced by "
+            "`model.children[index][-1]`")
           .ADD_DATA_PROPERTY(nvSubtree, "Dimension of the subtree motion space (for CRBA)")
           .ADD_DATA_PROPERTY(U, "Joint Inertia square root (upper triangle)")
           .ADD_DATA_PROPERTY(D, "Diagonal of UDUT inertia decomposition")

--- a/include/pinocchio/bindings/python/multibody/data.hpp
+++ b/include/pinocchio/bindings/python/multibody/data.hpp
@@ -153,6 +153,17 @@ namespace pinocchio
           .ADD_DATA_PROPERTY(g, "Vector of generalized gravity (dim model.nv).")
           .ADD_DATA_PROPERTY(Fcrb, "Spatial forces set, used in CRBA")
           .ADD_DATA_PROPERTY(lastChild, "Index of the last child (for CRBA)")
+          .add_property(
+            "lastChild",
+            bp::make_function(
+              +[](const Data & self) { return self.lastChild; },
+              eigenpy::deprecated_member<>(
+                "Deprecated member. Use model.children last value instead.")),
+            bp::make_function(
+              +[](Data & self, const std::vector<int> & lastChild) { self.lastChild = lastChild; },
+              eigenpy::deprecated_member<>(
+                "Deprecated member. Use model.children last value instead.")),
+            "Deprecated member. Use model.children last value instead.")
           .ADD_DATA_PROPERTY(nvSubtree, "Dimension of the subtree motion space (for CRBA)")
           .ADD_DATA_PROPERTY(U, "Joint Inertia square root (upper triangle)")
           .ADD_DATA_PROPERTY(D, "Diagonal of UDUT inertia decomposition")

--- a/include/pinocchio/bindings/python/multibody/data.hpp
+++ b/include/pinocchio/bindings/python/multibody/data.hpp
@@ -152,7 +152,6 @@ namespace pinocchio
                "C(q,v)v")
           .ADD_DATA_PROPERTY(g, "Vector of generalized gravity (dim model.nv).")
           .ADD_DATA_PROPERTY(Fcrb, "Spatial forces set, used in CRBA")
-          .ADD_DATA_PROPERTY(lastChild, "Index of the last child (for CRBA)")
           .add_property(
             "lastChild",
             bp::make_function(

--- a/include/pinocchio/src/multibody/data.hxx
+++ b/include/pinocchio/src/multibody/data.hxx
@@ -308,6 +308,7 @@ namespace pinocchio
     std::vector<Matrix6x> Fcrb;
 
     /// \brief Index of the last child (for CRBA)
+    /// \deprecated Use ModelTpl::children last value instead.
     PINOCCHIO_DEPRECATED std::vector<int> lastChild;
 
     /// \brief Dimension of the subtree motion space (for CRBA)

--- a/include/pinocchio/src/multibody/data.hxx
+++ b/include/pinocchio/src/multibody/data.hxx
@@ -307,8 +307,12 @@ namespace pinocchio
     /// \brief Spatial forces set, used in CRBA and CCRBA
     std::vector<Matrix6x> Fcrb;
 
-    /// \brief Index of the last child (for CRBA)
-    /// \deprecated Use ModelTpl::children last value instead.
+    /** \brief Index of the last child (for CRBA)
+     * \deprecated Use ModelTpl::children instead:
+     *  - If joint `index` doesn't have any child it can be checked with
+     * `model.children[index].empty()`
+     *  - In other case `data.lastChild[index]` can be replaced by `model.children[index].back()`
+     */
     PINOCCHIO_DEPRECATED std::vector<int> lastChild;
 
     /// \brief Dimension of the subtree motion space (for CRBA)


### PR DESCRIPTION
## Description

- Document `DataTpl::lastChild` deprecation
- Document `getConstraintJacobian` new behavior.

Close #2926 

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [ ] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
