### PR TITLE
Improve contributing guide, add an AI-assisted policy and a code of conduct

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -7,7 +7,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        If your question is more about how to use Pinocchio, please open a [discussion](https://github.com/stack-of-tasks/pinocchio/discussions)
+        Follow the [contributing guidelines](../../development/contributing.md).
+
+        If you have a question about how to use Pinocchio, open a [discussion](https://github.com/stack-of-tasks/pinocchio/discussions).
 
   - type: textarea
     id: description
@@ -22,8 +24,9 @@ body:
     attributes:
       label: Reproduction steps
       description: |
-        Steps to reproduce the behavior. Please try to provide a minimal example to reproduce the bug and a DockerFile if it's an installation issue. Error messages and stack traces are also helpful.
-        Please use [Markdown code blocks](https://help.github.com/en/articles/creating-and-highlighting-code-blocks) for both code and stack traces.
+        Steps to reproduce the behavior. Provide a minimal example that reproduces the bug
+        and a Dockerfile if it's an installation issue. Error messages and stack traces are also helpful.
+        Use [Markdown code blocks](https://help.github.com/en/articles/creating-and-highlighting-code-blocks) for code and stack traces.
       value: |
         ```python
         import pinocchio as pin
@@ -33,7 +36,7 @@ body:
     id: traceback
     attributes:
       label: Relevant log output / Error message
-      description: Please copy and paste any relevant log output / error message.
+      description: Copy and paste any relevant log output or error message.
       placeholder: Segmentation fault...
       render: shell
 
@@ -63,6 +66,7 @@ body:
           required: true
         - label: I have provided a minimal and working example to reproduce the bug
           required: true
-        - label: I have used [Markdown code blocks](https://help.github.com/en/articles/creating-and-highlighting-code-blocks) for both code and stack traces/compiler
-            errors.
+        - label: I have used [Markdown code blocks](https://help.github.com/en/articles/creating-and-highlighting-code-blocks) for code, stack traces
+            and compiler errors
           required: true
+        - label: I have used an AI assistant

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -66,7 +66,7 @@ body:
           required: true
         - label: I have provided a minimal and working example to reproduce the bug
           required: true
-        - label: I have used [Markdown code blocks](https://help.github.com/en/articles/creating-and-highlighting-code-blocks) for code, stack traces
-            and compiler errors
+        - label: I have used [Markdown code blocks](https://help.github.com/en/articles/creating-and-highlighting-code-blocks) for code, stack traces and
+            compiler errors
           required: true
         - label: I have used an AI assistant

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -4,6 +4,13 @@ title: "[Feature]: feature title"
 labels: ["feature request"]
 
 body:
+  - type: markdown
+    attributes:
+      value: |
+        Follow the [contributing guidelines](../../development/contributing.md).
+
+        If you have a question about how to use Pinocchio, open a [discussion](https://github.com/stack-of-tasks/pinocchio/discussions).
+
   - type: textarea
     id: description
     attributes:
@@ -16,14 +23,14 @@ body:
     id: motivation
     attributes:
       label: Motivation
-      description: Please outline the motivation for the proposal. Is your feature request related to a problem? e.g.,"I'm always frustrated when [...]".
-        If this is related to another GitHub issue, please link here too.
+      description: Outline the motivation for the proposal. Is the request related to a problem? For example, "I'm always frustrated when [...]".
+        If it is related to another GitHub issue, link it here.
 
   - type: textarea
     id: alternatives
     attributes:
       label: Alternatives
-      description: A clear and concise description of any alternative solutions or features you've considered, if any.
+      description: A clear and concise description of the alternative solutions or features you considered.
 
   - type: textarea
     id: additional-context
@@ -37,5 +44,6 @@ body:
       label: Checklist
       options:
         - label: I have checked that there is no similar [issue](https://github.com/stack-of-tasks/pinocchio/issues)/[discussion](https://github.com/stack-of-tasks/pinocchio/discussions)
-            in the repo.
+            in the repo
           required: true
+        - label: I have used an AI assistant

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -23,8 +23,8 @@ body:
     id: motivation
     attributes:
       label: Motivation
-      description: Outline the motivation for the proposal. Is the request related to a problem? For example, "I'm always frustrated when [...]".
-        If it is related to another GitHub issue, link it here.
+      description: Outline the motivation for the proposal. Is the request related to a problem? For example, "I'm always frustrated when [...]". If it
+        is related to another GitHub issue, link it here.
 
   - type: textarea
     id: alternatives

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,25 @@
-Thanks for taking the time to make and fill out this pull request!
+<!--
+Follow the [contributing guidelines](../development/contributing.md).
+-->
 
 ## Description
 
 <!--
-Please include a clear and concise description of the changes included in this pull request.
-Explain what are you changing and why.
+Describe the changes included in this pull request.
+Explain what you change and why.
 
-If applicable, link the related issue using "Fixes #issue_number".
+If the pull request fixes an issue, link it with "Fixes #issue_number".
 -->
 
 ## Checklist
 
+- [ ] I have read the [contributing guidelines](../development/contributing.md)
 - [ ] I have run `pre-commit run --all-files` or `pixi run lint`
-- [ ] I have performed a self-review of my own code
+- [ ] I have reviewed my own code
+- [ ] I have followed the [code convention](../development/convention.md)
 - [ ] I have commented my code where necessary
-- [ ] I have made corresponding changes to the doxygen documentation
+- [ ] I have made corresponding changes to the Doxygen documentation
 - [ ] I have added tests that prove my fix or feature works
-- [ ] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
+- [ ] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label for CI or infra changes
 - [ ] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
+- [ ] I have used an AI assistant

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -89,4 +89,3 @@ This Code of Conduct is adapted from the Contributor Covenant, version 3.0, perm
 Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
 
 For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).
-

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,92 @@
+
+# Contributor Covenant 3.0 Code of Conduct
+
+## Our Pledge
+
+We pledge to make our community welcoming, safe, and equitable for all.
+
+We are committed to fostering an environment that respects and promotes the dignity, rights, and contributions of all individuals, regardless of characteristics including race, ethnicity, caste, color, age, physical characteristics, neurodiversity, disability, sex or gender, gender identity or expression, sexual orientation, language, philosophy or religion, national or social origin, socio-economic position, level of education, or other status. The same privileges of participation are extended to everyone who participates in good faith and in accordance with this Covenant.
+
+## Encouraged Behaviors
+
+While acknowledging differences in social norms, we all strive to meet our community's expectations for positive behavior. We also understand that our words and actions may be interpreted differently than we intend based on culture, background, or native language.
+
+With these considerations in mind, we agree to behave mindfully toward each other and act in ways that center our shared values, including:
+
+1. Respecting the **purpose of our community**, our activities, and our ways of gathering.
+2. Engaging **kindly and honestly** with others.
+3. Respecting **different viewpoints** and experiences.
+4. **Taking responsibility** for our actions and contributions.
+5. Gracefully giving and accepting **constructive feedback**.
+6. Committing to **repairing harm** when it occurs.
+7. Behaving in other ways that promote and sustain the **well-being of our community**.
+
+
+## Restricted Behaviors
+
+We agree to restrict the following behaviors in our community. Instances, threats, and promotion of these behaviors are violations of this Code of Conduct.
+
+1. **Harassment.** Violating explicitly expressed boundaries or engaging in unnecessary personal attention after any clear request to stop.
+2. **Character attacks.** Making insulting, demeaning, or pejorative comments directed at a community member or group of people.
+3. **Stereotyping or discrimination.** Characterizing anyone’s personality or behavior on the basis of immutable identities or traits.
+4. **Sexualization.** Behaving in a way that would generally be considered inappropriately intimate in the context or purpose of the community.
+5. **Violating confidentiality**. Sharing or acting on someone's personal or private information without their permission.
+6. **Endangerment.** Causing, encouraging, or threatening violence or other harm toward any person or group.
+7. Behaving in other ways that **threaten the well-being** of our community.
+
+### Other Restrictions
+
+1. **Misleading identity.** Impersonating someone else for any reason, or pretending to be someone else to evade enforcement actions.
+2. **Failing to credit sources.** Not properly crediting the sources of content you contribute.
+3. **Promotional materials**. Sharing marketing or other commercial content in a way that is outside the norms of the community.
+4. **Irresponsible communication.** Failing to responsibly present content which includes, links or describes any other restricted behaviors.
+
+
+## Reporting an Issue
+
+Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
+
+When an incident does occur, it is important to report it promptly. To report a possible violation, **send an email to temporary@temporary.fr**
+
+Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
+
+
+## Addressing and Repairing Harm
+
+****
+
+If an investigation by the Community Moderators finds that this Code of Conduct has been violated, the following enforcement ladder may be used to determine how best to repair harm, based on the incident's impact on the individuals involved and the community as a whole. Depending on the severity of a violation, lower rungs on the ladder may be skipped.
+
+1) Warning
+   1) Event: A violation involving a single incident or series of incidents.
+   2) Consequence: A private, written warning from the Community Moderators.
+   3) Repair: Examples of repair include a private written apology, acknowledgement of responsibility, and seeking clarification on expectations.
+2) Temporarily Limited Activities
+   1) Event: A repeated incidence of a violation that previously resulted in a warning, or the first incidence of a more serious violation.
+   2) Consequence: A private, written warning with a time-limited cooldown period designed to underscore the seriousness of the situation and give the community members involved time to process the incident. The cooldown period may be limited to particular communication channels or interactions with particular community members.
+   3) Repair: Examples of repair may include making an apology, using the cooldown period to reflect on actions and impact, and being thoughtful about re-entering community spaces after the period is over.
+3) Temporary Suspension
+   1) Event: A pattern of repeated violation which the Community Moderators have tried to address with warnings, or a single serious violation.
+   2) Consequence: A private written warning with conditions for return from suspension. In general, temporary suspensions give the person being suspended time to reflect upon their behavior and possible corrective actions.
+   3) Repair: Examples of repair include respecting the spirit of the suspension, meeting the specified conditions for return, and being thoughtful about how to reintegrate with the community when the suspension is lifted.
+4) Permanent Ban
+   1) Event: A pattern of repeated code of conduct violations that other steps on the ladder have failed to resolve, or a violation so serious that the Community Moderators determine there is no way to keep the community safe with this person as a member.
+   2) Consequence: Access to all community spaces, tools, and communication channels is removed. In general, permanent bans should be rarely used, should have strong reasoning behind them, and should only be resorted to if working through other remedies has failed to change the behavior.
+   3) Repair: There is no possible repair in cases of this severity.
+
+This enforcement ladder is intended as a guideline. It does not limit the ability of Community Managers to use their discretion and judgment, in keeping with the best interests of our community.
+
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public or other spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+
+## Attribution
+
+This Code of Conduct is adapted from the Contributor Covenant, version 3.0, permanently available at [https://www.contributor-covenant.org/version/3/0/](https://www.contributor-covenant.org/version/3/0/).
+
+Contributor Covenant is stewarded by the Organization for Ethical Source and licensed under CC BY-SA 4.0. To view a copy of this license, visit [https://creativecommons.org/licenses/by-sa/4.0/](https://creativecommons.org/licenses/by-sa/4.0/)
+
+For answers to common questions about Contributor Covenant, see the FAQ at [https://www.contributor-covenant.org/faq](https://www.contributor-covenant.org/faq). Translations are provided at [https://www.contributor-covenant.org/translations](https://www.contributor-covenant.org/translations). Additional enforcement and community guideline resources can be found at [https://www.contributor-covenant.org/resources](https://www.contributor-covenant.org/resources). The enforcement ladder was inspired by the work of [Mozilla’s code of conduct team](https://github.com/mozilla/inclusion).
+

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -46,7 +46,7 @@ We agree to restrict the following behaviors in our community. Instances, threat
 
 Tensions can occur between community members even when they are trying their best to collaborate. Not every conflict represents a code of conduct violation, and this Code of Conduct reinforces encouraged behaviors and norms that can help avoid conflicts and minimize harm.
 
-When an incident does occur, it is important to report it promptly. To report a possible violation, **send an email to temporary@temporary.fr**
+When an incident does occur, it is important to report it promptly. To report a possible violation, **send an email to simple-robotics-contact@inria.fr**
 
 Community Moderators take reports of violations seriously and will make every effort to respond in a timely manner. They will investigate all reports of code of conduct violations, reviewing messages, logs, and recordings, or interviewing witnesses and other participants. Community Moderators will keep investigation and enforcement actions as transparent as possible while prioritizing safety and confidentiality. In order to honor these values, enforcement actions are carried out in private with the involved parties, but communicating to the whole community may be part of a mutually agreed upon resolution.
 

--- a/README.md
+++ b/README.md
@@ -49,23 +49,26 @@ or via pip (currently only available on Linux):
 
 ## Table of contents
 
-  - [Table of contents](#table-of-contents)
-  - [Pinocchio main features](#pinocchio-main-features)
-  - [Documentation](#documentation)
-  - [Examples](#examples)
-  - [Tutorials](#tutorials)
-  - [Pinocchio continuous integrations](#pinocchio-continuous-integrations)
-  - [Performances](#performances)
-  - [Ongoing developments](#ongoing-developments)
-  - [Installation](#installation)
-    - [ROS](#ros)
-  - [Visualization](#visualization)
-  - [Citing Pinocchio](#citing-pinocchio)
-  - [Questions and Issues](#questions-and-issues)
-  - [Core-dev team](#core-dev-team)
-  - [Credits](#credits)
-  - [Open-source projects relying on Pinocchio](#open-source-projects-relying-on-pinocchio)
-  - [Acknowledgments](#acknowledgments)
+- [Table of contents](#table-of-contents)
+- [Pinocchio main features](#pinocchio-main-features)
+- [Documentation](#documentation)
+- [Examples](#examples)
+- [Tutorials](#tutorials)
+- [Pinocchio continuous integrations](#pinocchio-continuous-integrations)
+- [Performances](#performances)
+- [Ongoing developments](#ongoing-developments)
+- [Installation](#installation)
+   * [Conda](#conda)
+   * [Docker](#docker)
+   * [ROS](#ros)
+- [Visualization](#visualization)
+- [Citing Pinocchio](#citing-pinocchio)
+- [Citing specific algorithmic contributions](#citing-specific-algorithmic-contributions)
+- [Contribution](#contribution)
+- [Core-dev team](#core-dev-team)
+- [Credits](#credits)
+- [Open-source projects relying on Pinocchio](#open-source-projects-relying-on-pinocchio)
+- [Acknowledgments](#acknowledgments)
 
 ## Pinocchio main features
 
@@ -258,9 +261,9 @@ If you use these algorithms, please consider citing them in your research articl
 - Carpentier, J., Budhiraja, R., & Mansard, N. (2021, July). [Proximal and sparse resolution of constrained dynamic equations](https://hal.science/hal-03271811/). In Robotics: Science and Systems (RSS 2021).
 - Carpentier, J., & Mansard, N. (2018, June). [Analytical derivatives of rigid body dynamics algorithms](https://hal.science/hal-01790971/). In Robotics: Science and Systems (RSS 2018).
 
-## Questions and Issues
+## Contribution
 
-Do you have a question or an issue? You may either directly open a [new question](https://github.com/stack-of-tasks/pinocchio/discussions/new?category=q-a) or a [new issue](https://github.com/stack-of-tasks/pinocchio/issues) or, directly contact us via the mailing list <pinocchio@inria.fr>.
+If you want to ask a question, report a bug, request a new feature or contributing with a pull requests please, follow the [contribution guideline](./development/contributing.md).
 
 ## Core-dev team
 

--- a/development/build.md
+++ b/development/build.md
@@ -52,6 +52,7 @@ In this case, use the following CMake options:
 - `BUILD_WITH_ACCELERATE_SUPPORT`: Apple Accelerate backend support (macOS only)
 - `BUILD_PYTHON_INTERFACE`: Python bindings
 - `BUILD_PYTHON_BINDINGS_WITH_BOOST_MPFR_SUPPORT`: MPFR support in the Python bindings
+- `BUILD_PYTHON_BINDINGS_WITH_FLOAT32_SUPPORT`: float32 support in the Python bindings
 - `GENERATE_PYTHON_STUBS`: Python stubs generation
 - `BUILD_BENCHMARK`: benchmarks
 

--- a/development/build.md
+++ b/development/build.md
@@ -1,10 +1,10 @@
-# Build and install from source with Pixi
+# Build and develop with pixi
 
-To build **Pinocchio** from source the easiest way is to use [Pixi](https://pixi.sh/latest/#installation).
+The easiest way to set up a development environment is to use [pixi](https://pixi.sh/latest/#installation).
 
-[Pixi](https://pixi.sh/latest/) is a cross-platform package management tool for developers that
-will install all required dependencies in `.pixi` directory.
-It's used by our CI agent so you have the guarantee to get the right dependencies.
+[pixi](https://pixi.sh/latest/) is a cross-platform package manager for developers.
+It installs all required dependencies in the `.pixi` directory.
+It's used by our CI, so you get the same stable and tested dependencies.
 
 Run the following command to install dependencies, configure, build and test the project:
 
@@ -12,5 +12,64 @@ Run the following command to install dependencies, configure, build and test the
 pixi run test
 ```
 
-The project will be built in the `build` directory.
-You can run `pixi shell` and build the project with `cmake` and `ninja` manually.
+The project is built in the `build` directory.
+
+The typical workflow is:
+
+```bash
+pixi shell
+pixi run configure
+ninja -C build
+```
+
+After `pixi run configure`, use `cmake` and `ninja` manually to reconfigure and build the project.
+
+## Environments
+
+The pixi manifest contains many environments. The most common ones are:
+
+- **default**: core pinocchio, URDF parser and Python bindings
+- **collision**: **default** + collision support (with coal)
+- **all-benchmark**: all pinocchio features
+
+To activate a specific environment, run:
+
+```bash
+pixi shell -e all-benchmark
+```
+
+Using **all-benchmark** makes it easy to choose which features to build.
+In this case, use the following CMake options:
+
+- `BUILD_WITH_URDF_SUPPORT`: URDF parser support
+- `BUILD_WITH_SDF_SUPPORT`: SDF parser support
+- `BUILD_WITH_COLLISION_SUPPORT`: collision support
+- `BUILD_WITH_AUTODIFF_SUPPORT`: automatic differentiation support with CppAD
+- `BUILD_WITH_CASADI_SUPPORT`: CasADi support
+- `BUILD_WITH_CODEGEN_SUPPORT`: code generation support with CppADCodeGen (no Windows support)
+- `BUILD_WITH_OPENMP_SUPPORT`: parallel algorithms with OpenMP
+- `BUILD_WITH_EXTRA_SUPPORT`: extra features support
+- `BUILD_WITH_ACCELERATE_SUPPORT`: Apple Accelerate backend support (macOS only)
+- `BUILD_PYTHON_INTERFACE`: Python bindings
+- `BUILD_PYTHON_BINDINGS_WITH_BOOST_MPFR_SUPPORT`: MPFR support in the Python bindings
+- `GENERATE_PYTHON_STUBS`: Python stubs generation
+- `BUILD_BENCHMARK`: benchmarks
+
+With the **all-benchmark** environment, all these options are ON.
+To turn one off, pass the corresponding `-D` flag to `cmake`:
+
+```bash
+cmake -B build -DBUILD_WITH_SDF_SUPPORT=OFF
+```
+
+## Faster build
+
+When you work on a single feature with one associated test, turn off
+the explicit template instantiation. This avoids building the whole library.
+
+- Set `ENABLE_TEMPLATE_INSTANTIATION` to OFF: `cmake -B build -DENABLE_TEMPLATE_INSTANTIATION=OFF`
+- Build and run the corresponding test:
+```bash
+ninja -C build pinocchio-test-cpp-<name>
+ctest --test-dir build --output-on-failure -R pinocchio-test-cpp-<name>
+```

--- a/development/contributing.md
+++ b/development/contributing.md
@@ -84,6 +84,18 @@ In your pull request:
 - Make sure the CI is green. Ask for help if you're stuck on a CI issue.
 - Check all the appropriate items in the pull request template checklist.
 
+### Keeping the pull request up-to-date
+
+You must rebase your work on the upstream `devel` branch.
+
+```bash
+git pull --rebase origin devel
+```
+
+Don't omit the `--rebase` argument or a merge commit will be created.
+Using merge commit to update your pull request is discouraged as it create
+a non linear git history.
+
 ### Running tests
 
 To run the full test suite:

--- a/development/contributing.md
+++ b/development/contributing.md
@@ -1,86 +1,172 @@
 # Contributing Guidelines
+
 Thank you for your interest in contributing to `pinocchio`.
-Whether it's a bug report, new feature, correction, or additional
-documentation, we greatly value feedback and contributions from our community.
+Whether it's a bug report, a new feature, a fix, or documentation, we value every contribution.
 
-Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
-information to effectively respond to your bug report or contribution.
+Read this document before opening an issue or a pull request.
 
-## Reporting Bugs/Feature Requests
-We welcome you to use the GitHub issue tracker to report bugs or suggest features.
+All communication on this project must follow the [Code of Conduct](../CODE_OF_CONDUCT.md).
 
-When filing an issue, please check [existing open][issues], or [recently closed][closed-issues], issues to make sure
- somebody else hasn't already reported the issue.
-Please try to include as much information as you can. Details like these are incredibly useful:
+## Table of contents
 
-  * A reproducible test case or series of steps
-  * The version of our code being used
-  * Any modifications you've made relevant to the bug
-  * Anything unusual about your environment or deployment
+- [Contributing Guidelines](#contributing-guidelines)
+   * [Reporting bugs and feature requests](#reporting-bugs-and-feature-requests)
+   * [Asking questions](#asking-questions)
+   * [Contributing via pull requests](#contributing-via-pull-requests)
+      + [Choosing an issue](#choosing-an-issue)
+      + [Set up the development environment](#set-up-the-development-environment)
+      + [Pull request content](#pull-request-content)
+      + [Running tests](#running-tests)
+      + [Code style](#code-style)
+      + [Changelog](#changelog)
+   * [AI-assisted contributions](#ai-assisted-contributions)
+      + [Responsibility](#responsibility)
+      + [Disclosure](#disclosure)
+      + [Communication](#communication)
+      + [Translation](#translation)
+      + [AI agent](#ai-agent)
+   * [Licensing](#licensing)
 
-## Contributing via Pull Requests
-The following guidance should be up-to-date, but the documentation as found [here](https://gepetto.github.io/doc/pinocchio/doxygen-html/) should prove as the final say.
+## Reporting bugs and feature requests
 
-Contributions via pull requests are much appreciated.
-Before sending us a pull request, please ensure that:
+Use the GitHub [issue tracker](https://github.com/stack-of-tasks/pinocchio/issues) to report bugs or suggest features.
 
- 1. Limited scope. Your PR should do one thing or one set of things. Avoid adding “random fixes” to PRs. Put those on separate PRs.
- 2. Give your PR a descriptive title. Add a short summary, if required.
- 3. Make sure the pipeline is green.
- 4. Don’t be afraid to request reviews from maintainers.
- 5. New code = new tests. If you are adding new functionality, always make sure to add some tests exercising the code and serving as live documentation of your original intention.
+Before opening an issue, check existing open and closed issues to avoid duplicates.
 
-To send us a pull request, please:
+Use the appropriate template and give as much detail as possible.
+If you don't use the template, maintainers may close your issue without explanation.
 
- 1. Fork the repository.
- 2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
- 3. Ensure local tests pass. (`make test`)
- 4. Commit to your fork using clear commit messages.
- 5. Send a pull request, answering any default questions in the pull request interface.
- 6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+## Asking questions
 
-GitHub provides additional documentation on [forking a repository](https://help.github.com/articles/fork-a-repo/) and [creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
+Ask questions in the [discussions section](https://github.com/stack-of-tasks/pinocchio/discussions).
+It separates development topics from community questions.
+Questions posted in the issue tracker will be moved to the discussions section.
 
-## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on.
-As this project, by default, uses the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'][help-wanted] issues is a great place to start.
+## Contributing via pull requests
+
+### Choosing an issue
+
+Every external contributor pull request needs an associated issue.
+Open an issue first. Core developers will review it.
+
+An issue is ready for a pull request when:
+
+- It has the **ready** label.
+- It is not assigned.
+- It does not have the **core developers** label.
+
+Issues with the **core developers** label are reserved for core developers.
+
+If an issue meets these criteria, claim it with a short comment.
+
+### Set up the development environment
+
+The easiest way to set up a development environment is to use pixi, as described in the [build documentation](build.md).
+
+See the CI workflows for examples with other package managers.
+
+### Pull request content
+
+To create a pull request, follow the GitHub guides on
+[forking a repository](https://help.github.com/articles/fork-a-repo/) and
+[creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
+
+In your pull request:
+
+- Use a descriptive title and follow the pull request template.
+- If the pull request is not ready for review, keep it as a draft.
+- Keep it to a single self-contained change. Don't mix unrelated fixes.
+- Follow the [code convention](./convention.md).
+- Keep backward compatibility. Don't break the API.
+- Write tests that cover your changes.
+- Add an entry to the [changelog](../CHANGELOG.md).
+- Make sure code style checks pass (`pixi run lint` or `pre-commit run --all-files`).
+- Make sure the CI is green. Ask for help if you're stuck on a CI issue.
+- Check all the appropriate items in the pull request template checklist.
+
+### Running tests
+
+To run the full test suite:
+
+```bash
+pixi run test
+```
+
+You can also run tests manually with `ctest`. Use the `-R` option to run a single test:
+
+```bash
+ctest --test-dir build --output-on-failure -R <test-name>
+```
+
+### Code style
+
+Code style is enforced with [pre-commit](https://pre-commit.com/) hooks configured in [.pre-commit-config.yaml](../.pre-commit-config.yaml).
+Before pushing your changes, run:
+
+```bash
+pixi run lint
+```
+
+or directly:
+
+```bash
+pre-commit run --all-files
+```
+
+### Changelog
+
+Add changelog entries under the `## [Unreleased]` section,
+in the matching [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
+category (`Added`, `Changed`, `Fixed`, `Removed`).
+
+Each entry is a short message followed by the pull request link, e.g.:
+
+```
+- Add spline joint to default joint collection ([#2784](https://github.com/stack-of-tasks/pinocchio/pull/2784))
+```
+
+CI and infra-only changes should not be listed. Use the **no changelog** label in this case.
+
+## AI-assisted contributions
+
+AI-assisted contributions are more and more common.
+To avoid wasting maintainers time, follow the rules below.
+
+AI-assisted contributions (issues, pull requests and discussions) are allowed under these rules.
+Any AI-assisted contribution that doesn't follow them can be closed without explanation.
+
+### Responsibility
+
+You are responsible for the whole contribution.
+Review it, understand it and be able to explain everything the AI assistant produced.
+Don't shift this work to the reviewers.
+
+The standard pull request guidelines apply.
+If some AI-proposed code doesn't look necessary or doesn't address the issue, remove it.
+Some AI assistants write too many tests. Keep only the tests you need, unit test maintenance is costly.
+
+### Disclosure
+
+Disclose that you used an AI assistant.
+Describing what it did is optional.
+
+### Communication
+
+Human-to-human communication matters.
+Never copy-paste AI-generated text into an issue, pull request description or comment.
+Write it yourself, it shows you understand the topic.
+If you want to quote the AI assistant, use a code or quote block.
+
+### Translation
+
+You can use an AI assistant for translation and grammar fixes.
+You are still responsible for everything it produces.
+
+### AI agent
+
+Don't submit contributions automatically with an AI agent.
+It breaks the responsibility and communication rules.
 
 ## Licensing
-Any contribution that you make to this repository will be under the BSD Clause 2 License, as dictated by that [license]:
 
-~~~
-BSD 2-Clause License
-
-Copyright (c) 2014-2021, CNRS
-Copyright (c) 2018-2021, INRIA
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-The views and conclusions contained in the software and documentation are those
-of the authors and should not be interpreted as representing official policies,
-either expressed or implied, of the Pinocchio project.
-~~~
-
-[issues](https://github.com/stack-of-tasks/pinocchio/issues)
-[closed-issues](https://github.com/stack-of-tasks/pinocchio/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20)
-[help-wanted](https://github.com/stack-of-tasks/pinocchio/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22)
-[license](https://opensource.org/licenses/BSD-2-Clause)
+All contributions to this repository are under the BSD 2-Clause License, as stated in [LICENSE](../LICENSE).


### PR DESCRIPTION
## Description

This PR add a lot of content to the contributing guide and an AI-assisted contribution section.
It also add a code of conduct.

TODO:
- [x] Improve PR/issue template phrasing
- [x] Add a real contact address in CODE_OF_CONDUCT.

## Checklist

- [x] I have read the [contribution guideline](../development/contributing.md)
- [x] I have run `pre-commit run --all-files` or `pixi run lint`
- [x] I have performed a self-review of my own code
- [x] I have followed the [code convention](../development/convention.md)
- [x] I have commented my code where necessary
- [x] I have made corresponding changes to the doxygen documentation
- [x] I have added tests that prove my fix or feature works
- [x] I have updated the [CHANGELOG](https://github.com/stack-of-tasks/pinocchio/blob/devel/CHANGELOG.md) or added the "no changelog" label if it's a CI-related issue
- [x] I have updated the [README credits section](https://github.com/stack-of-tasks/pinocchio?tab=readme-ov-file#credits)
- [x] I have used an AI-assistant

