### PR TITLE
Attaching a massless link with a fixed joint changes the parent body's center of mass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ### Added
 - Add `DataTpl::lastChild` deprecation notice in Python binding
+- Fix `addFrame` to ignore frame without inertial to preserse parent body's CoM
 
 ## [4.1.0] - 2026-07-07
 

--- a/README.md
+++ b/README.md
@@ -305,6 +305,7 @@ In addition to the core dev team, the following people have also been involved i
 -   [Lucas Joseph](https://github.com/LucasJoseph): Ellipsoid Joint
 -   [Megane Millan](https://github.com/MegMll): core developer (MJCF, joint mimic, etc.)
 -   [Tingfan Wu](https://github.com/tingfan): Viser visualizer mesh-scale bug fix
+-   [Kazuki Sugihara](https://github.com/sugikazu75): addFrame bug fix
 
 If you have participated in the development of **Pinocchio**, please add your name and contribution to this list.
 

--- a/include/pinocchio/src/multibody/model.hxx
+++ b/include/pinocchio/src/multibody/model.hxx
@@ -1578,7 +1578,7 @@ namespace pinocchio
     }
     // else: we must add a new frames to the current stack
     frames.push_back(frame);
-    if (append_inertia && !check_expression_if_real<Scalar, false>(frame.inertia.isZero(Scalar(0))))
+    if (append_inertia && check_expression_if_real<Scalar>(frame.inertia.mass() > Scalar(0.)))
       inertias[frame.parentJoint] += frame.placement.act(frame.inertia);
     nframes++;
     return FrameIndex(nframes - 1);

--- a/include/pinocchio/src/multibody/model.hxx
+++ b/include/pinocchio/src/multibody/model.hxx
@@ -1578,7 +1578,7 @@ namespace pinocchio
     }
     // else: we must add a new frames to the current stack
     frames.push_back(frame);
-    if (append_inertia)
+    if (append_inertia && !frame.inertia.isZero(Scalar(0)))
       inertias[frame.parentJoint] += frame.placement.act(frame.inertia);
     nframes++;
     return FrameIndex(nframes - 1);

--- a/include/pinocchio/src/multibody/model.hxx
+++ b/include/pinocchio/src/multibody/model.hxx
@@ -1578,7 +1578,7 @@ namespace pinocchio
     }
     // else: we must add a new frames to the current stack
     frames.push_back(frame);
-    if (append_inertia && !frame.inertia.isZero(Scalar(0)))
+    if (append_inertia && !check_expression_if_real<Scalar, false>(frame.inertia.isZero(Scalar(0))))
       inertias[frame.parentJoint] += frame.placement.act(frame.inertia);
     nframes++;
     return FrameIndex(nframes - 1);

--- a/unittest/model.cpp
+++ b/unittest/model.cpp
@@ -1293,4 +1293,32 @@ BOOST_AUTO_TEST_CASE(test_colwise_sparsity_pattern_and_span_indexes)
   }
 }
 
+BOOST_AUTO_TEST_CASE(test_add_frame_with_zero_inertia_preserves_the_parent_inertia)
+{
+  // A frame carrying no inertia must leave the parent body untouched.
+
+  // The mass matters: masses whose reciprocal round trip is exact (every power of two, and most
+  // short decimals such as 1.0, 0.1, 1.5) never showed the drift. 0.41 does.
+  const double mass = 0.41;
+  BOOST_REQUIRE(mass * (1. / mass) != 1.);
+
+  Model model;
+  const JointIndex joint_id =
+    model.addJoint(0, JointModelFreeFlyer(), SE3::Identity(), "root_joint");
+  model.appendBodyToJoint(
+    joint_id, Inertia(mass, Eigen::Vector3d(0.1, 0.2, 0.3), Eigen::Matrix3d::Identity()),
+    SE3::Identity());
+
+  const Inertia reference = model.inertias[joint_id];
+
+  for (int i = 0; i < 4; ++i)
+  {
+    model.addFrame(
+      Frame("massless_frame" + std::to_string(i), joint_id, 0, SE3::Identity(), OP_FRAME));
+    BOOST_CHECK_EQUAL(model.inertias[joint_id].mass(), reference.mass());
+    BOOST_CHECK(model.inertias[joint_id].lever() == reference.lever());
+    BOOST_CHECK(model.inertias[joint_id].inertia().matrix() == reference.inertia().matrix());
+  }
+}
+
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Thank you for developng and maintaining this library!

## What happens

Attaching a link with no `<inertial>` link in URDF  through a fixed joint changes `Model.inertias[parent].lever` by 2 ULP per link. The mass stays exactly the same; only the center of mass moves.
It broke bit-level reproducibility of our trajectory optimization resulting in different trajectory.

I have added new test in 8337089 which does not pass without  7e1e990

```
/home/sugihara/ros/pinocchio_ws/src/pinocchio/unittest/model.cpp(1296): Entering test case "test_add_frame_with_zero_inertia_preserves_the_parent_inertia"
/home/sugihara/ros/pinocchio_ws/src/pinocchio/unittest/model.cpp(1303): info: check mass * (1. / mass) != 1. has passed
/home/sugihara/ros/pinocchio_ws/src/pinocchio/unittest/model.cpp(1318): info: check model.inertias[joint_id].mass() == reference.mass() has passed
/home/sugihara/ros/pinocchio_ws/src/pinocchio/unittest/model.cpp(1319): error: in "Test/test_add_frame_with_zero_inertia_preserves_the_parent_inertia": check model.inertias[joint_id].lever() == reference.lever() has failed
/home/sugihara/ros/pinocchio_ws/src/pinocchio/unittest/model.cpp(1320): info: check model.inertias[joint_id].inertia().matrix() == reference.inertia().matrix() has passed
/home/sugihara/ros/pinocchio_ws/src/pinocchio/unittest/model.cpp(1318): info: check model.inertias[joint_id].mass() == reference.mass() has passed
/home/sugihara/ros/pinocchio_ws/src/pinocchio/unittest/model.cpp(1319): error: in "Test/test_add_frame_with_zero_inertia_preserves_the_parent_inertia": check model.inertias[joint_id].lever() == reference.lever() has failed
/home/sugihara/ros/pinocchio_ws/src/pinocchio/unittest/model.cpp(1320): info: check model.inertias[joint_id].inertia().matrix() == reference.inertia().matrix() has passed
/home/sugihara/ros/pinocchio_ws/src/pinocchio/unittest/model.cpp(1318): info: check model.inertias[joint_id].mass() == reference.mass() has passed
/home/sugihara/ros/pinocchio_ws/src/pinocchio/unittest/model.cpp(1319): error: in "Test/test_add_frame_with_zero_inertia_preserves_the_parent_inertia": check model.inertias[joint_id].lever() == reference.lever() has failed
/home/sugihara/ros/pinocchio_ws/src/pinocchio/unittest/model.cpp(1320): info: check model.inertias[joint_id].inertia().matrix() == reference.inertia().matrix() has passed
/home/sugihara/ros/pinocchio_ws/src/pinocchio/unittest/model.cpp(1318): info: check model.inertias[joint_id].mass() == reference.mass() has passed
/home/sugihara/ros/pinocchio_ws/src/pinocchio/unittest/model.cpp(1319): error: in "Test/test_add_frame_with_zero_inertia_preserves_the_parent_inertia": check model.inertias[joint_id].lever() == reference.lever() has failed
/home/sugihara/ros/pinocchio_ws/src/pinocchio/unittest/model.cpp(1320): info: check model.inertias[joint_id].inertia().matrix() == reference.inertia().matrix() has passed
/home/sugihara/ros/pinocchio_ws/src/pinocchio/unittest/model.cpp(1296): Leaving test case "test_add_frame_with_zero_inertia_preserves_the_parent_inertia"; testing time: 185us
```


## Why

and `Inertia::operator+=` rescales the lever in place:
```cpp
    lever() *= (mass() * mab_inv);          // mab_inv = 1 / (mass() + Yb.mass())
```
For a massless addend `mab_inv == 1/mass()`, so the lever is multiplied by `mass() * (1/mass())`.
That is not exactly 1.0 for a large class of masses, so each call loses a couple of ULP.

## Reproduction

[repro.py](https://gist.github.com/sugikazu75/d67a815c13a3051545946e97686b6c7f#file-repro-py)  
Reproduced on v4.0.0 and  origin/devel

```bash
python3 repro.py
```

```
$ python repro.py 
pinocchio 4.0.0

mass = 0.41    m * (1/m) - 1 = -1.110e-16    exactly 1.0? False
  n | mass unchanged | lever[0]                  | ULP from reference
  --+----------------+---------------------------+-------------------
  0 | True           | 0.09999999999999998       | 0
  1 | True           | 0.09999999999999995       | 2
  2 | True           | 0.09999999999999992       | 4
  3 | True           | 0.0999999999999999        | 6
  4 | True           | 0.09999999999999987       | 8

mass = 1.0    m * (1/m) - 1 = +0.000e+00    exactly 1.0? True
  n | mass unchanged | lever[0]                  | ULP from reference
  --+----------------+---------------------------+-------------------
  0 | True           | 0.1                       | 0
  1 | True           | 0.1                       | 0
  2 | True           | 0.1                       | 0
  3 | True           | 0.1                       | 0
  4 | True           | 0.1                       | 0

8 applications of `lever *= m * (1/m)`: 0.09999999999999987
model built with 4 massless links:        0.09999999999999987
identical: True
addFrame(append_inertia=True ) -> lever unchanged: False
addFrame(append_inertia=False) -> lever unchanged: True

RESULT: massless links perturb the parent inertia
```

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
