### PR TITLE
bindings/python: make bindings scalar-generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Added
 - Add `DataTpl::lastChild` deprecation notice in Python binding
 - Fix `addFrame` to ignore frame without inertial to preserse parent body's CoM
+- Add scalar-generic Python bindings
 
 ### Fixed
 - Fix `ellipsoid-joint-kinematics.py` example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ## [Unreleased]
 
 ### Added
-- Add `DataTpl::lastChild` deprecation notice in Python binding
-- Fix `addFrame` to ignore frame without inertial to preserse parent body's CoM
-- Add scalar-generic Python bindings
+- Add `DataTpl::lastChild` deprecation notice in Python binding ([#2928](https://github.com/stack-of-tasks/pinocchio/pull/2927))
+
+### Fixed
+- Fix `addFrame` to ignore frame without inertial to preserse parent body's CoM ([#2929](https://github.com/stack-of-tasks/pinocchio/pull/2929))
+- Fix scalar-generic Python bindings ([#2939](https://github.com/stack-of-tasks/pinocchio/pull/2939))
 
 ### Fixed
 - Fix `ellipsoid-joint-kinematics.py` example

--- a/README.md
+++ b/README.md
@@ -306,6 +306,7 @@ In addition to the core dev team, the following people have also been involved i
 -   [Megane Millan](https://github.com/MegMll): core developer (MJCF, joint mimic, etc.)
 -   [Tingfan Wu](https://github.com/tingfan): Viser visualizer mesh-scale bug fix
 -   [Kazuki Sugihara](https://github.com/sugikazu75): addFrame bug fix
+-   [Sergi Martinez](https://github.com/Sergim96): scalar-generic Python bindings
 
 If you have participated in the development of **Pinocchio**, please add your name and contribution to this list.
 

--- a/bindings/python/algorithm/expose-frames.cpp
+++ b/bindings/python/algorithm/expose-frames.cpp
@@ -286,7 +286,7 @@ namespace pinocchio
 
       bp::def(
         "computeSupportedInertiaByFrame",
-        &computeSupportedInertiaByFrame<double, 0, JointCollectionDefaultTpl>,
+        &computeSupportedInertiaByFrame<Scalar, Options, JointCollectionDefaultTpl>,
         bp::args("model", "data", "frame_id", "with_subtree"),
         "Computes the supported inertia by the frame (given by frame_id) and returns it.\n"
         "The supported inertia corresponds to the sum of the inertias of all the child frames "
@@ -296,7 +296,7 @@ namespace pinocchio
 
       bp::def(
         "computeSupportedForceByFrame",
-        &computeSupportedForceByFrame<double, 0, JointCollectionDefaultTpl>,
+        &computeSupportedForceByFrame<Scalar, Options, JointCollectionDefaultTpl>,
         bp::args("model", "data", "frame_id"),
         "Computes the supported force of the frame (given by frame_id) and returns it.\n"
         "The supported force corresponds to the sum of all the forces experienced after the given "

--- a/bindings/python/algorithm/expose-model.cpp
+++ b/bindings/python/algorithm/expose-model.cpp
@@ -107,6 +107,7 @@ namespace pinocchio
       typedef std::vector<GeometryModel> GeometryModelVector;
       StdVectorPythonVisitor<GeometryModelVector>::expose("StdVec_GeometryModel");
 
+#ifdef PINOCCHIO_PYTHON_PLAIN_SCALAR_TYPE
       bp::def(
         "appendModel",
         (context::Model (*)(
@@ -181,6 +182,7 @@ namespace pinocchio
         "\tlist_of_joints_to_lock: list of joint indexes to lock\n"
         "\treference_configuration: reference configuration to compute the "
         "placement of the locked joints\n");
+#endif // ifdef PINOCCHIO_PYTHON_PLAIN_SCALAR_TYPE
 
       bp::def(
         "findCommonAncestor", findCommonAncestor_proxy, bp::args("model", "joint1_id", "joint2_id"),
@@ -192,6 +194,7 @@ namespace pinocchio
         "Returns a tuple containing the index of the common joint ancestor, the position of this "
         "ancestor in model.supports[joint1_id] and model.supports[joint2_id].\n");
 
+#ifdef PINOCCHIO_PYTHON_PLAIN_SCALAR_TYPE
       bp::def(
         "transformJointIntoMimic",
         transformJointIntoMimic_proxy<Scalar, Options, JointCollectionDefaultTpl>,
@@ -204,6 +207,7 @@ namespace pinocchio
         "\tindex_mimicking: index of the joint that will mimic\n"
         "\tscaling: Scaling of joint velocity and configuration\n"
         "\toffset: Offset of joint configuration\n");
+#endif // ifdef PINOCCHIO_PYTHON_PLAIN_SCALAR_TYPE
     }
 
   } // namespace python

--- a/bindings/python/algorithm/expose-model.cpp
+++ b/bindings/python/algorithm/expose-model.cpp
@@ -101,15 +101,17 @@ namespace pinocchio
     void exposeModelAlgo()
     {
       using namespace Eigen;
+      typedef context::Scalar Scalar;
+      using context::Options;
 
       typedef std::vector<GeometryModel> GeometryModelVector;
       StdVectorPythonVisitor<GeometryModelVector>::expose("StdVec_GeometryModel");
 
       bp::def(
         "appendModel",
-        (Model (*)(
-          const Model &, const Model &, const FrameIndex,
-          const SE3 &))&appendModel<double, 0, JointCollectionDefaultTpl>,
+        (context::Model (*)(
+          const context::Model &, const context::Model &, const FrameIndex,
+          const context::SE3 &))&appendModel<Scalar, Options, JointCollectionDefaultTpl>,
         bp::args("modelA", "modelB", "frame_in_modelA", "aMb"),
         "Append a child model into a parent model, after a specific frame given by its index.\n\n"
         "Parameters:\n"
@@ -119,7 +121,7 @@ namespace pinocchio
         "\taMb: pose of modelB universe joint (index 0) in frameInModelA\n");
 
       bp::def(
-        "appendModel", &appendModel_proxy<double, 0, JointCollectionDefaultTpl>,
+        "appendModel", &appendModel_proxy<Scalar, Options, JointCollectionDefaultTpl>,
         bp::args("modelA", "modelB", "geomModelA", "geomModelB", "frame_in_modelA", "aMb"),
         "Append a child (geometry) model into a parent (geometry) model, after a specific frame "
         "given by its index.\n\n"
@@ -133,10 +135,10 @@ namespace pinocchio
 
       bp::def(
         "buildReducedModel",
-        (Model (*)(
-          const Model &, const std::vector<JointIndex> &,
-          const Eigen::MatrixBase<VectorXd> &))&pinocchio::
-          buildReducedModel<double, 0, JointCollectionDefaultTpl, VectorXd>,
+        (context::Model (*)(
+          const context::Model &, const std::vector<JointIndex> &,
+          const Eigen::MatrixBase<context::VectorXs> &))&pinocchio::
+          buildReducedModel<Scalar, Options, JointCollectionDefaultTpl, context::VectorXs>,
         bp::args("model", "list_of_joints_to_lock", "reference_configuration"),
         "Build a reduce model from a given input model and a list of joint to lock.\n\n"
         "Parameters:\n"
@@ -148,9 +150,10 @@ namespace pinocchio
       bp::def(
         "buildReducedModel",
         (bp::tuple (*)(
-          const Model &, const GeometryModel &, const std::vector<JointIndex> &,
+          const context::Model &, const GeometryModel &, const std::vector<JointIndex> &,
           const Eigen::MatrixBase<
-            VectorXd> &))&buildReducedModel<double, 0, JointCollectionDefaultTpl, VectorXd>,
+            context::
+              VectorXs> &))&buildReducedModel<Scalar, Options, JointCollectionDefaultTpl, context::VectorXs>,
         bp::args("model", "geom_model", "list_of_joints_to_lock", "reference_configuration"),
         "Build a reduced model and a reduced geometry model from a given input model,"
         "an input geometry model and a list of joints to lock.\n\n"
@@ -164,9 +167,9 @@ namespace pinocchio
       bp::def(
         "buildReducedModel",
         (bp::tuple (*)(
-          const Model &, const std::vector<GeometryModel> &, const std::vector<JointIndex> &,
-          const Eigen::MatrixBase<VectorXd> &))
-          buildReducedModel<double, 0, JointCollectionDefaultTpl, VectorXd>,
+          const context::Model &, const std::vector<GeometryModel> &,
+          const std::vector<JointIndex> &, const Eigen::MatrixBase<context::VectorXs> &))
+          buildReducedModel<Scalar, Options, JointCollectionDefaultTpl, context::VectorXs>,
         bp::args(
           "model", "list_of_geom_models", "list_of_joints_to_lock", "reference_configuration"),
         "Build a reduced model and the related reduced geometry models from a given "
@@ -191,7 +194,7 @@ namespace pinocchio
 
       bp::def(
         "transformJointIntoMimic",
-        transformJointIntoMimic_proxy<double, 0, JointCollectionDefaultTpl>,
+        transformJointIntoMimic_proxy<Scalar, Options, JointCollectionDefaultTpl>,
         bp::args("input_model", "index_mimicked", "index_mimicking", "scaling", "offset"),
         "Transform of a joint of the model into a mimic joint. Keep the type of the joint as it "
         "was previously. \n\n"

--- a/bindings/python/multibody/sample-models.cpp
+++ b/bindings/python/multibody/sample-models.cpp
@@ -13,6 +13,7 @@ namespace pinocchio
   {
     namespace bp = boost::python;
 
+#ifdef PINOCCHIO_PYTHON_PLAIN_SCALAR_TYPE
     context::Model buildSampleModelHumanoidRandom(bool usingFF, bool mimic)
     {
       context::Model model;
@@ -27,14 +28,14 @@ namespace pinocchio
       return model;
     }
 
-#ifdef PINOCCHIO_WITH_COLLISION
+  #ifdef PINOCCHIO_WITH_COLLISION
     GeometryModel buildSampleGeometryModelManipulator(const context::Model & model)
     {
       GeometryModel geom;
       buildModels::manipulatorGeometries(model, geom);
       return geom;
     }
-#endif
+  #endif
 
     context::Model buildSampleModelHumanoid(bool usingFF)
     {
@@ -43,17 +44,19 @@ namespace pinocchio
       return model;
     }
 
-#ifdef PINOCCHIO_WITH_COLLISION
+  #ifdef PINOCCHIO_WITH_COLLISION
     GeometryModel buildSampleGeometryModelHumanoid(const context::Model & model)
     {
       GeometryModel geom;
       buildModels::humanoidGeometries(model, geom);
       return geom;
     }
-#endif
+  #endif
+#endif // ifdef PINOCCHIO_PYTHON_PLAIN_SCALAR_TYPE
 
     void exposeSampleModels()
     {
+#ifdef PINOCCHIO_PYTHON_PLAIN_SCALAR_TYPE
       bp::def(
         "buildSampleModelHumanoidRandom",
         static_cast<context::Model (*)(bool, bool)>(
@@ -67,13 +70,13 @@ namespace pinocchio
         static_cast<context::Model (*)(bool)>(pinocchio::python::buildSampleModelManipulator),
         (bp::arg("mimic") = false), "Generate a (hard-coded) model of a simple manipulator.");
 
-#ifdef PINOCCHIO_WITH_COLLISION
+  #ifdef PINOCCHIO_WITH_COLLISION
       bp::def(
         "buildSampleGeometryModelManipulator",
         static_cast<GeometryModel (*)(const context::Model &)>(
           pinocchio::python::buildSampleGeometryModelManipulator),
         bp::args("model"), "Generate a (hard-coded) geometry model of a simple manipulator.");
-#endif
+  #endif
 
       bp::def(
         "buildSampleModelHumanoid",
@@ -81,13 +84,14 @@ namespace pinocchio
         (bp::arg("using_free_flyer") = true),
         "Generate a (hard-coded) model of a simple humanoid.");
 
-#ifdef PINOCCHIO_WITH_COLLISION
+  #ifdef PINOCCHIO_WITH_COLLISION
       bp::def(
         "buildSampleGeometryModelHumanoid",
         static_cast<GeometryModel (*)(const context::Model &)>(
           pinocchio::python::buildSampleGeometryModelHumanoid),
         bp::args("model"), "Generate a (hard-coded) geometry model of a simple humanoid.");
-#endif
+  #endif
+#endif // ifdef PINOCCHIO_PYTHON_PLAIN_SCALAR_TYPE
     }
   } // namespace python
 

--- a/bindings/python/multibody/sample-models.cpp
+++ b/bindings/python/multibody/sample-models.cpp
@@ -3,6 +3,7 @@
 //
 
 #include "pinocchio/multibody/sample-models.hpp"
+#include "pinocchio/bindings/python/fwd.hpp"
 
 #include <boost/python.hpp>
 
@@ -12,22 +13,22 @@ namespace pinocchio
   {
     namespace bp = boost::python;
 
-    Model buildSampleModelHumanoidRandom(bool usingFF, bool mimic)
+    context::Model buildSampleModelHumanoidRandom(bool usingFF, bool mimic)
     {
-      Model model;
+      context::Model model;
       buildModels::humanoidRandom(model, usingFF, mimic);
       return model;
     }
 
-    Model buildSampleModelManipulator(bool mimic)
+    context::Model buildSampleModelManipulator(bool mimic)
     {
-      Model model;
+      context::Model model;
       buildModels::manipulator(model, mimic);
       return model;
     }
 
 #ifdef PINOCCHIO_WITH_COLLISION
-    GeometryModel buildSampleGeometryModelManipulator(const Model & model)
+    GeometryModel buildSampleGeometryModelManipulator(const context::Model & model)
     {
       GeometryModel geom;
       buildModels::manipulatorGeometries(model, geom);
@@ -35,15 +36,15 @@ namespace pinocchio
     }
 #endif
 
-    Model buildSampleModelHumanoid(bool usingFF)
+    context::Model buildSampleModelHumanoid(bool usingFF)
     {
-      Model model;
+      context::Model model;
       buildModels::humanoid(model, usingFF);
       return model;
     }
 
 #ifdef PINOCCHIO_WITH_COLLISION
-    GeometryModel buildSampleGeometryModelHumanoid(const Model & model)
+    GeometryModel buildSampleGeometryModelHumanoid(const context::Model & model)
     {
       GeometryModel geom;
       buildModels::humanoidGeometries(model, geom);
@@ -55,34 +56,35 @@ namespace pinocchio
     {
       bp::def(
         "buildSampleModelHumanoidRandom",
-        static_cast<Model (*)(bool, bool)>(pinocchio::python::buildSampleModelHumanoidRandom),
+        static_cast<context::Model (*)(bool, bool)>(
+          pinocchio::python::buildSampleModelHumanoidRandom),
         (bp::arg("using_free_flyer") = true, bp::arg("mimic") = false),
         "Generate a (hard-coded) model of a humanoid robot with 6-DOF limbs and random joint "
         "placements.\nOnly meant for unit tests.");
 
       bp::def(
         "buildSampleModelManipulator",
-        static_cast<Model (*)(bool)>(pinocchio::python::buildSampleModelManipulator),
+        static_cast<context::Model (*)(bool)>(pinocchio::python::buildSampleModelManipulator),
         (bp::arg("mimic") = false), "Generate a (hard-coded) model of a simple manipulator.");
 
 #ifdef PINOCCHIO_WITH_COLLISION
       bp::def(
         "buildSampleGeometryModelManipulator",
-        static_cast<GeometryModel (*)(const Model &)>(
+        static_cast<GeometryModel (*)(const context::Model &)>(
           pinocchio::python::buildSampleGeometryModelManipulator),
         bp::args("model"), "Generate a (hard-coded) geometry model of a simple manipulator.");
 #endif
 
       bp::def(
         "buildSampleModelHumanoid",
-        static_cast<Model (*)(bool)>(pinocchio::python::buildSampleModelHumanoid),
+        static_cast<context::Model (*)(bool)>(pinocchio::python::buildSampleModelHumanoid),
         (bp::arg("using_free_flyer") = true),
         "Generate a (hard-coded) model of a simple humanoid.");
 
 #ifdef PINOCCHIO_WITH_COLLISION
       bp::def(
         "buildSampleGeometryModelHumanoid",
-        static_cast<GeometryModel (*)(const Model &)>(
+        static_cast<GeometryModel (*)(const context::Model &)>(
           pinocchio::python::buildSampleGeometryModelHumanoid),
         bp::args("model"), "Generate a (hard-coded) geometry model of a simple humanoid.");
 #endif

--- a/bindings/python/utils/dependencies.cpp
+++ b/bindings/python/utils/dependencies.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <eigenpy/deprecation-policy.hpp>
+#include <eigenpy/registration.hpp>
 
 #include <boost/python.hpp>
 
@@ -65,8 +66,11 @@ namespace pinocchio
 
     void exposeDependencies()
     {
-      bp::class_<DeprecatedBool>("DeprecatedBool", bp::no_init)
-        .def("__bool__", &DeprecatedBool::__bool__);
+      if (!eigenpy::register_symbolic_link_to_registered_type<DeprecatedBool>())
+      {
+        bp::class_<DeprecatedBool>("DeprecatedBool", bp::no_init)
+          .def("__bool__", &DeprecatedBool::__bool__);
+      }
 
       bp::scope().attr("WITH_COLLISION") = WITH_COLLISION;
       // To conserve back compatibility

--- a/include/pinocchio/src/algorithm/frames.hxx
+++ b/include/pinocchio/src/algorithm/frames.hxx
@@ -381,6 +381,8 @@ namespace pinocchio
     assert(model.check(data) && "data is not consistent with model.");
 
     typedef ModelTpl<Scalar, Options, JointCollectionTpl> Model;
+    typedef typename Model::Frame Frame;
+    typedef typename Model::SE3 SE3;
     typedef InertiaTpl<Scalar, Options> Inertia;
 
     const Frame & frame = model.frames[frame_id];
@@ -419,7 +421,7 @@ namespace pinocchio
       I += data.oMi[j_id].act(model.inertias[j_id]);
     }
 
-    const pinocchio::SE3 oMf = data.oMi[joint_id] * frame.placement;
+    const SE3 oMf = data.oMi[joint_id] * frame.placement;
     return oMf.actInv(I);
   }
 
@@ -430,6 +432,8 @@ namespace pinocchio
     const FrameIndex frame_id)
   {
     typedef ModelTpl<Scalar, Options, JointCollectionTpl> Model;
+    typedef typename Model::Frame Frame;
+    typedef typename Model::SE3 SE3;
     typedef InertiaTpl<Scalar, Options> Inertia;
     typedef MotionTpl<Scalar, Options> Motion;
     typedef ForceTpl<Scalar, Options> Force;
@@ -439,7 +443,7 @@ namespace pinocchio
 
     // Compute 'in body' forces
     const Inertia fI = computeSupportedInertiaByFrame(model, data, frame_id, false);
-    const pinocchio::SE3 oMf = data.oMi[joint_id] * frame.placement;
+    const SE3 oMf = data.oMi[joint_id] * frame.placement;
     const Motion v = getFrameVelocity(model, data, frame_id, LOCAL);
     const Motion a = getFrameAcceleration(model, data, frame_id, LOCAL);
     Force f = fI.vxiv(v) + fI * (a - oMf.actInv(model.gravity));

--- a/include/pinocchio/src/algorithm/loop-constrained-aba.hxx
+++ b/include/pinocchio/src/algorithm/loop-constrained-aba.hxx
@@ -282,6 +282,7 @@ namespace pinocchio
 
     typedef std::pair<JointIndex, JointIndex> JointPair;
     typedef typename Data::Matrix6 Matrix6;
+    typedef typename Data::Force Force;
 
     typedef boost::fusion::vector<const Model &, Data &> ArgsType;
 
@@ -293,6 +294,7 @@ namespace pinocchio
       Data & data)
     {
       typedef typename Model::JointIndex JointIndex;
+      typedef typename Data::Force Force;
       typedef typename Data::Matrix6x Matrix6x;
 
       typedef typename SizeDepType<JointModel::NV>::template ColsReturn<Matrix6x>::Type ColBlock;
@@ -337,6 +339,7 @@ namespace pinocchio
 
     typedef std::pair<JointIndex, JointIndex> JointPair;
     typedef typename Data::Matrix6 Matrix6;
+    typedef typename Data::Force Force;
 
     typedef boost::fusion::vector<const Model &, Data &> ArgsType;
 
@@ -411,6 +414,7 @@ namespace pinocchio
         typedef typename Model::JointIndex JointIndex;
         typedef typename Data::Matrix6 Matrix6;
         typedef typename ConstraintModel::Matrix36 Matrix36;
+        typedef typename ConstraintData::Motion Motion;
 
         cdata.contact_force.setZero();
 
@@ -600,6 +604,7 @@ namespace pinocchio
     typedef ModelTpl<Scalar, Options, JointCollectionTpl> Model;
     typedef typename Model::JointIndex JointIndex;
     typedef typename ConstraintModel::Matrix36 Matrix36;
+    typedef typename ConstraintData::Force Force;
 
     data.u = tau;
     data.oa_gf[0] = -model.gravity;
@@ -680,7 +685,7 @@ namespace pinocchio
             contact_acc_err =
               cdata.oMc1.actInv((data.oa[joint1_id])) - cdata.contact_acceleration_desired;
 
-          const auto mu_lambda = Force(mu * contact_acc_err.toVector());
+          const Force mu_lambda = Force(mu * contact_acc_err.toVector());
           cdata.contact_force += mu_lambda;
 
           if (joint1_id > 0)
@@ -698,7 +703,7 @@ namespace pinocchio
             contact_acc_err.linear() -=
               cdata.c1Mc2.rotation() * cdata.oMc2.actInv(data.oa[joint2_id]).linear();
 
-          const auto mu_lambda = Force(mu * contact_acc_err.toVector());
+          const Force mu_lambda = Force(mu * contact_acc_err.toVector());
           cdata.contact_force.linear() += mu_lambda.linear();
 
           if (joint1_id > 0)

--- a/include/pinocchio/src/algorithm/model.hxx
+++ b/include/pinocchio/src/algorithm/model.hxx
@@ -127,7 +127,9 @@ namespace pinocchio
           {
             go.parentFrame = parentFrame;
           }
-          go.placement = (pframe_placement * pfMAB) * go.placement;
+          typedef typename GeometryObject::SE3 GeometrySE3;
+          const GeometrySE3 geometry_placement(pframe_placement * pfMAB);
+          go.placement = geometry_placement * go.placement;
           geomModel.addGeometryObject(go);
         }
       }
@@ -843,7 +845,7 @@ namespace pinocchio
         {
           const FrameIndex reduced_frame_id = reduced_model.getFrameId(parent_joint_name);
           reduced_joint_id = reduced_model.frames[reduced_frame_id].parentJoint;
-          relative_placement = reduced_model.frames[reduced_frame_id].placement;
+          relative_placement = SE3(reduced_model.frames[reduced_frame_id].placement);
         }
 
         GeometryObject reduced_geom(geom);
@@ -890,6 +892,7 @@ namespace pinocchio
 
     typedef ModelTpl<Scalar, Options, JointCollectionTpl> Model;
     typedef typename Model::JointModel JointModel;
+    typedef JointModelMimicTpl<Scalar, Options, JointCollectionTpl> JointModelMimic;
 
     output_model = input_model;
 

--- a/include/pinocchio/src/algorithm/solvers/admm-solver.hxx
+++ b/include/pinocchio/src/algorithm/solvers/admm-solver.hxx
@@ -145,7 +145,8 @@ namespace pinocchio
         break;
       }
       case (ADMMUpdateRule::OSQP):
-        admm_update_rule_container.osqp_rule = ADMMOSQPUpdateRule(settings.ratio_primal_dual, 1e-8);
+        admm_update_rule_container.osqp_rule =
+          ADMMOSQPUpdateRule(settings.ratio_primal_dual, Scalar(1e-8));
         break;
       case (ADMMUpdateRule::LINEAR):
         admm_update_rule_container.linear_rule =
@@ -518,7 +519,7 @@ namespace pinocchio
     {
       PINOCCHIO_TRACY_ZONE_SCOPED_N("ADMMConstraintSolverTpl::solve - lanczos");
       workspace.lanczos_decomposition.compute(G);
-      L = ::pinocchio::computeLargestEigenvalue(workspace.lanczos_decomposition.Ts(), 1e-8);
+      L = ::pinocchio::computeLargestEigenvalue(workspace.lanczos_decomposition.Ts(), Scalar(1e-8));
 #ifndef NDEBUG
       const bool enforce_symmetry = true;
       MatrixXs delassus = G.matrix(enforce_symmetry);

--- a/include/pinocchio/src/multibody/sample-models.hxx
+++ b/include/pinocchio/src/multibody/sample-models.hxx
@@ -103,6 +103,9 @@ namespace pinocchio
           ModelTpl<Scalar, Options, JointCollectionTpl>::SE3::Random(),
         bool setRandomLimits = true)
       {
+        typedef ModelTpl<Scalar, Options, JointCollectionTpl> Model;
+        typedef typename Model::Inertia Inertia;
+        typedef typename Model::SE3 SE3;
         typedef typename JointModel::ConfigVector_t CV;
         typedef typename JointModel::TangentVector_t TV;
 
@@ -220,7 +223,7 @@ namespace pinocchio
         model.addBodyFrame(pre + "effector_body", joint_id);
         const int nq = mimic ? 5 : 6;
 
-        const JointModel & base_joint = model.joints[root_joint_id];
+        const typename Model::JointModel & base_joint = model.joints[root_joint_id];
         const int idx_q = base_joint.idx_q();
         const int idx_v = base_joint.idx_v();
 
@@ -255,7 +258,7 @@ namespace pinocchio
       {
         typedef ModelTpl<Scalar, Options, JointCollectionTpl> Model;
         typedef typename Model::FrameIndex FrameIndex;
-        typedef typename Model::SE3 SE3;
+        typedef typename GeometryObject::SE3 SE3;
 
         const Eigen::Vector4d meshColor(1., 1., 0.78, 1.0);
 
@@ -512,7 +515,7 @@ namespace pinocchio
     {
       typedef ModelTpl<Scalar, Options, JointCollectionTpl> Model;
       typedef typename Model::FrameIndex FrameIndex;
-      typedef typename Model::SE3 SE3;
+      typedef typename GeometryObject::SE3 SE3;
 
       details::addManipulatorGeometries(model, geom, "rleg_");
       details::addManipulatorGeometries(model, geom, "lleg_");


### PR DESCRIPTION
This PR extracts the scalar-generic Python binding changes from https://github.com/stack-of-tasks/pinocchio/pull/2932, following @jcarpent review.

It introduces a Python binding context and replaces hardcoded scalar and Eigen types with the context-provided `Scalar` and related types.

This PR intentionally does not add the float32 Python module. Float32 support will be submitted separately in a follow-up PR.

### Tests

- Full project build completed successfully.
- 225/225 tests passed.