### PR TITLE
Fix aligned map comparison with GCC 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Fix `ellipsoid-joint-kinematics.py` example ([#2935](https://github.com/stack-of-tasks/pinocchio/pull/2935))
 - Fix `biais` typo in documentation and comments (English is `bias`) ([#2936](https://github.com/stack-of-tasks/pinocchio/pull/2936))
 
+### Fixed
+- Fix GCC 10 compilation of aligned matrix map comparisons ([#2930](https://github.com/stack-of-tasks/pinocchio/issues/2930))
+
 ## [4.1.0] - 2026-07-07
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -307,6 +307,7 @@ In addition to the core dev team, the following people have also been involved i
 -   [Tingfan Wu](https://github.com/tingfan): Viser visualizer mesh-scale bug fix
 -   [Kazuki Sugihara](https://github.com/sugikazu75): addFrame bug fix
 -   [Sergi Martinez](https://github.com/Sergim96): scalar-generic Python bindings
+-   [tandede](https://github.com/tandede): GCC 10 compatibility for aligned matrix map comparisons
 
 If you have participated in the development of **Pinocchio**, please add your name and contribution to this list.
 

--- a/include/pinocchio/src/utils/eigen-helpers.hxx
+++ b/include/pinocchio/src/utils/eigen-helpers.hxx
@@ -138,9 +138,8 @@ namespace pinocchio
 
     } // namespace helper
 
-    template<typename D1, int Level1, typename D2, int Level2>
-    bool
-    compare_maps(const Eigen::MapBase<D1, Level1> & map1, const Eigen::MapBase<D2, Level2> & map2)
+    template<typename D1, typename D2>
+    bool compare_maps(const Eigen::MatrixBase<D1> & map1, const Eigen::MatrixBase<D2> & map2)
     {
       if ((map1.rows() != map2.rows()) || (map1.cols() != map2.cols()))
         return false;

--- a/unittest/matrix-stack.cpp
+++ b/unittest/matrix-stack.cpp
@@ -54,22 +54,6 @@ BOOST_AUTO_TEST_CASE(matrix_stack_empty)
   BOOST_CHECK(matrix_stack_copy.data() == nullptr);
 }
 
-BOOST_AUTO_TEST_CASE(compare_aligned_row_maps)
-{
-  using RowVector = Eigen::Matrix<double, 1, Eigen::Dynamic>;
-  using AlignedRowMap = Eigen::Map<RowVector, Eigen::Aligned16>;
-
-  alignas(16) double values1[] = {1., 2., 3., 4.};
-  alignas(16) double values2[] = {1., 2., 3., 4.};
-  const AlignedRowMap map1(values1, 4);
-  const AlignedRowMap map2(values2, 4);
-
-  BOOST_CHECK(internal::compare_maps(map1, map2));
-
-  values2[3] = 5.;
-  BOOST_CHECK(!internal::compare_maps(map1, map2));
-}
-
 BOOST_AUTO_TEST_CASE(matrix_stack_default)
 {
 

--- a/unittest/matrix-stack.cpp
+++ b/unittest/matrix-stack.cpp
@@ -54,6 +54,22 @@ BOOST_AUTO_TEST_CASE(matrix_stack_empty)
   BOOST_CHECK(matrix_stack_copy.data() == nullptr);
 }
 
+BOOST_AUTO_TEST_CASE(compare_aligned_row_maps)
+{
+  using RowVector = Eigen::Matrix<double, 1, Eigen::Dynamic>;
+  using AlignedRowMap = Eigen::Map<RowVector, Eigen::Aligned16>;
+
+  alignas(16) double values1[] = {1., 2., 3., 4.};
+  alignas(16) double values2[] = {1., 2., 3., 4.};
+  const AlignedRowMap map1(values1, 4);
+  const AlignedRowMap map2(values2, 4);
+
+  BOOST_CHECK(internal::compare_maps(map1, map2));
+
+  values2[3] = 5.;
+  BOOST_CHECK(!internal::compare_maps(map1, map2));
+}
+
 BOOST_AUTO_TEST_CASE(matrix_stack_default)
 {
 


### PR DESCRIPTION
## Description

Fixes #2930.

`compare_maps()` currently accepts its inputs through `Eigen::MapBase`. With an aligned dynamic row-vector map such as `Eigen::Map<RowVector, Eigen::Aligned16>`, GCC 10 cannot deduce that overload because `MapBase` is an ambiguous base class of the concrete map type. This prevents `MatrixStackTpl` equality comparison from compiling.

The helper only relies on the common matrix-expression operations `rows()`, `cols()`, and element comparison. It does not use any `MapBase`-specific behavior. This change therefore accepts both operands through their unambiguous `Eigen::MatrixBase` base instead and removes the no-longer-needed map access-level template parameters.

The size checks and exact element-comparison semantics remain unchanged.

The existing `MatrixStackTpl::operator==` tests in `matrix-stack.cpp` already exercise `compare_maps()` multiple times, so no additional direct test is needed.

The changelog records the compatibility fix, and the README credits section has been updated as requested by the contribution checklist.

## Verification

- Eigen 3.4 build: 312/312 build steps completed
- Eigen 3.4 test suite: 136/136 passed
- Eigen 5.0.1 build: 314/314 build steps completed
- Eigen 5.0.1 test suite: 136/136 passed
- `pinocchio-test-cpp-matrix-stack` passed after removing the redundant direct test
- `pre-commit run --all-files`
- `pre-commit run --files unittest/matrix-stack.cpp`
- `git diff --check`

## Checklist

- [x] I have run `pre-commit run --all-files`
- [x] I have performed a self-review of my own code
- [x] I have commented my code where necessary
- [x] Doxygen changes are not applicable because this internal helper fix does not change the public API
- [x] Existing `MatrixStackTpl::operator==` tests cover this helper; the redundant direct test was removed per review
- [x] I have updated the CHANGELOG
- [x] I have updated the README credits section