### PR TITLE
Fix CasADi header propagation for legacy CMake exports

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,7 @@ include("${JRL_CMAKE_MODULES}/base.cmake")
 
 compute_project_args(PROJECT_ARGS LANGUAGES CXX)
 project(${PROJECT_NAME} ${PROJECT_ARGS})
+include("${CMAKE_CURRENT_LIST_DIR}/development/cmake/pinocchio-casadi.cmake")
 
 set(INSTALL_PKG_CONFIG_FILE OFF CACHE BOOL "" FORCE)
 
@@ -386,12 +387,7 @@ endif(BUILD_WITH_AUTODIFF_SUPPORT)
 
 if(BUILD_WITH_CASADI_SUPPORT)
     add_project_dependency(casadi 3.4.5 REQUIRED)
-
-    # Normalize CasADi link target across versions. Prefer imported target (casadi::casadi), then
-    # legacy target (casadi)
-    if(NOT TARGET casadi::casadi AND TARGET casadi)
-        add_library(casadi::casadi ALIAS casadi)
-    endif()
+    pinocchio_prepare_casadi_target(PINOCCHIO_CASADI_LINK_TARGET)
 endif(BUILD_WITH_CASADI_SUPPORT)
 
 if(BUILD_WITH_OPENMP_SUPPORT)

--- a/bindings/python/CMakeLists.txt
+++ b/bindings/python/CMakeLists.txt
@@ -304,7 +304,7 @@ if(BUILD_PYTHON_INTERFACE)
 
     if(BUILD_WITH_CASADI_SUPPORT)
         pinocchio_python_bindings_specific_type(casadi)
-        target_link_libraries(${PYWRAP}_casadi PUBLIC casadi::casadi)
+        target_link_libraries(${PYWRAP}_casadi PUBLIC ${PINOCCHIO_CASADI_LINK_TARGET})
         list(APPEND STUBGEN_DEPENDENCIES "${PYWRAP}_casadi")
 
         if(PINOCCHIO_BUILD_BINDING_WITH_PCH)

--- a/development/cmake-tests/casadi-legacy-target/CMakeLists.txt
+++ b/development/cmake-tests/casadi-legacy-target/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(pinocchio-casadi-legacy-target-smoke LANGUAGES CXX)
+
+include("${CMAKE_CURRENT_LIST_DIR}/../../cmake/pinocchio-casadi.cmake")
+
+add_library(casadi INTERFACE IMPORTED)
+set(casadi_INCLUDE_DIRS "${CMAKE_CURRENT_LIST_DIR}/include")
+
+pinocchio_prepare_casadi_target(PINOCCHIO_CASADI_LINK_TARGET)
+
+if(NOT PINOCCHIO_CASADI_LINK_TARGET STREQUAL "casadi::casadi")
+    message(FATAL_ERROR "Expected Pinocchio to normalize the CasADi link target name.")
+endif()
+
+get_target_property(_pinocchio_casadi_include_dirs casadi INTERFACE_INCLUDE_DIRECTORIES)
+
+if(NOT _pinocchio_casadi_include_dirs MATCHES "include")
+    message(
+        FATAL_ERROR
+        "Expected the legacy casadi target to pick up fallback include directories."
+    )
+endif()

--- a/development/cmake-tests/casadi-legacy-target/include/casadi/casadi.hpp
+++ b/development/cmake-tests/casadi-legacy-target/include/casadi/casadi.hpp
@@ -1,0 +1,4 @@
+struct pinocchio_fake_casadi_header
+{
+  int value;
+};

--- a/development/cmake/pinocchio-casadi.cmake
+++ b/development/cmake/pinocchio-casadi.cmake
@@ -1,0 +1,79 @@
+include_guard(GLOBAL)
+
+include(CheckIncludeFileCXX)
+
+function(pinocchio_prepare_casadi_target out_var)
+    if(TARGET casadi::casadi)
+        set(_pinocchio_casadi_target casadi::casadi)
+        set(_pinocchio_casadi_target_to_patch casadi::casadi)
+    elseif(TARGET casadi)
+        set(_pinocchio_casadi_target casadi)
+        set(_pinocchio_casadi_target_to_patch casadi)
+    else()
+        message(
+            FATAL_ERROR
+            "CasADi support was requested, but neither casadi::casadi nor casadi was exported by the package."
+        )
+    endif()
+
+    get_target_property(
+        _pinocchio_casadi_include_dirs
+        ${_pinocchio_casadi_target_to_patch}
+        INTERFACE_INCLUDE_DIRECTORIES
+    )
+
+    if(NOT _pinocchio_casadi_include_dirs)
+        foreach(
+            _pinocchio_casadi_include_var
+            IN ITEMS
+                casadi_INCLUDE_DIRS
+                casadi_INCLUDE_DIR
+                CASADI_INCLUDE_DIRS
+                CASADI_INCLUDE_DIR
+        )
+            if(
+                DEFINED ${_pinocchio_casadi_include_var}
+                AND NOT "${${_pinocchio_casadi_include_var}}" STREQUAL ""
+            )
+                set_property(
+                    TARGET ${_pinocchio_casadi_target_to_patch}
+                    APPEND
+                    PROPERTY INTERFACE_INCLUDE_DIRECTORIES
+                             "${${_pinocchio_casadi_include_var}}"
+                )
+            endif()
+        endforeach()
+
+        get_target_property(
+            _pinocchio_casadi_include_dirs
+            ${_pinocchio_casadi_target_to_patch}
+            INTERFACE_INCLUDE_DIRECTORIES
+        )
+    endif()
+
+    set(_pinocchio_saved_required_includes "${CMAKE_REQUIRED_INCLUDES}")
+    if(_pinocchio_casadi_include_dirs)
+        set(CMAKE_REQUIRED_INCLUDES "${_pinocchio_casadi_include_dirs}")
+    else()
+        unset(CMAKE_REQUIRED_INCLUDES)
+    endif()
+
+    check_include_file_cxx("casadi/casadi.hpp" PINOCCHIO_CASADI_HEADER_FOUND)
+
+    set(CMAKE_REQUIRED_INCLUDES "${_pinocchio_saved_required_includes}")
+
+    if(NOT PINOCCHIO_CASADI_HEADER_FOUND)
+        message(
+            FATAL_ERROR
+            "CasADi support requires the exported target to expose casadi headers. "
+            "Set casadi_INCLUDE_DIRS/CASADI_INCLUDE_DIRS or use a package that exports "
+            "INTERFACE_INCLUDE_DIRECTORIES."
+        )
+    endif()
+
+    if(NOT TARGET casadi::casadi AND TARGET casadi)
+        add_library(casadi::casadi ALIAS casadi)
+    endif()
+
+    set(${out_var} casadi::casadi PARENT_SCOPE)
+endfunction()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -508,7 +508,11 @@ endif()
 # Define casadi target.
 if(BUILD_WITH_CASADI_SUPPORT)
     pinocchio_specific_type(casadi CASADI_SCOPE)
-    target_link_libraries(${PROJECT_NAME}_casadi ${CASADI_SCOPE} casadi::casadi)
+    target_link_libraries(
+        ${PROJECT_NAME}_casadi
+        ${CASADI_SCOPE}
+        ${PINOCCHIO_CASADI_LINK_TARGET}
+    )
 endif()
 
 if(BUILD_WITH_PYTHON_PARSER_SUPPORT)


### PR DESCRIPTION
## Summary

- normalize modern `casadi::casadi` and legacy `casadi` target exports
- backfill interface include directories from legacy package variables
- fail early when the exported target still cannot expose `casadi/casadi.hpp`
- use the normalized target in core and Python CasADi targets
- add a self-contained legacy-export configure regression

## Why

Some CasADi packages export only the legacy target and keep include directories in package variables, causing Pinocchio builds to miss `casadi/casadi.hpp`. This fixes #2605.

## Verification

- legacy lowercase list variable
- legacy uppercase single variable
- modern target export
- expected missing-header failure
- VS2022 configure smoke and `git diff --check`

A full build against a real CasADi installation was not performed.

Fixes #2605