### PR TITLE
Fix GeometryModel::collisionPairMapping not updated on removeGeometryObject

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix GCC 10 compilation of aligned matrix map comparisons ([#2930](https://github.com/stack-of-tasks/pinocchio/issues/2930))
 - Fix MJCF parser dropping the `pos`/`quat` of a fixed base root body, which offset the whole kinematic tree and left its inertia at the origin ([#2934](https://github.com/stack-of-tasks/pinocchio/pull/2934))
 - Fix MJCF parser placing the sites of a jointless body relative to its parent body instead of its supporting joint ([#2934](https://github.com/stack-of-tasks/pinocchio/pull/2934))
-
-### Fixed
-- Fix `GeometryModel::collisionPairMapping` not being updated in `removeGeometryObject`
+- Fix `GeometryModel::collisionPairMapping` not being updated in `removeGeometryObject` ([#2937](https://github.com/stack-of-tasks/pinocchio/pull/2937)
 
 ## [4.1.0] - 2026-07-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix MJCF parser dropping the `pos`/`quat` of a fixed base root body, which offset the whole kinematic tree and left its inertia at the origin ([#2934](https://github.com/stack-of-tasks/pinocchio/pull/2934))
 - Fix MJCF parser placing the sites of a jointless body relative to its parent body instead of its supporting joint ([#2934](https://github.com/stack-of-tasks/pinocchio/pull/2934))
 
+### Fixed
+- Fix `GeometryModel::collisionPairMapping` not being updated in `removeGeometryObject`
+
 ## [4.1.0] - 2026-07-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ In addition to the core dev team, the following people have also been involved i
 -   [Sergi Martinez](https://github.com/Sergim96): scalar-generic Python bindings
 -   [tandede](https://github.com/tandede): GCC 10 compatibility for aligned matrix map comparisons
 -   [Amane Inoue](https://github.com/isaka1022): MJCF parser bug fixes
+-   [Benjamin Delpech](https://github.com/benjiiDELPECH): collisionPairMapping bug fix
 
 If you have participated in the development of **Pinocchio**, please add your name and contribution to this list.
 

--- a/include/pinocchio/src/geometry/geometry.hxx
+++ b/include/pinocchio/src/geometry/geometry.hxx
@@ -686,6 +686,13 @@ namespace pinocchio
     PINOCCHIO_THROW_IF(
       (it == geometryObjects.end()), std::invalid_argument,
       (std::string("Object ") + name + std::string(" does not belong to model")).c_str());
+
+    // Sized for the object about to be removed, and filled in lockstep with collisionPairs
+    // below so surviving pairs land at their post-removal index without a second pass.
+    MatrixXi new_collision_pair_mapping =
+      MatrixXi::Constant((Eigen::Index)ngeoms - 1, (Eigen::Index)ngeoms - 1, -1);
+    int new_pair_index = 0;
+
     // Remove all collision pairs that contain i as first or second index,
     for (CollisionPairVector::iterator itCol = collisionPairs.begin();
          itCol != collisionPairs.end(); ++itCol)
@@ -702,8 +709,14 @@ namespace pinocchio
           itCol->first--;
         if (itCol->second > i)
           itCol->second--;
+
+        new_collision_pair_mapping((Eigen::Index)itCol->second, (Eigen::Index)itCol->first) =
+          new_collision_pair_mapping((Eigen::Index)itCol->first, (Eigen::Index)itCol->second) =
+            new_pair_index++;
       }
     }
+    collisionPairMapping = new_collision_pair_mapping;
+
     geometryObjects.erase(it);
     ngeoms--;
   }

--- a/unittest/geometry-algorithms.cpp
+++ b/unittest/geometry-algorithms.cpp
@@ -153,6 +153,49 @@ BOOST_AUTO_TEST_CASE(test_simple_boxes)
   BOOST_CHECK(geomData.collisionResults.size() == 1);
 }
 
+BOOST_AUTO_TEST_CASE(test_remove_collision_four_geometries)
+{
+  GeometryModel geomModel;
+
+  std::shared_ptr<coal::Box> box(new coal::Box(1, 1, 1));
+  geomModel.addGeometryObject(GeometryObject("geom0", (JointIndex)0, SE3::Identity(), box));
+  geomModel.addGeometryObject(GeometryObject("geom1", (JointIndex)0, SE3::Identity(), box));
+  geomModel.addGeometryObject(GeometryObject("geom2", (JointIndex)0, SE3::Identity(), box));
+  geomModel.addGeometryObject(GeometryObject("geom3", (JointIndex)0, SE3::Identity(), box));
+
+  // collision pairs : (0,1),(0,3),(1,2),(2,3)
+  geomModel.addCollisionPair(CollisionPair(0, 1));
+  geomModel.addCollisionPair(CollisionPair(0, 3));
+  geomModel.addCollisionPair(CollisionPair(1, 2));
+  geomModel.addCollisionPair(CollisionPair(2, 3));
+
+  geomModel.removeGeometryObject("geom1");
+
+  BOOST_CHECK(geomModel.ngeoms == 3);
+  BOOST_CHECK(geomModel.collisionPairs.size() == 2);
+  BOOST_CHECK_EQUAL(
+    geomModel.collisionPairMapping.rows(), static_cast<Eigen::Index>(geomModel.ngeoms));
+  BOOST_CHECK_EQUAL(
+    geomModel.collisionPairMapping.cols(), static_cast<Eigen::Index>(geomModel.ngeoms));
+
+  // Surviving pairs (geom2 -> 1, geom3 -> 2):
+  // old (0,3) -> new (0,2), old (2,3) -> new (1,2)
+  BOOST_CHECK(CollisionPair(0, 2) == geomModel.collisionPairs[0]);
+  BOOST_CHECK(CollisionPair(1, 2) == geomModel.collisionPairs[1]);
+
+  BOOST_CHECK_EQUAL(geomModel.collisionPairMapping(0, 2), 0);
+  BOOST_CHECK_EQUAL(geomModel.collisionPairMapping(2, 0), 0);
+  BOOST_CHECK_EQUAL(geomModel.collisionPairMapping(1, 2), 1);
+  BOOST_CHECK_EQUAL(geomModel.collisionPairMapping(2, 1), 1);
+
+  // old (0,2) -> new (0,1) collision pair does not exist, and the diagonal is never valid.
+  BOOST_CHECK_EQUAL(geomModel.collisionPairMapping(0, 1), -1);
+  BOOST_CHECK_EQUAL(geomModel.collisionPairMapping(1, 0), -1);
+  BOOST_CHECK_EQUAL(geomModel.collisionPairMapping(0, 0), -1);
+  BOOST_CHECK_EQUAL(geomModel.collisionPairMapping(1, 1), -1);
+  BOOST_CHECK_EQUAL(geomModel.collisionPairMapping(2, 2), -1);
+}
+
 #if defined(PINOCCHIO_WITH_URDFDOM)
 BOOST_AUTO_TEST_CASE(loading_model_and_check_distance)
 {

--- a/unittest/geometry-algorithms.cpp
+++ b/unittest/geometry-algorithms.cpp
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(test_remove_collision_four_geometries)
 {
   GeometryModel geomModel;
 
-  std::shared_ptr<coal::Box> box(new coal::Box(1, 1, 1));
+  std::shared_ptr<coal::Box> box = std::make_shared<coal::Box>(1, 1, 1);
   geomModel.addGeometryObject(GeometryObject("geom0", (JointIndex)0, SE3::Identity(), box));
   geomModel.addGeometryObject(GeometryObject("geom1", (JointIndex)0, SE3::Identity(), box));
   geomModel.addGeometryObject(GeometryObject("geom2", (JointIndex)0, SE3::Identity(), box));

--- a/unittest/geometry-algorithms.cpp
+++ b/unittest/geometry-algorithms.cpp
@@ -122,6 +122,11 @@ BOOST_AUTO_TEST_CASE(test_simple_boxes)
   geomModel.removeGeometryObject("ff2_collision_object");
   geomData = pinocchio::GeometryData(geomModel);
 
+  BOOST_CHECK_EQUAL(
+    geomModel.collisionPairMapping.rows(), static_cast<Eigen::Index>(geomModel.ngeoms));
+  BOOST_CHECK_EQUAL(
+    geomModel.collisionPairMapping.cols(), static_cast<Eigen::Index>(geomModel.ngeoms));
+
   BOOST_CHECK(geomModel.ngeoms == 2);
   BOOST_CHECK(geomModel.geometryObjects.size() == 2);
   BOOST_CHECK(geomModel.collisionPairs.size() == 1);

--- a/unittest/geometry-algorithms.cpp
+++ b/unittest/geometry-algorithms.cpp
@@ -133,6 +133,19 @@ BOOST_AUTO_TEST_CASE(test_simple_boxes)
   BOOST_CHECK(
     (geomModel.collisionPairs[0].first == 0 && geomModel.collisionPairs[0].second == 1)
     || (geomModel.collisionPairs[0].first == 1 && geomModel.collisionPairs[0].second == 0));
+
+  BOOST_CHECK_EQUAL(
+    geomModel.collisionPairMapping(
+      static_cast<Eigen::Index>(geomModel.collisionPairs[0].second),
+      static_cast<Eigen::Index>(geomModel.collisionPairs[0].first)),
+    0);
+  BOOST_CHECK_EQUAL(
+    geomModel.collisionPairMapping(
+      static_cast<Eigen::Index>(geomModel.collisionPairs[0].first),
+      static_cast<Eigen::Index>(geomModel.collisionPairs[0].second)),
+    0);
+  BOOST_CHECK_EQUAL(geomModel.collisionPairMapping(0, 0), -1);
+  BOOST_CHECK_EQUAL(geomModel.collisionPairMapping(1, 1), -1);
   BOOST_CHECK(geomData.activeCollisionPairs.size() == 1);
   BOOST_CHECK(geomData.distanceRequests.size() == 1);
   BOOST_CHECK(geomData.distanceResults.size() == 1);


### PR DESCRIPTION
## Summary

`GeometryModel::removeGeometryObject` correctly removed and reindexed `collisionPairs` when a `GeometryObject` was deleted, but left `collisionPairMapping` untouched — wrong size (still `ngeoms+1`) and stale pair indices that could point past the end of the shrunk `collisionPairs` vector.

This rebuilds `collisionPairMapping` in the same pass that already walks `collisionPairs` to erase/reindex the surviving pairs, so it stays in sync with both the new object count and the renumbered pair list — no extra pass needed.

Closes #2846.

## Test plan

- [x] Added `BOOST_CHECK_EQUAL` on `collisionPairMapping.rows()/cols()` vs `ngeoms` in `test_simple_boxes`, after the existing `removeGeometryObject` call.
- [x] Verified the new assertions fail without the fix (`3 != 2`) and pass with it — confirmed locally via `ctest -R pinocchio-test-cpp-geometry-algorithms`.
