### PR TITLE
fix(mjcf): propagate fixed-base root body pos/quat and inertia

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix GCC 10 compilation of aligned matrix map comparisons ([#2930](https://github.com/stack-of-tasks/pinocchio/issues/2930))
 
 ### Fixed
-- Fix MJCF parser dropping the `pos`/`quat` of a fixed base root body, which offset the whole kinematic tree and left its inertia at the origin
+- Fix MJCF parser dropping the `pos`/`quat` of a fixed base root body, which offset the whole kinematic tree and left its inertia at the origin ([#2934](https://github.com/stack-of-tasks/pinocchio/pull/2934))
+- Fix MJCF parser placing the sites of a jointless body relative to its parent body instead of its supporting joint ([#2934](https://github.com/stack-of-tasks/pinocchio/pull/2934))
 
 ## [4.1.0] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `ellipsoid-joint-kinematics.py` example ([#2935](https://github.com/stack-of-tasks/pinocchio/pull/2935))
 - Fix `biais` typo in documentation and comments (English is `bias`) ([#2936](https://github.com/stack-of-tasks/pinocchio/pull/2936))
 - Fix GCC 10 compilation of aligned matrix map comparisons ([#2930](https://github.com/stack-of-tasks/pinocchio/issues/2930))
-
-### Fixed
 - Fix MJCF parser dropping the `pos`/`quat` of a fixed base root body, which offset the whole kinematic tree and left its inertia at the origin ([#2934](https://github.com/stack-of-tasks/pinocchio/pull/2934))
 - Fix MJCF parser placing the sites of a jointless body relative to its parent body instead of its supporting joint ([#2934](https://github.com/stack-of-tasks/pinocchio/pull/2934))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `biais` typo in documentation and comments (English is `bias`) ([#2936](https://github.com/stack-of-tasks/pinocchio/pull/2936))
 - Fix GCC 10 compilation of aligned matrix map comparisons ([#2930](https://github.com/stack-of-tasks/pinocchio/issues/2930))
 
+### Fixed
+- Fix MJCF parser dropping the `pos`/`quat` of a fixed base root body, which offset the whole kinematic tree and left its inertia at the origin
+
 ## [4.1.0] - 2026-07-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -308,6 +308,7 @@ In addition to the core dev team, the following people have also been involved i
 -   [Kazuki Sugihara](https://github.com/sugikazu75): addFrame bug fix
 -   [Sergi Martinez](https://github.com/Sergim96): scalar-generic Python bindings
 -   [tandede](https://github.com/tandede): GCC 10 compatibility for aligned matrix map comparisons
+-   [Amane Inoue](https://github.com/isaka1022): MJCF parser bug fixes
 
 If you have participated in the development of **Pinocchio**, please add your name and contribution to this list.
 

--- a/include/pinocchio/src/parsers/mjcf/mjcf-graph.hxx
+++ b/include/pinocchio/src/parsers/mjcf/mjcf-graph.hxx
@@ -45,13 +45,10 @@ namespace pinocchio
           const boost::optional<const JointModel &> root_joint,
           const boost::optional<const std::string &> root_joint_name)
         {
-          // Base::addRootJoint folds Y into the universe inertia untransformed.
-          const Inertia universe_inertia_before = Base::model.inertias[0];
-
-          Base::addRootJoint(Y, body_name, root_joint, root_joint_name);
-
           if (root_joint.has_value())
           {
+            Base::addRootJoint(Y, body_name, root_joint, root_joint_name);
+
             Eigen::VectorXd qroot(root_joint->template lieGroup<LieGroupMap>().neutral());
 
             // update the reference_config with the size of the root joint
@@ -88,11 +85,12 @@ namespace pinocchio
           }
           else
           {
-            // Unlike URDF, MJCF lets the fixed root body carry its own pos/quat, which
-            // Base::addRootJoint ignores for both the body frame and the universe inertia.
-            const FrameIndex bodyFrameId = Base::model.getFrameId(body_name, BODY);
-            Base::model.inertias[0] = universe_inertia_before + body_placement.act(Y);
-            Base::model.frames[bodyFrameId].placement = body_placement;
+            // Unlike URDF, MJCF lets the fixed root body carry its own pos/quat, so the body
+            // frame cannot simply reuse the universe placement as Base::addRootJoint does.
+            const Frame & parent_frame = Base::model.frames[0];
+            Base::model.addFrame(Frame(
+              body_name, parent_frame.parentJoint, 0, parent_frame.placement * body_placement, BODY,
+              Y));
           }
         }
       };

--- a/include/pinocchio/src/parsers/mjcf/mjcf-graph.hxx
+++ b/include/pinocchio/src/parsers/mjcf/mjcf-graph.hxx
@@ -39,11 +39,15 @@ namespace pinocchio
         void addRootJoint(
           const Inertia & Y,
           const std::string & body_name,
+          const SE3 & body_placement,
           Eigen::VectorXd & reference_config,
           Eigen::VectorXd & qpos0,
           const boost::optional<const JointModel &> root_joint,
           const boost::optional<const std::string &> root_joint_name)
         {
+          // Base::addRootJoint folds Y into the universe inertia untransformed.
+          const Inertia universe_inertia_before = Base::model.inertias[0];
+
           Base::addRootJoint(Y, body_name, root_joint, root_joint_name);
 
           if (root_joint.has_value())
@@ -81,6 +85,14 @@ namespace pinocchio
                 }
               }
             }
+          }
+          else
+          {
+            // Unlike URDF, MJCF lets the fixed root body carry its own pos/quat, which
+            // Base::addRootJoint ignores for both the body frame and the universe inertia.
+            const FrameIndex bodyFrameId = Base::model.getFrameId(body_name, BODY);
+            Base::model.inertias[0] = universe_inertia_before + body_placement.act(Y);
+            Base::model.frames[bodyFrameId].placement = body_placement;
           }
         }
       };

--- a/src/parsers/mjcf/mjcf-graph.cpp
+++ b/src/parsers/mjcf/mjcf-graph.cpp
@@ -1472,7 +1472,8 @@ namespace pinocchio
           // We only add the root joint if we have a fixed base
           // (first body doesn't have any joint). Otherwise, the root joint is ignored.
           mjcfVisitor.addRootJoint(
-            rootBody.bodyInertia, rootLinkName, referenceConfig, qpos0, rootJoint, rootJointName);
+            rootBody.bodyInertia, rootLinkName, rootBody.bodyPlacement, referenceConfig, qpos0,
+            rootJoint, rootJointName);
         }
         else
         {

--- a/src/parsers/mjcf/mjcf-graph.cpp
+++ b/src/parsers/mjcf/mjcf-graph.cpp
@@ -1129,7 +1129,9 @@ namespace pinocchio
           JointIndex parentJoint = mjcfVisitor.model.frames[bodyId].parentJoint;
           for (const auto & site : currentBody.siteChildren)
           {
-            SE3 placement = bodyPose * site.sitePlacement;
+            // Frames are expressed in their supporting joint, which only matches bodyPose when
+            // the body it hangs off sits at that joint's origin.
+            SE3 placement = mjcfVisitor.model.frames[bodyId].placement * site.sitePlacement;
             mjcfVisitor.model.addFrame(
               Frame(site.siteName, parentJoint, bodyId, placement, OP_FRAME));
           }

--- a/unittest/mjcf.cpp
+++ b/unittest/mjcf.cpp
@@ -1189,6 +1189,56 @@ BOOST_AUTO_TEST_CASE(build_model_no_root_joint)
   BOOST_CHECK_EQUAL(model_m.nq, 29);
 }
 
+/// @brief test that a fixed-base root body's own pos/quat is not dropped,
+/// and that it is correctly propagated to its children (regression test for #2782)
+/// @param
+BOOST_AUTO_TEST_CASE(build_model_fixed_base_root_body_placement)
+{
+  typedef pinocchio::SE3::Vector3 Vector3;
+  typedef pinocchio::SE3::Matrix3 Matrix3;
+
+  std::istringstream xmlData(R"(
+            <mujoco model="fixed_base_test">
+                <worldbody>
+                    <body name="base" pos="1 2 3" quat="0.7071068 0 0 0.7071068">
+                        <geom type="box" size="0.1 0.1 0.1"/>
+                        <body name="link1" pos="0 0 0.5">
+                            <joint name="j1" type="hinge" axis="0 1 0"/>
+                            <geom type="box" size="0.05 0.05 0.2"/>
+                        </body>
+                    </body>
+                </worldbody>
+            </mujoco>)");
+
+  auto namefile = createTempFile(xmlData);
+
+  pinocchio::Model model_m;
+  pinocchio::mjcf::buildModel(namefile.name(), model_m);
+
+  pinocchio::Data data(model_m);
+  pinocchio::framesForwardKinematics(model_m, data, pinocchio::neutral(model_m));
+
+  Matrix3 rotation_matrix;
+  rotation_matrix << 0., -1., 0., 1., 0., 0., 0., 0., 1.;
+
+  const pinocchio::SE3 expected_base(rotation_matrix, Vector3(1., 2., 3.));
+  const pinocchio::SE3 expected_link1(rotation_matrix, Vector3(1., 2., 3.5));
+
+  const pinocchio::FrameIndex baseFrameId = model_m.getFrameId("base", pinocchio::BODY);
+  const pinocchio::FrameIndex link1FrameId = model_m.getFrameId("link1", pinocchio::BODY);
+
+  BOOST_CHECK(data.oMf[baseFrameId].isApprox(expected_base, 1e-6));
+  BOOST_CHECK(data.oMf[link1FrameId].isApprox(expected_link1, 1e-6));
+
+  // The base geom has no offset of its own, so its inertia must be carried by
+  // the exact same placement as the base frame.
+  const double massBase = 1000 * 0.2 * 0.2 * 0.2; // density * volume
+  const pinocchio::Inertia expected_universe_inertia =
+    expected_base.act(pinocchio::Inertia::FromBox(massBase, 0.2, 0.2, 0.2));
+
+  BOOST_CHECK(model_m.inertias[0].isApprox(expected_universe_inertia, 1e-6));
+}
+
 double degreesToRadian(double degrees)
 {
   return degrees * (M_PI / 180.0);

--- a/unittest/mjcf.cpp
+++ b/unittest/mjcf.cpp
@@ -1189,8 +1189,8 @@ BOOST_AUTO_TEST_CASE(build_model_no_root_joint)
   BOOST_CHECK_EQUAL(model_m.nq, 29);
 }
 
-/// @brief test that a fixed-base root body's own pos/quat is not dropped,
-/// and that it is correctly propagated to its children (regression test for #2782)
+/// @brief test that a fixed-base root body's own pos/quat is not dropped, and that it reaches
+/// its inertia, its children and their sites (regression test for #2782)
 /// @param
 BOOST_AUTO_TEST_CASE(build_model_fixed_base_root_body_placement)
 {
@@ -1201,7 +1201,10 @@ BOOST_AUTO_TEST_CASE(build_model_fixed_base_root_body_placement)
             <mujoco model="fixed_base_test">
                 <worldbody>
                     <body name="base" pos="1 2 3" quat="0.7071068 0 0 0.7071068">
-                        <geom type="box" size="0.1 0.1 0.1"/>
+                        <geom type="box" size="0.1 0.2 0.3"/>
+                        <body name="fixedchild" pos="0 0 0.4">
+                            <site name="s_fixed" pos="0 0.1 0"/>
+                        </body>
                         <body name="link1" pos="0 0 0.5">
                             <joint name="j1" type="hinge" axis="0 1 0"/>
                             <geom type="box" size="0.05 0.05 0.2"/>
@@ -1223,18 +1226,25 @@ BOOST_AUTO_TEST_CASE(build_model_fixed_base_root_body_placement)
 
   const pinocchio::SE3 expected_base(rotation_matrix, Vector3(1., 2., 3.));
   const pinocchio::SE3 expected_link1(rotation_matrix, Vector3(1., 2., 3.5));
+  const pinocchio::SE3 expected_fixedchild(rotation_matrix, Vector3(1., 2., 3.4));
+  const pinocchio::SE3 expected_site(rotation_matrix, Vector3(0.9, 2., 3.4));
 
   const pinocchio::FrameIndex baseFrameId = model_m.getFrameId("base", pinocchio::BODY);
   const pinocchio::FrameIndex link1FrameId = model_m.getFrameId("link1", pinocchio::BODY);
+  const pinocchio::FrameIndex fixedchildFrameId = model_m.getFrameId("fixedchild", pinocchio::BODY);
+  const pinocchio::FrameIndex siteFrameId = model_m.getFrameId("s_fixed", pinocchio::OP_FRAME);
 
   BOOST_CHECK(data.oMf[baseFrameId].isApprox(expected_base, 1e-6));
   BOOST_CHECK(data.oMf[link1FrameId].isApprox(expected_link1, 1e-6));
+  BOOST_CHECK(data.oMf[fixedchildFrameId].isApprox(expected_fixedchild, 1e-6));
+  BOOST_CHECK(data.oMf[siteFrameId].isApprox(expected_site, 1e-6));
 
   // The base geom has no offset of its own, so its inertia must be carried by
-  // the exact same placement as the base frame.
-  const double massBase = 1000 * 0.2 * 0.2 * 0.2; // density * volume
+  // the exact same placement as the base frame. The box is deliberately not a cube,
+  // so that a placement applied the wrong way round is caught.
+  const double massBase = 1000 * 0.2 * 0.4 * 0.6; // density * volume
   const pinocchio::Inertia expected_universe_inertia =
-    expected_base.act(pinocchio::Inertia::FromBox(massBase, 0.2, 0.2, 0.2));
+    expected_base.act(pinocchio::Inertia::FromBox(massBase, 0.2, 0.4, 0.6));
 
   BOOST_CHECK(model_m.inertias[0].isApprox(expected_universe_inertia, 1e-6));
 }


### PR DESCRIPTION
## Description

Fixes #2782.

When the first body under `<worldbody>` has no `<joint>` (fixed base), its own `pos`/`quat` was dropped, so the whole kinematic tree ended up at the wrong place.

`MjcfGraph::parseRootTree` calls `MjcfVisitor::addRootJoint` without the root body's placement, and that call delegates to `UrdfVisitor::addRootJoint`, which places the root body frame at the identity and folds its inertia into the universe inertia untransformed. That is correct for URDF, where the root link has no pos/quat of its own, but MJCF lets the root body carry one.

`MjcfVisitor::addRootJoint` now takes the root body's placement and, on the fixed-base path, builds the body frame itself instead of calling the base and patching the result afterwards. That keeps the placement and the inertia consistent from the start, and leaves the `mass > 0` guard inside `Model::addFrame` in charge of whether the inertia is folded in at all. The path taken when a `root_joint` is supplied is untouched.

`UrdfVisitor::addRootJoint` is shared with the URDF and SDF parsers and is not modified.

### Sites of jointless bodies

Moving the root body exposed a second bug, which this PR also fixes. Sites were placed with

```cpp
SE3 placement = bodyPose * site.sitePlacement;
```

where `bodyPose` is the body's placement relative to its *parent body*, while the frame is registered relative to its *supporting joint*. Those two agree only when the body it hangs off sits at that joint's origin, which used to be guaranteed for a fixed root because the root frame was the identity.

This is reachable without any of the above: a jointless body nested under another jointless body already misplaces its sites today. Using the body frame's placement fixes both cases.

### Known limitations, not addressed here

- When a `root_joint` is supplied, the root body's `pos`/`quat` is still ignored. Neither path honoured it before, so this PR makes the two asymmetric. For a floating base the placement arguably belongs in the reference configuration rather than in the frame, and I did not want to guess at that inside a bug fix.
- `parseContactInformation` has the same convention mismatch as the site code: `equality/connect` and `equality/weld` anchors are body-local in MJCF but are used directly as joint-relative (`mjcf-graph.cpp:1400` and `:1408`). A `weld` whose `body2` is a fixed root at a non-zero `pos` therefore gets an anchor off by that `pos` once this PR takes effect, and a jointless body nested under another one is already affected today. I left it alone because the fix has to decide what orientation the constraint frame should take, and unlike the placements above I could not find a way to check that against MuJoCo directly. Happy to take it on here, or in a follow-up, if you tell me which convention you want.

## How this was tested

Reproduced against the released 4.1.0, then rebuilt from source with the fix. Values are `data.oMf[...].translation` after `framesForwardKinematics` at the neutral configuration, and `model.inertias[0].lever`, for a root body at `pos="1 2 3"` rotated 90° about z with one child at `pos="0 0 0.5"`.

| | `base` frame | `link1` frame | universe inertia lever |
| --- | --- | --- | --- |
| before | `[0, 0, 0]` | `[0, 0, 0.5]` | `[0, 0, 0]` |
| after | `[1, 2, 3]` | `[1, 2, 3.5]` | `[1, 2, 3]` |
| MuJoCo (`mj_forward`, `xpos`/`xipos`) | `[1, 2, 3]` | `[1, 2, 3.5]` | `[1, 2, 3]` |

Rotation is dropped the same way before the fix (identity instead of the 90° z rotation) and matches after it. Collision geometry placements follow the corrected frames.

For the site fix, a jointless child at `pos="0 0 0.4"` under that root, carrying a site at `pos="0 0.1 0"`: MuJoCo puts the site at `[0.9, 2, 3.4]`, and its position expressed in the parent body is `[0, 0.1, 0]`. The released 4.1.0 gets the relative position right only because it puts the whole subtree at the origin; with the root placement restored and the site code left alone it becomes `[0.346, -1, 0.2]`. With this PR both the absolute and the relative position match MuJoCo.

A root body with `mass="0"` and a non-zero `diaginertia` leaves the universe inertia at zero, matching what `Model::addFrame` does elsewhere.

Every expected value in the new test was cross-checked against `mujoco`'s `mj_forward`. Full suite: `ctest` 200/200 passed. `pixi run lint` passes with no changes.

`computeTotalMass` still excludes the fixed root body's mass, since the universe inertia is not part of the total. That behaviour is unchanged by this PR.

## Checklist

- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [ ] I have made corresponding changes to the doxygen documentation — no public API documentation changes, the modified visitor is internal
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md)
- [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits) — left alone, that list looks reserved for sustained contributions
